### PR TITLE
fix(externs): add loadStyles to externs

### DIFF
--- a/scripts/externs.core.js
+++ b/scripts/externs.core.js
@@ -34,6 +34,7 @@ function $definedComponents(){};
  */
 function components(){};
 function loadComponents(){};
+function loadStyles(){};
 
 
 /**


### PR DESCRIPTION
Fixes `loadStyles is not a function` in production builds