### PR TITLE
fix(copy): wait for processCopyTaskDestDir execution

### DIFF
--- a/src/compiler/copy/copy-tasks.ts
+++ b/src/compiler/copy/copy-tasks.ts
@@ -56,11 +56,11 @@ export async function processCopyTasks(config: Config, compilerCtx: CompilerCtx,
   }
 
   if (config.generateWWW) {
-    processCopyTaskDestDir(config, compilerCtx, allCopyTasks, copyTask, config.wwwDir);
+    await processCopyTaskDestDir(config, compilerCtx, allCopyTasks, copyTask, config.wwwDir);
   }
 
   if (config.generateDistribution) {
-    processCopyTaskDestDir(config, compilerCtx, allCopyTasks, copyTask, config.collectionDir);
+    await processCopyTaskDestDir(config, compilerCtx, allCopyTasks, copyTask, config.collectionDir);
   }
 }
 


### PR DESCRIPTION
Otherwise the `allCopyTasks` of `copyTasks` function is always empty when resolving.