### PR TITLE
test(slot): Add failing test demonstrating rendering/array bug with slots

### DIFF
--- a/test/karma/src/components.d.ts
+++ b/test/karma/src/components.d.ts
@@ -543,6 +543,39 @@ declare global {
 declare global {
 
   namespace StencilComponents {
+    interface SlotArrayBasic {
+
+    }
+  }
+
+  interface HTMLSlotArrayBasicElement extends StencilComponents.SlotArrayBasic, HTMLStencilElement {}
+
+  var HTMLSlotArrayBasicElement: {
+    prototype: HTMLSlotArrayBasicElement;
+    new (): HTMLSlotArrayBasicElement;
+  };
+  interface HTMLElementTagNameMap {
+    'slot-array-basic': HTMLSlotArrayBasicElement;
+  }
+  interface ElementTagNameMap {
+    'slot-array-basic': HTMLSlotArrayBasicElement;
+  }
+  namespace JSX {
+    interface IntrinsicElements {
+      'slot-array-basic': JSXElements.SlotArrayBasicAttributes;
+    }
+  }
+  namespace JSXElements {
+    export interface SlotArrayBasicAttributes extends HTMLAttributes {
+
+    }
+  }
+}
+
+
+declare global {
+
+  namespace StencilComponents {
     interface SlotArrayComplexRoot {
 
     }

--- a/test/karma/src/slot-array-basic/cmp.css
+++ b/test/karma/src/slot-array-basic/cmp.css
@@ -1,0 +1,7 @@
+.first {
+  background: yellow;
+}
+
+.last {
+  background: limegreen;
+}

--- a/test/karma/src/slot-array-basic/cmp.tsx
+++ b/test/karma/src/slot-array-basic/cmp.tsx
@@ -1,0 +1,16 @@
+import { Component } from '../../../../dist/index';
+
+@Component({
+  tag: 'slot-array-basic',
+  styleUrl: 'cmp.css',
+  shadow: true
+})
+export class SlotArrayBasic {
+  render() {
+    return [
+      <div class="first">first</div>,
+      <slot />,
+      <div class="last">last</div>
+    ];
+  }
+}

--- a/test/karma/src/slot-array-basic/index.html
+++ b/test/karma/src/slot-array-basic/index.html
@@ -1,0 +1,12 @@
+<meta charset="utf8">
+<script src="/build/app.js"></script>
+
+<style>
+  .middle {
+    background: papayawhip;
+  }
+</style>
+
+<slot-array-basic>
+  <p class="middle">Middle Slotted Content</p>
+</slot-array-basic>

--- a/test/karma/src/slot-array-basic/karma.spec.ts
+++ b/test/karma/src/slot-array-basic/karma.spec.ts
@@ -1,0 +1,23 @@
+import { setupDomTests } from '../util';
+
+describe('slot array basic', () => {
+  const { setupDom, tearDownDom } = setupDomTests(document);
+  let app: HTMLElement;
+
+  beforeEach(async () => {
+    app = await setupDom('/slot-array-basic/index.html');
+  });
+  afterEach(tearDownDom);
+
+  it('renders slotted content in the right position for polyfilled elements', async () => {
+    if (!('attachShadow' in HTMLElement.prototype)) {
+      const elm = app.querySelector('slot-array-basic');
+      expect(elm.children[0].classList).toContain('first');
+      expect(elm.children[0].textContent.trim()).toBe('first');
+
+      expect(elm.children[1].classList).toBe('middle');
+
+      expect(elm.children[2].classList).toContain('last');
+    }
+  });
+});


### PR DESCRIPTION
Here's a potentially relevant Slack conversation: https://stencil-worldwide.slack.com/archives/C789G3X1R/p1525872210000427

This adds a test which fails in Firefox and Edge. The page renders like this in Chrome:
![image](https://user-images.githubusercontent.com/389077/39842481-25d68044-53ac-11e8-8b2a-465e241caed1.png)

But renders out-of-order in ES5 browsers:
![image](https://user-images.githubusercontent.com/389077/39842507-32548c26-53ac-11e8-8347-21e1a390c921.png)

This seems *really* similar to the "slot-array-top" test, which oddly enough is still passing. So I'm not sure what's going on.

Let me know if you need any more details. Thanks!