### PR TITLE
fix(svg): isSvgMode must be reset when an svg node is patched

### DIFF
--- a/src/core/renderer/patch.ts
+++ b/src/core/renderer/patch.ts
@@ -339,6 +339,9 @@ export function createRendererPatch(plt: PlatformApi, domApi: DomApi): RendererA
       // and also only if the text is different than before
       domApi.$setTextContent(elm, newVNode.vtext);
     }
+
+    // reset svgMode when svg node is fully patched
+    if ('svg' === newVNode.vtag && isSvgMode) isSvgMode = false;
   }
 
   // internal variables to be reused per patch() call

--- a/src/core/renderer/test/patch-svg.spec.ts
+++ b/src/core/renderer/test/patch-svg.spec.ts
@@ -55,4 +55,24 @@ describe('renderer', () => {
       expect(elm.lastChild.constructor.name).toEqual('HTMLDivElement');
     });
   });
+
+  describe('created trailing svg element', () => {
+    
+    it('should not affect subsequent created element', function() {
+      
+      const divWithSVGChild = patch(vnode0,  h('div', null,
+        h('div', null,
+          h('svg', null)
+        )
+      ));
+      const oneMoreChildAdded = patch(divWithSVGChild, h('div', null, [
+          h('div', null,
+            h('svg', null)
+          ),
+          h('div', null)
+        ]
+      ));
+      expect(oneMoreChildAdded.vchildren[1].elm.constructor.name).toEqual('HTMLDivElement');
+    });
+  })
 });


### PR DESCRIPTION
patchVNode function does not reset isSvgMode after patching svg nodes, therefore, if the next element in the DOM tree has to be created by domApi.$createElement funcion, it is created as an SVG Element.

The bug can be tested in a [demo I created](https://github.com/yesobo/stencil-svg-bug) based on stencil-app-starter with @stencil/core 0.3.0 where it is unable to add a new div element follwing a svg node already rendered in the DOM tree.

PR #460  fixes subsequent SVG nodes created in the same patchVNode stage but it does'nt take into account when a previous SVG element was already rendered in a previous stage