### PR TITLE
fix(dev-server): set the correct domain for dev-server iframe

### DIFF
--- a/src/dev-server/serve-dev-client.ts
+++ b/src/dev-server/serve-dev-client.ts
@@ -7,6 +7,8 @@ import { serveOpenInEditor } from './open-in-editor';
 import * as http  from 'http';
 import * as path from 'path';
 
+let cachedDevServerClientScript: string;
+
 
 export async function serveDevClient(devServerConfig: d.DevServerConfig, fs: d.FileSystem, req: d.HttpRequest, res: http.ServerResponse) {
   try {
@@ -59,7 +61,14 @@ async function serveDevClientScript(devServerConfig: d.DevServerConfig, fs: d.Fi
 }
 
 
-export function getDevServerClientScript(devServerConfig: d.DevServerConfig) {
-  const devServerClientUrl = util.getDevServerClientUrl(devServerConfig);
-  return `\n<iframe src="${devServerClientUrl}" style="width:0;height:0;border:0"></iframe>`;
+export async function getDevServerClientScript(devServerConfig: d.DevServerConfig, fs: d.FileSystem) {
+  if (!cachedDevServerClientScript) {
+    const dirTemplatePath = path.join(devServerConfig.devServerDir, 'templates', 'dev-client-iframe.html');
+    const dirTemplate = await fs.readFile(dirTemplatePath);
+
+    cachedDevServerClientScript = dirTemplate
+      .replace('{{DEV_SERVER_URL}}', util.DEV_SERVER_URL);
+  }
+
+  return cachedDevServerClientScript;
 }

--- a/src/dev-server/serve-file.ts
+++ b/src/dev-server/serve-file.ts
@@ -18,7 +18,7 @@ export async function serveFile(devServerConfig: d.DevServerConfig, fs: d.FileSy
 
       if (util.isHtmlFile(req.filePath) && !util.isDevServerClient(req.pathname)) {
         // auto inject our dev server script
-        content += getDevServerClientScript(devServerConfig);
+        content += await getDevServerClientScript(devServerConfig, fs);
 
       } else if (util.isCssFile(req.filePath)) {
         content = updateStyleUrls(req.url, content);

--- a/src/dev-server/templates/dev-client-iframe.html
+++ b/src/dev-server/templates/dev-client-iframe.html
@@ -1,0 +1,15 @@
+
+<script>
+  if (!window.location.origin) {
+    // polyfill for IE11, credit: https://tosbourn.com/a-fix-for-window-location-origin-in-internet-explorer/
+    window.location.origin = window.location.protocol + '//' + window.location.hostname + (window.location.port ? (':' + window.location.port) : '');
+  }
+
+  var iframeEl = document.createElement('iframe')
+  iframeEl.style.width = 0
+  iframeEl.style.height = 0
+  iframeEl.style.border = 0
+  iframeEl.src = window.location.origin + '{{DEV_SERVER_URL}}'
+  document.currentScript.parentNode.insertBefore(iframeEl, document.currentScript)
+  document.currentScript.remove()
+</script>

--- a/src/dev-server/test/req-hander.spec.ts
+++ b/src/dev-server/test/req-hander.spec.ts
@@ -18,6 +18,8 @@ describe('request-handler', async () => {
   const root = path.resolve('/');
   const tmplDirPath = normalizePath(path.join(__dirname, '..', 'templates', 'directory-index.html'));
   const tmplDir = nodeFs.readFileSync(tmplDirPath, 'utf8');
+  const tmplDevClientIframePath = normalizePath(path.join(__dirname, '..', 'templates', 'dev-client-iframe.html'));
+  const tmplDevClientIframe = nodeFs.readFileSync(tmplDevClientIframePath, 'utf8');
   const contentTypes = {
     'html': 'text/html',
     'css': 'text/css',
@@ -39,6 +41,7 @@ describe('request-handler', async () => {
 
     await fs.mkdir(stencilConfig.devServer.root);
     await fs.writeFile(path.join(stencilConfig.devServer.devServerDir, 'templates', 'directory-index.html'), tmplDir);
+    await fs.writeFile(path.join(stencilConfig.devServer.devServerDir, 'templates', 'dev-client-iframe.html'), tmplDevClientIframe);
 
     config = validateDevServer(stencilConfig);
     req = {} as any;

--- a/src/dev-server/test/serve-dev-client.spec.ts
+++ b/src/dev-server/test/serve-dev-client.spec.ts
@@ -1,0 +1,49 @@
+import { DEV_SERVER_URL } from '../util';
+import { mockConfig } from '../../testing/mocks';
+import { getDevServerClientScript } from '../serve-dev-client';
+import { normalizePath } from '../../compiler/util';
+import { TestingFs } from '../../testing/testing-fs';
+import { validateDevServer } from '../../compiler/config/validate-dev-server';
+import * as d from '../../declarations';
+import * as nodeFs from 'fs';
+import * as path from 'path';
+
+
+describe('dev-server, serve-dev-client', () => {
+
+  let config: d.DevServerConfig;
+  let fs: TestingFs;
+  const root = path.resolve('/');
+  const tmplDirPath = normalizePath(path.join(__dirname, '..', 'templates', 'dev-client-iframe.html'));
+  const tmplDir = nodeFs.readFileSync(tmplDirPath, 'utf8');
+  const contentTypes = {
+    'html': 'text/html',
+    'css': 'text/css',
+    'js': 'application/javascript',
+    'svg': 'image/svg+xml'
+  };
+
+  beforeEach(async () => {
+    fs = new TestingFs();
+
+    const stencilConfig = mockConfig();
+    stencilConfig.flags.serve = true;
+
+    stencilConfig.devServer = {
+      contentTypes: contentTypes,
+      devServerDir: normalizePath(path.join(__dirname, '..')),
+      root: normalizePath(path.join(root, 'www'))
+    };
+
+    await fs.mkdir(stencilConfig.devServer.root);
+    await fs.writeFile(path.join(stencilConfig.devServer.devServerDir, 'templates', 'dev-client-iframe.html'), tmplDir);
+
+    config = validateDevServer(stencilConfig);
+  });
+
+  it('should get iframe injection script with DEV_SERVER_URL included', async () => {
+    const devServerClientScript = await getDevServerClientScript(config, fs);
+    expect(devServerClientScript).toContain(DEV_SERVER_URL);
+  });
+
+});

--- a/src/dev-server/test/util.spec.ts
+++ b/src/dev-server/test/util.spec.ts
@@ -1,5 +1,5 @@
 import * as d from '../../declarations';
-import { getBrowserUrl, getDevServerClientUrl } from '../util';
+import { getBrowserUrl } from '../util';
 
 
 describe('dev-server, util', () => {
@@ -42,16 +42,6 @@ describe('dev-server, util', () => {
     };
     const url = getBrowserUrl(devServerConfig);
     expect(url).toBe('http://staging.stenciljs.com:3333/');
-  });
-
-  it('should get path for dev server', () => {
-    const devServerConfig: d.DevServerConfig = {
-      protocol: 'http',
-      address: '0.0.0.0',
-      port: 3333
-    };
-    const url = getDevServerClientUrl(devServerConfig);
-    expect(url).toBe('http://localhost:3333/~dev-server');
   });
 
 });

--- a/src/dev-server/util.ts
+++ b/src/dev-server/util.ts
@@ -49,11 +49,6 @@ export function getBrowserUrl(devServerConfig: d.DevServerConfig, pathname = '/'
 }
 
 
-export function getDevServerClientUrl(devServerConfig: d.DevServerConfig) {
-  return getBrowserUrl(devServerConfig, DEV_SERVER_URL);
-}
-
-
 export function getContentType(devServerConfig: d.DevServerConfig, filePath: string) {
   const last = filePath.replace(/^.*[/\\]/, '').toLowerCase();
   const ext = last.replace(/^.*\./, '').toLowerCase();


### PR DESCRIPTION
This PR moves the creation of the dev server iframe to the client side by injecting a script, which uses `location.origin` + `{{DEV_SERVER_URL}}` as the src-attribute of the created iframe.

This ensures, that the dev-server is working for localhost and also over the network, when the stencil app is called over an IP address.

Related issue: #940 