### PR TITLE
fix: Avoid Object.entries (breaks Node 6)

### DIFF
--- a/src/compiler/transpile/create-component-types.ts
+++ b/src/compiler/transpile/create-component-types.ts
@@ -205,7 +205,9 @@ function updateImportReferenceFactory(config: d.Config, allTypes: { [key: string
   }
 
   return (obj: ImportData, typeReferences: { [key: string]: AttributeTypeReference }) => {
-    Object.entries(typeReferences).forEach(([typeName, type]) => {
+    Object.keys(typeReferences).map(typeName => {
+      return [typeName, typeReferences[typeName]] as [string, AttributeTypeReference];
+    }).forEach(([typeName, type]) => {
       let importFileLocation: string;
 
       // If global then there is no import statement needed


### PR DESCRIPTION
I'm on Windows and a lot of tests still fail, but a quick `npm link` against a project worked, so caveat emptor :)