### PR TITLE
perf(html): inlined loader is minified

### DIFF
--- a/src/compiler/app/app-loader.ts
+++ b/src/compiler/app/app-loader.ts
@@ -61,7 +61,7 @@ export async function generateLoader(
         config.logger[d.level](d.messageText);
       });
       if (!minifyJsResults.diagnostics.length) {
-        loaderContent = minifyJsResults.output;
+        ctx.appFiles.loader = loaderContent = minifyJsResults.output;
       }
     }
 


### PR DESCRIPTION
BEFORE:
<img width="993" alt="screen shot 2017-11-25 at 01 10 40" src="https://user-images.githubusercontent.com/127379/33225767-2f6a2364-d17e-11e7-988d-7840aba93829.png">

AFTER:
<img width="1155" alt="screen shot 2017-11-25 at 01 15 25" src="https://user-images.githubusercontent.com/127379/33225762-27d2e3a2-d17e-11e7-8c2d-78ff2ad330bc.png">
