### PR TITLE
chore(testing): use normalizePath for windows friendly path

### DIFF
--- a/scripts/packages/testing/jest.preprocessor.js
+++ b/scripts/packages/testing/jest.preprocessor.js
@@ -12,30 +12,11 @@ function normalizePath(str) {
   var NON_ASCII_REGEX = /[^\x00-\x80]+/;
   var SLASH_REGEX = /\\/g;
 
-  if (typeof str !== 'string') {
-    throw new Error(`invalid path to normalize`);
-  }
-  str = str.trim();
-
   if (EXTENDED_PATH_REGEX.test(str) || NON_ASCII_REGEX.test(str)) {
     return str;
   }
 
   str = str.replace(SLASH_REGEX, '/');
-
-  // always remove the trailing /
-  // this makes our file cache look ups consistent
-  if (str.charAt(str.length - 1) === '/') {
-    const colonIndex = str.indexOf(':');
-    if (colonIndex > -1) {
-      if (colonIndex < str.length - 2) {
-        str = str.substring(0, str.length - 1);
-      }
-
-    } else if (str.length > 1) {
-      str = str.substring(0, str.length - 1);
-    }
-  }
 
   return str;
 }


### PR DESCRIPTION
Brings our `normalizePath` function that we use across stencil into the jest preprocessor file. This function is then used to ensure that the path `require` uses is windows friendly. Only changes I have made to the function are to use `var` instead of `const` to match our use of ES5 in this file.