### PR TITLE
Fix the <dialog> TypeScript interface

### DIFF
--- a/src/declarations/jsx.ts
+++ b/src/declarations/jsx.ts
@@ -40,7 +40,7 @@ declare global {
       del: JSXElements.DelHTMLAttributes;
       details: JSXElements.DetailsHTMLAttributes;
       dfn: JSXElements.HTMLAttributes;
-      dialog: JSXElements.HTMLAttributes;
+      dialog: JSXElements.DialogHTMLAttributes;
       div: JSXElements.HTMLAttributes;
       dl: JSXElements.HTMLAttributes;
       dt: JSXElements.HTMLAttributes;
@@ -225,6 +225,11 @@ declare global {
       cite?: string;
       dateTime?: string;
       datetime?: string;
+    }
+
+    export interface DialogHTMLAttributes extends HTMLAttributes {
+      open?: boolean;
+      returnValue?: string;
     }
 
     export interface EmbedHTMLAttributes extends HTMLAttributes {


### PR DESCRIPTION
I used the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement) as a reference for the interface to define.

Closes #711