### PR TITLE
Update NodeResolveConfig

### DIFF
--- a/src/declarations/config.ts
+++ b/src/declarations/config.ts
@@ -175,7 +175,7 @@ export interface NodeResolveConfig {
   only?: Array<string | RegExp>;
   modulesOnly?: boolean;
   customResolveOptions?: {
-    [key: string]: string
+    [key: string]: string | string[]
   };
 }
 


### PR DESCRIPTION
Update `NodeResolveConfig` `customResolveOptions` to allow `string[]`. Some node-resolve options, such as `moduleDirectory`, can take a string array.