### PR TITLE
test(windows): add drive letter to distFilePath

### DIFF
--- a/src/compiler/transpile/compiler-host.ts
+++ b/src/compiler/transpile/compiler-host.ts
@@ -78,7 +78,10 @@ function writeFileInMemory(config: Config, ctx: CompilerCtx, sourceFile: ts.Sour
     tsFilePath = normalizePath(config.sys.path.join(config.rootDir, tsFilePath));
   }
 
-  distFilePath = normalizePath(distFilePath);
+  // Windows: config.sys.path.resolve() required for tests to pass.
+  // jsFilePath needs drive letter.
+  const resolvedDistFilePath = config.sys.path.resolve(distFilePath);
+  distFilePath = normalizePath(resolvedDistFilePath);
 
   // get or create the ctx module file object
   if (!ctx.moduleFiles[tsFilePath]) {


### PR DESCRIPTION
#646 build.spec.ts fails on Windows