### PR TITLE
chore(sys): calculate relative path to 'sys-util.js'

### DIFF
--- a/src/sys/node/node-logger.ts
+++ b/src/sys/node/node-logger.ts
@@ -11,7 +11,10 @@ export class NodeLogger implements d.Logger {
   buildLogFilePath: string = null;
 
   constructor() {
-    const sysUtil = require(path.join(__dirname, './sys-util.js'));
+    const rootDir = path.join(__dirname, '../../..');
+    const distDir = path.join(rootDir, 'dist');
+    const sysUtil = require(path.join(distDir, 'sys/node/sys-util.js'));
+
     this.chalk = sysUtil.chalk;
   }
 


### PR DESCRIPTION
Calculate the path to the `sys-util.js` file just like it's done in the node-sys.ts. I needed this change to programatically invoke the stencil compiler from within a third party package.