### PR TITLE
WIP fix(build): always regenerate buildConditionals

### DIFF
--- a/src/compiler/app/build-conditionals.ts
+++ b/src/compiler/app/build-conditionals.ts
@@ -9,7 +9,8 @@ export async function setBuildConditionals(config: Config, compilerCtx: Compiler
     // cool we can use the last build conditionals
     // because it's a rebuild, and was probably only a css or html change
     // if it was a typescript change we need to do a full rebuild again
-    return existingCoreBuild;
+    console.log('would return existing core build');
+    // return existingCoreBuild;
   }
 
   // figure out which sections of the core code this build doesn't even need


### PR DESCRIPTION
**WIP, don't merge as-is!**

Here's how to reproduce the bug I'm seeing:

* Clone the stencil-component-starter, `npm install`
* Change `npm run dev` to create es5 builds: `    "dev": "sd concurrent \"stencil build --dev --es5 --watch\" \"stencil-dev-server\" ",`
* Run `npm run dev`, let it build, works fine
* Modify and save `index.html`
* In Chrome, you'll see a console error:

```
Uncaught TypeError: Cannot set property 'ES6Promise' of undefined
    at mycomponent.core.pf.js:49
    at mycomponent.core.pf.js:49
```

My env is Win10, Node 6.12.0. I can't get it to reproduce on OS X, Node 6.

In this case, Chrome is trying to load the ES5/polyfilled components. I think this is caused by a race condition. Here's what appears to be happening:

* On Windows, when you generate ES5 builds, it gets generated at the same time as ESM builds: https://github.com/ionic-team/stencil/blob/master/src/compiler/app/generate-app-files.ts#L37-L40
* I see the `lastBuildConditionals` getting set twice here: https://github.com/ionic-team/stencil/blob/master/src/compiler/app/build-conditionals.ts#L38. Usually for ESM, then for ES5.
* When the ES5 build gets cached, its `es5` and `polyfills` props are set to `true`, and as such the `coreEsm` build gets built with `core.pf.js` and what not

So the race condition is:

1. Both ES5 and ESM builds check if there's a cached `buildConditionals`, which returns false
1. They both begin to rebuild the build conditionals
1. ESM conditionals gets set, immediately followed by ES5
1. ES5 conditionals get "dirty" with `es5=true`
1. Next build, ES5 conditionals get used from the cache, and everything gets built as ES5

This PR "fixes" it by never reusing the last build conditionals. Which is clearly overkill! But, I'm not sure how to ensure an "atomic" interaction with the cached build conditionals, where only the ESM version of the build gets generated. So I wanted to see what you all thought.