### PR TITLE
fix(proxy): proxy all method calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2817,13 +2817,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2831,6 +2824,13 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -6492,14 +6492,6 @@
         "any-observable": "0.2.0"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -6517,6 +6509,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/src/client/platform-client.ts
+++ b/src/client/platform-client.ts
@@ -10,7 +10,7 @@ import { createQueueClient } from './queue-client';
 import { h, t } from '../core/renderer/h';
 import { initHostConstructor } from '../core/instance/init';
 import { parseComponentMeta, parseComponentRegistry } from '../util/data-parse';
-import { proxyControllerProp } from '../core/instance/proxy';
+import { proxyController } from '../core/instance/proxy';
 import { SSR_VNODE_ID } from '../util/constants';
 
 
@@ -296,9 +296,7 @@ export function createPlatformClient(Context: CoreContext, App: AppGlobal, win: 
   }
 
   function propConnect(ctrlTag: string) {
-    const obj: any = {};
-    proxyControllerProp(domApi, controllerComponents, obj, ctrlTag, 'create');
-    return obj;
+    return proxyController(domApi, controllerComponents, ctrlTag);
   }
 
   function getContextItem(contextKey: string) {

--- a/src/core/instance/proxy.ts
+++ b/src/core/instance/proxy.ts
@@ -211,23 +211,31 @@ function defineProperty(obj: any, propertyKey: string, value: any, getter?: any,
   Object.defineProperty(obj, propertyKey, descriptor);
 }
 
-
-export function proxyControllerProp(domApi: DomApi, controllerComponents: {[tag: string]: HostElement}, obj: any, ctrlTag: string, proxyMethodName: string) {
-  obj[proxyMethodName] = function() {
-    const orgArgs = arguments;
-
-    return new Promise(resolve => {
-      let ctrlElm = controllerComponents[ctrlTag];
-
-      if (!ctrlElm) {
-        ctrlElm = controllerComponents[ctrlTag] = domApi.$createElement(ctrlTag) as any;
-        domApi.$appendChild(domApi.$body, ctrlElm);
-      }
-
-      ctrlElm.componentOnReady((ctrlElm: any) => {
-        ctrlElm[proxyMethodName].apply(ctrlElm, orgArgs).then(resolve);
-      });
-    });
+export function proxyController(domApi: DomApi, controllerComponents: { [tag: string]: HostElement }, ctrlTag: string) {
+  return {
+    create: proxyProp(domApi, controllerComponents, ctrlTag, 'create'),
+    componentOnReady: proxyProp(domApi, controllerComponents, ctrlTag, 'componentOnReady')
   };
 }
 
+export function loadComponent(domApi: DomApi, controllerComponents: { [tag: string]: HostElement }, ctrlTag: string): Promise<any> {
+  return new Promise(resolve => {
+    let ctrlElm = controllerComponents[ctrlTag];
+    if (!ctrlElm) {
+      ctrlElm = domApi.$body.querySelector(ctrlTag) as HostElement;
+    }
+    if (!ctrlElm) {
+      ctrlElm = controllerComponents[ctrlTag] = domApi.$createElement(ctrlTag) as any;
+      domApi.$appendChild(domApi.$body, ctrlElm);
+    }
+    ctrlElm.componentOnReady(resolve);
+  });
+}
+
+function proxyProp(domApi: DomApi, controllerComponents: { [tag: string]: HostElement }, ctrlTag: string, proxyMethodName: string) {
+  return function () {
+    const args = arguments;
+    return loadComponent(domApi, controllerComponents, ctrlTag)
+      .then(ctrlElm => ctrlElm[proxyMethodName].apply(ctrlElm, args));
+  };
+}

--- a/src/server/platform-server.ts
+++ b/src/server/platform-server.ts
@@ -13,7 +13,7 @@ import { DID_LOAD_ERROR, INIT_INSTANCE_ERROR, DID_UPDATE_ERROR, LOAD_BUNDLE_ERRO
   QUEUE_EVENTS_ERROR, RENDER_ERROR, WILL_LOAD_ERROR } from '../util/constants';
 import { noop } from '../util/helpers';
 import { parseComponentMeta } from '../util/data-parse';
-import { proxyControllerProp } from '../core/instance/proxy';
+import { proxyController } from '../core/instance/proxy';
 
 
 export function createPlatformServer(
@@ -311,9 +311,7 @@ export function createPlatformServer(
   }
 
   function propConnect(ctrlTag: string) {
-    const obj: any = {};
-    proxyControllerProp(domApi, controllerComponents, obj, ctrlTag, 'create');
-    return obj;
+    return proxyController(domApi, controllerComponents, ctrlTag);
   }
 
   function getContextItem(contextKey: string) {


### PR DESCRIPTION
So, still using ES6 proxies, so @adamdbradley it is up to you to merge it... I have figured out that we don't even need this PR to make `ion-menu` to work... (`getInstance()`) has been replaced with `componentOnRead()`