### PR TITLE
feat(test): extend jest-expect

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
   "types": "./dist/index.d.ts",
   "jest": {
     "testEnvironment": "node",
+    "setupTestFrameworkScriptFile": "<rootDir>/scripts/setupTests.js",
     "moduleFileExtensions": [
       "ts",
       "tsx",

--- a/scripts/setupTests.js
+++ b/scripts/setupTests.js
@@ -1,0 +1,1 @@
+require('../src/testing/expect');

--- a/src/core/instance/test/render.spec.ts
+++ b/src/core/instance/test/render.spec.ts
@@ -1,9 +1,7 @@
 import { ComponentMeta, HostElement, PlatformApi } from '../../../util/interfaces';
 import { mockPlatform, mockElement } from '../../../testing/mocks';
-import { testClasslist, testAttributes } from '../../../testing/utils';
 import { render } from '../render';
 import { h } from '../../renderer/h';
-
 
 describe('instance render', () => {
 
@@ -79,8 +77,7 @@ describe('instance render', () => {
       }
 
       doRender(MyComponent);
-
-      testClasslist(elm, ['a', 'clAss', 'My-class_']);
+      expect(elm).toMatchClasses(['a', 'clAss', 'My-class_']);
     });
 
     it('should set attributes', () => {
@@ -101,8 +98,8 @@ describe('instance render', () => {
 
       doRender(MyComponent);
 
-      testClasslist(elm, ['a', 'b', 'c', 'my-class']);
-      testAttributes(elm, {
+      expect(elm).toMatchClasses(['a', 'b', 'c', 'my-class']);
+      expect(elm).toMatchAttributes({
         side: '  left   top ',
         empty: '',
         class: 'a b c my-class',
@@ -131,8 +128,8 @@ describe('instance render', () => {
 
       doRender(MyComponent);
 
-      testClasslist(elm, ['a', 'hola']);
-      testAttributes(elm, {
+      expect(elm).toMatchClasses(['a', 'hola']);
+      expect(elm).toMatchAttributes({
         class: 'a hola',
         number: '12',
         appear: 'true'
@@ -148,7 +145,7 @@ describe('instance render', () => {
         }
       });
 
-      testClasslist(elm, ['my-component']);
+      expect(elm).toMatchClasses(['my-component']);
     });
 
     it('should apply theme with mode', () => {
@@ -162,7 +159,7 @@ describe('instance render', () => {
         }
       });
 
-      testClasslist(elm, ['my-component', 'my-component-ios']);
+      expect(elm).toMatchClasses(['my-component', 'my-component-ios']);
     });
 
     it('should apply theme with mode and color', () => {
@@ -177,7 +174,7 @@ describe('instance render', () => {
         }
       });
 
-      testClasslist(elm, [
+      expect(elm).toMatchClasses([
         'my-component',
         'my-component-md',
         'my-component-main',
@@ -211,7 +208,7 @@ describe('instance render', () => {
         }
       });
 
-      testClasslist(elm, [
+      expect(elm).toMatchClasses([
         'a',
         'hola',
         'my-component',
@@ -220,7 +217,7 @@ describe('instance render', () => {
         'my-component-md-main'
       ]);
 
-      testAttributes(elm, {
+      expect(elm).toMatchAttributes({
         'class': 'a hola my-component my-component-md my-component-main my-component-md-main',
         'number': '12',
         'appear': 'true',

--- a/src/core/renderer/test/patch.spec.ts
+++ b/src/core/renderer/test/patch.spec.ts
@@ -112,14 +112,14 @@ describe('renderer', () => {
       let vnode1 = h('div', null, h('i', { class: { i: true, am: true, a: true, 'class': true } }));
       elm = patch(vnode0, vnode1).elm;
 
-      testClasslist(elm.firstChild, ['i', 'am', 'a', 'class']);
+      expect(elm.firstChild).toMatchClasses(['i', 'am', 'a', 'class']);
     });
 
     it('should not remove duplicate css classes', () => {
       let vnode1 = h('div', { class: 'middle aligned center aligned' }, 'Hello');
       elm = patch(vnode0, vnode1).elm;
       expect(elm.className).toEqual('middle aligned center aligned');
-    })
+    });
 
     it('can create elements with text content', () => {
       elm = patch(vnode0, h('div', null, 'I am a string')).elm;
@@ -133,9 +133,8 @@ describe('renderer', () => {
       elm.classList.add('horse');
       var vnode1 = h('i', { class: {i: true, am: true } });
       elm = patch(vnode0, vnode1).elm;
-      expect(elm.classList.contains('i')).toBeTruthy();
-      expect(elm.classList.contains('am')).toBeTruthy();
-      expect(elm.classList.contains('horse')).toBeTruthy();
+
+      expect(elm).toMatchClasses(['i', 'am', 'horse']);
     });
 
     it('changes elements classes from previous vnode', () => {
@@ -143,9 +142,8 @@ describe('renderer', () => {
       var vnode2 = h('i', { class: { i: true, am: true, horse: false } });
       patch(vnode0, vnode1);
       elm = patch(vnode1, vnode2).elm;
-      expect(elm.classList.contains('i')).toBeTruthy();
-      expect(elm.classList.contains('am')).toBeTruthy();
-      expect(!elm.classList.contains('horse')).toBeTruthy();
+
+      expect(elm).toMatchClasses(['i', 'am']);
     });
 
     it('preserves memoized classes', () => {
@@ -153,13 +151,10 @@ describe('renderer', () => {
       var vnode1 = h('i', { class: cachedClass });
       var vnode2 = h('i', { class: cachedClass });
       elm = patch(vnode0, vnode1).elm;
-      expect(elm.classList.contains('i')).toBeTruthy();
-      expect(elm.classList.contains('am')).toBeTruthy();
-      expect(!elm.classList.contains('horse')).toBeTruthy();
+      expect(elm).toMatchClasses(['i', 'am']);
+
       elm = patch(vnode1, vnode2).elm;
-      expect(elm.classList.contains('i')).toBeTruthy();
-      expect(elm.classList.contains('am')).toBeTruthy();
-      expect(!elm.classList.contains('horse')).toBeTruthy();
+      expect(elm).toMatchClasses(['i', 'am']);
     });
 
     it('removes missing classes', () => {
@@ -167,9 +162,7 @@ describe('renderer', () => {
       var vnode2 = h('i', { class: {i: true, am: true } });
       patch(vnode0, vnode1);
       elm = patch(vnode1, vnode2).elm;
-      expect(elm.classList.contains('i')).toBeTruthy();
-      expect(elm.classList.contains('am')).toBeTruthy();
-      expect(!elm.classList.contains('horse')).toBeTruthy();
+      expect(elm).toMatchClasses(['i', 'am']);
     });
 
     it('removes classes when class set to empty string', () => {
@@ -177,9 +170,7 @@ describe('renderer', () => {
       var vnode2 = h('i', { class: '' });
       patch(vnode0, vnode1);
       elm = patch(vnode1, vnode2).elm;
-      expect(elm.classList.contains('i')).toBeFalsy();
-      expect(elm.classList.contains('am')).toBeFalsy();
-      expect(!elm.classList.contains('horse')).toBeTruthy();
+      expect(elm).toMatchClasses([]);
     });
 
 

--- a/src/core/renderer/test/set-accessor.spec.ts
+++ b/src/core/renderer/test/set-accessor.spec.ts
@@ -94,7 +94,8 @@ describe('setAccessor', () => {
 
     setAccessor(plt, elm, 'myprop', oldValue, newValue, false);
     expect(elm.myprop).toBeUndefined();
-    expect(elm.getAttribute('myprop')).toBe('false');
+
+    expect(elm).toMatchAttributes({ 'myprop': 'false' });
   });
 
   it('should set true boolean to attribute', () => {
@@ -103,7 +104,7 @@ describe('setAccessor', () => {
 
     setAccessor(plt, elm, 'myprop', oldValue, newValue, false);
     expect(elm.myprop).toBeUndefined();
-    expect(elm.getAttribute('myprop')).toBe('true');
+    expect(elm).toMatchAttributes({ 'myprop': 'true' });
   });
 
   it('should set number to attribute', () => {
@@ -112,7 +113,7 @@ describe('setAccessor', () => {
 
     setAccessor(plt, elm, 'myprop', oldValue, newValue, false);
     expect(elm.myprop).toBeUndefined();
-    expect(elm.getAttribute('myprop')).toBe('88');
+    expect(elm).toMatchAttributes({ 'myprop': '88' });
   });
 
   it('should set string to attribute', () => {
@@ -121,7 +122,7 @@ describe('setAccessor', () => {
 
     setAccessor(plt, elm, 'myprop', oldValue, newValue, false);
     expect(elm.myprop).toBeUndefined();
-    expect(elm.getAttribute('myprop')).toBe('stringval');
+    expect(elm).toMatchAttributes({ 'myprop': 'stringval' });
   });
 
   var elm: any;
@@ -184,8 +185,7 @@ describe('setAccessor for inputs', () => {
         let inputElm = mockElement('input');
         setAccessor(plt, inputElm, propName, oldValue, newValue, false);
 
-        expect(inputElm.hasAttribute(propName)).toBe(true);
-        expect(inputElm.getAttribute(propName)).toBe(newValue.toString());
+        expect(inputElm).toMatchAttributes({ [propName]: newValue.toString() });
       }
 
       it(`aria-disabled should be added when set to true`, () => {
@@ -222,7 +222,7 @@ describe('setAccessor for inputs', () => {
         let inputElm = mockElement('input');
         setAccessor(plt, inputElm, propName, oldValue, newValue, false);
 
-        expect(inputElm.hasAttribute(propName)).toBe(false);
+        expect(inputElm).toMatchAttributes({ });
       }
       it(`accept`, () => {
         testSpecialAttribute('accept', undefined, undefined);
@@ -267,8 +267,7 @@ describe('setAccessor for inputs', () => {
         let inputElm = mockElement('input');
         setAccessor(plt, inputElm, propName, oldValue, newValue, false);
 
-        expect(inputElm.hasAttribute(propName)).toBe(true);
-        expect(inputElm.getAttribute(propName)).toBe(newValue.toString());
+        expect(inputElm).toMatchAttributes({ [propName]: newValue.toString() });
         expect((inputElm as any)[propName]).toBe(newValue);
       }
 
@@ -333,8 +332,7 @@ describe('setAccessor for inputs', () => {
         let inputElm = mockElement('input');
         setAccessor(plt, inputElm, propName, oldValue, newValue, false);
 
-        expect(inputElm.hasAttribute(propName)).toBe(true);
-        expect(inputElm.getAttribute(propName)).toBe('');
+        expect(inputElm).toMatchAttributes({ [propName]: '' });
         expect((inputElm as any)[propName]).toBe(newValue);
       }
 
@@ -376,8 +374,7 @@ describe('setAccessor for inputs', () => {
         let inputElm = mockElement('input');
         setAccessor(plt, inputElm, propName, oldValue, newValue, false);
 
-        expect(inputElm.hasAttribute(propName)).toBe(true);
-        expect(inputElm.getAttribute(propName)).toBe(newValue.toString());
+        expect(inputElm).toMatchAttributes({ [propName]: newValue.toString() });
         expect((inputElm as any)[propName]).toBe(newValue.toString());
       }
 

--- a/src/testing/expect/index.ts
+++ b/src/testing/expect/index.ts
@@ -1,0 +1,43 @@
+import { testClasslist, testAttributes } from '../utils';
+
+const extension = {
+  toMatchClasses(element: HTMLElement, classlist: string[]) {
+    try {
+      testClasslist(element, classlist);
+      return {
+        message: () => 'expected to not match classes',
+        pass: true,
+      };
+    } catch (msg) {
+      return {
+        message: () => msg,
+        pass: false,
+      };
+    }
+  },
+  toMatchAttributes(element: HTMLElement, attributes: { [attr: string]: string }) {
+    try {
+      testAttributes(element, attributes);
+      return {
+        message: () => 'expected to not match attributes',
+        pass: true,
+      };
+    } catch (msg) {
+      return {
+        message: () => msg,
+        pass: false,
+      };
+    }
+  }
+};
+
+declare global {
+  namespace jest {
+    interface Matchers {
+      toMatchClasses(classlist: string[]): void;
+      toMatchAttributes(attributes: { [attr: string]: string }): void;
+    }
+  }
+}
+
+expect.extend(extension);

--- a/src/testing/render.ts
+++ b/src/testing/render.ts
@@ -4,6 +4,7 @@ import { hydrateHtml } from '../server/hydrate-html';
 import { mockLogger, mockStencilSystem } from './mocks';
 import { validateBuildConfig } from '../util/validate-config';
 
+import './expect';
 
 export async function render(opts: RenderTestOptions): Promise<any> {
   validateRenderOptions(opts);

--- a/src/testing/utils.ts
+++ b/src/testing/utils.ts
@@ -1,16 +1,26 @@
 
 export function testClasslist(el: HTMLElement, classes: string[]) {
-  expect(el.classList).toHaveLength(classes.length);
+  if (el.classList.length !== classes.length) {
+    throw new Error(`expected ${classes.length} classes, found ${el.classList.length}`);
+  }
   for (var c of classes) {
-    expect(el.classList.contains(c)).toBeTruthy();
+    if (!el.classList.contains(c)) {
+      throw new Error(`expected class "${c}", but it was not found`);
+    }
   }
 }
 
-export function testAttributes(el: HTMLElement, attributes: any) {
+export function testAttributes(el: HTMLElement, attributes: { [attr: string]: string }) {
   const keys = Object.keys(attributes);
-  expect(el.attributes).toHaveLength(keys.length);
+  if (el.attributes.length !== keys.length) {
+    throw `expected ${keys.length} classes, found ${el.attributes.length}`;
+  }
   for (var attr of keys) {
-    expect(el.hasAttribute(attr)).toBeTruthy();
-    expect(el.getAttribute(attr)).toEqual(attributes[attr]);
+    if (!el.hasAttribute(attr)) {
+      throw `expected attribute "${attr}",  but it was not found`;
+    }
+    if (el.getAttribute(attr) !== attributes[attr]) {
+      throw `expected attribute "${attr}" to be equal to "${attributes[attr]}, but it is "${el.getAttribute(attr)}"`;
+    }
   }
 }


### PR DESCRIPTION
Adds to `@stentil/core/testing`

```ts
expect(HTMLElement).toMatchClasses(classes: string[]);
expect(HTMLElement).toMatchAttributes(attributes: {[attr: string]: string});
```

and updates existing tests to use the new APIs
