### PR TITLE
fix(dev-server): set src for dev-server iframe to requested url

### DIFF
--- a/src/declarations/dev-server.ts
+++ b/src/declarations/dev-server.ts
@@ -1,4 +1,5 @@
 import * as d from '.';
+import * as http from 'http';
 
 
 export interface DevServerConfig {
@@ -54,6 +55,7 @@ export interface HttpRequest {
   filePath?: string;
   stats?: d.FsStats;
   headers?: {[name: string]: string};
+  originalRequest?: http.IncomingMessage;
 }
 
 

--- a/src/dev-server/request-handler.ts
+++ b/src/dev-server/request-handler.ts
@@ -69,7 +69,8 @@ function normalizeHttpRequest(devServerConfig: d.DevServerConfig, incomingReq: h
   const req: d.HttpRequest = {
     method: (incomingReq.method || 'GET').toUpperCase() as any,
     acceptHeader: (incomingReq.headers && typeof incomingReq.headers.accept === 'string' && incomingReq.headers.accept) || '',
-    url: (incomingReq.url || '').trim() || ''
+    url: (incomingReq.url || '').trim() || '',
+    originalRequest: incomingReq
   };
 
   const parsedUrl = url.parse(req.url);

--- a/src/dev-server/serve-dev-client.ts
+++ b/src/dev-server/serve-dev-client.ts
@@ -60,7 +60,8 @@ async function serveDevClientScript(devServerConfig: d.DevServerConfig, fs: d.Fi
 }
 
 
-export function getDevServerClientScript(devServerConfig: d.DevServerConfig) {
-  const devServerClientUrl = util.getDevServerClientUrl(devServerConfig);
+export function getDevServerClientScript(scriptSourceConfig: d.DevServerConfig) {
+  const baseUrl = scriptSourceConfig.baseUrl || '/';
+  const devServerClientUrl = `//${scriptSourceConfig.address}${baseUrl}${util.DEV_SERVER_URL.replace('/', '')}`;
   return `\n<iframe src="${devServerClientUrl}" style="width:0;height:0;border:0"></iframe>`;
 }

--- a/src/dev-server/serve-file.ts
+++ b/src/dev-server/serve-file.ts
@@ -18,7 +18,10 @@ export async function serveFile(devServerConfig: d.DevServerConfig, fs: d.FileSy
 
       if (util.isHtmlFile(req.filePath) && !util.isDevServerClient(req.pathname)) {
         // auto inject our dev server script
-        content += getDevServerClientScript(devServerConfig);
+        content += getDevServerClientScript({
+          address: req.originalRequest.headers.host,
+          baseUrl: devServerConfig.baseUrl
+        });
 
       } else if (util.isCssFile(req.filePath)) {
         content = updateStyleUrls(req.url, content);

--- a/src/dev-server/test/util.spec.ts
+++ b/src/dev-server/test/util.spec.ts
@@ -1,5 +1,5 @@
 import * as d from '../../declarations';
-import { getBrowserUrl, getDevServerClientUrl } from '../util';
+import { DEV_SERVER_URL, getBrowserUrl, getDevServerClientUrl } from '../util';
 
 
 describe('dev-server, util', () => {
@@ -59,7 +59,7 @@ describe('dev-server, util', () => {
     expect(url).toBe('http://staging.stenciljs.com:3333/');
   });
 
-  it('should get path for dev server w/ base url', () => {
+  it('should get path for dev server w/ base url and port', () => {
     const devServerConfig: d.DevServerConfig = {
       protocol: 'http',
       address: '0.0.0.0',
@@ -67,18 +67,28 @@ describe('dev-server, util', () => {
       baseUrl: '/my-base-url/'
     };
     const url = getDevServerClientUrl(devServerConfig);
-    expect(url).toBe('http://localhost:3333/my-base-url/~dev-server');
+    expect(url).toBe(`${devServerConfig.protocol}://localhost:3333/my-base-url${DEV_SERVER_URL}`);
   });
 
-  it('should get path for dev server', () => {
+  it('should get path for dev server w/ base url and w/out port', () => {
     const devServerConfig: d.DevServerConfig = {
       protocol: 'http',
       address: '0.0.0.0',
-      port: 3333,
-      baseUrl: '/'
+      baseUrl: '/my-base-url/'
     };
     const url = getDevServerClientUrl(devServerConfig);
-    expect(url).toBe('http://localhost:3333/~dev-server');
+    expect(url).toBe(`${devServerConfig.protocol}://localhost/my-base-url${DEV_SERVER_URL}`);
+  });
+
+  it('should get path for dev server w/ custom address, base url and port', () => {
+    const devServerConfig: d.DevServerConfig = {
+      protocol: 'http',
+      address: '1.2.3.4',
+      port: 3333,
+      baseUrl: '/my-base-url/'
+    };
+    const url = getDevServerClientUrl(devServerConfig);
+    expect(url).toBe(`${devServerConfig.protocol}://${devServerConfig.address}:3333/my-base-url${DEV_SERVER_URL}`);
   });
 
 });

--- a/src/dev-server/util.ts
+++ b/src/dev-server/util.ts
@@ -44,7 +44,7 @@ const DEFAULT_HEADERS: d.DevResponseHeaders = {
 
 export function getBrowserUrl(devServerConfig: d.DevServerConfig, pathname = '/') {
   const address = (devServerConfig.address === `0.0.0.0`) ? `localhost` : devServerConfig.address;
-  const port = (devServerConfig.port === 80 || devServerConfig.port === 443) ? '' : (':' + devServerConfig.port);
+  const port = (!devServerConfig.port || devServerConfig.port === 80 || devServerConfig.port === 443) ? '' : (':' + devServerConfig.port);
   let path = devServerConfig.baseUrl;
   if (pathname.startsWith('/')) {
     pathname = pathname.substring(1);


### PR DESCRIPTION
Build the absolute url of the dev-server iframe by using the host-header of the incoming request. This ensures, that the client can always connect to to the dev-server. It doesn't matter if it's another network device (not localhost) or if a `<base href="http://domain.tld">` tag is set in the index.html