### PR TITLE
fix(fs-watch): reload window if service worker changed

### DIFF
--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -132,6 +132,7 @@ const ARG_OPTS = {
     'log',
     'open',
     'prerender',
+    'service-worker',
     'prod',
     'serve',
     'skip-node-check',

--- a/src/cli/test/parse-flags.spec.ts
+++ b/src/cli/test/parse-flags.spec.ts
@@ -284,6 +284,12 @@ describe('parseFlags', () => {
     expect(flags.serve).toBe(true);
   });
 
+  it('should parse --service-worker', () => {
+    process.argv[2] = '--service-worker';
+    const flags = parseFlags(process);
+    expect(flags.serviceWorker).toBe(true);
+  });
+
   it('should parse --stats', () => {
     process.argv[2] = '--stats';
     const flags = parseFlags(process);

--- a/src/compiler/build/build-ctx.ts
+++ b/src/compiler/build/build-ctx.ts
@@ -29,6 +29,7 @@ export class BuildContext implements d.BuildCtx {
   hasCopyChanges = false;
   hasFinished = false;
   hasIndexHtmlChanges = false;
+  hasServiceWorkerChanges = false;
   hasScriptChanges = true;
   hasSlot: boolean = null;
   hasStyleChanges = true;

--- a/src/compiler/build/build-hmr.ts
+++ b/src/compiler/build/build-hmr.ts
@@ -26,6 +26,10 @@ export function genereateHmr(config: d.Config, compilerCtx: d.CompilerCtx, build
     hmr.indexHtmlUpdated = true;
   }
 
+  if (buildCtx.hasServiceWorkerChanges) {
+    hmr.serviceWorkerUpdated = true;
+  }
+
   const componentsUpdated = getComponentsUpdated(compilerCtx, buildCtx);
   if (componentsUpdated) {
     hmr.componentsUpdated = componentsUpdated;

--- a/src/compiler/config/test/validate-service-worker.spec.ts
+++ b/src/compiler/config/test/validate-service-worker.spec.ts
@@ -3,13 +3,13 @@ import { mockStencilSystem } from '../../../testing/mocks';
 import { normalizePath } from '../../../compiler/util';
 import { validateServiceWorker } from '../validate-service-worker';
 
-
 describe('validateServiceWorker', () => {
 
   const config: d.Config = {
     fsNamespace: 'app',
     sys: mockStencilSystem(),
-    devMode: false
+    devMode: false,
+    flags: {}
   };
 
   let outputTarget: d.OutputTargetWww;
@@ -153,6 +153,17 @@ describe('validateServiceWorker', () => {
     config.devMode = true;
     validateServiceWorker(config, outputTarget);
     expect(outputTarget.serviceWorker).toBe(null);
+  });
+
+  it('should create sw config when in devMode if flag serviceWorker', () => {
+    outputTarget = {
+      dir: '/www',
+      serviceWorker: true as any
+    };
+    config.devMode = true;
+    config.flags.serviceWorker = true;
+    validateServiceWorker(config, outputTarget);
+    expect(outputTarget.serviceWorker).not.toBe(null);
   });
 
   it('should do nothing when falsy', () => {

--- a/src/compiler/config/validate-service-worker.ts
+++ b/src/compiler/config/validate-service-worker.ts
@@ -4,7 +4,7 @@ import { HOST_CONFIG_FILENAME } from '../prerender/host-config';
 
 
 export function validateServiceWorker(config: d.Config, outputTarget: d.OutputTargetWww) {
-  if (config.devMode) {
+  if (config.devMode && !config.flags.serviceWorker) {
     outputTarget.serviceWorker = null;
     return;
   }

--- a/src/compiler/fs-watch/fs-watch-rebuild.ts
+++ b/src/compiler/fs-watch/fs-watch-rebuild.ts
@@ -2,7 +2,7 @@ import * as d from '../../declarations';
 import { BuildContext } from '../build/build-ctx';
 import { configFileReload } from '../config/config-reload';
 import { isCopyTaskFile } from '../copy/config-copy-tasks';
-import { normalizePath, pathJoin } from '../util';
+import { hasServiceWorkerChanges, normalizePath, pathJoin } from '../util';
 
 
 export function generateBuildFromFsWatch(config: d.Config, compilerCtx: d.CompilerCtx, fsWatchResults: d.FsWatchResults) {
@@ -45,6 +45,8 @@ export function generateBuildFromFsWatch(config: d.Config, compilerCtx: d.Compil
 
   // figure out if any changed files were index.html files
   buildCtx.hasIndexHtmlChanges = hasIndexHtmlChanges(config, buildCtx);
+
+  buildCtx.hasServiceWorkerChanges = hasServiceWorkerChanges(config, buildCtx);
 
   // we've got watch results, which means this is a rebuild!!
   buildCtx.isRebuild = true;

--- a/src/compiler/service-worker/generate-sw.ts
+++ b/src/compiler/service-worker/generate-sw.ts
@@ -1,6 +1,5 @@
 import * as d from '../../declarations';
-import { buildWarn, catchError, hasError } from '../util';
-
+import { buildWarn, catchError, hasError, hasServiceWorkerChanges } from '../util';
 
 export async function generateServiceWorkers(config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) {
   const wwwServiceOutputs = (config.outputTargets as d.OutputTargetWww[]).filter(o => o.type === 'www' && o.serviceWorker);
@@ -85,7 +84,8 @@ async function canSkipGenerateSW(config: d.Config, compilerCtx: d.CompilerCtx, b
     return true;
   }
 
-  if ((compilerCtx.hasSuccessfulBuild && buildCtx.appFileBuildCount === 0) || hasError(buildCtx.diagnostics)) {
+  const hasServiceWorkerChanged = await hasServiceWorkerChanges(config, buildCtx);
+  if ((compilerCtx.hasSuccessfulBuild && buildCtx.appFileBuildCount === 0 && !hasServiceWorkerChanged) || hasError(buildCtx.diagnostics)) {
     // no need to rebuild index.html if there were no app file changes
     return true;
   }

--- a/src/compiler/service-worker/generate-sw.ts
+++ b/src/compiler/service-worker/generate-sw.ts
@@ -84,7 +84,7 @@ async function canSkipGenerateSW(config: d.Config, compilerCtx: d.CompilerCtx, b
     return true;
   }
 
-  const hasServiceWorkerChanged = await hasServiceWorkerChanges(config, buildCtx);
+  const hasServiceWorkerChanged = hasServiceWorkerChanges(config, buildCtx);
   if ((compilerCtx.hasSuccessfulBuild && buildCtx.appFileBuildCount === 0 && !hasServiceWorkerChanged) || hasError(buildCtx.diagnostics)) {
     // no need to rebuild index.html if there were no app file changes
     return true;

--- a/src/compiler/util.ts
+++ b/src/compiler/util.ts
@@ -2,6 +2,16 @@ import * as d from '../declarations';
 import { BANNER } from '../util/constants';
 
 
+export function hasServiceWorkerChanges(config: d.Config, buildCtx: d.BuildCtx) {
+  if (config.devMode && !config.flags.serviceWorker) {
+    return false;
+  }
+  const wwwServiceOutputs = (config.outputTargets as d.OutputTargetWww[]).filter(o => o.type === 'www' && o.serviceWorker);
+  return wwwServiceOutputs.some(outputTarget => {
+    return buildCtx.filesChanged.some(fileChanged => config.sys.path.basename(fileChanged).toLowerCase() === config.sys.path.basename(outputTarget.serviceWorker.swSrc).toLowerCase());
+  });
+}
+
 /**
  * Test if a file is a typescript source file, such as .ts or .tsx.
  * However, d.ts files and spec.ts files return false.

--- a/src/declarations/build.ts
+++ b/src/declarations/build.ts
@@ -101,10 +101,10 @@ export interface HotModuleReplacement {
   externalStylesUpdated?: string[];
   imagesUpdated?: string[];
   indexHtmlUpdated?: boolean;
-  serviceWorkerUpdated?: boolean;
   inlineStylesUpdated?: HmrStyleUpdate[];
   scriptsAdded?: string[];
   scriptsDeleted?: string[];
+  serviceWorkerUpdated?: boolean;
   versionId?: string;
 }
 

--- a/src/declarations/build.ts
+++ b/src/declarations/build.ts
@@ -31,6 +31,7 @@ export interface BuildCtx {
   hasCopyChanges: boolean;
   hasFinished: boolean;
   hasIndexHtmlChanges: boolean;
+  hasServiceWorkerChanges: boolean;
   hasScriptChanges: boolean;
   hasSlot: boolean;
   hasStyleChanges: boolean;
@@ -100,6 +101,7 @@ export interface HotModuleReplacement {
   externalStylesUpdated?: string[];
   imagesUpdated?: string[];
   indexHtmlUpdated?: boolean;
+  serviceWorkerUpdated?: boolean;
   inlineStylesUpdated?: HmrStyleUpdate[];
   scriptsAdded?: string[];
   scriptsDeleted?: string[];

--- a/src/declarations/config.ts
+++ b/src/declarations/config.ts
@@ -91,6 +91,7 @@ export interface ConfigFlags {
   open?: boolean;
   port?: number;
   prerender?: boolean;
+  serviceWorker?: boolean;
   prod?: boolean;
   root?: string;
   serve?: boolean;

--- a/src/declarations/config.ts
+++ b/src/declarations/config.ts
@@ -91,10 +91,10 @@ export interface ConfigFlags {
   open?: boolean;
   port?: number;
   prerender?: boolean;
-  serviceWorker?: boolean;
   prod?: boolean;
   root?: string;
   serve?: boolean;
+  serviceWorker?: boolean;
   ssr?: boolean;
   stats?: boolean;
   version?: boolean;

--- a/src/dev-server/dev-client/app-update.ts
+++ b/src/dev-server/dev-client/app-update.ts
@@ -50,6 +50,11 @@ function appHmr(win: Window, doc: Document, hmr: d.HotModuleReplacement) {
     shouldWindowReload = true;
   }
 
+  if (hmr.serviceWorkerUpdated) {
+    logReload(`Updated Service Worker: sw.js`);
+    shouldWindowReload = true;
+  }
+
   if (hmr.scriptsAdded && hmr.scriptsAdded.length > 0) {
     logReload(`Added scripts: ${hmr.scriptsAdded.join(', ')}`);
     shouldWindowReload = true;


### PR DESCRIPTION
- Add `service-worker` flag.
- Allow service worker to be injected on dev builds if `service-worker` flag is set.
- If service worker file changes then reload window.

Fixes: #789 