### PR TITLE
Use own service worker

### DIFF
--- a/src/util/interfaces.ts
+++ b/src/util/interfaces.ts
@@ -1110,7 +1110,7 @@ export interface Workbox {
   generateSW(swConfig: any): Promise<any>;
   generateFileManifest(): Promise<any>;
   getFileManifestEntries(): Promise<any>;
-  injectManifest(): Promise<any>;
+  injectManifest(swConfig: any): Promise<any>;
 }
 
 


### PR DESCRIPTION
Pull request for #192 

If swSrc config is not specified then the service worker
will be genereted otherwise injectManfiest will be executed.

Notes:
1; Now there is an inconsistency with the base paths since the base path of the `copy` functionality is the `/src` directory but the base path of the `swSrc` is the root of the project. Couldn't find any option for workbox to set the base path of the `swSrc`. Maybe we could prefix the path with `src/`. What do you think? Does it make sense?

2; When using `swSrc` then the config won't be passed to WorkboxSW's constructor. This is normal since WorkboxSW needs to be instantiated manually by the user.
All of these things are documented in the workbox docs. Quote:
> Note: This option is only valid when used with generateSW(). When using injectManifest(), you can explicitly pass the desired value in to the WorkboxSW() constructor in your swSrc file.

