### PR TITLE
chore(polyfill): add array.includes

### DIFF
--- a/scripts/polyfills/array-includes.js
+++ b/scripts/polyfills/array-includes.js
@@ -1,0 +1,5 @@
+/*!
+Array.prototype.includes
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes
+*/
+Array.prototype.includes||Object.defineProperty(Array.prototype,"includes",{value:function(r,e){if(null==this)throw new TypeError('"this" is null or not defined');var t=Object(this),n=t.length>>>0;if(0===n)return!1;var i,o,a=0|e,u=Math.max(0<=a?a:n-Math.abs(a),0);for(;u<n;){if((i=t[u])===(o=r)||"number"==typeof i&&"number"==typeof o&&isNaN(i)&&isNaN(o))return!0;u++}return!1}});

--- a/src/compiler/app/app-polyfills.ts
+++ b/src/compiler/app/app-polyfills.ts
@@ -23,6 +23,7 @@ const POLYFILLS = [
   'template.js',
   'document-register-element.js',
   'array-find.js',
+  'array-includes.js',
   'object-assign.js',
   'string-startswith.js',
   'string-endswith.js',


### PR DESCRIPTION
Today, array.includes() is actually faster than indexOf
![screenshot from 2018-03-04 16-20-34](https://user-images.githubusercontent.com/127379/36947291-0c496c56-1fca-11e8-9ebc-275fc1902c49.png)

But more important, it's a more explicit API that revels the true intent of the developer.
