### PR TITLE
fix(serviceworker): service worker should not be injected when false

### DIFF
--- a/src/util/cli/cli-utils.ts
+++ b/src/util/cli/cli-utils.ts
@@ -31,7 +31,7 @@ export function overrideConfigFromArgv(config: BuildConfig, argv: CliArgv) {
   }
 
   if (config.devMode) {
-    if (argv.serviceWorker && !config.serviceWorker) {
+    if (argv.serviceWorker && config.serviceWorker === undefined) {
       // dev mode, but forcing service worker
       // but they didn't provide a sw config
       // so still force it to generate w/ our defaults
@@ -43,7 +43,7 @@ export function overrideConfigFromArgv(config: BuildConfig, argv: CliArgv) {
       config.serviceWorker = false;
     }
 
-  } else if (!config.serviceWorker) {
+  } else if (config.serviceWorker === undefined) {
     // prod mode, and they didn't provide a sw config
     // so force it generate with our defaults
     config.serviceWorker = true;

--- a/src/util/cli/test/cli.spec.ts
+++ b/src/util/cli/test/cli.spec.ts
@@ -99,6 +99,24 @@ describe('cli', () => {
       expect(config.serviceWorker).toBe(true);
     });
 
+    it('should not enable service worker in prod mode if service worker config is false', () => {
+      config.devMode = false;
+      config.serviceWorker = false;
+      const argv: CliArgv = {};
+      overrideConfigFromArgv(config, argv);
+      validateBuildConfig(config);
+      expect(config.serviceWorker).toBe(false);
+    });
+
+    it('should not enable service worker in dev mode if service worker config is false', () => {
+      config.devMode = true;
+      config.serviceWorker = false;
+      const argv: CliArgv = {};
+      overrideConfigFromArgv(config, argv);
+      validateBuildConfig(config);
+      expect(config.serviceWorker).toBe(false);
+    });
+
   });
 
   describe('parseCmdArgs', () => {


### PR DESCRIPTION
We were originally checking `!serviceWorker.config` to know when the service worker config was not there. This had a side effect of forcing the service worker config to be true when it was explicitly set to false by the user. This fixes that issue and includes some extra unit tests to make sure this does not break again.