### PR TITLE
Add test to demonstrate slot rendering bug in ES5 browsers

### DIFF
--- a/test/karma/package.json
+++ b/test/karma/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "dev": "sd concurrent \"../../bin/stencil build --dev --watch\" \"stencil-dev-server\" ",
+    "build.stencil": "node ../../bin/stencil build --dev --watch",
+    "dev": "sd concurrent \"npm run build.stencil\" \"stencil-dev-server\" ",
     "karma": " karma start karma.config.js",
     "karma.prod": "npm run tsc && ../../bin/stencil build && karma start karma.config.js",
     "tsc": "node ../../node_modules/.bin/tsc -p tsconfig.json"

--- a/test/karma/src/components.d.ts
+++ b/test/karma/src/components.d.ts
@@ -299,6 +299,39 @@ declare global {
 declare global {
 
   namespace StencilComponents {
+    interface SlotArray {
+
+    }
+  }
+
+  interface HTMLSlotArrayElement extends StencilComponents.SlotArray, HTMLStencilElement {}
+
+  var HTMLSlotArrayElement: {
+    prototype: HTMLSlotArrayElement;
+    new (): HTMLSlotArrayElement;
+  };
+  interface HTMLElementTagNameMap {
+    'slot-array': HTMLSlotArrayElement;
+  }
+  interface ElementTagNameMap {
+    'slot-array': HTMLSlotArrayElement;
+  }
+  namespace JSX {
+    interface IntrinsicElements {
+      'slot-array': JSXElements.SlotArrayAttributes;
+    }
+  }
+  namespace JSXElements {
+    export interface SlotArrayAttributes extends HTMLAttributes {
+
+    }
+  }
+}
+
+
+declare global {
+
+  namespace StencilComponents {
     interface SlotBasicRoot {
 
     }

--- a/test/karma/src/slot-array/cmp.tsx
+++ b/test/karma/src/slot-array/cmp.tsx
@@ -1,0 +1,16 @@
+import { Component } from '../../../../dist/index';
+
+@Component({
+  tag: 'slot-array',
+  shadow: true
+})
+export class SvgAttr {
+
+  render() {
+    return [
+      <span>Content should be on top</span>,
+      <slot />
+    ]
+  }
+
+}

--- a/test/karma/src/slot-array/index.html
+++ b/test/karma/src/slot-array/index.html
@@ -1,0 +1,3 @@
+<script src="/build/app.js"></script>
+
+<slot-array><p>Slotted content should be on bottom</p></slot-array>

--- a/test/karma/src/slot-array/karma.spec.ts
+++ b/test/karma/src/slot-array/karma.spec.ts
@@ -1,0 +1,20 @@
+import { setupDomTests } from '../util';
+
+describe('slot array', () => {
+  const { setupDom, tearDownDom, renderTest } = setupDomTests(document);
+
+  beforeEach(setupDom);
+  afterEach(tearDownDom);
+
+  it('renders slotted content in the right position for polyfilled elements', async function() {
+    if (!('attachShadow' in HTMLElement.prototype)) {
+      const component = await renderTest('/slot-array/index.html');
+      const children = component.childNodes;
+      const firstNode = children.item(1);
+      expect(firstNode.nodeName).toEqual('SPAN');
+
+      const secondNode = children.item(2);
+      expect(secondNode.nodeName).toEqual('P');
+    }
+  });
+});


### PR DESCRIPTION
Two things in this PR:

1. Karma testing is (mostly) working on Windows. I'm still running into problems firing up ChromeHeadless but I can manually launch the browser.
2. Add a test that currently fails in ES5 browsers (tested with IE11 & Firefox). In Chrome, the `<slot />` content is rendered in the proper location, but in polyfill-land the order is reversed. This seems to only affect components with `shadow: true`, where the `render()` method returns an array, and where the last element in the array is the `<slot />`.

Cool setup for tests, btw!