### PR TITLE
fix(build): es5 builds when TS injects __generator

### DIFF
--- a/src/compiler/bundle/component-modules.ts
+++ b/src/compiler/bundle/component-modules.ts
@@ -66,8 +66,7 @@ function bundleComponents(config: BuildConfig, ctx: BuildContext, manifestBundle
 
 function bundleComponentsResults(config: BuildConfig, ctx: BuildContext, manifestBundle: ManifestBundle, bundleCacheKey: string, resultsCode: string) {
   // module bundling finished, assign its content to the user's bundle
-  // wrap our component code with our own iife
-  manifestBundle.compiledModuleText = wrapComponentImports(resultsCode);
+  manifestBundle.compiledModuleText = resultsCode;
 
   // replace build time expressions, like process.env.NODE_ENV === 'production'
   // with a hard coded boolean

--- a/src/compiler/bundle/generate-bundles.ts
+++ b/src/compiler/bundle/generate-bundles.ts
@@ -1,5 +1,5 @@
 import { BuildConfig, BuildContext, ComponentMeta, ComponentRegistry, CompiledModeStyles, ModuleFile, ManifestBundle, SourceTarget } from '../../util/interfaces';
-import { componentRequiresScopedStyles, generatePreamble, pathJoin } from '../util';
+import { componentRequiresScopedStyles, generatePreamble, pathJoin, hasError } from '../util';
 import { DEFAULT_STYLE_MODE } from '../../util/constants';
 import { formatLoadComponents, formatLoadStyles } from '../../util/data-serialize';
 import { getAppFileName, getBundleFileName, getAppWWWBuildDir } from '../app/app-file-naming';
@@ -30,11 +30,14 @@ function generateBundleFiles(config: BuildConfig, ctx: BuildContext, manifestBun
 
   if (sourceTarget === 'es5') {
     const transpileResults = transpileToEs5(compiledModuleText);
-    if (transpileResults.diagnostics && transpileResults.diagnostics.length) {
+    const transpileDiagnostics = transpileResults.diagnostics;
+    if (transpileDiagnostics && transpileDiagnostics.length > 0) {
       ctx.diagnostics.push(...transpileResults.diagnostics);
-    } else {
-      compiledModuleText = transpileResults.code;
     }
+    if (hasError(transpileDiagnostics)) {
+      return;
+    }
+    compiledModuleText = transpileResults.code;
   }
 
   let moduleText = formatLoadComponents(

--- a/src/compiler/transpile/core-build.ts
+++ b/src/compiler/transpile/core-build.ts
@@ -55,7 +55,7 @@ export function transpileToEs5(input: string) {
 
   loadTypeScriptDiagnostics('', diagnostics, tsResults.diagnostics);
 
-  if (diagnostics.length) {
+  if (diagnostics.length > 0) {
     results.diagnostics = diagnostics;
     results.code = input;
     return results;

--- a/src/compiler/util.ts
+++ b/src/compiler/util.ts
@@ -365,7 +365,10 @@ export function catchError(diagnostics: Diagnostic[], err: Error) {
 }
 
 
-export function hasError(diagnostics: Diagnostic[]) {
+export function hasError(diagnostics: Diagnostic[]): boolean {
+  if (!diagnostics) {
+    return false;
+  }
   return diagnostics.some(d => d.level === 'error' && d.type !== 'runtime');
 }
 

--- a/src/util/data-serialize.ts
+++ b/src/util/data-serialize.ts
@@ -1,6 +1,7 @@
 import { BundleIds, ComponentMeta, ComponentRegistry, CompiledModeStyles, EventMeta, ListenMeta,
   LoadComponentRegistry, MemberMeta, MembersMeta, ModuleFile, PropChangeMeta, StylesMeta } from './interfaces';
 import { DEFAULT_STYLE_MODE, ENCAPSULATION, MEMBER_TYPE, PROP_TYPE, SLOT_META } from '../util/constants';
+import { wrapComponentImports } from '../compiler/bundle/component-modules';
 
 
 export function formatComponentLoader(cmpMeta: ComponentMeta): LoadComponentRegistry {
@@ -168,6 +169,9 @@ export function formatLoadComponents(
   const componentMetaStr = moduleFiles.map(moduleFile => {
     return formatComponentMeta(moduleFile.cmpMeta);
   }).join(',\n');
+
+  // wrap our component code with our own iife
+  moduleBundleOutput = wrapComponentImports(moduleBundleOutput);
 
   return [
     `${getWindowNamespace(namespace)}.loadComponents(\n`,

--- a/src/util/test/data-serialize.spec.ts
+++ b/src/util/test/data-serialize.spec.ts
@@ -42,6 +42,15 @@ describe('data serialize', () => {
       expect(r.split('(')[0]).toBe(`App.loadComponents`);
     });
 
+    it('should inject iife', () => {
+      const namespace = 'App';
+      const moduleId = 'moduleId';
+      const r = formatLoadComponents(namespace, moduleId, 'hola', []);
+      expect(r.includes(`/**** component modules ****/
+function importComponent(exports, h, Context, publicPath) {
+"use strict";
+hola
+},`)).toBeTruthy();
+    });
   });
-
 });


### PR DESCRIPTION
Typescript sometimes injects __generator code when transpiling code that uses async/await from es2015 to es5, generating broken JS code:

<img width="584" alt="screen shot 2017-11-25 at 00 41 47" src="https://user-images.githubusercontent.com/127379/33225630-7924c3b8-d17b-11e7-98fb-fa05cff6cb82.png">

Notice that "components module", parameter is not a function.


The implemented fix is to move `wrapComponentImports(resultsCode)` later in the compilator process, this way we ensure that "components module" is always a function.

fixes https://github.com/ionic-team/stencil/issues/329
fixes https://github.com/ionic-team/stencil/issues/328