### PR TITLE
Esm es5 exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,11 +50,11 @@
     "chokidar": "2.0.3",
     "jsdom": "11.11.0",
     "rollup": "0.64.1",
-    "rollup-plugin-commonjs": "9.1.3",
+    "rollup-plugin-commonjs": "9.1.5",
     "rollup-plugin-node-builtins": "2.1.2",
     "rollup-plugin-node-globals": "1.2.1",
     "rollup-plugin-node-resolve": "3.3.0",
-    "rollup-pluginutils": "2.3.0",
+    "rollup-pluginutils": "2.3.1",
     "typescript": "~2.9.1",
     "workbox-build": "^3.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "chokidar": "2.0.3",
     "jsdom": "11.11.0",
-    "rollup": "0.63.5",
+    "rollup": "0.64.1",
     "rollup-plugin-commonjs": "9.1.3",
     "rollup-plugin-node-builtins": "2.1.2",
     "rollup-plugin-node-globals": "1.2.1",

--- a/src/compiler/distribution/dist-esm.ts
+++ b/src/compiler/distribution/dist-esm.ts
@@ -13,8 +13,11 @@ export async function generateEsmIndex(config: d.Config, compilerCtx: d.Compiler
   const defineLibraryEsm = getDefineCustomElementsPath(config, outputTarget, 'es5');
   await addExport(config, compilerCtx, outputTarget, esm, defineLibraryEsm);
 
-  const collectionIndexPath = pathJoin(config, outputTarget.collectionDir, 'index.js');
-  await addExport(config, compilerCtx, outputTarget, esm, collectionIndexPath);
+  const exportsIndexPath =  pathJoin(config, getDistEsmBuildDir(config, outputTarget), `es5`, `index.js`);
+  const fileExists = await compilerCtx.fs.access(exportsIndexPath);
+  if (fileExists) {
+    await addExport(config, compilerCtx, outputTarget, esm, exportsIndexPath);
+  }
 
   const distIndexEsmPath = getDistEsmIndexPath(config, outputTarget);
   await Promise.all([


### PR DESCRIPTION
This PR is to add an index.js file to the esm es5 directory so that we can have all utilities exported as es5 instead of referencing the collection directory.