### PR TITLE
build: Lower minVersion to 6.10

### DIFF
--- a/bin/stencil
+++ b/bin/stencil
@@ -10,7 +10,7 @@ process.env.IONIC_CLI_BIN = __filename;
 var util = require('./util');
 var path = require('path');
 
-var minVersion = 6.11;
+var minVersion = 6.10;
 var versionMatch = process.version.match(/(\d+).(\d+)/);
 if (versionMatch && parseFloat(versionMatch[0]) < minVersion) {
   console.error(util.chalk.red('ERR: Your Node.js version is ' + util.chalk.bold(process.version) + '. Please update to the latest Node LTS version.\n'));


### PR DESCRIPTION
Hi folks!

I'd love to try this out in our company, but we're stuck on Node 6.10.2. And it takes about a month for us to upgrade runtimes due to the way we package, test, and distribute things.

On a whim I tried lowering the minimum version to 6.10, and it seems to be building the component fine.