### PR TITLE
Updates the CSS variable regexp for pseudo-classes

### DIFF
--- a/src/client/css-shim/init-css-shim.ts
+++ b/src/client/css-shim/init-css-shim.ts
@@ -49,7 +49,18 @@ function loadLinkStyles(doc: Document, customStyle: CustomStyle, linkElm: HTMLLi
   });
 }
 
+// This regexp tries to determine when a variable is declared, for example:
+//
+// .my-el { --highlight-color: green; }
+//
+// but we don't want to trigger when a classname uses "--" or a pseudo-class is
+// used. We assume that the only characters that can preceed a variable
+// declaration are "{", from an opening block, ";" from a preceeding rule, or a
+// space. This prevents the regexp from matching a word in a selector, since
+// they would need to start with a "." or "#". (We assume element names don't
+// start with "--").
+const CSS_VARIABLE_REGEXP = /[\s;{]--[-a-zA-Z0-9]+\s*:/m;
 
 export function hasCssVariables(css: string) {
-  return css.indexOf('var(') > -1 || /--[-a-zA-Z0-9\s]+:/.test(css);
+  return css.indexOf('var(') > -1 || CSS_VARIABLE_REGEXP.test(css);
 }

--- a/src/client/css-shim/test/init-css-shim.spec.ts
+++ b/src/client/css-shim/test/init-css-shim.spec.ts
@@ -30,6 +30,22 @@ describe('hasCssVariables', () => {
     expect(hasCssVariables(text)).toBe(false);
   });
 
+  it('false for normal CSS with a pseudo class', () => {
+    const text = `
+      .test--el:hover {
+        background-color: green
+      }
+    `;
+    expect(hasCssVariables(text)).toBe(false);
+  });
+
+  it('false for minified CSS with a pseudo class', () => {
+    const text = `
+      .test--el:hover{background-color: green}
+    `;
+    expect(hasCssVariables(text)).toBe(false);
+  });
+
   it('true for -- declaration w/ spaces', () => {
     const text = `
     element {
@@ -57,6 +73,16 @@ describe('hasCssVariables', () => {
     expect(hasCssVariables(text)).toBe(true);
   });
 
+  it('true for minified CSS with a semicolon', () => {
+    const text = `element{background-color: green;--main-text-color: black}`;
+    expect(hasCssVariables(text)).toBe(true);
+  });
+
+  it('true for minified CSS without a semicolon', () => {
+    const text = `element{--main-text-color: black}`;
+    expect(hasCssVariables(text)).toBe(true);
+  });
+   
   it('true for var()', () => {
     const text = `
       element {


### PR DESCRIPTION
Changes the logic to better ensure that the "--" happens at the
beginning of a word, where it would appear for a variable declaration,
rather than inside a selector.

Fixes #603