### PR TITLE
test(build.spec) remove drive letter added by sys.path.resolve

### DIFF
--- a/src/compiler/bundle/rollup-plugins/in-memory-fs-read.ts
+++ b/src/compiler/bundle/rollup-plugins/in-memory-fs-read.ts
@@ -16,6 +16,13 @@ export default function inMemoryFsRead(config: Config, compilerCtx: CompilerCtx)
         if (importee.indexOf('.js') === -1) {
           importee += '.js';
         }
+
+        // Remove drive letter added by sys.path.resolve
+        // Windows: importee = 'C:/__tmp__in__memory__/cmp-a.js'
+        const colonIndex = importee.indexOf(':');
+        if (colonIndex === 1) {
+          importee = importee.substr(2);
+        }
       }
 
       // it's possible the importee is a file pointing directly to the source ts file


### PR DESCRIPTION
#646 build.spec.ts fails on Windows
