### PR TITLE
fix(compiler): pass non standard type values to docs

### DIFF
--- a/src/compiler/docs/generate-json-doc.ts
+++ b/src/compiler/docs/generate-json-doc.ts
@@ -83,6 +83,8 @@ function generateJsDocMembers(cmpMeta: d.ComponentMeta, jsonCmp: d.JsonDocsCompo
 
       } else if (memberMeta.propType === PROP_TYPE.Any) {
         propData.type = 'any';
+      } else {
+        propData.type = memberMeta.attribType.text;
       }
 
       if (memberMeta.memberType === MEMBER_TYPE.PropMutable) {

--- a/src/compiler/docs/markdown-attrs.ts
+++ b/src/compiler/docs/markdown-attrs.ts
@@ -70,6 +70,6 @@ function getPropType(propType: PROP_TYPE) {
     case PROP_TYPE.String:
       return 'string';
   }
-  return '';
+  return ''
 }
 

--- a/src/compiler/docs/markdown-props.ts
+++ b/src/compiler/docs/markdown-props.ts
@@ -43,7 +43,7 @@ class Row {
 
     content.push(`#### ${this.memberName}`);
     content.push(``);
-    content.push(getPropType(this.memberMeta.propType));
+    content.push(getPropType(this.memberMeta));
     content.push(``);
 
     const doc = getMemberDocumentation(this.memberMeta.jsdoc);
@@ -59,7 +59,8 @@ class Row {
 }
 
 
-function getPropType(propType: PROP_TYPE) {
+function getPropType(prop: d.MemberMeta) {
+  const propType = prop.propType;
   switch (propType) {
     case PROP_TYPE.Any:
       return 'any';
@@ -70,6 +71,6 @@ function getPropType(propType: PROP_TYPE) {
     case PROP_TYPE.String:
       return 'string';
   }
-  return '';
+  return prop.attribType.text;
 }
 


### PR DESCRIPTION
If the type info is not string,number,bool, or any, the docs process will just return an empty string.
This uses the cmpMeta, searches for the attribute text, and uses that when the propType is a custom type.