### PR TITLE
Fix path to util for logger

### DIFF
--- a/src/server/renderer.ts
+++ b/src/server/renderer.ts
@@ -150,7 +150,7 @@ function validateRendererConfig(config: BuildConfig) {
     // if a logger was not provided then use the
     // defaul stencil command line logger found in bin
     const path = require('path');
-    const logger = require(path.join(__dirname, '../../cli/util')).logger;
+    const logger = require(path.join(__dirname, '../cli/util')).logger;
     config.logger = new logger.CommandLineLogger({
       level: config.logLevel,
       process: process,


### PR DESCRIPTION
Either I was partly wrong about the path or something changed to the building over the weekend (I'm afraid it's likely the former). Either way, after installing `next` from npm, this path doesn't escape the `dist` dir.