### PR TITLE
Makes polyfills writable properties

### DIFF
--- a/scripts/polyfills/array-find.js
+++ b/scripts/polyfills/array-find.js
@@ -2,4 +2,4 @@
 Array.prototype.find
 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
 */
-Array.prototype.find||Object.defineProperty(Array.prototype,"find",{value:function(c,e){if(null==this)throw new TypeError('"this" is null or not defined');var b=Object(this),f=b.length>>>0;if("function"!==typeof c)throw new TypeError("predicate must be a function");for(var a=0;a<f;){var d=b[a];if(c.call(e,d,a,b))return d;a++}}});
+Array.prototype.find||Object.defineProperty(Array.prototype,"find",{writable:!0,configurable:!0,value:function(c,e){if(null==this)throw new TypeError('"this" is null or not defined');var b=Object(this),f=b.length>>>0;if("function"!==typeof c)throw new TypeError("predicate must be a function");for(var a=0;a<f;){var d=b[a];if(c.call(e,d,a,b))return d;a++}}});

--- a/scripts/polyfills/array-includes.js
+++ b/scripts/polyfills/array-includes.js
@@ -2,4 +2,4 @@
 Array.prototype.includes
 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes
 */
-Array.prototype.includes||Object.defineProperty(Array.prototype,"includes",{value:function(r,e){if(null==this)throw new TypeError('"this" is null or not defined');var t=Object(this),n=t.length>>>0;if(0===n)return!1;var i,o,a=0|e,u=Math.max(0<=a?a:n-Math.abs(a),0);for(;u<n;){if((i=t[u])===(o=r)||"number"==typeof i&&"number"==typeof o&&isNaN(i)&&isNaN(o))return!0;u++}return!1}});
+Array.prototype.includes||Object.defineProperty(Array.prototype,"includes",{writable:!0,configurable:!0,value:function(r,e){if(null==this)throw new TypeError('"this" is null or not defined');var t=Object(this),n=t.length>>>0;if(0===n)return!1;var i,o,a=0|e,u=Math.max(0<=a?a:n-Math.abs(a),0);for(;u<n;){if((i=t[u])===(o=r)||"number"==typeof i&&"number"==typeof o&&isNaN(i)&&isNaN(o))return!0;u++}return!1}});

--- a/scripts/polyfills/string-endswith.js
+++ b/scripts/polyfills/string-endswith.js
@@ -1,4 +1,4 @@
 /*!
 String.prototype.endsWith
 */
-String.prototype.endsWith||(String.prototype.endsWith=function(b,a){if(void 0===a||a>this.length)a=this.length;return this.substring(a-b.length,a)===b});
+String.prototype.endsWith||Object.defineProperty(String.prototype,"endsWith",{writable:!0,configurable:!0,value:function(b,a){if(void 0===a||a>this.length)a=this.length;return this.substring(a-b.length,a)===b}});

--- a/scripts/polyfills/string-startswith.js
+++ b/scripts/polyfills/string-startswith.js
@@ -1,4 +1,4 @@
 /*!
 String.prototype.startsWith
 */
-String.prototype.startsWith||Object.defineProperty(String.prototype,"startsWith",{value:function(b,a){return this.substr(!a||0>a?0:+a,b.length)===b}});
+String.prototype.startsWith||Object.defineProperty(String.prototype,"startsWith",{writable:!0,configurable:!0,value:function(b,a){return this.substr(!a||0>a?0:+a,b.length)===b}});


### PR DESCRIPTION
Defining polyfills as non-writable causes "Assignment to read-only
properties is not allowed in strict mode" errors in certain
circumstances, such as using MobX and its ObservableArray subclass of
Array.

This follows the conventions from polyfill.io around the options passed
to `defineProperty`.

Fixes ionic-team/stencil#606