### PR TITLE
feat(listeners): enableListener accepts passive option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/client/platform-client-legacy.ts
+++ b/src/client/platform-client-legacy.ts
@@ -36,7 +36,7 @@ export function createPlatformClientLegacy(Context: CoreContext, App: AppGlobal,
   Context.publicPath = publicPath;
 
   if (Build.listener) {
-    Context.enableListener = (instance, eventName, enabled, attachTo) => enableEventListener(plt, instance, eventName, enabled, attachTo);
+    Context.enableListener = (instance, eventName, enabled, attachTo, passive) => enableEventListener(plt, instance, eventName, enabled, attachTo, passive);
   }
 
   if (Build.event) {

--- a/src/client/platform-client.ts
+++ b/src/client/platform-client.ts
@@ -31,7 +31,7 @@ export function createPlatformClient(Context: CoreContext, App: AppGlobal, win: 
   Context.publicPath = publicPath;
 
   if (Build.listener) {
-    Context.enableListener = (instance, eventName, enabled, attachTo) => enableEventListener(plt, instance, eventName, enabled, attachTo);
+    Context.enableListener = (instance, eventName, enabled, attachTo, passive) => enableEventListener(plt, instance, eventName, enabled, attachTo, passive);
   }
 
   if (Build.event) {

--- a/src/core/instance/listeners.ts
+++ b/src/core/instance/listeners.ts
@@ -47,7 +47,7 @@ export function createListenerCallback(elm: HostElement, eventMethodName: string
 }
 
 
-export function enableEventListener(plt: PlatformApi, instance: ComponentInstance, eventName: string, shouldEnable: boolean, attachTo?: string|Element) {
+export function enableEventListener(plt: PlatformApi, instance: ComponentInstance, eventName: string, shouldEnable: boolean, attachTo?: string|Element, passive?: boolean) {
   if (instance) {
     // cool, we've got an instance, it's get the element it's on
     const elm = instance.__el;
@@ -67,7 +67,7 @@ export function enableEventListener(plt: PlatformApi, instance: ComponentInstanc
             eventName,
             (ev: any) => instance[listenMeta.eventMethodName](ev),
             listenMeta.eventCapture,
-            listenMeta.eventPassive,
+            (passive === undefined) ? listenMeta.eventPassive : !!passive,
             attachTo
           );
         }

--- a/src/core/instance/test/listeners.spec.ts
+++ b/src/core/instance/test/listeners.spec.ts
@@ -1,9 +1,37 @@
-import { createListenerCallback, enableEventListener, replayQueuedEventsOnInstance } from '../listeners';
+import { createListenerCallback, enableEventListener, replayQueuedEventsOnInstance, initElementListeners } from '../listeners';
 import { DomApi, HostElement } from '../../../util/interfaces';
 import { mockComponentInstance, mockDispatchEvent, mockDomApi, mockPlatform, mockWindow } from '../../../testing/mocks';
 
 
 describe('instance listeners', () => {
+
+  it('should only add enabled listeners', () => {
+    const instance = mockComponentInstance(plt, domApi, {
+      listenersMeta: [{
+        eventMethodName: 'test',
+        eventName: 'disabled1',
+        eventDisabled: true
+      },
+      {
+        eventMethodName: 'test2',
+        eventName: 'disabled2',
+        eventDisabled: true
+      },
+      {
+        eventMethodName: 'test3',
+        eventName: 'enabled',
+        eventCapture: true,
+        eventDisabled: false
+      }]
+    });
+    spyOn(instance.__el, 'addEventListener');
+    initElementListeners(plt, instance.__el);
+    expect(instance.__el.addEventListener).toHaveBeenCalledTimes(1);
+    expect(instance.__el.addEventListener).toBeCalledWith('enabled', expect.any(Function), {
+      capture: true,
+      passive: false
+    });
+  });
 
   describe('replayQueuedEventsOnInstance', () => {
 
@@ -31,6 +59,7 @@ describe('instance listeners', () => {
       };
       spyOn(elm._instance, 'myMethod');
       replayQueuedEventsOnInstance(elm);
+      expect(elm._instance.myMethod).not.toHaveBeenCalled();
       expect(elm._queuedEvents).toBeUndefined();
     });
 
@@ -87,14 +116,168 @@ describe('instance listeners', () => {
 
   describe('enableEventListener', () => {
 
-    function newTestComponent(plt: any) {
+    it('should enable/disable a disabled event', () => {
+      testEnableDisableEvent('d_passive');
+    });
+
+    it('should enable/disable an enabled event', () => {
+      testEnableDisableEvent('e_passive');
+    });
+
+    function testEnableDisableEvent(eventName: string) {
+      const instance = newTestComponent();
+      spyOn(instance.__el, 'addEventListener').and.callThrough();
+      spyOn(instance.__el, 'removeEventListener').and.callThrough();
+
+      // Remove listener (it was never added, should do nothing)
+      enableEventListener(plt, instance, eventName, false);
+      mockDispatchEvent(domApi, instance.__el, eventName);
+      expect(instance.test).not.toBeCalled();
+      expect(instance.__el.addEventListener).toHaveBeenCalledTimes(0);
+      expect(instance.__el.removeEventListener).toHaveBeenCalledTimes(0);
+
+      // Add listener
+      enableEventListener(plt, instance, eventName, true);
+      mockDispatchEvent(domApi, instance.__el, eventName, 'hello');
+      expect(instance.test).toBeCalled();
+      expect(instance.__el.addEventListener).toHaveBeenCalledTimes(1);
+      expect(instance.__el.removeEventListener).toHaveBeenCalledTimes(0);
+
+      // Add listener, second time, should do nothing
+      enableEventListener(plt, instance, eventName, true);
+      expect(instance.__el.addEventListener).toHaveBeenCalledTimes(2);
+      expect(instance.__el.removeEventListener).toHaveBeenCalledTimes(1);
+
+      // Remove listener
+      enableEventListener(plt, instance, eventName, false);
+      mockDispatchEvent(domApi, instance.__el, eventName);
+      expect(instance.test).toHaveBeenCalledTimes(1);
+      expect(instance.__el.addEventListener).toHaveBeenCalledTimes(2);
+      expect(instance.__el.removeEventListener).toHaveBeenCalledTimes(2);
+    }
+
+    it('should not listen for unregistered events', () => {
+      const instance = newTestComponent();
+      spyOn(instance.__el, 'addEventListener').and.callThrough();
+      spyOn(instance.__el, 'removeEventListener').and.callThrough();
+
+      enableEventListener(plt, instance, 'unknown_event', true);
+      enableEventListener(plt, instance, 'unknown_event', false);
+
+      expect(instance.__el.addEventListener).not.toBeCalled();
+      expect(instance.__el.removeEventListener).not.toBeCalled();
+    });
+
+    it('should listen to body', () => {
+      const instance = newTestComponent();
+      testAttachTo('body', instance, doc.body);
+    });
+
+    it('should listen to document', () => {
+      const instance = newTestComponent();
+      testAttachTo('document', instance, doc);
+    });
+
+    it('should listen to window', () => {
+      const instance = newTestComponent();
+      testAttachTo('window', instance, win);
+    });
+
+    it('should listen to parent', () => {
+      const instance = newTestComponent();
+      const parent = domApi.$createElement('div');
+      parent.appendChild(instance.__el);
+      testAttachTo('parent', instance, parent);
+    });
+
+    it('should listen to child', () => {
+      const instance = newTestComponent();
+      const child = domApi.$createElement('div');
+      instance.__el.appendChild(child);
+      testAttachTo('child', instance, child);
+    });
+
+    it('should listen to custom', () => {
+      const instance = newTestComponent();
+      const custom = domApi.$createElement('div');
+      testAttachTo(custom, instance, custom);
+    });
+
+    function testAttachTo(attachTo: any, instance: any, el: any) {
+      domApi.$supportsEventOptions = true;
+
+      mockDispatchEvent(domApi, el, 'd_passive', 'hello');
+      expect(instance.test).not.toHaveBeenCalled();
+
+      enableEventListener(plt, instance, 'd_passive', false, attachTo);
+      mockDispatchEvent(domApi, el, 'd_passive', 'hello');
+      expect(instance.test).not.toHaveBeenCalled();
+
+      enableEventListener(plt, instance, 'd_passive', true, attachTo);
+      mockDispatchEvent(domApi, el, 'd_passive', 'hello');
+      mockDispatchEvent(domApi, el, 'd_passive', 'hello');
+      expect(instance.test).toHaveBeenCalledTimes(2);
+
+      enableEventListener(plt, instance, 'd_passive', false);
+      mockDispatchEvent(domApi, el, 'd_passive', 'hello');
+      expect(instance.test).toHaveBeenCalledTimes(2);
+
+      enableEventListener(plt, instance, 'd_passive', true, attachTo);
+      mockDispatchEvent(domApi, el, 'd_passive', 'hello');
+      expect(instance.test).toHaveBeenCalledTimes(3);
+
+      enableEventListener(plt, instance, 'd_passive', false, attachTo);
+      mockDispatchEvent(domApi, el, 'd_passive', 'hello');
+      expect(instance.test).toHaveBeenCalledTimes(3);
+    }
+
+    it('should pass the events options properly', () => {
+      testEventsOptions('d_passive', undefined, true, true);
+      testEventsOptions('d_non_passive', undefined, false, false);
+
+      testEventsOptions('d_passive', true, true, true);
+      testEventsOptions('d_non_passive', true, true, false);
+
+      testEventsOptions('d_passive', false, false, true);
+      testEventsOptions('d_non_passive', false, false, false);
+    });
+
+    function testEventsOptions(eventName, passive, expectedPassive, expectedCapture) {
+      domApi.$supportsEventOptions = true;
+      const instance = newTestComponent();
+      spyOn(instance.__el, 'addEventListener');
+
+      enableEventListener(plt, instance, eventName, true, undefined, passive);
+
+      expect(instance.__el.addEventListener).toBeCalledWith(eventName, expect.any(Function), {
+        passive: expectedPassive,
+        capture: expectedCapture
+      });
+    }
+
+    function newTestComponent() {
+      domApi.$supportsEventOptions = true;
       const instance = mockComponentInstance(plt, domApi, {
         listenersMeta: [{
           eventMethodName: 'test',
-          eventName: 'myevent',
+          eventName: 'd_passive',
           eventCapture: true,
           eventPassive: true,
           eventDisabled: true
+        },
+        {
+          eventMethodName: 'test',
+          eventName: 'd_non_passive',
+          eventCapture: false,
+          eventPassive: false,
+          eventDisabled: true
+        },
+        {
+          eventMethodName: 'test',
+          eventName: 'e_passive',
+          eventCapture: false,
+          eventPassive: true,
+          eventDisabled: false
         }]
       });
       instance.test = function (ev: any) {
@@ -103,143 +286,58 @@ describe('instance listeners', () => {
       spyOn(instance, 'test').and.callThrough();
       return instance;
     }
-
-    it('should enable/disable the event', () => {
-      const instance = newTestComponent(plt);
-
-      enableEventListener(plt, instance, 'myevent', false);
-      mockDispatchEvent(domApi, instance.__el, 'myevent');
-      expect(instance.test).not.toBeCalled();
-
-      enableEventListener(plt, instance, 'myevent', true);
-      mockDispatchEvent(domApi, instance.__el, 'myevent', 'hello');
-      expect(instance.test).toBeCalled();
-
-      enableEventListener(plt, instance, 'myevent', false);
-      mockDispatchEvent(domApi, instance.__el, 'myevent');
-      expect(instance.test).toHaveBeenCalledTimes(1);
-    });
-
-    it('should listen to body', () => {
-      const instance = newTestComponent(plt);
-      testAttachTo('body', instance, doc.body);
-    });
-
-    it('should listen to document', () => {
-      const instance = newTestComponent(plt);
-      testAttachTo('document', instance, doc);
-    });
-
-    it('should listen to window', () => {
-      const instance = newTestComponent(plt);
-      testAttachTo('window', instance, win);
-    });
-
-    it('should listen to parent', () => {
-      const instance = newTestComponent(plt);
-      const parent = domApi.$createElement('div');
-      parent.appendChild(instance.__el);
-      testAttachTo('parent', instance, parent);
-    });
-
-    it('should listen to child', () => {
-      const instance = newTestComponent(plt);
-      const child = domApi.$createElement('div');
-      instance.__el.appendChild(child);
-      testAttachTo('child', instance, child);
-    });
-
-    it('should listen to custom', () => {
-      const instance = newTestComponent(plt);
-      const custom = domApi.$createElement('div');
-      testAttachTo(custom, instance, custom);
-    });
-
-    function testAttachTo(attachTo: any, instance: any, el: any) {
-      mockDispatchEvent(domApi, el, 'myevent', 'hello');
-      expect(instance.test).not.toHaveBeenCalled();
-
-      enableEventListener(plt, instance, 'myevent', false, attachTo);
-      mockDispatchEvent(domApi, el, 'myevent', 'hello');
-      expect(instance.test).not.toHaveBeenCalled();
-
-      enableEventListener(plt, instance, 'myevent', true, attachTo);
-      mockDispatchEvent(domApi, el, 'myevent', 'hello');
-      mockDispatchEvent(domApi, el, 'myevent', 'hello');
-      expect(instance.test).toHaveBeenCalledTimes(2);
-
-      enableEventListener(plt, instance, 'myevent', false);
-      mockDispatchEvent(domApi, el, 'myevent', 'hello');
-      expect(instance.test).toHaveBeenCalledTimes(2);
-
-      enableEventListener(plt, instance, 'myevent', true, attachTo);
-      mockDispatchEvent(domApi, el, 'myevent', 'hello');
-      expect(instance.test).toHaveBeenCalledTimes(3);
-
-      enableEventListener(plt, instance, 'myevent', false, attachTo);
-      mockDispatchEvent(domApi, el, 'myevent', 'hello');
-      expect(instance.test).toHaveBeenCalledTimes(3);
-    }
   });
 
 
-  describe('addListener', () => {
+  describe('domApi.$addEventListener', () => {
     it('should register simple event', () => {
       testAddEventListener(
-        elm, 'myevent', false, false,
-        elm, 'myevent', false);
+        elm, 'd_passive', false, false,
+        elm, 'd_passive', false);
     });
 
     it('should register event with attachTo', () => {
       testAddEventListener(
-        elm, 'body:myevent', true, true,
-        elm.ownerDocument.body, 'myevent', false);
+        elm, 'body:d_passive', true, true,
+        elm.ownerDocument.body, 'd_passive', false);
     });
 
     it('should register event with modifier', () => {
       testAddEventListener(
-        elm, 'myevent.enter', false, true,
-        elm, 'myevent', 13);
+        elm, 'd_passive.enter', false, true,
+        elm, 'd_passive', 13);
     });
 
     it('should register event with modifier and attachTo', () => {
       testAddEventListener(
-        elm, 'body:myevent.enter', false, true,
-        elm.ownerDocument.body, 'myevent', 13);
+        elm, 'body:d_passive.enter', false, true,
+        elm.ownerDocument.body, 'd_passive', 13);
     });
 
     function testAddEventListener(el: any, eventName: string, capture: boolean, passive: boolean,
       target: any, targetName: string, keyCode: any) {
       let calledCallback = false;
-      let calledAdd = false;
-      let calledRm = false;
       let internalCallback: Function;
+
+      target.addEventListener = function (name: any, callback: any, options: any) {
+        internalCallback = callback;
+      };
+
+      spyOn(target, 'addEventListener').and.callThrough();
+      spyOn(target, 'removeEventListener').and.callThrough();
 
       const f = () => {
         calledCallback = true;
       };
 
-      target.addEventListener = function (name: any, callback: any, options: any) {
-        calledAdd = true;
-        internalCallback = callback;
-        expect(name).toEqual(targetName);
-        expect(options.passive).toEqual(passive);
-        // expect(options.capture).toEqual(capture);
-      };
-
-      target.removeEventListener = function (name: any, callback: any, options: any) {
-        calledRm = true;
-        expect(callback).toEqual(internalCallback);
-        expect(name).toEqual(targetName);
-        expect(options.passive).toEqual(passive);
-        expect(options.capture).toEqual(capture);
-      };
-
+      // test if target-addEventListener is called properly
       domApi.$addEventListener(el, eventName, f, capture, passive);
+      expect(target.addEventListener).toHaveBeenCalledWith(targetName, internalCallback, {
+        passive: passive,
+        capture: capture
+      });
 
-      expect(calledAdd).toBeTruthy();
-      expect(calledRm).toBeFalsy();
-
+      // test key based events are dispatched properly
       if (keyCode !== false) {
         internalCallback({keyCode: keyCode + 1});
         expect(calledCallback).toBeFalsy();
@@ -248,24 +346,29 @@ describe('instance listeners', () => {
       internalCallback({keyCode: keyCode});
       expect(calledCallback).toBeTruthy();
 
+      // test if the listener is removed
       domApi.$removeEventListener(el, eventName);
-      expect(calledRm).toBeTruthy();
+      expect(target.removeEventListener).toHaveBeenCalledWith(targetName, internalCallback, {
+        passive: passive,
+        capture: capture
+      });
     }
   });
 
-  let domApi: DomApi;
-  let elm: HostElement;
-  let plt: any;
-  let win: any;
-  let doc: any;
 
-  beforeEach(() => {
-    win = mockWindow();
-    doc = win.document;
-    domApi = mockDomApi(win, doc);
-    domApi.$supportsEventOptions = true;
-    plt = mockPlatform(win, domApi);
-    elm = domApi.$createElement('ion-cmp') as any;
-  });
+});
 
+let domApi: DomApi;
+let elm: HostElement;
+let plt: any;
+let win: any;
+let doc: any;
+
+beforeEach(() => {
+  win = mockWindow();
+  doc = win.document;
+  plt = mockPlatform(win);
+  domApi = plt.domApi;
+  domApi.$supportsEventOptions = true;
+  elm = domApi.$createElement('ion-cmp') as any;
 });

--- a/src/core/renderer/dom-api.ts
+++ b/src/core/renderer/dom-api.ts
@@ -18,6 +18,8 @@ export function createDomApi(win: any, doc: Document): DomApi {
 
     $body: doc.body,
 
+    $supportsEventOptions: false,
+
     $nodeType: (node: any) =>
       node.nodeType,
 
@@ -223,7 +225,8 @@ export function createDomApi(win: any, doc: Document): DomApi {
     }
 
     domApi.$dispatchEvent = (elm, eventName, data) => elm && elm.dispatchEvent(new win.CustomEvent(eventName, data));
-
+  }
+  if (Build.event || Build.listener) {
     // test if this browser supports event options or not
     try {
       (win as Window).addEventListener('e', null,
@@ -233,7 +236,6 @@ export function createDomApi(win: any, doc: Document): DomApi {
       );
     } catch (e) {}
   }
-
 
   domApi.$parentElement = (elm: Node, parentNode?: any): any => {
     // if the parent node is a document fragment (shadow root)

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -28,6 +28,11 @@ export function mockPlatform(win?: any, domApi?: DomApi) {
     false,
     null
   );
+  if (domApi) {
+    plt.domApi = domApi;
+  } else {
+    domApi = plt.domApi;
+  }
   plt.isClient = true;
 
   const $mockedQueue = plt.queue = mockQueue();

--- a/src/util/interfaces.ts
+++ b/src/util/interfaces.ts
@@ -38,7 +38,7 @@ export interface AddEventListener {
 
 
 export interface EventListenerEnable {
-  (instance: any, eventName: string, enabled: boolean, attachTo?: string|Element): void;
+  (instance: any, eventName: string, enabled: boolean, attachTo?: string|Element, passive?: boolean): void;
 }
 
 


### PR DESCRIPTION
@adamdbradley 
it could also be `options: {passive, capture}` so capture can also be configured, instead of `passive: boolean`

It also fixes a problem with domApi.supportPassiveEvents