### PR TITLE
fix(queue): expose queue types

### DIFF
--- a/src/client/queue-client.ts
+++ b/src/client/queue-client.ts
@@ -1,7 +1,7 @@
 import * as d from '../declarations';
 
 
-export function createQueueClient(App: d.AppGlobal, win: Window) {
+export function createQueueClient(App: d.AppGlobal, win: Window): d.QueueApi {
   const now: d.Now = () => win.performance.now();
 
   const resolved = Promise.resolve();
@@ -103,6 +103,5 @@ export function createQueueClient(App: d.AppGlobal, win: Window) {
         App.raf(flush);
       }
     }
-
-  } as d.QueueApi;
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,8 @@ export {
   Config,
   EventEmitter,
   EventListenerEnable,
-  FunctionalComponent
+  FunctionalComponent,
+  QueueApi
 } from './declarations/index';
 
 


### PR DESCRIPTION
Use case:

```ts
import { QueueApi } from '@stencil/core';

@Prop({ context: 'queue' }) queue: QueueApi;
```


**NOTE**: at ionic, it's called `QueueController`, should we rename it in stencil?