### PR TITLE
refactor(testing): use typescript hosted tsconfig.json parser

### DIFF
--- a/scripts/jest.preprocessor.js
+++ b/scripts/jest.preprocessor.js
@@ -1,15 +1,18 @@
-const tsc = require('typescript');
-const tsConfig = require('../src/tsconfig.json');
+const fs = require('fs');
+const path = require('path');
+
+const ts = require('typescript');
+const tsConfig = parseTsConfig(path.resolve(__dirname, '../src/tsconfig.json'));
 
 // force the output to use commonjs modules required by jest
-tsConfig.compilerOptions.module = 'commonjs';
+tsConfig.options.module = 'commonjs';
 
 module.exports = {
   process(src, path) {
     if (path.endsWith('.ts')) {
-      return tsc.transpile(
+      return ts.transpile(
         src,
-        tsConfig.compilerOptions,
+        tsConfig.options,
         path,
         []
       );
@@ -17,3 +20,24 @@ module.exports = {
     return src;
   },
 };
+
+function parseTsConfig(configPath) {
+  const jsonText = fs.readFileSync(configPath, "utf-8");
+  const result = ts.parseConfigFileTextToJson(configPath, jsonText);
+  if (result.error) {
+      throw new Error("JSON parse error");
+  }
+
+  const host = {
+    useCaseSensitiveFileNames: ts.sys.useCaseSensitiveFileNames,
+    readDirectory: ts.sys.readDirectory,
+    fileExists: path => fs.existsSync(path),
+    readFile: path => fs.readFileSync(path, "utf-8"),
+  };
+  const parsed = ts.parseJsonConfigFileContent(result.config, host, path.dirname(configPath));
+  if (parsed.errors && parsed.errors.length !== 0) {
+      throw new Error(parsed.errors.map(e => e.messageText).join("\n"));
+  }
+
+  return parsed;
+}

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,26 +1,63 @@
 {
   "compilerOptions": {
-    "alwaysStrict": true,
-    "allowSyntheticDefaultImports": true,
-    "allowUnreachableCode": false,
-    "declaration": true,
-    "experimentalDecorators": true,
-    "forceConsistentCasingInFileNames": true,
-    "jsx": "react",
-    "jsxFactory": "h",
-    "lib": [
+    /* Basic Options */
+    "target": "es2015",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
+    "module": "es2015",                       /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "lib": [                                  /* Specify library files to be included in the compilation:  */
       "dom",
       "es2015"
     ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "outDir": "../dist/transpiled-core",
-    "pretty": true,
-    "target": "es2015"
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    "jsx": "react",                           /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "../dist/transpiled-core",      /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    // "strict": true,                        /* Enable all strict type-checking options. */
+    "noImplicitAny": true,                    /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    "alwaysStrict": true,                     /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    "noUnusedLocals": true,                   /* Report errors on unused locals. */
+    "noUnusedParameters": true,               /* Report errors on unused parameters. */
+    "noImplicitReturns": true,                /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+
+    /* Source Map Options */
+    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    "experimentalDecorators": true,           /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Not Listed */
+    "allowUnreachableCode": false,
+    "forceConsistentCasingInFileNames": true,
+    "jsxFactory": "h",
+    "pretty": true
   },
   "include": [
     "**/*.ts",


### PR DESCRIPTION
I think We should use tsconfig.json parser that hosted by typescript.
tsconfig.json is not json. It can write a comment, It has a `extend` feature.