### PR TITLE
feat(compiler) - Component Namespacing

### DIFF
--- a/src/compiler/transpile/datacollection/component-decorator.ts
+++ b/src/compiler/transpile/datacollection/component-decorator.ts
@@ -5,7 +5,7 @@ import { getDeclarationParameters, isDecoratorNamed, serializeSymbol } from './u
 import * as ts from 'typescript';
 
 
-export function getComponentDecoratorMeta(diagnostics: d.Diagnostic[], checker: ts.TypeChecker, node: ts.ClassDeclaration): d.ComponentMeta | undefined {
+export function getComponentDecoratorMeta(config: d.Config, diagnostics: d.Diagnostic[], checker: ts.TypeChecker, node: ts.ClassDeclaration): d.ComponentMeta | undefined {
   if (!node.decorators) {
     return undefined;
   }
@@ -24,7 +24,7 @@ export function getComponentDecoratorMeta(diagnostics: d.Diagnostic[], checker: 
   const symbol = checker.getSymbolAtLocation(node.name);
 
   const cmpMeta: d.ComponentMeta = {
-    tagNameMeta: `SCOPED-${componentOptions.tag}`,
+    tagNameMeta: config.componentsPrefix ? `${config.componentsPrefix}-${componentOptions.tag}` : componentOptions.tag,
     originalTagNameMeta: componentOptions.tag,
     stylesMeta: {},
     assetsDirsMeta: [],

--- a/src/compiler/transpile/datacollection/component-decorator.ts
+++ b/src/compiler/transpile/datacollection/component-decorator.ts
@@ -24,7 +24,8 @@ export function getComponentDecoratorMeta(diagnostics: d.Diagnostic[], checker: 
   const symbol = checker.getSymbolAtLocation(node.name);
 
   const cmpMeta: d.ComponentMeta = {
-    tagNameMeta: componentOptions.tag,
+    tagNameMeta: `SCOPED-${componentOptions.tag}`,
+    originalTagNameMeta: componentOptions.tag,
     stylesMeta: {},
     assetsDirsMeta: [],
     hostMeta: getHostMeta(diagnostics, componentOptions.host),

--- a/src/compiler/transpile/datacollection/index.ts
+++ b/src/compiler/transpile/datacollection/index.ts
@@ -35,7 +35,7 @@ function visitFactory(config: d.Config, diagnostics: d.Diagnostic[], compilerCtx
     }
 
     if (ts.isClassDeclaration(node)) {
-      const cmpMeta = visitClass(diagnostics, checker, node as ts.ClassDeclaration, sourceFile);
+      const cmpMeta = visitClass(config, diagnostics, checker, node as ts.ClassDeclaration, sourceFile);
       if (cmpMeta) {
         const tsFilePath = normalizePath(sourceFile.getSourceFile().fileName);
         componentMetaList[tsFilePath] = cmpMeta;
@@ -48,8 +48,8 @@ function visitFactory(config: d.Config, diagnostics: d.Diagnostic[], compilerCtx
   };
 }
 
-export function visitClass(diagnostics: d.Diagnostic[], checker: ts.TypeChecker, classNode: ts.ClassDeclaration, sourceFile: ts.SourceFile): d.ComponentMeta | undefined {
-  let cmpMeta = getComponentDecoratorMeta(diagnostics, checker, classNode);
+export function visitClass(config: d.Config, diagnostics: d.Diagnostic[], checker: ts.TypeChecker, classNode: ts.ClassDeclaration, sourceFile: ts.SourceFile): d.ComponentMeta | undefined {
+  let cmpMeta = getComponentDecoratorMeta(config, diagnostics, checker, classNode);
 
   if (!cmpMeta) {
     return undefined;

--- a/src/compiler/transpile/datacollection/test/component-decorator.spec.ts
+++ b/src/compiler/transpile/datacollection/test/component-decorator.spec.ts
@@ -11,11 +11,12 @@ describe('component decorator', () => {
       let response;
       const sourceFilePath = path.resolve(__dirname, './fixtures/component-simple');
       gatherMetadata(sourceFilePath, (checker, classNode) => {
-        response = getComponentDecoratorMeta([], checker, classNode);
+        response = getComponentDecoratorMeta({}, [], checker, classNode);
       });
 
       expect(response).toEqual({
         tagNameMeta: 'ion-action-sheet',
+        originalTagNameMeta: 'ion-action-sheet',
         hostMeta: {},
         stylesMeta: {},
         encapsulation: ENCAPSULATION.NoEncapsulation,
@@ -33,11 +34,12 @@ describe('component decorator', () => {
       let response;
       const sourceFilePath = path.resolve(__dirname, './fixtures/component-shadow');
       gatherMetadata(sourceFilePath, (checker, classNode) => {
-        response = getComponentDecoratorMeta([], checker, classNode);
+        response = getComponentDecoratorMeta({}, [], checker, classNode);
       });
 
       expect(response).toEqual({
         tagNameMeta: 'ion-action-sheet',
+        originalTagNameMeta: 'ion-action-sheet',
         hostMeta: {},
         stylesMeta: {},
         encapsulation: ENCAPSULATION.ShadowDom,
@@ -55,11 +57,12 @@ describe('component decorator', () => {
       let response;
       const sourceFilePath = path.resolve(__dirname, './fixtures/component-scoped');
       gatherMetadata(sourceFilePath, (checker, classNode) => {
-        response = getComponentDecoratorMeta([], checker, classNode);
+        response = getComponentDecoratorMeta({}, [], checker, classNode);
       });
 
       expect(response).toEqual({
         tagNameMeta: 'ion-action-sheet',
+        originalTagNameMeta: 'ion-action-sheet',
         hostMeta: {},
         stylesMeta: {},
         assetsDirsMeta: [],
@@ -77,11 +80,12 @@ describe('component decorator', () => {
       let response;
       const sourceFilePath = path.resolve(__dirname, './fixtures/component-example');
       gatherMetadata(sourceFilePath, (checker, classNode) => {
-        response = getComponentDecoratorMeta([], checker, classNode);
+        response = getComponentDecoratorMeta({}, [], checker, classNode);
       });
 
       expect(response).toEqual({
         tagNameMeta: 'ion-action-sheet',
+        originalTagNameMeta: 'ion-action-sheet',
         encapsulation: ENCAPSULATION.NoEncapsulation,
         jsdoc: {
           documentation: 'This is an actionSheet class',
@@ -111,5 +115,28 @@ describe('component decorator', () => {
         dependencies: []
       });
     });
+
+    it('adds prefix if provided', () => {
+      let response;
+      const sourceFilePath = path.resolve(__dirname, './fixtures/component-scoped');
+      gatherMetadata(sourceFilePath, (checker, classNode) => {
+        response = getComponentDecoratorMeta({ componentsPrefix: 'scoped' }, [], checker, classNode);
+      });
+
+      expect(response).toEqual({
+        tagNameMeta: 'scoped-ion-action-sheet',
+        originalTagNameMeta: 'ion-action-sheet',
+        hostMeta: {},
+        stylesMeta: {},
+        assetsDirsMeta: [],
+        encapsulation: ENCAPSULATION.ScopedCss,
+        jsdoc: {
+          documentation: '',
+          name: 'ActionSheet',
+          type: 'typeof ActionSheet'
+        },
+        dependencies: []
+      });
+    })
   });
 });

--- a/src/compiler/transpile/transformers/scope-tag-names.ts
+++ b/src/compiler/transpile/transformers/scope-tag-names.ts
@@ -3,10 +3,11 @@ import * as d from '../../../declarations';
 
 export default  (moduleFiles: d.ModuleFiles): ts.TransformerFactory<ts.SourceFile> => {
   const convertibleTagNames: { [key: string]: d.ComponentMeta } = {};
-
   Object.keys(moduleFiles).map(key => {
-    convertibleTagNames[moduleFiles[key].cmpMeta.originalTagNameMeta] =
-      moduleFiles[key].cmpMeta;
+    const metas = moduleFiles[key].cmpMeta
+    if(metas) {
+      convertibleTagNames[metas.originalTagNameMeta] = metas
+    }
   });
 
   function getNewTagName(tagName: string) {

--- a/src/compiler/transpile/transformers/scope-tag-names.ts
+++ b/src/compiler/transpile/transformers/scope-tag-names.ts
@@ -1,0 +1,64 @@
+import * as ts from 'typescript';
+import * as d from '../../../declarations';
+
+export default  (moduleFiles: d.ModuleFiles): ts.TransformerFactory<ts.SourceFile> => {
+  const convertibleTagNames: { [key: string]: d.ComponentMeta } = {};
+
+  Object.keys(moduleFiles).map(key => {
+    convertibleTagNames[moduleFiles[key].cmpMeta.originalTagNameMeta] =
+      moduleFiles[key].cmpMeta;
+  });
+
+  function getNewTagName(tagName: string) {
+    if (convertibleTagNames[tagName]) {
+      return convertibleTagNames[tagName].tagNameMeta;
+    }
+    return tagName;
+  }
+
+  function visitJsxElement(node: ts.JsxElement) {
+    const { openingElement, closingElement, children } = node;
+    const oTagName = openingElement.tagName;
+    openingElement.tagName = ts.createLiteral(
+      getNewTagName(oTagName.getText())
+    );
+    closingElement.tagName = ts.createLiteral(
+      getNewTagName(oTagName.getText())
+    );
+    return ts.updateJsxElement(node, openingElement, children, closingElement);
+  }
+
+  function visitJsxSelfClosingElement(node: ts.JsxSelfClosingElement) {
+    node.tagName = ts.createLiteral(getNewTagName(node.tagName.getText()));
+    return node;
+  }
+
+  return (context: ts.TransformationContext) => {
+    function visitor(node: ts.Node): ts.VisitResult<ts.Node> {
+      switch (node.kind) {
+        case ts.SyntaxKind.JsxElement:
+          return ts.visitEachChild(
+            visitJsxElement(<ts.JsxElement>node),
+            visitor,
+            context
+          );
+
+        case ts.SyntaxKind.JsxSelfClosingElement:
+          return ts.visitEachChild(
+            visitJsxSelfClosingElement(<ts.JsxSelfClosingElement>node),
+            visitor,
+            context
+          );
+
+        default:
+      }
+      return ts.visitEachChild(node, visitor, context);
+    }
+    return (node: ts.SourceFile) => {
+      if (node.isDeclarationFile) {
+        return node;
+      }
+      return ts.visitEachChild(node, visitor, context);
+    };
+  };
+};

--- a/src/compiler/transpile/transpile.ts
+++ b/src/compiler/transpile/transpile.ts
@@ -12,6 +12,7 @@ import { moduleGraph } from './transformers/module-graph';
 import { removeCollectionImports } from './transformers/remove-collection-imports';
 import { removeDecorators } from './transformers/remove-decorators';
 import { removeStencilImports } from './transformers/remove-stencil-imports';
+import scopedTagNames from './transformers/scope-tag-names';
 import * as ts from 'typescript';
 
 
@@ -81,6 +82,7 @@ function transpileProgram(program: ts.Program, tsHost: ts.CompilerHost, config: 
 
     // NOTE! order of transforms and being in either "before" or "after" is very important!!!!
     before: [
+      scopedTagNames(compilerCtx.moduleFiles),
       removeDecorators(),
       addComponentMetadata(compilerCtx.moduleFiles),
       buildConditionalsTransform(buildConditionals)

--- a/src/declarations/component.ts
+++ b/src/declarations/component.ts
@@ -58,6 +58,7 @@ export interface ComponentConstructorHost {
 export interface ComponentMeta {
   // "Meta" suffix to ensure property renaming
   tagNameMeta?: string;
+  originalTagNameMeta?: string,
   bundleIds?: string | BundleIds | GetModuleFn;
   stylesMeta?: d.StylesMeta;
   membersMeta?: MembersMeta;

--- a/src/declarations/config.ts
+++ b/src/declarations/config.ts
@@ -11,6 +11,7 @@ export interface Config {
   commonjs?: BundlingConfig;
   cwd?: string;
   nodeResolve?: NodeResolveConfig;
+  componentsPrefix?: string;
   configPath?: string;
   copy?: CopyTasks;
   devInspector?: boolean;


### PR DESCRIPTION
# Simplify component namespacing

## Purpose of the pull request

Prevent component tag names conflicts across libraries and avoid prefix duplication across the codebase.  

##  Background

Let's assume we have 2 distinct libraries built on top of Stencil:  `Ionic` and `Cinoi` ;-)

Wouldn't if be awesome to remove unnecessary component scope specification across each codebase by simply provide and expected component tag name prefix ?

At the moment we must specify component prefix within each components

**Ionic Team**

```tsx
// card.tsx
@Component({ tag: 'ion-card' })

// jumbotron.tsx
@Component({ tag: 'ion-jumbotron' })
```

**Cinoi Team**
```tsx
// card.tsx
@Component({ tag: 'cin-card' })

// jumbotron.tsx
@Component({ tag: 'cin-jumbotron' })


```

## Pull Request results



 **Ionic Team**

```tsx
// card.tsx
@Component({ tag: 'card' })

// jumbotron.tsx
@Component({ tag: 'jumbotron' })
//stencil.config.js
{
  componentsPrefix: 'cin'
}
```

**Cinoi Team**
```tsx
// card.tsx
@Component({ tag: 'card' })

// jumbotron.tsx
@Component({ tag: 'jumbotron' })

//stencil.config.js
{
  componentsPrefix: 'cin'
}
```


