### PR TITLE
fix(set-accesor): boolean values

### DIFF
--- a/src/core/test/render.spec.ts
+++ b/src/core/test/render.spec.ts
@@ -373,8 +373,7 @@ describe('instance render', () => {
         empty: '',
         class: 'a b c my-class',
         number: '12',
-        appear: 'true',
-        'no-appear': 'false'
+        appear: '',
       });
     });
 

--- a/src/renderer/vdom/set-accessor.ts
+++ b/src/renderer/vdom/set-accessor.ts
@@ -102,7 +102,6 @@ export function setAccessor(plt: d.PlatformApi, elm: HTMLElement, memberName: st
           cmpMeta.membersMeta[memberName].attribName,
           newValue,
           cmpMeta.membersMeta[memberName].propType === PROP_TYPE.Boolean,
-          (newValue == null)
         );
       }
 

--- a/src/renderer/vdom/test/attributes.spec.ts
+++ b/src/renderer/vdom/test/attributes.spec.ts
@@ -19,7 +19,7 @@ describe('attributes', function() {
     hostElm = patch(hostElm, vnode0, vnode1).elm;
     expect(hostElm.getAttribute('href')).toEqual('/foo');
     expect(hostElm.getAttribute('minlength')).toEqual('1');
-    expect(hostElm.getAttribute('value')).toEqual('true');
+    expect(hostElm.getAttribute('value')).toEqual('');
   });
 
   it('can be memoized', async function() {
@@ -29,11 +29,11 @@ describe('attributes', function() {
     hostElm = patch(hostElm, vnode0, vnode1).elm;
     expect(hostElm.getAttribute('href')).toEqual('/foo');
     expect(hostElm.getAttribute('minlength')).toEqual('1');
-    expect(hostElm.getAttribute('value')).toEqual('true');
+    expect(hostElm.getAttribute('value')).toEqual('');
     hostElm = patch(hostElm, vnode1, vnode2).elm;
     expect(hostElm.getAttribute('href')).toEqual('/foo');
     expect(hostElm.getAttribute('minlength')).toEqual('1');
-    expect(hostElm.getAttribute('value')).toEqual('true');
+    expect(hostElm.getAttribute('value')).toEqual('');
   });
 
   it('are not omitted when falsy values are provided', function() {
@@ -41,7 +41,7 @@ describe('attributes', function() {
     hostElm = patch(hostElm, vnode0, vnode1).elm;
     expect(hostElm.getAttribute('href')).toEqual(null);
     expect(hostElm.getAttribute('minlength')).toEqual('0');
-    expect(hostElm.getAttribute('value')).toEqual('false');
+    expect(hostElm.getAttribute('value')).toEqual(null);
   });
 
   it('are set correctly when namespaced', function() {
@@ -71,16 +71,16 @@ describe('attributes', function() {
       expect(hostElm.hasAttribute('required')).toEqual(true);
       expect(hostElm.getAttribute('required')).toEqual('');
       expect(hostElm.hasAttribute('readonly')).toEqual(true);
-      expect(hostElm.getAttribute('readonly')).toEqual('');
+      expect(hostElm.getAttribute('readonly')).toEqual('1');
       expect(hostElm.hasAttribute('noresize')).toEqual(true);
-      expect(hostElm.getAttribute('noresize')).toEqual('');
+      expect(hostElm.getAttribute('noresize')).toEqual('truthy');
     });
 
     it('is omitted if the value is falsy', function() {
       const vnode1 = h('div', { required: false, readonly: 'false', noresize: null });
       hostElm = patch(hostElm, vnode0, vnode1).elm;
       expect(hostElm.getAttribute('required')).toEqual(null);
-      expect(hostElm.getAttribute('readonly')).toEqual(null);
+      expect(hostElm.getAttribute('readonly')).toEqual('false');
       expect(hostElm.getAttribute('noresize')).toEqual(null);
     });
   });

--- a/src/renderer/vdom/test/set-accessor.spec.ts
+++ b/src/renderer/vdom/test/set-accessor.spec.ts
@@ -237,7 +237,7 @@ describe('setAccessor for custom elements', () => {
     setAccessor(plt, elm, 'myprop', oldValue, newValue, false, false);
     expect(elm.myprop).toBeUndefined();
 
-    expect(elm).toMatchAttributes({ 'myprop': 'false' });
+    expect(elm).toMatchAttributes({ });
   });
 
   it('should add aria role attribute', () => {
@@ -296,7 +296,7 @@ describe('setAccessor for custom elements', () => {
 
     setAccessor(plt, elm, 'myprop', oldValue, newValue, false, false);
     expect(elm.myprop).toBeUndefined();
-    expect(elm).toMatchAttributes({ 'myprop': 'true' });
+    expect(elm).toMatchAttributes({ 'myprop': '' });
   });
 
   it('should set number to attribute', () => {
@@ -371,7 +371,8 @@ describe('setAccessor for inputs', () => {
         const inputElm = mockElement('input');
         setAccessor(plt, inputElm, propName, oldValue, newValue, false, false);
 
-        expect(inputElm).toMatchAttributes({ [propName]: newValue.toString() });
+        const expected = newValue === true ? '' : newValue.toString();
+        expect(inputElm).toMatchAttributes({ [propName]: expected });
       }
 
       it(`aria-disabled should be added when set to true`, () => {

--- a/src/renderer/vdom/update-attribute.ts
+++ b/src/renderer/vdom/update-attribute.ts
@@ -1,11 +1,14 @@
 import { toLowerCase } from '../../util/helpers';
 
 
-export function updateAttribute(elm: HTMLElement, memberName: string, newValue: any, isBoolean?: boolean, forceRemove?: boolean) {
+export function updateAttribute(
+  elm: HTMLElement,
+  memberName: string,
+  newValue: any,
+  isBooleanAttr = typeof newValue === 'boolean',
+) {
   const isXlinkNs = (memberName !== (memberName = memberName.replace(/^xlink\:?/, '')));
-  const isBooleanAttr = BOOLEAN_ATTRS[memberName] || isBoolean;
-
-  if ((isBooleanAttr && (!newValue || newValue === 'false')) || forceRemove) {
+  if (newValue == null || (isBooleanAttr && (!newValue || newValue === 'false'))) {
     if (isXlinkNs) {
       elm.removeAttributeNS(XLINK_NS, toLowerCase(memberName));
 
@@ -16,6 +19,8 @@ export function updateAttribute(elm: HTMLElement, memberName: string, newValue: 
   } else if (typeof newValue !== 'function') {
     if (isBooleanAttr) {
       newValue = '';
+    } else {
+      newValue = newValue.toString();
     }
     if (isXlinkNs) {
       elm.setAttributeNS(XLINK_NS, toLowerCase(memberName), newValue);
@@ -25,26 +30,5 @@ export function updateAttribute(elm: HTMLElement, memberName: string, newValue: 
     }
   }
 }
-
-
-const BOOLEAN_ATTRS: any = {
-  'allowfullscreen': 1,
-  'async': 1,
-  'autofocus': 1,
-  'autoplay': 1,
-  'checked': 1,
-  'controls': 1,
-  'disabled': 1,
-  'enabled': 1,
-  'formnovalidate': 1,
-  'hidden': 1,
-  'multiple': 1,
-  'noresize': 1,
-  'readonly': 1,
-  'required': 1,
-  'selected': 1,
-  'spellcheck': 1,
-};
-
 
 const XLINK_NS = 'http://www.w3.org/1999/xlink';

--- a/test/karma/test-app/attribute-boolean/cmp-root.tsx
+++ b/test/karma/test-app/attribute-boolean/cmp-root.tsx
@@ -1,0 +1,44 @@
+import { Component, Element, State, Method } from '../../../../dist';
+
+@Component({
+  tag: 'attribute-boolean-root'
+})
+export class AttributeBooleanRoot {
+
+  @Element() el: HTMLElement;
+
+  @State() state = false;
+
+  @Method()
+  toggleState() {
+    this.state = !this.state;
+  }
+
+  hostData() {
+    return {
+      'readonly': this.state,
+      'tappable': this.state,
+      'str': this.state ? 'hello' : null,
+      'aria-hidden': `${this.state}`,
+
+      'fixedtrue': 'true',
+      'fixedfalse': 'false',
+
+      'no-appear': undefined as any,
+      'no-appear2': false,
+    }
+  }
+
+  render() {
+    const AttributeBoolean = 'attribute-boolean' as any;
+    return [
+      <button onClick={this.toggleState.bind(this)}>Toggle attributes</button>,
+      <AttributeBoolean
+        boolState={this.state}
+        strState={this.state as any}
+        noreflect={this.state}
+        tappable={this.state}
+        aria-hidden={`${this.state}`}/>
+    ];
+  }
+}

--- a/test/karma/test-app/attribute-boolean/cmp.tsx
+++ b/test/karma/test-app/attribute-boolean/cmp.tsx
@@ -1,0 +1,11 @@
+import { Component, Prop } from '../../../../dist';
+
+@Component({
+  tag: 'attribute-boolean'
+})
+export class AttributeBoolean {
+
+  @Prop({ reflectToAttr: true }) boolState: boolean;
+  @Prop({ reflectToAttr: true }) strState: string;
+  @Prop() noreflect: boolean;
+}

--- a/test/karma/test-app/attribute-boolean/index.html
+++ b/test/karma/test-app/attribute-boolean/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf8">
+<script src="/build/testapp.js"></script>
+
+<attribute-boolean-root></attribute-boolean-root>

--- a/test/karma/test-app/attribute-boolean/karma.spec.ts
+++ b/test/karma/test-app/attribute-boolean/karma.spec.ts
@@ -1,0 +1,53 @@
+import { setupDomTests, flush } from '../util';
+
+
+describe('attribute-boolean', function() {
+  const { setupDom, tearDownDom } = setupDomTests(document);
+  let app: HTMLElement;
+
+  beforeEach(async () => {
+    app = await setupDom('/attribute-boolean/index.html');
+  });
+  afterEach(tearDownDom);
+
+  it('button click rerenders', async () => {
+    const root = app.querySelector('attribute-boolean-root');
+    expect(root.getAttribute('aria-hidden')).toBe('false');
+    expect(root.getAttribute('fixedtrue')).toBe('true');
+    expect(root.getAttribute('fixedfalse')).toBe('false');
+    expect(root.getAttribute('readonly')).toBe(null);
+    expect(root.getAttribute('tappable')).toBe(null);
+    expect(root.getAttribute('str')).toBe(null);
+    expect(root.getAttribute('no-appear')).toBe(null);
+    expect(root.getAttribute('no-appear-two')).toBe(null);
+
+    const child = root.querySelector('attribute-boolean');
+    expect(child.getAttribute('aria-hidden')).toBe('false');
+    expect(child.getAttribute('str-state')).toBe('false');
+    expect(child.getAttribute('bool-state')).toBe(null);
+    expect(child.getAttribute('noreflect')).toBe(null);
+    expect(child.getAttribute('tappable')).toBe(null);
+
+
+    const button = app.querySelector('button');
+    button.click();
+
+    await flush(app);
+
+
+    expect(root.getAttribute('aria-hidden')).toBe('true');
+    expect(root.getAttribute('fixedtrue')).toBe('true');
+    expect(root.getAttribute('fixedfalse')).toBe('false');
+    expect(root.getAttribute('readonly')).toBe('');
+    expect(root.getAttribute('tappable')).toBe('');
+    expect(root.getAttribute('str')).toBe('hello');
+    expect(root.getAttribute('no-appear')).toBe(null);
+    expect(root.getAttribute('no-appear-two')).toBe(null);
+
+    expect(child.getAttribute('aria-hidden')).toBe('true');
+    expect(child.getAttribute('str-state')).toBe('true');
+    expect(child.getAttribute('bool-state')).toBe('');
+    expect(child.getAttribute('noreflect')).toBe(null);
+    expect(child.getAttribute('tappable')).toBe('');
+  });
+});

--- a/test/karma/test-app/attribute-host/karma.spec.ts
+++ b/test/karma/test-app/attribute-host/karma.spec.ts
@@ -15,7 +15,7 @@ describe('attribute-host', function() {
     const button = app.querySelector('button');
 
     expect(elm.getAttribute('content')).toBe('attributes removed');
-    expect(elm.getAttribute('padding')).toBe('false');
+    expect(elm.getAttribute('padding')).toBe(null);
     expect(elm.getAttribute('bold')).toBe('false');
     expect(elm.getAttribute('margin')).toBe(null);
     expect(elm.getAttribute('color')).toBe(null);
@@ -44,7 +44,7 @@ describe('attribute-host', function() {
     }
 
     expect(elm.getAttribute('content')).toBe('attributes added');
-    expect(elm.getAttribute('padding')).toBe('true');
+    expect(elm.getAttribute('padding')).toBe('');
     expect(elm.getAttribute('bold')).toBe('true');
     expect(elm.getAttribute('margin')).toBe('');
     expect(elm.getAttribute('color')).toBe('lime');
@@ -62,7 +62,7 @@ describe('attribute-host', function() {
     }
 
     expect(elm.getAttribute('content')).toBe('attributes removed');
-    expect(elm.getAttribute('padding')).toBe('false');
+    expect(elm.getAttribute('padding')).toBe(null);
     expect(elm.getAttribute('bold')).toBe('false');
     expect(elm.getAttribute('margin')).toBe(null);
     expect(elm.getAttribute('color')).toBe(null);
@@ -80,7 +80,7 @@ describe('attribute-host', function() {
     }
 
     expect(elm.getAttribute('content')).toBe('attributes added');
-    expect(elm.getAttribute('padding')).toBe('true');
+    expect(elm.getAttribute('padding')).toBe('');
     expect(elm.getAttribute('bold')).toBe('true');
     expect(elm.getAttribute('margin')).toBe('');
     expect(elm.getAttribute('color')).toBe('lime');

--- a/test/karma/test-app/components.d.ts
+++ b/test/karma/test-app/components.d.ts
@@ -99,6 +99,76 @@ declare global {
 declare global {
 
   namespace StencilComponents {
+    interface AttributeBooleanRoot {
+      'toggleState': () => void;
+    }
+  }
+
+  interface HTMLAttributeBooleanRootElement extends StencilComponents.AttributeBooleanRoot, HTMLStencilElement {}
+
+  var HTMLAttributeBooleanRootElement: {
+    prototype: HTMLAttributeBooleanRootElement;
+    new (): HTMLAttributeBooleanRootElement;
+  };
+  interface HTMLElementTagNameMap {
+    'attribute-boolean-root': HTMLAttributeBooleanRootElement;
+  }
+  interface ElementTagNameMap {
+    'attribute-boolean-root': HTMLAttributeBooleanRootElement;
+  }
+  namespace JSX {
+    interface IntrinsicElements {
+      'attribute-boolean-root': JSXElements.AttributeBooleanRootAttributes;
+    }
+  }
+  namespace JSXElements {
+    export interface AttributeBooleanRootAttributes extends HTMLAttributes {
+
+    }
+  }
+}
+
+
+declare global {
+
+  namespace StencilComponents {
+    interface AttributeBoolean {
+      'boolState': boolean;
+      'noreflect': boolean;
+      'strState': string;
+    }
+  }
+
+  interface HTMLAttributeBooleanElement extends StencilComponents.AttributeBoolean, HTMLStencilElement {}
+
+  var HTMLAttributeBooleanElement: {
+    prototype: HTMLAttributeBooleanElement;
+    new (): HTMLAttributeBooleanElement;
+  };
+  interface HTMLElementTagNameMap {
+    'attribute-boolean': HTMLAttributeBooleanElement;
+  }
+  interface ElementTagNameMap {
+    'attribute-boolean': HTMLAttributeBooleanElement;
+  }
+  namespace JSX {
+    interface IntrinsicElements {
+      'attribute-boolean': JSXElements.AttributeBooleanAttributes;
+    }
+  }
+  namespace JSXElements {
+    export interface AttributeBooleanAttributes extends HTMLAttributes {
+      'boolState'?: boolean;
+      'noreflect'?: boolean;
+      'strState'?: string;
+    }
+  }
+}
+
+
+declare global {
+
+  namespace StencilComponents {
     interface AttributeComplex {
       'bool0': boolean;
       'bool1': boolean;

--- a/test/karma/test-app/reflect-to-attr/karma.spec.ts
+++ b/test/karma/test-app/reflect-to-attr/karma.spec.ts
@@ -10,24 +10,15 @@ describe('reflect-to-attr', function() {
   });
   afterEach(tearDownDom);
 
-  // @Prop({reflectToAttr: true}) str = 'single';
-  // @Prop({reflectToAttr: true}) nu = 2;
-  // @Prop({reflectToAttr: true}) undef: string;
-  // @Prop({reflectToAttr: true}) null: string = null;
-  // @Prop({reflectToAttr: true}) bool = false;
-  // @Prop({reflectToAttr: true}) otherBool = true;
-
-  // @Prop({reflectToAttr: true, mutable: true}) dynamicStr: string;
-  // @Prop({reflectToAttr: true}) dynamicNu: number;
   it('should have proper attributes', async () => {
 
     const cmp = app.querySelector('reflect-to-attr') as any;
 
     expect(cmp.getAttribute('str')).toEqual('single');
     expect(cmp.getAttribute('nu')).toEqual('2');
-    expect(cmp.hasAttribute('undef')).toEqual(false);
-    expect(cmp.hasAttribute('null')).toEqual(false);
-    expect(cmp.hasAttribute('bool')).toEqual(false);
+    expect(cmp.getAttribute('undef')).toEqual(null);
+    expect(cmp.getAttribute('null')).toEqual(null);
+    expect(cmp.getAttribute('bool')).toEqual(null);
     expect(cmp.getAttribute('other-bool')).toEqual('');
 
     cmp.str = 'second';
@@ -44,7 +35,7 @@ describe('reflect-to-attr', function() {
     expect(cmp.getAttribute('undef')).toEqual('no undef');
     expect(cmp.getAttribute('null')).toEqual('no null');
     expect(cmp.getAttribute('bool')).toEqual('');
-    expect(cmp.hasAttribute('other-bool')).toEqual(false);
+    expect(cmp.getAttribute('other-bool')).toEqual(null);
 
     expect(cmp.getAttribute('dynamic-str')).toEqual('value');
     expect(cmp.getAttribute('dynamic-nu')).toEqual('123');


### PR DESCRIPTION
- Setting boolean true / false to an attribute should render as a boolean attribute in HTML

```html
// tappable: false
<div></div>
```

```html
// tappable: true
<div tappable></div>
```

- Passing a boolean to a string prop, should cast the boolean to string and render as string

```html
// str: false
<my-component str="false"></my-component >
```

```html
// str: true
<my-component  str="true"></my-component >
```

- Passing a string to an attribute should always render the string

```html
// aria-hidden: "false"
<div aria-hidden="false"></div>
```

```html
// aria-hidden: "true"
<div aria-hidden="true"></div>
```