### PR TITLE
Expose Rollup Node Resolution Config

### DIFF
--- a/src/compiler/bundle/rollup-bundle.ts
+++ b/src/compiler/bundle/rollup-bundle.ts
@@ -1,4 +1,4 @@
-import { BuildCtx, CompilerCtx, Config, EntryModule, JSModuleList } from '../../declarations';
+import { BuildCtx, CompilerCtx, Config, EntryModule, JSModuleList, NodeResolveConfig } from '../../declarations';
 import bundleEntryFile from './rollup-plugins/bundle-entry-file';
 import bundleJson from './rollup-plugins/json';
 import { createOnWarnFn, loadRollupDiagnostics } from '../../util/logger/logger-rollup';
@@ -23,16 +23,19 @@ export async function createBundle(config: Config, compilerCtx: CompilerCtx, bui
     ...config.commonjs
   };
 
+  const nodeResolveConfig: NodeResolveConfig = {
+    jsnext: true,
+    main: true,
+    ...config.nodeResolve
+  };
+
   const rollupConfig: RollupDirOptions = {
     input: entryModules.map(b => b.entryKey),
     experimentalCodeSplitting: true,
     preserveSymlinks: false,
     plugins: [
       resolveCollections(compilerCtx),
-      config.sys.rollup.plugins.nodeResolve({
-        jsnext: true,
-        main: true
-      }),
+      config.sys.rollup.plugins.nodeResolve(nodeResolveConfig),
       config.sys.rollup.plugins.commonjs(commonjsConfig),
       bundleJson(config),
       globals(),

--- a/src/declarations/config.ts
+++ b/src/declarations/config.ts
@@ -9,6 +9,7 @@ export interface Config {
   buildLogFilePath?: string;
   bundles?: ConfigBundle[];
   commonjs?: BundlingConfig;
+  nodeResolve?: NodeResolveConfig;
   configPath?: string;
   copy?: CopyTasks;
   devInspector?: boolean;
@@ -53,6 +54,21 @@ export interface Config {
 export interface BundlingConfig {
   namedExports?: {
     [key: string]: string[];
+  };
+}
+
+export interface NodeResolveConfig {
+  module?: boolean;
+  jsnext?: boolean;
+  main?: boolean;
+  browser?: boolean;
+  extensions?: string[];
+  preferBuiltins?: boolean;
+  jail?: string;
+  only?: Array<string | RegExp>;
+  modulesOnly?: boolean;
+  customResolveOptions?: {
+    [key: string]: string
   };
 }
 


### PR DESCRIPTION
This PR is to expose configuration for Rollup node-resolve plugin.  This should allow developers to change configuration if need be based on a per application basis. This is to fix issue #652.