### PR TITLE
Improve loader to allow using an explicit resources url setting

### DIFF
--- a/src/client/loader.ts
+++ b/src/client/loader.ts
@@ -31,6 +31,8 @@ export function init(
 
   createComponentOnReadyPrototype(win, HTMLElementPrototype, App);
 
+  resourcesUrl = resourcesUrl || App.resourcesUrl;
+ 
   // figure out the script element for this current script
   y = doc.querySelectorAll('script');
   for (x = y.length - 1; x >= 0; x--) {
@@ -43,7 +45,7 @@ export function init(
   // get the resource path attribute on this script element
   y = scriptElm.getAttribute('data-resources-url');
 
-  if (y) {
+  if (!resourcesUrl && y) {
     // the script element has a data-resources-url attribute, always use that
     resourcesUrl = y;
   }

--- a/src/declarations/app-global.ts
+++ b/src/declarations/app-global.ts
@@ -3,6 +3,7 @@ import * as d from './index';
 
 export interface AppGlobal {
   ael?: (elm: Element|Document|Window, eventName: string, cb: d.EventListenerCallback, opts?: d.ListenOptions) => void;
+  resourcesUrl?: string;
   components?: d.ComponentHostData[];
   componentOnReady?: (elm: d.HostElement, resolve: (elm: d.HostElement) => void) => void;
   Context?: any;


### PR DESCRIPTION
Hi, 

First of all thank you for this great library, really can change the game.

We have a scenario where we have to target some legacy applications with a component package built using Stencil. In this case the loading of the main script is done by `jQuery.ajax`, so not with a direct script reference. So the current loader mechanism fails to work as it finds the wrong `script` on the page to parse the base URL. 

This little pull request gives another layer of flexibility to the consumer side of a component library by providing an option to configure the resources URL explicitly similar to this.

```js
<script>
    // Configure the resources URL explicitly in the consumer application
    window.MyComponents = window.MyComponents || {};
    window.MyComponents.resourcesUrl = "base URL for components";
</script>
...
// Later somewhere in the jungle of the legacy application.
$.getScript(...);
```

Please have a look at this and let me know if you need more details about this special use-case.
