### PR TITLE
fix(styles): escape unicode chars & octal literals in css

### DIFF
--- a/src/compiler/style/style.ts
+++ b/src/compiler/style/style.ts
@@ -144,13 +144,10 @@ function hasPluginInstalled(config: d.Config, filePath: string) {
 export async function setStyleText(config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx, cmpMeta: d.ComponentMeta, styleMeta: d.StyleMeta, styles: string[]) {
   // join all the component's styles for this mode together into one line
 
-  // debugging css unicode escape issues read by js is probably the funnest thing ever
-  styleMeta.compiledStyleText = styles.map(style => {
-    return style.replace('\\', '\\\\');
-  }).join('\n\n');
-
   if (config.minifyCss) {
-    styleMeta.compiledStyleText = await minifyStyle(config, compilerCtx, buildCtx.diagnostics, styleMeta.compiledStyleText);
+    styleMeta.compiledStyleText = await minifyStyle(config, compilerCtx, buildCtx.diagnostics, styles.join(''));
+  } else {
+    styleMeta.compiledStyleText = styles.join('\n\n').trim();
   }
 
   if (requiresScopedStyles(cmpMeta.encapsulation)) {
@@ -168,7 +165,7 @@ export async function setStyleText(config: d.Config, compilerCtx: d.CompilerCtx,
 
 export function escapeCssForJs(style: string) {
   return style
-    .replace(/\\[0-7]/g, (v) => '\\' + v)
+    .replace(/\\[\D0-7]/g, (v) => '\\' + v)
     .replace(/\r\n|\r|\n/g, `\\n`)
     .replace(/\"/g, `\\"`)
     .replace(/\@/g, `\\@`);

--- a/src/compiler/style/test/style.spec.ts
+++ b/src/compiler/style/test/style.spec.ts
@@ -27,7 +27,22 @@ describe('component-styles', () => {
       expect(r.diagnostics).toEqual([]);
 
       const content = await c.fs.readFile('/www/build/app/cmp-a.js');
-      expect(content).toContain('\F113');
+      expect(content).toContain('\\\\F113');
+    });
+
+    it('should escape octal literals', async () => {
+      c.config.bundles = [ { components: ['cmp-a'] } ];
+      await c.fs.writeFiles({
+        '/src/cmp-a.css': `.myclass:before { content: "\\2014 \\00A0"; }`,
+        '/src/cmp-a.tsx': `@Component({ tag: 'cmp-a', styleUrl: 'cmp-a.css' }) export class CmpA {}`,
+      });
+      await c.fs.commit();
+
+      const r = await c.build();
+      expect(r.diagnostics).toEqual([]);
+
+      const content = await c.fs.readFile('/www/build/app/cmp-a.js');
+      expect(content).toContain('\\\\2014 \\\\00A0');
     });
 
     it('should build one component w/ inline style', async () => {
@@ -138,6 +153,11 @@ describe('component-styles', () => {
     /* this is all weird cuz we're testing by writing css in JS
      then testing that CSS works in JS so there's more escaping
      that you'd think, but it's more of a unit test thing */
+
+    it(`should escape unicode characters`, () => {
+      const escaped = escapeCssForJs(`p { content: '\\F113' }`);
+      expect(escaped).toBe(`p { content: '\\\\F113' }`);
+    });
 
     it(`should octal escape sequences 0 to 7 (not 8 or 9)`, () => {
       let escaped = escapeCssForJs(`p { content: '\\0660' }`);


### PR DESCRIPTION
Fixes #656

Seems to be caused by [the replace statement here](https://github.com/ionic-team/stencil/blob/b32d9da2acfa68ed38ad0c2af4f832193ee8771c/src/compiler/style/style.ts#L149) as it escapes the first escape character it encounters. Which then breaks the escapes applied by the call to `escapeCssForJs` as it looks for an octal literal.

This reverts the change introduced for #545 , and instead fixes it by expanding the RegEx for identifying octal literals in the `escapeCssForJs` function to also identify non-digit characters.