### PR TITLE
feat(onReady): onReady callback

### DIFF
--- a/src/compiler/app/build-core-content.ts
+++ b/src/compiler/app/build-core-content.ts
@@ -272,6 +272,7 @@ const RESERVED_PROPERTIES: string[] = [
   '$onRender',
   '$',
   'componentOnReady',
+  'onReady',
 
 
   /**

--- a/src/core/instance/init-component-instance.ts
+++ b/src/core/instance/init-component-instance.ts
@@ -67,6 +67,12 @@ export function initComponentLoaded(plt: PlatformApi, elm: HostElement, hydrated
       // fire off the ref if it exists
       callNodeRefs(elm._vnode);
 
+      // fire off the user's elm.onReady function
+      if (elm.onReady) {
+        elm.onReady(elm);
+        elm.onReady = null;
+      }
+
       // fire off the user's elm.componentOnReady() callbacks that were
       // put directly on the element (well before anything was ready)
       if (elm._onReadyCallbacks) {

--- a/src/core/instance/test/init.spec.ts
+++ b/src/core/instance/test/init.spec.ts
@@ -14,11 +14,11 @@ describe('instance init', () => {
       let called1 = false;
       let called2 = false;
 
-      let p1 = elm.componentOnReady().then(() => {
+      const p1 = elm.componentOnReady().then(() => {
         called1 = true;
       });
 
-      let p2 = elm.componentOnReady().then(() => {
+      const p2 = elm.componentOnReady().then(() => {
         called2 = true;
       });
 
@@ -49,6 +49,47 @@ describe('instance init', () => {
     });
 
   });
+
+  it('should call onReady before initHostElement', () => {
+    let called1 = false;
+    let called2 = false;
+
+    elm.onReady = () => {
+      called1 = true;
+    };
+
+    initHostElement(plt, cmpMeta, elm);
+
+    elm.componentOnReady(() => {
+      called2 = true;
+    });
+
+    initComponentLoaded(plt, elm);
+    expect(called1).toBe(true);
+    expect(called2).toBe(true);
+  });
+
+
+  it('should call onReady after initHostElement', () => {
+    let called1 = false;
+    let called2 = false;
+
+    initHostElement(plt, cmpMeta, elm);
+
+    elm.onReady = () => {
+      called2 = true;
+    };
+
+    elm.componentOnReady(() => {
+      called1 = true;
+    });
+
+    initComponentLoaded(plt, elm);
+    expect(called1).toBe(true);
+    expect(called2).toBe(true);
+  });
+
+});
 
   const plt: PlatformApi = <any>mockPlatform();
   const domApi = mockDomApi();

--- a/src/declarations/component.ts
+++ b/src/declarations/component.ts
@@ -251,6 +251,7 @@ export interface HostElement extends HTMLElement {
   $rendered?: boolean;
   $onRender: (() => void)[];
   componentOnReady?: (cb?: (elm: HostElement) => void) => Promise<void>;
+  onReady?: (cb?: HostElement) => void;
   color?: string;
   mode?: string;
 


### PR DESCRIPTION
There are two use cases for `element.componentOnReady()`

```ts
// returning a promise
element.componentOnReady().then(() => {
   console.log("component is ready");
}

// passing a callback
element.componentOnReady(() => {
   console.log("component is ready");
});
```

but non of them work in vanilla JS
```html
<script>
  const el = document.queryElement('ion-menu-controller');
  el.componentOnReady().then(() => {
     el.open('right');
  });
</script>
</body>
```

The reason is that at this point the CustomElement has not been registered yet and `componentOnReady` is undefined.

I propose using a object property that references a callback function that is called when the element gets initialised, this "third" approach would work even if the custom element is not registered yet:

```js
el.componentOnReady = function() {
   console.log('component is ready');
}
```

**The problem** is that the property `componentOnReady` conflicts with the stencil's HostElement prototype that also has a componentOnReady: https://github.com/ionic-team/stencil/blob/master/src/core/instance/init-host-element.ts#L34


Because object properties have precedence over prototype properties, stencil runtime would have to "delete" the property:
```js
delete el.componentOnReady;
```
in order for `prototype.componentOnReady` to be called in future usages.

**If we don't delete the `componentOnReady` property, other code paths that expect a promise from this function will break.**

It's a well-known anti-pattern to use "delete" because it cases deoptimization in most of the JS engines.

That's why I propose to use a different event-like property: `onReady`

```js
el.onReady = function() {
   console.log('component is ready');
}
```
