### PR TITLE
fix(test): imports

### DIFF
--- a/scripts/packages/testing/jest.preprocessor.js
+++ b/scripts/packages/testing/jest.preprocessor.js
@@ -14,7 +14,7 @@ var injectTestingScript = [
 
 module.exports = {
   process: function(sourceText, filePath) {
-    if (filePath.endsWith('.ts') || filePath.endsWith('.tsx')) {
+    if (filePath.endsWith('.js') || filePath.endsWith('.ts') || filePath.endsWith('.tsx')) {
       var opts = {
         module: 'commonjs'
       };

--- a/src/compiler/transpile/transpile.ts
+++ b/src/compiler/transpile/transpile.ts
@@ -129,7 +129,7 @@ function generateComponentTypesFile(config: BuildConfig, ctx: BuildContext) {
     if (filePath.startsWith('.') || filePath.startsWith('/')) {
       importFilePath = './' + normalizePath(
         config.sys.path.relative(config.collectionDir, filePath)
-      );
+      ).replace(/\.js$/, '');
     } else {
       importFilePath = filePath;
     }


### PR DESCRIPTION
In ionic-core, testing a component that imports index, automatically breaks the testing:
```ts
import { StencilElement } from '../../index';
```

fixes https://github.com/ionic-team/stencil/issues/225