### PR TITLE
fix(styles): styles are now applied in browsers using the legacy client

### DIFF
--- a/src/client/platform-client-legacy.ts
+++ b/src/client/platform-client-legacy.ts
@@ -13,6 +13,7 @@ import { ENCAPSULATION, SSR_VNODE_ID } from '../util/constants';
 import { h } from '../core/renderer/h';
 import { initCssVarShim } from './css-shim/init-css-shim';
 import { initHostElement } from '../core/instance/init-host-element';
+import { initStyleTemplate } from '../core/instance/styles';
 import { parseComponentLoader } from '../util/data-parse';
 import { proxyController } from '../core/instance/proxy-controller';
 import { toDashCase } from '../util/helpers';
@@ -165,6 +166,8 @@ export function createPlatformClientLegacy(Context: CoreContext, App: AppGlobal,
         if (cmpMeta) {
           // connect the component's constructor to its metadata
           cmpMeta.componentConstructor = exports[pascalCasedTagName];
+
+          initStyleTemplate(domApi, cmpMeta.componentConstructor);
         }
       });
 


### PR DESCRIPTION
The `initStyleTemplate` method is what decides how to apply styles. In ES6 builds it will use the `template` element to apply styles and in ES5 builds we just keep the styles in memory and then manually create style tags. Before this fix we were not using this method in the legacy client, meaning ES5 builds did not know how to handle styles. This PR fixes that.