### PR TITLE
fix(): add event listeners and custom events types to components.d.ts

### DIFF
--- a/src/compiler/transpile/create-component-types.ts
+++ b/src/compiler/transpile/create-component-types.ts
@@ -1,5 +1,5 @@
 import * as d from '../../declarations';
-import { dashToPascalCase } from '../../util/helpers';
+import { captializeFirstLetter, dashToPascalCase } from '../../util/helpers';
 import { gatherMetadata } from './datacollection/index';
 import { getComponentsDtsTypesFilePath } from '../collections/distribution';
 import { MEMBER_TYPE } from '../../util/constants';
@@ -7,6 +7,7 @@ import { normalizeAssetsDir } from '../component-plugins/assets-plugin';
 import { normalizePath } from '../util';
 import { normalizeStyles } from '../style/normalize-styles';
 import * as ts from 'typescript';
+import { AttributeTypeReference } from '../../declarations';
 
 
 export async function generateComponentTypes(config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx, tsOptions: ts.CompilerOptions, tsHost: ts.CompilerHost, tsFilePaths: string[], componentsDtsSrcFilePath: string) {
@@ -164,6 +165,35 @@ function sortImportNames(a: MemberNameData, b: MemberNameData) {
  */
 function updateReferenceTypeImports(config: d.Config, importDataObj: ImportData, allTypes: { [key: string]: number }, cmpMeta: d.ComponentMeta, filePath: string) {
 
+
+  const updateImportReferences = updateImportReferenceFactory(config, allTypes, filePath);
+
+  // cmpMeta.eventsMeta[0].eventType.typeReferences
+
+  importDataObj = Object.keys(cmpMeta.membersMeta)
+  .filter((memberName) => {
+    const member: d.MemberMeta = cmpMeta.membersMeta[memberName];
+
+    return [ MEMBER_TYPE.Prop, MEMBER_TYPE.PropMutable ].indexOf(member.memberType) !== -1 &&
+      member.attribType.typeReferences;
+  })
+  .reduce((obj, memberName) => {
+    const member: d.MemberMeta = cmpMeta.membersMeta[memberName];
+    return updateImportReferences(obj, member.attribType.typeReferences);
+  }, importDataObj);
+
+  cmpMeta.eventsMeta
+  .filter((meta: d.EventMeta) => {
+    return meta.eventType && meta.eventType.typeReferences;
+  })
+  .reduce((obj, meta) => {
+    return updateImportReferences(obj, meta.eventType.typeReferences);
+  }, importDataObj);
+
+  return importDataObj;
+}
+
+function updateImportReferenceFactory(config: d.Config, allTypes: { [key: string]: number }, filePath: string) {
   function getIncrememntTypeName(name: string): string {
     if (allTypes[name] == null) {
       allTypes[name] = 1;
@@ -174,17 +204,8 @@ function updateReferenceTypeImports(config: d.Config, importDataObj: ImportData,
     return `${name}${allTypes[name]}`;
   }
 
-  return Object.keys(cmpMeta.membersMeta)
-  .filter((memberName) => {
-    const member: d.MemberMeta = cmpMeta.membersMeta[memberName];
-
-    return METADATA_MEMBERS_TYPED.indexOf(member.memberType) !== -1 &&
-      member.attribType.typeReferences;
-  })
-  .reduce((obj, memberName) => {
-    const member: d.MemberMeta = cmpMeta.membersMeta[memberName];
-    Object.keys(member.attribType.typeReferences).forEach(typeName => {
-      const type = member.attribType.typeReferences[typeName];
+  return (obj: ImportData, typeReferences: { [key: string]: AttributeTypeReference }) => {
+    Object.entries(typeReferences).forEach(([typeName, type]) => {
       let importFileLocation: string;
 
       // If global then there is no import statement needed
@@ -223,7 +244,7 @@ function updateReferenceTypeImports(config: d.Config, importDataObj: ImportData,
     });
 
     return obj;
-  }, importDataObj);
+  };
 }
 
 
@@ -238,7 +259,10 @@ export function createTypesAsString(cmpMeta: d.ComponentMeta, importPath: string
   const tagNameAsPascal = dashToPascalCase(cmpMeta.tagNameMeta);
   const interfaceName = `HTML${tagNameAsPascal}Element`;
   const jsxInterfaceName = `${tagNameAsPascal}Attributes`;
-  const interfaceOptions = membersToInterfaceOptions(cmpMeta.membersMeta);
+  const propAttributes = membersToPropAttributes(cmpMeta.membersMeta);
+  const methodAttributes = membersToMethodAttributes(cmpMeta.membersMeta);
+  methodAttributes;
+  const eventAttributes = membersToEventAttributes(cmpMeta.eventsMeta);
 
   return `
 import {
@@ -265,39 +289,95 @@ declare global {
   }
   namespace JSXElements {
     export interface ${jsxInterfaceName} extends HTMLAttributes {
-      ${Object.keys(interfaceOptions)
-        .sort(sortInterfaceMembers)
-        .map((key: string) => `${key}?: ${interfaceOptions[key]};`).join('\n      ')}
+      ${attributesToMultiLineString(propAttributes)}
+      ${attributesToMultiLineString(eventAttributes)}
     }
   }
 }
 `;
 }
 
-
-function sortInterfaceMembers(a: string, b: string) {
-  const aLower = a.toLowerCase();
-  const bLower = b.toLowerCase();
-
-  if (aLower < bLower) return -1;
-  if (aLower > bLower) return 1;
-  if (a < b) return -1;
-  if (a > b) return 1;
-  return 0;
+interface TypeInfo {
+  [key: string]: {
+    type: string;
+    jsdoc?: string;
+  };
 }
 
+function attributesToMultiLineString(attributes: TypeInfo, optional = true) {
 
-function membersToInterfaceOptions(membersMeta: d.MembersMeta): { [key: string]: string } {
+  return Object.keys(attributes)
+    .sort()
+    .reduce((fullList, key) => {
+      if (attributes[key].jsdoc) {
+        fullList.push(`/**`);
+        fullList.push(` * ${attributes[key].jsdoc.replace(/\r?\n|\r/g, ' ')}`);
+        fullList.push(` */`);
+      }
+      fullList.push(`${key}${optional ? '?' : '' }: ${attributes[key].type};`);
+      return fullList;
+    }, <string[]>[])
+    .join('\n      ');
+}
+
+function membersToPropAttributes(membersMeta: d.MembersMeta): TypeInfo {
   const interfaceData = Object.keys(membersMeta)
     .filter((memberName) => {
-      return METADATA_MEMBERS_TYPED.indexOf(membersMeta[memberName].memberType) !== -1;
+      return [ MEMBER_TYPE.Prop, MEMBER_TYPE.PropMutable ].indexOf(membersMeta[memberName].memberType) !== -1;
     })
     .reduce((obj, memberName) => {
       const member: d.MemberMeta = membersMeta[memberName];
-      obj[memberName] = member.attribType.text;
+      obj[memberName] = {
+        type: member.attribType.text,
+      };
+
+      if (member.jsdoc) {
+        obj[memberName].jsdoc = member.jsdoc.documentation;
+      }
 
       return obj;
-    }, <{ [key: string]: string }>{});
+    }, <TypeInfo>{});
+
+  return interfaceData;
+}
+
+function membersToMethodAttributes(membersMeta: d.MembersMeta): TypeInfo {
+  const interfaceData = Object.keys(membersMeta)
+    .filter((memberName) => {
+      return [ MEMBER_TYPE.Method ].indexOf(membersMeta[memberName].memberType) !== -1;
+    })
+    .reduce((obj, memberName) => {
+      const member: d.MemberMeta = membersMeta[memberName];
+      obj[memberName] = {
+        type: `() => void`, // TODO this is not good enough
+      };
+
+      if (member.jsdoc) {
+        obj[memberName].jsdoc = member.jsdoc.documentation;
+      }
+
+      return obj;
+    }, <TypeInfo>{});
+
+  return interfaceData;
+}
+
+
+function membersToEventAttributes(eventMetaList: d.EventMeta[]): TypeInfo {
+  const interfaceData = eventMetaList
+    .reduce((obj, eventMetaObj) => {
+      const memberName = `on${captializeFirstLetter(eventMetaObj.eventName)}`;
+      const eventType = (eventMetaObj.eventType) ? `CustomEvent<${eventMetaObj.eventType.text}` : `CustomEvent`;
+      obj[memberName] = {
+        type: `(event: ${eventType}) => void`, // TODO this is not good enough
+      };
+
+      if (eventMetaObj.jsdoc) {
+        obj[memberName].jsdoc = eventMetaObj.jsdoc.documentation;
+      }
+
+      return obj;
+    }, <TypeInfo>{});
 
   return interfaceData;
 }
@@ -343,9 +423,6 @@ async function getCollectionTypesImport(config: d.Config, compilerCtx: d.Compile
   return typeImport;
 }
 
-
-
-const METADATA_MEMBERS_TYPED = [ MEMBER_TYPE.Prop, MEMBER_TYPE.PropMutable ];
 
 export interface ImportData {
   [key: string]: MemberNameData[];

--- a/src/compiler/transpile/create-component-types.ts
+++ b/src/compiler/transpile/create-component-types.ts
@@ -367,7 +367,7 @@ function membersToEventAttributes(eventMetaList: d.EventMeta[]): TypeInfo {
   const interfaceData = eventMetaList
     .reduce((obj, eventMetaObj) => {
       const memberName = `on${captializeFirstLetter(eventMetaObj.eventName)}`;
-      const eventType = (eventMetaObj.eventType) ? `CustomEvent<${eventMetaObj.eventType.text}` : `CustomEvent`;
+      const eventType = (eventMetaObj.eventType) ? `CustomEvent<${eventMetaObj.eventType.text}>` : `CustomEvent`;
       obj[memberName] = {
         type: `(event: ${eventType}) => void`, // TODO this is not good enough
       };

--- a/src/compiler/transpile/datacollection/index.ts
+++ b/src/compiler/transpile/datacollection/index.ts
@@ -66,7 +66,7 @@ export function visitClass(config: Config, checker: ts.TypeChecker, classNode: t
       ...getStateDecoratorMeta(checker, classNode),
       ...getPropDecoratorMeta(checker, classNode, sourceFile, diagnostics)
     },
-    eventsMeta: getEventDecoratorMeta(checker, classNode),
+    eventsMeta: getEventDecoratorMeta(checker, classNode, sourceFile),
     listenersMeta: getListenDecoratorMeta(checker, classNode)
   };
 

--- a/src/compiler/transpile/datacollection/prop-decorator.ts
+++ b/src/compiler/transpile/datacollection/prop-decorator.ts
@@ -1,6 +1,6 @@
-import { AttributeTypeInfo, AttributeTypeReference, Diagnostic, MemberMeta, MembersMeta, PropOptions } from '../../../declarations';
+import { AttributeTypeInfo, Diagnostic, MemberMeta, MembersMeta, PropOptions } from '../../../declarations';
 import { catchError } from '../../util';
-import { isDecoratorNamed, serializeSymbol } from './utils';
+import { getAttributeTypeInfo, isDecoratorNamed, serializeSymbol } from './utils';
 import { toDashCase } from '../../../util/helpers';
 import { MEMBER_TYPE, PROP_TYPE } from '../../../util/constants';
 import * as ts from 'typescript';
@@ -89,104 +89,6 @@ export function getPropDecoratorMeta(checker: ts.TypeChecker, classNode: ts.Clas
     }, {} as MembersMeta);
 }
 
-
-
-
-function getAttributeTypeInfo(type: ts.TypeNode, sourceFile: ts.SourceFile): AttributeTypeInfo {
-  const typeInfo: AttributeTypeInfo = {
-    text: type.getFullText().trim()
-  };
-  const typeReferences = getAllTypeReferences(type)
-    .reduce((allReferences, rt)  => {
-      allReferences[rt] = getTypeReferenceLocation(rt, sourceFile);
-      return allReferences;
-    }, {} as { [key: string]: AttributeTypeReference});
-
-  if (Object.keys(typeReferences).length > 0) {
-    typeInfo.typeReferences = typeReferences;
-  }
-  return typeInfo;
-}
-
-function getAllTypeReferences(node: ts.TypeNode): string[] {
-  const referencedTypes: string[] = [];
-
-  function visit(node: ts.Node): ts.VisitResult<ts.Node> {
-    switch (node.kind) {
-    case ts.SyntaxKind.TypeReference:
-      referencedTypes.push((<ts.TypeReferenceNode>node).typeName.getText().trim());
-      if ((<ts.TypeReferenceNode>node).typeArguments) {
-        (<ts.TypeReferenceNode>node).typeArguments
-          .filter(ta => ts.isTypeReferenceNode(ta))
-          .forEach(tr => referencedTypes.push((<ts.TypeReferenceNode>tr).typeName.getText().trim()));
-      }
-    /* tslint:disable */
-    default:
-      return ts.forEachChild(node, (node) => {
-        return visit(node);
-      });
-    }
-    /* tslint:enable */
-  }
-
-  visit(node);
-
-  return referencedTypes;
-}
-
-function getTypeReferenceLocation(typeName: string, sourceFile: ts.SourceFile): AttributeTypeReference {
-
-  const sourceFileObj = sourceFile.getSourceFile();
-
-  // Loop through all top level imports to find any reference to the type for 'import' reference location
-  const importTypeDeclaration = sourceFileObj.statements.find(st => {
-    const statement = ts.isImportDeclaration(st) &&
-      ts.isImportClause(st.importClause) &&
-      st.importClause.namedBindings &&  ts.isNamedImports(st.importClause.namedBindings) &&
-      Array.isArray(st.importClause.namedBindings.elements) &&
-      st.importClause.namedBindings.elements.find(nbe => nbe.name.getText() === typeName);
-    if (!statement) {
-      return false;
-    }
-    return true;
-  });
-
-  if (importTypeDeclaration) {
-    const localImportPath = (<ts.StringLiteral>(<ts.ImportDeclaration>importTypeDeclaration).moduleSpecifier).text;
-    return {
-      referenceLocation: 'import',
-      importReferenceLocation: localImportPath
-    };
-  }
-
-  // Loop through all top level exports to find if any reference to the type for 'local' reference location
-  const isExported = sourceFileObj.statements.some(st => {
-    // Is the interface defined in the file and exported
-    const isInterfaceDeclarationExported = ((ts.isInterfaceDeclaration(st) &&
-      (<ts.Identifier>st.name).getText() === typeName) &&
-      Array.isArray(st.modifiers) &&
-      st.modifiers.some(mod => mod.kind === ts.SyntaxKind.ExportKeyword));
-
-    // Is the interface exported through a named export
-    const isTypeInExportDeclaration = ts.isExportDeclaration(st) &&
-      ts.isNamedExports(st.exportClause) &&
-      st.exportClause.elements.some(nee => nee.name.getText() === typeName);
-
-    return isInterfaceDeclarationExported || isTypeInExportDeclaration;
-  });
-
-  if (isExported) {
-    return {
-      referenceLocation: 'local'
-    };
-  }
-
-
-  // This is most likely a global type, if it is a local that is not exported then typescript will inform the dev
-  return {
-    referenceLocation: 'global',
-  };
-}
 
 function inferPropType(expression: ts.Expression | undefined) {
   if (expression == null) {

--- a/src/compiler/transpile/datacollection/utils.ts
+++ b/src/compiler/transpile/datacollection/utils.ts
@@ -1,4 +1,4 @@
-import { JSDoc } from '../../../declarations';
+import { AttributeTypeInfo, AttributeTypeReference, JSDoc } from '../../../declarations';
 import * as ts from 'typescript';
 
 
@@ -53,4 +53,100 @@ export function isMethod(member: ts.ClassElement, methodName: string): boolean {
     return member.getFirstToken().getText() === methodName;
   }
   return false;
+}
+
+export function getAttributeTypeInfo(type: ts.TypeNode, sourceFile: ts.SourceFile): AttributeTypeInfo {
+  const typeInfo: AttributeTypeInfo = {
+    text: type.getFullText().trim()
+  };
+  const typeReferences = getAllTypeReferences(type)
+    .reduce((allReferences, rt)  => {
+      allReferences[rt] = getTypeReferenceLocation(rt, sourceFile);
+      return allReferences;
+    }, {} as { [key: string]: AttributeTypeReference});
+
+  if (Object.keys(typeReferences).length > 0) {
+    typeInfo.typeReferences = typeReferences;
+  }
+  return typeInfo;
+}
+
+function getAllTypeReferences(node: ts.TypeNode): string[] {
+  const referencedTypes: string[] = [];
+
+  function visit(node: ts.Node): ts.VisitResult<ts.Node> {
+    switch (node.kind) {
+    case ts.SyntaxKind.TypeReference:
+      referencedTypes.push((<ts.TypeReferenceNode>node).typeName.getText().trim());
+      if ((<ts.TypeReferenceNode>node).typeArguments) {
+        (<ts.TypeReferenceNode>node).typeArguments
+          .filter(ta => ts.isTypeReferenceNode(ta))
+          .forEach(tr => referencedTypes.push((<ts.TypeReferenceNode>tr).typeName.getText().trim()));
+      }
+    /* tslint:disable */
+    default:
+      return ts.forEachChild(node, (node) => {
+        return visit(node);
+      });
+    }
+    /* tslint:enable */
+  }
+
+  visit(node);
+
+  return referencedTypes;
+}
+
+function getTypeReferenceLocation(typeName: string, sourceFile: ts.SourceFile): AttributeTypeReference {
+
+  const sourceFileObj = sourceFile.getSourceFile();
+
+  // Loop through all top level imports to find any reference to the type for 'import' reference location
+  const importTypeDeclaration = sourceFileObj.statements.find(st => {
+    const statement = ts.isImportDeclaration(st) &&
+      ts.isImportClause(st.importClause) &&
+      st.importClause.namedBindings &&  ts.isNamedImports(st.importClause.namedBindings) &&
+      Array.isArray(st.importClause.namedBindings.elements) &&
+      st.importClause.namedBindings.elements.find(nbe => nbe.name.getText() === typeName);
+    if (!statement) {
+      return false;
+    }
+    return true;
+  });
+
+  if (importTypeDeclaration) {
+    const localImportPath = (<ts.StringLiteral>(<ts.ImportDeclaration>importTypeDeclaration).moduleSpecifier).text;
+    return {
+      referenceLocation: 'import',
+      importReferenceLocation: localImportPath
+    };
+  }
+
+  // Loop through all top level exports to find if any reference to the type for 'local' reference location
+  const isExported = sourceFileObj.statements.some(st => {
+    // Is the interface defined in the file and exported
+    const isInterfaceDeclarationExported = ((ts.isInterfaceDeclaration(st) &&
+      (<ts.Identifier>st.name).getText() === typeName) &&
+      Array.isArray(st.modifiers) &&
+      st.modifiers.some(mod => mod.kind === ts.SyntaxKind.ExportKeyword));
+
+    // Is the interface exported through a named export
+    const isTypeInExportDeclaration = ts.isExportDeclaration(st) &&
+      ts.isNamedExports(st.exportClause) &&
+      st.exportClause.elements.some(nee => nee.name.getText() === typeName);
+
+    return isInterfaceDeclarationExported || isTypeInExportDeclaration;
+  });
+
+  if (isExported) {
+    return {
+      referenceLocation: 'local'
+    };
+  }
+
+
+  // This is most likely a global type, if it is a local that is not exported then typescript will inform the dev
+  return {
+    referenceLocation: 'global',
+  };
 }

--- a/src/declarations/component.ts
+++ b/src/declarations/component.ts
@@ -151,6 +151,7 @@ export interface EventMeta {
   eventBubbles?: boolean;
   eventCancelable?: boolean;
   eventComposed?: boolean;
+  eventType?: AttributeTypeInfo;
   jsdoc?: JSDoc;
 }
 

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -18,3 +18,5 @@ export const dashToPascalCase = (str: string) => toLowerCase(str).split('-').map
 export const toTitleCase = (str: string) => str.charAt(0).toUpperCase() + str.substr(1);
 
 export const noop = (): any => { /* noop*/ };
+
+export const captializeFirstLetter = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);


### PR DESCRIPTION
This PR is to add types for eventHandlers into component.d.ts file.  This should prevent the need for use of the @Listen decorator in most cases.

If a component events an event then we should listen to it by attaching to the event name within JSX.  This means that I have created translations from 'IonChange' to 'onIonChange'.