### PR TITLE
Correct link to the Stencil Worldwide Slack

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please see our [Contributor Code of Conduct](https://github.com/ionic-team/stenc
 
 ## Creating an Issue
 
-* If you have a question about using Stencil, please ask in the [Stencil Worldwide Slack](https://join.slack.com/t/stencil-worldwide/shared_invite/enQtMjQ2MzkyMTY0MTk0LTQ4ODgzYjFjNjdkNDY3YWVhMmNlMTljMWQxNTM3Yjg0ZTIyZTM1MmU2YWE5YzNjNzE1MmQ3ZTk2NjQ1YzM5ZDM group.
+* If you have a question about using Stencil, please ask in the [Stencil Worldwide Slack](https://stencil-worldwide.herokuapp.com/) group.
 
 * It is required that you clearly describe the steps necessary to reproduce the issue you are running into. Although we would love to help our users as much as possible, diagnosing issues without clear reproduction steps is extremely time-consuming and simply not sustainable.
 


### PR DESCRIPTION
Clicking the current link for Stencil Worldwide Slack in the [CONTRIBUTING.MD file](https://github.com/ionic-team/stencil/blob/master/.github/CONTRIBUTING.md) results in a web page that says "This invite link is no longer active."  

NOTE: This only happens when you are NOT logged into the group already.  If you ARE logged into the group, the current link works. 