### PR TITLE
feat(testing): layout the basic testing API

### DIFF
--- a/src/core/testing/test/util.spec.ts
+++ b/src/core/testing/test/util.spec.ts
@@ -1,0 +1,101 @@
+import { h } from '../../../core/renderer/h';
+import * as util from '../util';
+
+class IonTest {
+  render() {
+    return [
+      h('div', 0, 'hi')
+    ];
+  }
+}
+
+class IonThingOne {
+  render() {
+    return [
+      h('div', 0, 'thing')
+    ];
+  }
+}
+
+class IonThingTwo {
+  x = 18;
+  y = 24;
+  sum() { return this.x + this.y; }
+  render() {
+    return [
+      h('div', { c: 'thing' }, [
+        h('div', { c: 'child-thing' }, 'I am the eldest'),
+        h('div', { c: 'child-thing' }, 'Middle child rules'),
+        h('div', { c: 'child-thing' }, 'No youngest does'),
+        h('div', { c: 'child-thing' }, 'say wut now?'),
+        h('div', { c: 'random-sum' }, this.sum())
+      ])
+    ];
+  }
+}
+
+describe('testing utilities', () => {
+  describe('register', () => {
+    it('returns a platform', () => {
+      const plt = util.register();
+      expect(plt).toBeTruthy();
+      expect(typeof plt.defineComponent).toEqual('function');
+      expect(typeof plt.getComponentMeta).toEqual('function');
+      expect(typeof plt.getContextItem).toEqual('function');
+    });
+
+    it('registers the components', () => {
+      const plt = util.register(
+        [{
+          tagNameMeta: 'ion-test',
+          componentModule: IonTest
+        }, {
+          tagNameMeta: 'ion-thing-one',
+          componentModule: IonThingOne
+        }]
+      );
+      expect(plt.getComponentMeta({ tagName: 'ion-test' } as Element)).toBeTruthy();
+      expect(plt.getComponentMeta({ tagName: 'ion-thing-one' } as Element)).toBeTruthy();
+    });
+  });
+
+  describe('render', () => {
+    it('renders the specified component', async () => {
+      const plt = util.register(
+        [{
+          tagNameMeta: 'ion-test',
+          componentModule: IonTest
+        }]
+      );
+      const node = await util.render(plt, '<ion-test></ion-test>');
+      expect(node.innerHTML.toString()).toEqual('<div>hi</div>');
+    });
+
+    it('renders a node that can be queried for tests', async () => {
+      const plt = util.register(
+        [{
+          tagNameMeta: 'ion-thing-two',
+          componentModule: IonThingTwo
+        }]
+      );
+      const node = await util.render(plt, '<ion-thing-two></ion-thing-two>');
+      const children = node.getElementsByClassName('child-thing');
+      expect(children.length).toEqual(4);
+    });
+
+    it('allows the component class itself to be tested', async () => {
+      const plt = util.register(
+        [{
+          tagNameMeta: 'ion-thing-two',
+          componentModule: IonThingTwo
+        }]
+      );
+      const node = await util.render(plt, '<ion-thing-two></ion-thing-two>');
+      const c: IonThingTwo = node.$instance as IonThingTwo;
+      expect(c.sum()).toEqual(42);
+      c.x = 25;
+      c.y = 48;
+      expect(c.sum()).toEqual(73);
+    });
+  });
+});

--- a/src/core/testing/util.ts
+++ b/src/core/testing/util.ts
@@ -1,0 +1,60 @@
+import { initHostConstructor } from '../../core/instance/init';
+import { ComponentMeta, HostElement, PlatformApi } from '../../util/interfaces';
+import { MockedPlatform, mockConnect, mockDefine, mockPlatform } from '../../test';
+
+export function register(components?: Array<ComponentMeta>): PlatformApi {
+  const platform = mockPlatform();
+
+  if (components) {
+    components.forEach(c => mockDefine(platform, c));
+  }
+
+  return platform as PlatformApi;
+}
+
+export function render(platform: PlatformApi, html: string): Promise<HostElement> {
+  const node = mockConnect(platform as MockedPlatform, html);
+  return waitForLoad(platform, node);
+}
+
+function waitForLoad(platform: PlatformApi, rootNode: any): Promise<HostElement> {
+  return new Promise((resolve: (elm: HostElement) => void) => {
+    (<MockedPlatform>platform).$flushQueue(() => {
+      // flush to read attribute mode on host elment
+      (<MockedPlatform>platform).$flushLoadBundle(() => {
+        // flush to load component mode data
+        (<MockedPlatform>platform).$flushQueue(() => {
+          // flush to do the update
+          connectComponents(platform, rootNode);
+          resolve(rootNode.childNodes[0]);
+        });
+      });
+    });
+
+  }).catch(err => {
+    console.error('waitForLoad', err);
+    return null;
+  });
+}
+
+// Copied verbatim from test/inject.js, more of that should be moved here and cleaned up as needed or removed
+// in a couple of iterations of:
+//   1 -
+function connectComponents(platform: PlatformApi, node: HostElement) {
+  if (!node) return;
+
+  if (node.tagName) {
+    if (!node._hasConnected) {
+      const cmpMeta = platform.getComponentMeta(node);
+      if (cmpMeta) {
+        initHostConstructor(platform, node);
+        (<HostElement>node).connectedCallback();
+      }
+    }
+  }
+  if (node.childNodes) {
+    for (var i = 0; i < node.childNodes.length; i++) {
+      connectComponents(platform, <HostElement>node.childNodes[i]);
+    }
+  }
+}


### PR DESCRIPTION
This is just the start of the utilities. I am still relying too heavily on the existing mock* code from test/index.ts. That should probably get moved and cleaned up, but for now I am using a lot of it.

Two functions:
register() - creates a platform, registers the defined components
render() - can be used to test the DOM or (via $instance) the component class

I removed the idea of a compile() function for now since render() returns an object that defines the component class instance on $instance.

Next steps:

1. determine how to use with component defined in tsx file
2. refactor more test/index.ts code into here