### PR TITLE
chore(): replace uglify with terser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1631,7 +1631,8 @@
     "commander": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+      "dev": true
     },
     "common-tags": {
       "version": "1.8.0",
@@ -8537,6 +8538,37 @@
         }
       }
     },
+    "terser": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-3.7.7.tgz",
+      "integrity": "sha512-RRLIxE7S52vSOI9cEbOaisgBd2y6MNgfg2ihUkidsFnuP1eDmZ79+lBWbyvgfFTAc/r8nSjL0k3cpZDDIYiYiA==",
+      "requires": {
+        "commander": "~2.14.1",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.6"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "source-map-support": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+          "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
+      }
+    },
     "test-exclude": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
@@ -9218,6 +9250,7 @@
       "version": "3.3.9",
       "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
       "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+      "dev": true,
       "requires": {
         "commander": "~2.13.0",
         "source-map": "~0.6.1"
@@ -9226,7 +9259,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "rollup-plugin-node-globals": "1.2.1",
     "rollup-plugin-node-resolve": "3.3.0",
     "rollup-pluginutils": "2.3.0",
+    "terser": "3.7.7",
     "typescript": "~2.9.1",
-    "uglify-es": "3.3.9",
     "workbox-build": "^3.1.0"
   },
   "devDependencies": {

--- a/scripts/build-compiler.js
+++ b/scripts/build-compiler.js
@@ -115,8 +115,8 @@ function updateBuildIds(buildId, input) {
   let minifyStyleId = cleanCssPkg.name + cleanCssPkg.version;
   output = output.replace(/__BUILDID:MINIFYSTYLE__/g, minifyStyleId);
 
-  let uglifyPkg = require('../node_modules/uglify-es/package.json');
-  let minifyJsId = uglifyPkg.name + uglifyPkg.version;
+  let terserPkg = require('../node_modules/terser/package.json');
+  let minifyJsId = terserPkg.name + terserPkg.version;
   output = output.replace(/__BUILDID:MINIFYJS__/g, minifyJsId);
 
   let autoprefixerPkg = require('../node_modules/autoprefixer/package.json');

--- a/scripts/build-sys-node.js
+++ b/scripts/build-sys-node.js
@@ -18,7 +18,7 @@ const whitelist = [
   'child_process',
   'os',
   'typescript',
-  'uglify-es'
+  'terser'
 ];
 
 if (success) {

--- a/src/compiler/app/build-core-content.ts
+++ b/src/compiler/app/build-core-content.ts
@@ -137,7 +137,6 @@ const DEV_MINIFY_OPTS: any = {
   output: {
     ascii_only: false,
     beautify: true,
-    bracketize: true,
     comments: 'all',
     ie8: false,
     indent_level: 2,
@@ -212,7 +211,6 @@ const PROD_MINIFY_OPTS: any = {
   output: {
     ascii_only: false,
     beautify: false,
-    bracketize: false,
     comments: false,
     ie8: false,
     indent_level: 0,

--- a/src/compiler/minifier.ts
+++ b/src/compiler/minifier.ts
@@ -16,9 +16,10 @@ export async function minifyJs(config: d.Config, compilerCtx: d.CompilerCtx, jsT
     opts.output.beautify = false;
 
   } else {
-    opts.ecma = 6;
-    opts.output.ecma = 6;
-    opts.compress.ecma = 6;
+    opts.ecma = 8;
+    opts.output.ecma = 8;
+    opts.compress.ecma = 8;
+    opts.module = true;
     opts.toplevel = true;
     opts.compress.arrows = true;
     opts.output.beautify = false;
@@ -30,7 +31,6 @@ export async function minifyJs(config: d.Config, compilerCtx: d.CompilerCtx, jsT
     opts.compress.drop_console = false;
     opts.compress.drop_debugger = false;
     opts.output.beautify = true;
-    opts.output.bracketize = true;
     opts.output.indent_level = 2;
     opts.output.comments = 'all';
     opts.output.preserve_line = true;

--- a/src/declarations/index.ts
+++ b/src/declarations/index.ts
@@ -30,6 +30,6 @@ export * from './server';
 export * from './style';
 export * from './system';
 export * from './transpile';
-export * from './uglify';
+export * from './terser';
 export * from './vdom';
 export * from './worker';

--- a/src/declarations/terser.ts
+++ b/src/declarations/terser.ts
@@ -1,6 +1,6 @@
 
 
-export interface UglifyResult {
+export interface TerserResult {
   code: string;
   sourceMap: any;
   error: {

--- a/src/sys/node/node-sys-worker.ts
+++ b/src/sys/node/node-sys-worker.ts
@@ -1,7 +1,7 @@
 import * as d from '../../declarations';
 import { attachMessageHandler } from './worker/worker-child';
 import { copyTasksWorker } from '../../compiler/copy/copy-tasks-worker';
-import { loadUglifyDiagnostics } from '../../util/logger/logger-uglify';
+import { loadTerserDiagnostics } from '../../util/logger/logger-uglify';
 import { normalizePath } from '../../compiler/util';
 import { ShadowCss } from '../../compiler/style/shadow-css';
 import { transpileToEs5Worker } from '../../compiler/transpile/transpile-to-es5-worker';
@@ -11,7 +11,7 @@ const autoprefixer = require('autoprefixer');
 const CleanCSS = require('clean-css');
 const gzipSize = require('gzip-size');
 const postcss = require('postcss');
-const UglifyJS = require('uglify-es');
+const Terser = require('terser');
 
 
 export class NodeSystemWorker {
@@ -95,10 +95,10 @@ export class NodeSystemWorker {
   }
 
   minifyJs(input: string, opts?: any) {
-    const result: d.UglifyResult = UglifyJS.minify(input, opts);
+    const result: d.TerserResult = Terser.minify(input, opts);
     const diagnostics: d.Diagnostic[] = [];
 
-    loadUglifyDiagnostics(input, result, diagnostics);
+    loadTerserDiagnostics(input, result, diagnostics);
 
     return {
       output: (result.code as string),

--- a/src/util/logger/logger-uglify.ts
+++ b/src/util/logger/logger-uglify.ts
@@ -2,7 +2,7 @@ import * as d from '../../declarations';
 import { splitLineBreaks } from './logger-util';
 
 
-export function loadUglifyDiagnostics(sourceText: string, result: d.UglifyResult, diagnostics: d.Diagnostic[]) {
+export function loadTerserDiagnostics(sourceText: string, result: d.TerserResult, diagnostics: d.Diagnostic[]) {
   if (!result || !result.error) {
     return;
   }


### PR DESCRIPTION
DO NOT MERGE

Uglify-es is not longer maintained and there are bug reports affecting stencil that WILL never be fixed.

Terser is the fork of uglify where rollup, webpack and two of the main maintainers of uglify are involved.