### PR TITLE
fix(loader): set crossorigin to use-credentials

### DIFF
--- a/src/client/loader.ts
+++ b/src/client/loader.ts
@@ -110,7 +110,7 @@ export function init(
     // let's do this!
     x.src = resourcesUrl + appCore;
     x.setAttribute('type', 'module');
-    x.setAttribute('crossorigin', true);
+    x.setAttribute('crossorigin', 'use-credentials');
   }
 
   x.setAttribute('data-resources-url', resourcesUrl);


### PR DESCRIPTION
Updates the `crossorigin` attribute on the script tags generated from the loader.ts file to the value of 'use-credentials' instead of true. 
https://github.com/ionic-team/stencil/issues/786