### PR TITLE
fix(transpile): moduleFiles crash

### DIFF
--- a/src/compiler/transpile/transpile.ts
+++ b/src/compiler/transpile/transpile.ts
@@ -125,9 +125,16 @@ function transpileModules(config: BuildConfig, ctx: BuildContext, moduleFiles: M
   const metadata = gatherMetadata(checkProgram.getTypeChecker(), checkProgram.getSourceFiles());
 
   Object.keys(metadata).forEach(tsFilePath => {
-    ctx.moduleFiles[tsFilePath].cmpMeta = metadata[tsFilePath];
-    ctx.moduleFiles[tsFilePath].cmpMeta.stylesMeta = normalizeStyles(config, tsFilePath, metadata[tsFilePath].stylesMeta);
-    ctx.moduleFiles[tsFilePath].cmpMeta.assetsDirsMeta = normalizeAssetsDir(config, tsFilePath, metadata[tsFilePath].assetsDirsMeta);
+    const fileMetadata = metadata[tsFilePath];
+    // normalize metadata
+    fileMetadata.stylesMeta = normalizeStyles(config, tsFilePath, fileMetadata.stylesMeta);
+    fileMetadata.assetsDirsMeta = normalizeAssetsDir(config, tsFilePath, fileMetadata.assetsDirsMeta);
+
+    // assign metadata to module files
+    const moduleFile = ctx.moduleFiles[tsFilePath];
+    if (moduleFile) {
+      moduleFile.cmpMeta = fileMetadata;
+    }
   });
 
   // Generate d.ts files for component types


### PR DESCRIPTION
When compiling ionic/core:
```
[02:33.0]  compile started ...
/Users/manuelmartinez-almeida/repos/ionic/ionic/packages/core/src/components/app/test/cordova/page-one.tsx
/Users/manuelmartinez-almeida/repos/ionic/ionic/packages/core/src/components/app/test/cordova/page-tabs.tsx
/Users/manuelmartinez-almeida/repos/ionic/ionic/packages/core/src/components/app/test/cordova/page-three.tsx
/Users/manuelmartinez-almeida/repos/ionic/ionic/packages/core/src/components/app/test/cordova/page-two.tsx
/Users/manuelmartinez-almeida/repos/ionic/ionic/packages/core/src/components/tabs/test/basic/page-tab.tsx
/Users/manuelmartinez-almeida/repos/ionic/ionic/packages/core/src/components/tabs/test/translucent/translucent-page-tab.tsx
```

^these files are part of `metadata`, but are not in `moduleFiles`