### PR TITLE
fix #700 npm test broken on windows - cannot find module ... '\' disappeared

### DIFF
--- a/scripts/packages/testing/jest.preprocessor.js
+++ b/scripts/packages/testing/jest.preprocessor.js
@@ -11,7 +11,7 @@ try {
 }
 
 var injectTestingScript = [
-  'var StencilTesting = require("' + stencilTestingPath + '");',
+  'var StencilTesting = require("' + stencilTestingPath.replace(/\\/g,"/") + '");',
   'var h = StencilTesting.h;',
   'var resourcesUrl = "build/"',
   'var Context = {};'


### PR DESCRIPTION
I feel the problem comes from the \ / nightware.

Here is my proposal to fix it. It's works on Windows.

I do not have unix like platform. Please verify it ;-)

Sincerely,

Richard