### PR TITLE
fix(testing): fix preprocessor to only process .tsx files with stenci…

### DIFF
--- a/scripts/packages/testing/jest.preprocessor.js
+++ b/scripts/packages/testing/jest.preprocessor.js
@@ -2,7 +2,6 @@ var path = require('path');
 var ts = require('typescript');
 var testing = require('./index');
 
-
 var injectTestingScript = [
   'var StencilTesting = require("@stencil/core/testing");',
   'var h = StencilTesting.h;',
@@ -14,7 +13,11 @@ var injectTestingScript = [
 
 module.exports = {
   process: function(sourceText, filePath) {
-    if (filePath.endsWith('.js') || filePath.endsWith('.ts') || filePath.endsWith('.tsx')) {
+    if (filePath.endsWith('.d.ts')) {
+      return '';
+    }
+
+    else if (filePath.endsWith('.tsx')) {
       var opts = {
         module: 'commonjs'
       };
@@ -33,6 +36,13 @@ module.exports = {
       return results.code;
     }
 
-    return sourceText;
+    else {
+      return ts.transpile(
+        sourceText,
+        {},
+        filePath,
+        []
+      );
+    }
   }
 };


### PR DESCRIPTION
This PR fixes several issues in `@ionic/core` for testing, and greatly speeds up the time for testing. Originally, whenever importing a `.d.ts` file, it would take ~300 seconds to execute the tests. When I made the change to stop processing `.d.ts` files, it took it down to ~5.5 seconds for the tests to execute. When I stopped compiling .ts files with Stencil, it took the time down to ~1 second.

Thanks,
Dan