### PR TITLE
fix(types): Render HydrateAnchor

### DIFF
--- a/src/declarations/render.ts
+++ b/src/declarations/render.ts
@@ -55,7 +55,7 @@ export interface HydrateComponent {
 export interface HydrateAnchor {
   href?: string;
   target?: string;
-  [attrName: string]: string;
+  [attrName: string]: string | undefined;
 }
 
 


### PR DESCRIPTION
"While string index signatures are a powerful way to describe the “dictionary” pattern, they also enforce that all properties match their return type. This is because a string index declares that obj.property is also available as obj["property"]. " https://www.typescriptlang.org/docs/handbook/interfaces.html