### PR TITLE
fix(): export StencilComponents from core builds and all import to angular builds.

### DIFF
--- a/src/compiler/distribution/dist-angular.ts
+++ b/src/compiler/distribution/dist-angular.ts
@@ -47,10 +47,13 @@ async function angularDirectiveProxyOutput(config: d.Config, compilerCtx: d.Comp
   }
 
   const imports = `import { ${angularImports.sort().join(', ')} } from '@angular/core';`;
+  const sourceImports = outputTarget.componentCorePackage ? `import { StencilComponents } from '${ outputTarget.componentCorePackage };` : '';
+
   const final: string[] = [
     '/* auto-generated angular directive proxies */',
     '/* tslint:disable */',
     imports,
+    sourceImports,
     auxFunctions.join('\n'),
     proxies,
   ];

--- a/src/compiler/transpile/create-component-types.ts
+++ b/src/compiler/transpile/create-component-types.ts
@@ -77,7 +77,7 @@ async function generateComponentTypesFile(config: d.Config, compilerCtx: d.Compi
   });
 
   const componentsFileString = `
-declare namespace StencilComponents {
+export namespace StencilComponents {
 ${modules.map(m => {
     return `${m.StencilComponents}${m.JSXElements}`;
   })

--- a/src/declarations/output-targets.ts
+++ b/src/declarations/output-targets.ts
@@ -79,6 +79,7 @@ export interface OutputTargetAngular extends OutputTargetBase {
   resourcesUrl?: string;
 
   typesDir?: string;
+  componentCorePackage?: string;
   directivesProxyFile?: string;
   directivesArrayFile?: string;
   excludeComponents?: string[];


### PR DESCRIPTION
This PR is to fix issues with StencilComponents being removed from global scope.