### PR TITLE
Image decode definition

### DIFF
--- a/src/declarations/jsx.ts
+++ b/src/declarations/jsx.ts
@@ -283,6 +283,7 @@ declare global {
 
     export interface ImgHTMLAttributes extends HTMLAttributes {
       alt?: string;
+      decoding?: 'async' | 'auto' | 'sync';
       height?: number | string;
       sizes?: string;
       src?: string;


### PR DESCRIPTION
[https://twitter.com/addyosmani/status/938078402430382080](https://twitter.com/addyosmani/status/938078402430382080)

Just curious, do these definitions have to be manually maintained or are they pulling from somewhere? Thanks!