### PR TITLE
fix(init): check for activelyLoadingChildren before trying to splice it

### DIFF
--- a/src/core/instance/init.ts
+++ b/src/core/instance/init.ts
@@ -142,7 +142,7 @@ export function initLoad(plt: PlatformApi, elm: HostElement): any {
 export function propagateElementLoaded(elm: HostElement) {
   // load events fire from bottom to top
   // the deepest elements load first then bubbles up
-  if (elm._ancestorHostElement) {
+  if (elm._ancestorHostElement && elm._ancestorHostElement._activelyLoadingChildren) {
     // ok so this element already has a known ancestor host element
     // let's make sure we remove this element from its ancestor's
     // known list of child elements which are actively loading


### PR DESCRIPTION
Not entirely sure this is the correct fix as I am not familiar with this part of the codebase but it does make sense to me that we might have an ancestorHostElement but it might not have `_activelyLoadingChildren`, like when all the components have loaded.