### PR TITLE
fix(init): componentDidLoad called twice

### DIFF
--- a/src/core/instance/init-component-instance.ts
+++ b/src/core/instance/init-component-instance.ts
@@ -52,7 +52,7 @@ export function initComponentLoaded(plt: PlatformApi, elm: HostElement, hydrated
   // all is good, this component has been told it's time to finish loading
   // it's possible that we've already decided to destroy this element
   // check if this element has any actively loading child elements
-  if (elm._instance && !elm._hasDestroyed && (!elm.$activeLoading || !elm.$activeLoading.length)) {
+  if (!elm._hasLoaded && elm._instance && !elm._hasDestroyed && (!elm.$activeLoading || !elm.$activeLoading.length)) {
 
     // cool, so at this point this element isn't already being destroyed
     // and it does not have any child elements that are still loading


### PR DESCRIPTION
Tries to fix: https://github.com/ionic-team/stencil/issues/498

@adamdbradley I am not sure it is a good fix or that is actually solves the root of the problem. could you look at it? The fact that componentDidLoad runs twice sometimes breaks some components in ionic-core. Also having some unit tests for the lifecycle events would be great