### PR TITLE
fix(init-css-shims): CSS_URL_REGEXP check relative to root paths

### DIFF
--- a/src/client/polyfills/css-shim/load-link-styles.ts
+++ b/src/client/polyfills/css-shim/load-link-styles.ts
@@ -61,9 +61,10 @@ export function hasCssVariables(css: string) {
 }
 
 // This regexp find all url() usages with relative urls
-const CSS_URL_REGEXP = /url[\s]*\([\s]*['"]?(?!http)([^\'\"\)]*)[\s]*['"]?\)[\s]*/gim;
+const CSS_URL_REGEXP = /url[\s]*\([\s]*['"]?(?![http|/])([^\'\"\)]*)[\s]*['"]?\)[\s]*/gim;
 
 export function hasRelativeUrls(css: string) {
+  CSS_URL_REGEXP.lastIndex = 0;
   return CSS_URL_REGEXP.test(css);
 }
 

--- a/src/client/polyfills/css-shim/test/init-css-shim.spec.ts
+++ b/src/client/polyfills/css-shim/test/init-css-shim.spec.ts
@@ -114,6 +114,17 @@ describe('hasRelativeUrls', () => {
 
     expect(hasRelativeUrls(text)).toBe(true);
   });
+
+  it('false for relative urls without domain', () => {
+    const text = `
+      div {
+        background-image: url('/assets/images/mytestimage.jpg');
+      }
+    `;
+
+    expect(hasRelativeUrls(text)).toBe(false);
+  });
+
 });
 
 describe('fixRelativeUrls', () => {
@@ -141,6 +152,20 @@ describe('fixRelativeUrls', () => {
     expect(fixRelativeUrls(text, '/assets/css/styles.css')).toBe(`
       div {
         background-image: url('http://www.example.com/assets/images/mytestimage.jpg');
+      }
+    `);
+  });
+
+  it('should keep absolute urls', () => {
+    const text = `
+      div {
+        background-image: url('/assets/images/mytestimage.jpg');
+      }
+    `;
+
+    expect(fixRelativeUrls(text, '/assets/css/styles.css')).toBe(`
+      div {
+        background-image: url('/assets/images/mytestimage.jpg');
       }
     `);
   });

--- a/test/karma/test-app/init-css-shim/cmp-root.css
+++ b/test/karma/test-app/init-css-shim/cmp-root.css
@@ -1,0 +1,10 @@
+
+div#relativeToRoot {
+  background-image: url("/path/to/image.png");
+}
+div#relative {
+  background-image: url("../path/to/image.png");
+}
+div#absolute {
+  background-image: url("http://domain/path/to/image.png");
+}

--- a/test/karma/test-app/init-css-shim/cmp-root.tsx
+++ b/test/karma/test-app/init-css-shim/cmp-root.tsx
@@ -1,0 +1,18 @@
+import { Component } from '../../../../dist/index';
+
+
+@Component({
+  tag: 'init-css-root',
+  styleUrl: 'cmp-root.css'
+})
+export class InitCssRoot {
+
+  render() {
+    return [
+    <div id="relative"></div>,
+    <div id="relativeToRoot"></div>,
+    <div id="absolute"></div>
+  ];
+  }
+
+}

--- a/test/karma/test-app/init-css-shim/index.html
+++ b/test/karma/test-app/init-css-shim/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf8">
+<script src="/build/testapp.js"></script>
+
+<init-css-root></init-css-root>

--- a/test/karma/test-app/init-css-shim/karma.spec.ts
+++ b/test/karma/test-app/init-css-shim/karma.spec.ts
@@ -1,0 +1,34 @@
+import { setupDomTests } from '../util';
+
+describe('init-css-shim', () => {
+  const { setupDom, tearDownDom } = setupDomTests(document);
+  const imageUrl = '/path/to/image.png';
+
+  let app: HTMLElement;
+
+  beforeEach(async () => {
+    app = await setupDom('/init-css-shim/index.html');
+  });
+  afterEach(tearDownDom);
+
+  it('should not replace "relavive to root" paths', async () => {
+    const root = app.querySelector('init-css-root #relativeToRoot');
+    const imagePath = window.getComputedStyle(root).getPropertyValue('background-image');
+    expect(imagePath).toBe(`url("${window.location.origin}${imageUrl}")`);
+  });
+  
+  it('should not replace "absolute" paths', async () => {
+    const domain = 'http://domain';
+    const root = app.querySelector('init-css-root #absolute');
+    const imagePath = window.getComputedStyle(root).getPropertyValue('background-image');
+    expect(imagePath).toBe(`url("${domain}${imageUrl}")`);
+  });
+
+  it('should replace "relative" paths', async () => {
+    const relativePath = '/test-app';
+    const root = app.querySelector('init-css-root #relative');
+    const imagePath = window.getComputedStyle(root).getPropertyValue('background-image');
+    expect(imagePath).toBe(`url("${window.location.origin}${relativePath}${imageUrl}")`);
+  });
+
+});


### PR DESCRIPTION
Fixed: CSS_URL_REGEXP was checking only for absolute url ("http://domain/path") and taking relative to root url ("/relative/to/root") as relative, replacing it for "relative/path//relative/to/root"