### PR TITLE
fix #375

### DIFF
--- a/src/core/renderer/patch.ts
+++ b/src/core/renderer/patch.ts
@@ -139,6 +139,8 @@ export function createRendererPatch(plt: PlatformApi, domApi: DomApi): RendererA
           }
         }
       }
+
+      isSvgMode = false;
     }
 
     return vnode.elm;

--- a/src/core/renderer/test/patch-svg.spec.ts
+++ b/src/core/renderer/test/patch-svg.spec.ts
@@ -38,5 +38,16 @@ describe('renderer', () => {
       expect(elm.firstChild.namespaceURI).toEqual(SVGNamespace);
       expect(elm.firstChild.firstChild.namespaceURI).toEqual(XHTMLNamespace);
     });
+
+    it('should not affect subsequence element', function() {
+      elm = patch(vnode0, h('div', null, [
+        h('svg', null),
+        h('div', null)
+      ])).elm;
+
+      expect(elm.constructor.name).toEqual('HTMLDivElement')
+      expect(elm.firstChild.constructor.name).toEqual('SVGSVGElement')
+      expect(elm.lastChild.constructor.name).toEqual('HTMLDivElement')
+    })
   });
 });


### PR DESCRIPTION
Hi, I see @adamdbradley is assigned, but this is urgent for me so I just go ahead and investigate this any way. 

The issue is the SVG context is not reset after create the first SVG element (`isSVGMode` never set to `false`). Any element created after the `<svg/>` actually is a `SVGElement` thus not rendered by browser. I've added a simple test case, not sure if it covers all the cases though.

<img width="902" alt="screen shot 2018-01-18 at 1 59 01 am" src="https://user-images.githubusercontent.com/88299/35061366-a01c0574-fbf3-11e7-8836-99cc5f68d47b.png">


