### PR TITLE
feat(compiler): Add typescript transformer customization

### DIFF
--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -7,6 +7,7 @@ import { validateNamespace } from './validate-namespace';
 import { validateOutputTargets } from './validate-outputs';
 import { validatePaths } from './validate-paths';
 import { validatePlugins } from './validate-plugins';
+import { validateCustomTransformers } from './validate-custom-transformers';
 import { _deprecatedValidateConfigCollections } from './_deprecated-validate-config-collection';
 
 
@@ -89,11 +90,14 @@ export function validateConfig(config: d.Config, setEnvVariables?: boolean) {
 
   validateCopy(config);
 
+  validateCustomTransformers(config);
+  
   validatePlugins(config);
 
   validateAssetVerioning(config);
 
   validateDevServer(config);
+
 
   if (!config.watchIgnoredRegex) {
     config.watchIgnoredRegex = DEFAULT_WATCH_IGNORED_REGEX;

--- a/src/compiler/config/validate-custom-transformers.ts
+++ b/src/compiler/config/validate-custom-transformers.ts
@@ -1,0 +1,15 @@
+import * as d from '../../declarations'
+
+export function validateCustomTransformers(config: d.Config) {
+  config.customTransformers = config.customTransformers || {
+    prependBefore: [],
+    appendBefore: [],
+    appendAfter: [],
+    prependAfter: []
+  }
+
+  config.customTransformers.prependBefore = config.customTransformers.prependBefore || []
+  config.customTransformers.appendBefore = config.customTransformers.appendBefore || []
+  config.customTransformers.appendAfter = config.customTransformers.appendAfter || []
+  config.customTransformers.prependAfter = config.customTransformers.prependAfter || []
+}

--- a/src/compiler/transpile/transpile-service.ts
+++ b/src/compiler/transpile/transpile-service.ts
@@ -125,16 +125,20 @@ async function buildTsService(config: d.Config, compilerCtx: d.CompilerCtx, buil
 
       return {
         before: [
+          ...config.customTransformers.prependBefore,
           gatherMetadata(config, transpileCtx.compilerCtx, transpileCtx.buildCtx, typeChecker),
           removeDecorators(),
           addComponentMetadata(transpileCtx.compilerCtx.moduleFiles),
-          buildConditionalsTransform(buildConditionals)
+          buildConditionalsTransform(buildConditionals),
+          ...config.customTransformers.appendBefore,
         ],
         after: [
+          ...config.customTransformers.prependAfter,
           removeStencilImports(),
           removeCollectionImports(transpileCtx.compilerCtx),
           getModuleImports(config, transpileCtx.compilerCtx),
-          componentDependencies(transpileCtx.compilerCtx)
+          componentDependencies(transpileCtx.compilerCtx),
+          ...config.customTransformers.appendAfter,
         ]
       };
     }

--- a/src/declarations/config.ts
+++ b/src/declarations/config.ts
@@ -1,5 +1,5 @@
 import * as d from './index';
-
+import * as ts from 'typescript';
 
 export interface Config {
   assetVersioning?: ConfigAssetVersioning;
@@ -12,6 +12,7 @@ export interface Config {
   commonjs?: BundlingConfig;
   cwd?: string;
   nodeResolve?: NodeResolveConfig;
+  customTransformers?: CustomTransformersConfig;
   configPath?: string;
   copy?: d.CopyTask[];
   devInspector?: boolean;
@@ -54,6 +55,13 @@ export interface BundlingConfig {
   namedExports?: {
     [key: string]: string[];
   };
+}
+
+export interface CustomTransformersConfig {
+  prependBefore: Array<ts.TransformerFactory<ts.SourceFile>>
+  appendBefore: Array<ts.TransformerFactory<ts.SourceFile>>
+  prependAfter: Array<ts.TransformerFactory<ts.SourceFile>>
+  appendAfter: Array<ts.TransformerFactory<ts.SourceFile>>
 }
 
 export interface NodeResolveConfig {


### PR DESCRIPTION
It opens typescript internal behaviours and empower component building with StencilJS.

Ex: You can create a plugin which automatically scope all component tag names

sample of `stencil.config.js`
```js
const MyTransformer = require('my-custom-transformer');

exports.config = {
  namespace: "go-goats",
  outputTargets: [
    {
      type: 'dist'
    },
    {
      type: 'www',
      serviceWorker: false,
    }
  ],
  customTransformers: {
    prependBefore: [MyTransformer()]
  }
}

```
