### PR TITLE
fix(build): Avoid using Object.entries (breaks Node 6)

### DIFF
--- a/src/compiler/bundle/generate-bundles.ts
+++ b/src/compiler/bundle/generate-bundles.ts
@@ -34,8 +34,10 @@ export async function generateBundles(config: Config, compilerCtx: CompilerCtx, 
     })
   );
 
-  Object.entries(jsModules['esm'])
-    .filter(([key]) => !bundleKeys[key])
+  const esmModules = jsModules['esm'];
+  Object.keys(esmModules)
+    .filter(key => !bundleKeys[key])
+    .map(key => { return [key, esmModules[key]] as [string, { code: string}]; })
     .forEach(async ([key, value]) => {
       const fileName = getBundleFilename(key.replace('.js', ''), false, 'es2015');
       const jsText = replaceBundleIdPlaceholder(value.code, key);
@@ -43,8 +45,10 @@ export async function generateBundles(config: Config, compilerCtx: CompilerCtx, 
     });
 
   if (config.buildEs5) {
-    Object.entries(jsModules['es5'])
-      .filter(([key]) => !bundleKeys[key])
+    const es5Modules = jsModules['es5'];
+    Object.keys(es5Modules)
+      .filter(key => !bundleKeys[key])
+      .map(key => { return [key, es5Modules[key]] as [string, { code: string}]; })
       .forEach(async ([key, value]) => {
         const fileName = getBundleFilename(key.replace('.js', ''), false, 'es5');
         let jsText = replaceBundleIdPlaceholder(value.code, key);

--- a/src/compiler/bundle/rollup-bundle.ts
+++ b/src/compiler/bundle/rollup-bundle.ts
@@ -66,7 +66,10 @@ export async function writeEsModules(config: Config, rollupBundle: OutputChunk) 
 
 
 export async function writeLegacyModules(config: Config, rollupBundle: OutputChunk, entryModules: EntryModule[]) {
-  Object.entries((<any>rollupBundle).chunks).forEach(([key, value]) => {
+  const { chunks } = <any>rollupBundle;
+  Object.keys(chunks).map(key => {
+    return [key, chunks[key]];
+  }).forEach(([key, value]) => {
     const entryModule = entryModules.find(b => b.entryKey === `./${key}.js`);
     if (entryModule) {
       entryModule.dependencies = (<any>value).imports.slice();


### PR DESCRIPTION
Tested on Node 6.12.0 on Win10. Builds against stencil-component-starter. I couldn't get unit tests working, probably a separate set of changes on its own.

Cheers!

Fixes #463 