### PR TITLE
Fixed event name: onDoubleClick -> onDblClick, fixes #114

### DIFF
--- a/src/util/jsx-interfaces.ts
+++ b/src/util/jsx-interfaces.ts
@@ -895,8 +895,8 @@ declare global {
       onClickCapture?: EventHandler<MouseEvent>;
       onContextMenu?: EventHandler<MouseEvent>;
       onContextMenuCapture?: EventHandler<MouseEvent>;
-      onDoubleClick?: EventHandler<MouseEvent>;
-      onDoubleClickCapture?: EventHandler<MouseEvent>;
+      onDblClick?: EventHandler<MouseEvent>;
+      onDblClickCapture?: EventHandler<MouseEvent>;
       onDrag?: EventHandler<DragEvent>;
       onDragCapture?: EventHandler<DragEvent>;
       onDragEnd?: EventHandler<DragEvent>;


### PR DESCRIPTION
The event name is "dblclick" not "doubleclick" - this should fix #114