### PR TITLE
use source target to build global esm path

### DIFF
--- a/src/compiler/app/app-global-scripts.ts
+++ b/src/compiler/app/app-global-scripts.ts
@@ -29,7 +29,7 @@ export async function generateAppGlobalScript(config: Config, compilerCtx: Compi
     }
 
     config.outputTargets.filter(o => o.type === 'dist').forEach(outputTarget => {
-      const appGlobalFilePath = getGlobalEsmBuildPath(config, outputTarget as any, 'es5');
+      const appGlobalFilePath = getGlobalEsmBuildPath(config, outputTarget as any, sourceTarget);
       promises.push(compilerCtx.fs.writeFile(appGlobalFilePath, globalEsmContent));
     });
 


### PR DESCRIPTION
So we were running into issues when we set the source target of our components to es5. Periodically we would see that our `XXXX.global.js` was not transpiled to es5. Interesting it would happen pretty consistently on circleci. Anyway, after much digging into the stencil source we found that it wasn't that it wasn't being transpiled, it was that the file was being override. Basically in [generateAppGlobalScript(...)](https://github.com/ionic-team/stencil/blob/master/src/compiler/app/app-global-scripts.ts#L11)  'es5' was being use regardless of whether the `sourceTarget` was actually es5, [here](https://github.com/ionic-team/stencil/blob/master/src/compiler/app/app-global-scripts.ts#L32), it should really pass in the `sourceTarget` (which is the proposed fix) This meant that if source target was set to es5 the global files generated by the call to [generateBrowserCoreEsm(...) here](https://github.com/ionic-team/stencil/blob/master/src/compiler/app/generate-app-files.ts#L51) and the call to [generateBrowserCoreEs5(...) here](https://github.com/ionic-team/stencil/blob/master/src/compiler/app/generate-app-files.ts#L54) would share the same path. As these calls are running in an `await Promise.all` which ever finishes last gets to write the content, hence the transpiled/non-transpiled behaviour. Its not clear to me why two versions of the `XXXX.global.js` are being generated? May be there is a deeper issue here, I hope someone with more insight can let me know. I would be happy to amend my PR.