### PR TITLE
Fix default logger for ssr

### DIFF
--- a/src/server/renderer.ts
+++ b/src/server/renderer.ts
@@ -150,7 +150,7 @@ function validateRendererConfig(config: BuildConfig) {
     // if a logger was not provided then use the
     // defaul stencil command line logger found in bin
     const path = require('path');
-    const logger = require(path.join(__dirname, '../../bin/util')).logger;
+    const logger = require(path.join(__dirname, '../../cli/util')).logger;
     config.logger = new logger.CommandLineLogger({
       level: config.logLevel,
       process: process,


### PR DESCRIPTION
Fixes #147 since the `util.js` is built from `scripts/cli-entries/util.js` to `dist/cli/util.js`.