### PR TITLE
[FEATURE] Keep gitkeep files when emptying a directory

### DIFF
--- a/src/compiler/build/empty-dir.ts
+++ b/src/compiler/build/empty-dir.ts
@@ -1,4 +1,5 @@
 import * as d from '../../declarations';
+import * as p from 'path';
 
 
 export async function emptyOutputTargetDirs(config: d.Config, compilerCtx: d.CompilerCtx) {
@@ -13,6 +14,17 @@ export async function emptyOutputTargetDirs(config: d.Config, compilerCtx: d.Com
   await Promise.all(outputTargets.map(async outputTarget => {
     config.logger.debug(`empty dir: ${outputTarget.dir}`);
 
+    // Check if there is a .gitkeep file
+    // We want to keep it so people don't have to readd manually
+    // to their projects each time.
+    const gitkeepPath = p.join(outputTarget.dir, '.gitkeep');
+    const existsGitkeep = await compilerCtx.fs.access(gitkeepPath);
+
     await compilerCtx.fs.emptyDir(outputTarget.dir);
+
+    // If there was a .gitkeep file, add it again.
+    if (existsGitkeep) {
+      await compilerCtx.fs.writeFile(gitkeepPath, '', { immediateWrite: true });
+    }
   }));
 }


### PR DESCRIPTION
Both `stencil-app-starter` and `stencil-component-starter` launch
concurrently `stencil build --dev --watch` and `stencil-dev-server`.
This was causing a problem where launching it twice was required to see
the built app.

The first approach was to add a `.gitkeep`, and though that requires some
more tweaking (see https://github.com/ionic-team/stencil-app-starter/pull/50), it is a good one. Sadly, compiler completely empties the output targets
thus removing the `.gitkeep` file.

As using this kind of file is common in the git community, this PRs checks
for the existence of such a file and recreates it after emptying the dir.