### PR TITLE
feat(serviceworker): emit event when a new service worker is installed

### DIFF
--- a/src/compiler/service-worker/inject-sw-script.ts
+++ b/src/compiler/service-worker/inject-sw-script.ts
@@ -34,7 +34,19 @@ function getRegisterSwScript(swUrl: string) {
     if ('serviceWorker' in navigator && location.protocol !== 'file:') {
       window.addEventListener('load', function(){
         navigator.serviceWorker.register('${swUrl}')
-          .then(function(reg) { console.log('service worker registered', reg) })
+          .then(function(reg) {
+            console.log('service worker registered', reg);
+
+            reg.onupdatefound = function() {
+              var installingWorker = reg.installing;
+
+              installingWorker.onstatechange = function() {
+                if (installingWorker.state === 'installed') {
+                  window.dispatchEvent(new Event('swUpdate'))
+                }
+              }
+            }
+          })
           .catch(function(err) { console.log('service worker error', err) });
       });
     }


### PR DESCRIPTION
This PR allows our service worker registration code to emit an event when a new service worker is installed but not activated yet. This feature is mainly for the ionic-pwa-toolkit at the moment (so I can show some UI when a new service worker is ready to take over) but anyone could use that event to do anything they wanted to. Also, this is not a breaking change from the current behavior as it still just registers the service worker like the current registration code does and if the user does not want to use that event they would never have to even know about it.