### PR TITLE
Correctly identify collection modules with exports.

### DIFF
--- a/src/compiler/bundle/rollup-plugins/resolve-collections.ts
+++ b/src/compiler/bundle/rollup-plugins/resolve-collections.ts
@@ -15,9 +15,9 @@ export default function resolveCollections(compilerCtx: CompilerCtx) {
     name: 'resolveCollections',
 
     resolveId(importee) {
-      const isStencilCollection = compilerCtx.collections.some(c => c.collectionName === importee);
+      const stencilCollection = compilerCtx.collections.find(c => c.collectionName === importee);
 
-      if (isStencilCollection) {
+      if (stencilCollection && !stencilCollection.hasExports) {
         return COLLECTION_ID;
       }
 

--- a/src/compiler/collections/parse-collection-module.ts
+++ b/src/compiler/collections/parse-collection-module.ts
@@ -20,7 +20,7 @@ export function parseCollectionModule(config: Config, compilerCtx: CompilerCtx, 
   // figure out the full path to the collection collection file
   const collectionFilePath = pathJoin(config, collectionPackageRootDir, pkgData.collection);
 
-  config.logger.debug(`load colleciton: ${collectionFilePath}`);
+  config.logger.debug(`load collection: ${collectionFilePath}`);
 
   // we haven't cached the collection yet, let's read this file
   // sync on purpose :(
@@ -37,7 +37,7 @@ export function parseCollectionModule(config: Config, compilerCtx: CompilerCtx, 
     collectionJsonStr
   );
 
-  if (pkgData.module || pkgData['jsnext:main']) {
+  if (pkgData.module && pkgData.module !== pkgData.main) {
     collection.hasExports = true;
   }
 

--- a/src/compiler/collections/parse-collection-module.ts
+++ b/src/compiler/collections/parse-collection-module.ts
@@ -37,6 +37,10 @@ export function parseCollectionModule(config: Config, compilerCtx: CompilerCtx, 
     collectionJsonStr
   );
 
+  if (pkgData.module || pkgData['jsnext:main']) {
+    collection.hasExports = true;
+  }
+
   // remember the source of this collection node_module
   collection.moduleDir = collectionPackageRootDir;
 

--- a/src/declarations/collection.ts
+++ b/src/declarations/collection.ts
@@ -8,6 +8,7 @@ export interface Collection {
   global?: ModuleFile;
   compiler?: CollectionCompiler;
   isInitialized?: boolean;
+  hasExports?: boolean;
   dependencies?: string[];
   bundles?: {
     components: string[];

--- a/src/declarations/system.ts
+++ b/src/declarations/system.ts
@@ -124,6 +124,10 @@ export interface PackageJsonData {
   name?: string;
   version?: string;
   main?: string;
+  browser?: string;
+  module?: string;
+  'jsnext:main'?: string;
+  unpkg?: string;
   collection?: string;
   types?: string;
   files?: string[];


### PR DESCRIPTION
ensure that all modules are solved correctly if a module path is provided in package.json.