### PR TITLE
SlotAttributes interface must include slot attribute

### DIFF
--- a/src/declarations/jsx.ts
+++ b/src/declarations/jsx.ts
@@ -136,6 +136,7 @@ declare global {
 
     export interface SlotAttributes {
       name?: string;
+      slot?: string;
     }
 
     export interface AnchorHTMLAttributes extends HTMLAttributes {


### PR DESCRIPTION
This is useful when you want to pass a slot down to an other slot