### PR TITLE
docs: updates jsdocs props to match readme types

### DIFF
--- a/screenshot/screenshot-connector.js
+++ b/screenshot/screenshot-connector.js
@@ -1,0 +1,3 @@
+
+const { ScreenshotConnector } = require('./index.js');
+module.exports = ScreenshotConnector;

--- a/src/compiler/docs/docs-util.ts
+++ b/src/compiler/docs/docs-util.ts
@@ -1,5 +1,5 @@
 import * as d from '../../declarations';
-
+import { PROP_TYPE } from '../../util/constants';
 
 export class MarkdownTable {
   private rows: RowData[] = [];
@@ -28,9 +28,7 @@ export class MarkdownTable {
   toMarkdown() {
     return createTable(this.rows);
   }
-
 }
-
 
 function createTable(rows: RowData[]) {
   const content: string[] = [];
@@ -55,7 +53,6 @@ function createTable(rows: RowData[]) {
   return content;
 }
 
-
 function createBorder(th: RowData) {
   const border: RowData = {
     columns: [],
@@ -76,7 +73,6 @@ function createBorder(th: RowData) {
   return createRow(border);
 }
 
-
 function createRow(row: RowData) {
   const content: string[] = ['| '];
 
@@ -88,12 +84,10 @@ function createRow(row: RowData) {
   return content.join('').trim();
 }
 
-
 function normalize(rows: RowData[]) {
   normalizeColumCount(rows);
   normalizeColumnWidth(rows);
 }
-
 
 function normalizeColumCount(rows: RowData[]) {
   let columnCount = 0;
@@ -113,7 +107,6 @@ function normalizeColumCount(rows: RowData[]) {
     }
   });
 }
-
 
 function normalizeColumnWidth(rows: RowData[]) {
   const columnCount = rows[0].columns.length;
@@ -136,9 +129,7 @@ function normalizeColumnWidth(rows: RowData[]) {
       }
     });
   }
-
 }
-
 
 interface ColumnData {
   text: string;
@@ -150,7 +141,6 @@ interface RowData {
   isHeader?: boolean;
 }
 
-
 export function getMemberDocumentation(jsDoc: d.JsDoc) {
   if (jsDoc && typeof jsDoc.documentation === 'string') {
     return jsDoc.documentation.trim();
@@ -159,13 +149,15 @@ export function getMemberDocumentation(jsDoc: d.JsDoc) {
 }
 
 export function getMemberType(jsDoc: d.JsDoc) {
-  if (jsDoc && typeof jsDoc.type === "string") {
+  if (jsDoc && typeof jsDoc.type === 'string') {
     return jsDoc.type.trim();
   }
-  return "";
+  return '';
 }
 
-export function getMethodParameters({ parameters }: d.JsDoc): d.JsonDocMethodParameter[] {
+export function getMethodParameters({
+  parameters
+}: d.JsDoc): d.JsonDocMethodParameter[] {
   if (parameters) {
     return parameters.map(({ name, type, documentation }) => ({
       name,
@@ -184,4 +176,42 @@ export function getMethodReturns({ returns }: d.JsDoc): d.JsonDocsMethodReturn {
     };
   }
   return null;
+}
+
+export function getPropType(
+  memberMeta: d.MemberMeta,
+  format = (type: string) => type
+) {
+  if (memberMeta.attribType && memberMeta.attribType.text) {
+    if (!memberMeta.attribType.text.includes('(')) {
+      const typeSplit = memberMeta.attribType.text.split('|').map(t => {
+        return format(t.replace(/\'/g, '"').trim());
+      });
+
+      return typeSplit.join(', ');
+    }
+
+    return format(memberMeta.attribType.text);
+  }
+
+  let propType;
+  switch (memberMeta.propType) {
+    case PROP_TYPE.Any:
+      propType = 'any';
+      break;
+    case PROP_TYPE.Boolean:
+      propType = 'boolean';
+      break;
+    case PROP_TYPE.Number:
+      propType = 'number';
+      break;
+    case PROP_TYPE.String:
+      propType = 'string';
+      break;
+    default:
+      propType = '';
+      break;
+  }
+
+  return format(propType);
 }

--- a/src/compiler/docs/generate-json-doc.ts
+++ b/src/compiler/docs/generate-json-doc.ts
@@ -1,9 +1,20 @@
 import * as d from '../../declarations';
-import { getMemberDocumentation, getMethodParameters, getMethodReturns } from './docs-util';
-import { MEMBER_TYPE, PROP_TYPE } from '../../util/constants';
+import {
+  getMemberDocumentation,
+  getMethodParameters,
+  getMethodReturns,
+  getPropType
+} from './docs-util';
+import { MEMBER_TYPE } from '../../util/constants';
 
-
-export async function generateJsDocComponent(config: d.Config, compilerCtx: d.CompilerCtx, jsonDocs: d.JsonDocs, cmpMeta: d.ComponentMeta, dirPath: string, readmeContent: string) {
+export async function generateJsDocComponent(
+  config: d.Config,
+  compilerCtx: d.CompilerCtx,
+  jsonDocs: d.JsonDocs,
+  cmpMeta: d.ComponentMeta,
+  dirPath: string,
+  readmeContent: string
+) {
   const jsonCmp: d.JsonDocsComponent = {
     tag: cmpMeta.tagNameMeta,
     docs: getMemberDocumentation(cmpMeta.jsdoc),
@@ -22,8 +33,11 @@ export async function generateJsDocComponent(config: d.Config, compilerCtx: d.Co
   jsonDocs.components.push(jsonCmp);
 }
 
-
-async function generateJsDocsUsages(config: d.Config, compilerCtx: d.CompilerCtx, dirPath: string) {
+async function generateJsDocsUsages(
+  config: d.Config,
+  compilerCtx: d.CompilerCtx,
+  dirPath: string
+) {
   const rtn: d.JsonDocsUsage = {};
   const usagesDir = config.sys.path.join(dirPath, 'usage');
 
@@ -32,149 +46,134 @@ async function generateJsDocsUsages(config: d.Config, compilerCtx: d.CompilerCtx
 
     const usages: d.JsonDocsUsage = {};
 
-    await Promise.all(usageFilePaths.map(async f => {
-      if (!f.isFile) {
-        return;
-      }
+    await Promise.all(
+      usageFilePaths.map(async f => {
+        if (!f.isFile) {
+          return;
+        }
 
-      const fileName = config.sys.path.basename(f.relPath);
-      if (!fileName.endsWith('.md')) {
-        return;
-      }
+        const fileName = config.sys.path.basename(f.relPath);
+        if (!fileName.endsWith('.md')) {
+          return;
+        }
 
-      const parts = fileName.split('.');
-      parts.pop();
-      const key = parts.join('.');
+        const parts = fileName.split('.');
+        parts.pop();
+        const key = parts.join('.');
 
-      usages[key] = await compilerCtx.fs.readFile(f.absPath);
-    }));
+        usages[key] = await compilerCtx.fs.readFile(f.absPath);
+      })
+    );
 
-    Object.keys(usages).sort().forEach(key => {
-      rtn[key] = usages[key];
-    });
-
+    Object.keys(usages)
+      .sort()
+      .forEach(key => {
+        rtn[key] = usages[key];
+      });
   } catch (e) {}
 
   return rtn;
 }
 
-
-function generateJsDocMembers(cmpMeta: d.ComponentMeta, jsonCmp: d.JsonDocsComponent) {
+function generateJsDocMembers(
+  cmpMeta: d.ComponentMeta,
+  jsonCmp: d.JsonDocsComponent
+) {
   if (!cmpMeta.membersMeta) return;
 
-  Object.keys(cmpMeta.membersMeta).sort((a, b) => {
-    if (a.toLowerCase() < b.toLowerCase()) return -1;
-    if (a.toLowerCase() > b.toLowerCase()) return 1;
-    return 0;
+  Object.keys(cmpMeta.membersMeta)
+    .sort((a, b) => {
+      if (a.toLowerCase() < b.toLowerCase()) return -1;
+      if (a.toLowerCase() > b.toLowerCase()) return 1;
+      return 0;
+    })
+    .forEach(memberName => {
+      const memberMeta = cmpMeta.membersMeta[memberName];
 
-  }).forEach(memberName => {
-    const memberMeta = cmpMeta.membersMeta[memberName];
+      if (
+        memberMeta.memberType === MEMBER_TYPE.Prop ||
+        memberMeta.memberType === MEMBER_TYPE.PropMutable
+      ) {
+        const propData: d.JsonDocsProp = {
+          name: memberName
+        };
 
-    if (memberMeta.memberType === MEMBER_TYPE.Prop || memberMeta.memberType === MEMBER_TYPE.PropMutable) {
-      const propData: d.JsonDocsProp = {
-        name: memberName
-      };
+        propData = getPropType(memberMeta);
 
-      if (memberMeta.attribType && memberMeta.attribType.text) {
-        if (!memberMeta.attribType.text.includes('(')) {
-          const typeSplit = memberMeta.attribType.text.split('|').map(t => {
-            return t.replace(/\'/g, '"').trim();
-          });
-  
-          propData.type =  typeSplit.join(', ');
+        if (memberMeta.attribType.optional) {
+          propData.optional = true;
         }
-  
-        propData.type =  memberMeta.attribType.text;
-      } else {
-        const propType = memberMeta.propType;
-  
-        switch (propType) {
-          case PROP_TYPE.Any:
-            propData.type =  'any';
-            break;
-          case PROP_TYPE.Boolean:
-            propData.type =  'boolean';
-            break;
-          case PROP_TYPE.Number:
-            propData.type =  'number';
-            break;
-          case PROP_TYPE.String:
-            propData.type =  'string';
-            break;
-          default:
-            propData.type =  '';
+
+        if (memberMeta.memberType === MEMBER_TYPE.PropMutable) {
+          propData.mutable = true;
         }
-      }
-      
-      if (memberMeta.attribType.optional) {
-        propData.optional = true
-      }
 
-      if (memberMeta.memberType === MEMBER_TYPE.PropMutable) {
-        propData.mutable = true;
+        if (typeof memberMeta.attribName === 'string') {
+          propData.attr = memberMeta.attribName;
+        }
+
+        propData.docs = getMemberDocumentation(memberMeta.jsdoc);
+        jsonCmp.props.push(propData);
+      } else if (memberMeta.memberType === MEMBER_TYPE.Method) {
+        jsonCmp.methods.push({
+          name: memberName,
+          docs: getMemberDocumentation(memberMeta.jsdoc),
+          returns: getMethodReturns(memberMeta.jsdoc),
+          parameters: getMethodParameters(memberMeta.jsdoc)
+        });
       }
-
-      if (typeof memberMeta.attribName === 'string') {
-        propData.attr = memberMeta.attribName;
-      }
-
-      propData.docs = getMemberDocumentation(memberMeta.jsdoc);
-      jsonCmp.props.push(propData);
-
-    } else if (memberMeta.memberType === MEMBER_TYPE.Method) {
-      jsonCmp.methods.push({
-        name: memberName,
-        docs: getMemberDocumentation(memberMeta.jsdoc),
-        returns: getMethodReturns(memberMeta.jsdoc),
-        parameters: getMethodParameters(memberMeta.jsdoc)
-      });
-    }
-  });
+    });
 }
 
-
-function generateJsDocEvents(cmpMeta: d.ComponentMeta, jsonCmp: d.JsonDocsComponent) {
+function generateJsDocEvents(
+  cmpMeta: d.ComponentMeta,
+  jsonCmp: d.JsonDocsComponent
+) {
   if (!Array.isArray(cmpMeta.eventsMeta)) {
     return;
   }
 
-  cmpMeta.eventsMeta.sort((a, b) => {
-    if (a.eventName.toLowerCase() < b.eventName.toLowerCase()) return -1;
-    if (a.eventName.toLowerCase() > b.eventName.toLowerCase()) return 1;
-    return 0;
+  cmpMeta.eventsMeta
+    .sort((a, b) => {
+      if (a.eventName.toLowerCase() < b.eventName.toLowerCase()) return -1;
+      if (a.eventName.toLowerCase() > b.eventName.toLowerCase()) return 1;
+      return 0;
+    })
+    .forEach(eventMeta => {
+      const eventData: d.JsonDocsEvent = {
+        event: eventMeta.eventName,
+        bubbles: !!eventMeta.eventBubbles,
+        cancelable: !!eventMeta.eventCancelable,
+        composed: !!eventMeta.eventComposed,
+        docs: getMemberDocumentation(eventMeta.jsdoc)
+      };
 
-  }).forEach(eventMeta => {
-    const eventData: d.JsonDocsEvent = {
-      event: eventMeta.eventName,
-      bubbles: !!eventMeta.eventBubbles,
-      cancelable: !!eventMeta.eventCancelable,
-      composed: !!eventMeta.eventComposed,
-      docs: getMemberDocumentation(eventMeta.jsdoc)
-    };
-
-    jsonCmp.events.push(eventData);
-  });
+      jsonCmp.events.push(eventData);
+    });
 }
 
-
-function generateJsDocCssProps(cmpMeta: d.ComponentMeta, jsonCmp: d.JsonDocsComponent) {
+function generateJsDocCssProps(
+  cmpMeta: d.ComponentMeta,
+  jsonCmp: d.JsonDocsComponent
+) {
   if (!cmpMeta.styleDocs) {
     return;
   }
 
-  cmpMeta.styleDocs.sort((a, b) => {
-    if (a.annotation < b.annotation) return -1;
-    if (a.annotation > b.annotation) return 1;
-    if (a.name.toLowerCase() < b.name.toLowerCase()) return -1;
-    if (a.name.toLowerCase() > b.name.toLowerCase()) return 1;
-    return 0;
-
-  }).forEach(styleDoc => {
-    const cssPropData: d.JsonDocsStyle = {
-      annotation: styleDoc.annotation || '',
-      name: styleDoc.name,
-      docs: styleDoc.docs || ''
-    };
-    jsonCmp.styles.push(cssPropData);
-  });
+  cmpMeta.styleDocs
+    .sort((a, b) => {
+      if (a.annotation < b.annotation) return -1;
+      if (a.annotation > b.annotation) return 1;
+      if (a.name.toLowerCase() < b.name.toLowerCase()) return -1;
+      if (a.name.toLowerCase() > b.name.toLowerCase()) return 1;
+      return 0;
+    })
+    .forEach(styleDoc => {
+      const cssPropData: d.JsonDocsStyle = {
+        annotation: styleDoc.annotation || '',
+        name: styleDoc.name,
+        docs: styleDoc.docs || ''
+      };
+      jsonCmp.styles.push(cssPropData);
+    });
 }

--- a/src/compiler/docs/generate-json-doc.ts
+++ b/src/compiler/docs/generate-json-doc.ts
@@ -75,19 +75,39 @@ function generateJsDocMembers(cmpMeta: d.ComponentMeta, jsonCmp: d.JsonDocsCompo
         name: memberName
       };
 
-      if (memberMeta.propType === PROP_TYPE.Boolean) {
-        propData.type = 'boolean';
-
-      } else if (memberMeta.propType === PROP_TYPE.Number) {
-        propData.type = 'number';
-
-      } else if (memberMeta.propType === PROP_TYPE.String) {
-        propData.type = 'string';
-
-      } else if (memberMeta.propType === PROP_TYPE.Any) {
-        propData.type = 'any';
+      if (memberMeta.attribType && memberMeta.attribType.text) {
+        if (!memberMeta.attribType.text.includes('(')) {
+          const typeSplit = memberMeta.attribType.text.split('|').map(t => {
+            return t.replace(/\'/g, '"').trim();
+          });
+  
+          propData.type =  typeSplit.join(', ');
+        }
+  
+        propData.type =  memberMeta.attribType.text;
       } else {
-        propData.type = memberMeta.attribType.text;
+        const propType = memberMeta.propType;
+  
+        switch (propType) {
+          case PROP_TYPE.Any:
+            propData.type =  'any';
+            break;
+          case PROP_TYPE.Boolean:
+            propData.type =  'boolean';
+            break;
+          case PROP_TYPE.Number:
+            propData.type =  'number';
+            break;
+          case PROP_TYPE.String:
+            propData.type =  'string';
+            break;
+          default:
+            propData.type =  '';
+        }
+      }
+      
+      if (memberMeta.attribType.optional) {
+        propData.optional = true
       }
 
       if (memberMeta.memberType === MEMBER_TYPE.PropMutable) {

--- a/src/compiler/docs/generate-json-doc.ts
+++ b/src/compiler/docs/generate-json-doc.ts
@@ -98,7 +98,7 @@ function generateJsDocMembers(
           name: memberName
         };
 
-        propData = getPropType(memberMeta);
+        propData.type = getPropType(memberMeta);
 
         if (memberMeta.attribType.optional) {
           propData.optional = true;

--- a/src/compiler/docs/generate-json-doc.ts
+++ b/src/compiler/docs/generate-json-doc.ts
@@ -75,7 +75,7 @@ async function generateJsDocsUsages(
   return rtn;
 }
 
-function generateJsDocMembers(
+export function generateJsDocMembers(
   cmpMeta: d.ComponentMeta,
   jsonCmp: d.JsonDocsComponent
 ) {

--- a/src/compiler/docs/markdown-props.ts
+++ b/src/compiler/docs/markdown-props.ts
@@ -1,5 +1,5 @@
 import * as d from '../../declarations';
-import { MarkdownTable, getMemberDocumentation } from './docs-util';
+import { MarkdownTable, getMemberDocumentation, getPropType } from './docs-util';
 import { PROP_TYPE } from '../../util/constants';
 
 
@@ -77,36 +77,6 @@ export class PropRow {
   }
 
   get type() {
-
-    if (this.memberMeta.attribType && this.memberMeta.attribType.text) {
-      if (!this.memberMeta.attribType.text.includes('(')) {
-        const typeSplit = this.memberMeta.attribType.text.split('|').map(t => {
-          return '`' + t.replace(/\'/g, '"').trim() + '`';
-        });
-
-        return typeSplit.join(', ');
-      }
-
-      return '`' + this.memberMeta.attribType.text + '`';
-    }
-
-    const propType = this.memberMeta.propType;
-
-    switch (propType) {
-      case PROP_TYPE.Any:
-        return '`any`';
-
-      case PROP_TYPE.Boolean:
-        return '`boolean`';
-
-      case PROP_TYPE.Number:
-        return '`number`';
-
-      case PROP_TYPE.String:
-        return '`string`';
-    }
-
-    return '';
+    return getPropType(this.memberMeta, type => `\`${type}\``);
   }
-
 }

--- a/src/compiler/docs/test/docs-util.spec.ts
+++ b/src/compiler/docs/test/docs-util.spec.ts
@@ -1,5 +1,5 @@
-import { MarkdownTable } from '../docs-util';
-
+import { MarkdownTable, getPropType } from '../docs-util';
+import { PROP_TYPE } from '../../../util/constants';
 
 describe('markdown-table', () => {
 
@@ -49,3 +49,68 @@ describe('markdown-table', () => {
   });
 
 });
+
+describe('getPropType', () => {
+  it('advanced union types', () => {
+    const memberMeta = {
+      attribType: {
+        text: `(AlertButton | string)[]`,
+        optional: false
+      }
+    }
+    expect(getPropType(memberMeta)).toBe('(AlertButton | string)[]');
+  });
+
+  it('union types', () => {
+    const memberMeta = {
+      attribType: {
+        text: `string | string[]`,
+        optional: false
+      }
+    }
+    expect(getPropType(memberMeta)).toBe('string, string[]');
+  });
+
+  it('string union types', () => {
+    const memberMeta = {
+      attribType: {
+        text: `'submit' | 'reset' | 'button'`,
+        optional: false
+      }
+    }
+
+    expect(getPropType(memberMeta)).toBe('"submit", "reset", "button"');
+  });
+
+  it('any type', () => {
+    const memberMeta = {
+      propType: PROP_TYPE.Any
+    }
+
+    expect(getPropType(memberMeta)).toBe('any');
+  });
+
+  it('string type', () => {
+    const memberMeta = {
+      propType: PROP_TYPE.String
+    }
+
+    expect(getPropType(memberMeta)).toBe('string');
+  });
+
+  it('number type', () => {
+    const memberMeta = {
+      propType: PROP_TYPE.Number
+    }
+
+    expect(getPropType(memberMeta)).toBe('number');
+  });
+
+  it('boolean type', () => {
+    const memberMeta = {
+      propType: PROP_TYPE.Boolean
+    }
+
+    expect(getPropType(memberMeta)).toBe('boolean');
+  });
+})

--- a/src/compiler/docs/test/generate-json-doc.spec.ts
+++ b/src/compiler/docs/test/generate-json-doc.spec.ts
@@ -1,0 +1,170 @@
+import { generateJsDocMembers } from '../generate-json-doc'
+import { MEMBER_TYPE, PROP_TYPE } from '../../../util/constants';
+import { ComponentMeta } from '../../../declarations';
+
+
+describe('generateJsonDoc', () => {
+  it('advanced union types', () => {
+    const componentMeta: ComponentMeta = {
+      membersMeta: {
+        name1: {
+          attribType: {
+            text: `(AlertButton | string)[]`,
+            optional: false
+          },
+          memberType: MEMBER_TYPE.Prop
+        }
+      }
+    }
+    const jsonCmp = { props: [] }
+    generateJsDocMembers(componentMeta, jsonCmp)
+    expect(jsonCmp.props[0].type).toBe('(AlertButton | string)[]');
+  });
+
+  it('union types', () => {
+    const componentMeta: ComponentMeta = {
+      membersMeta: {
+        name1: {
+          attribType: {
+            text: `string | string[]`,
+            optional: false
+          },
+          memberType: MEMBER_TYPE.Prop
+        }
+      }
+    }
+    const jsonCmp = { props: [] }
+    generateJsDocMembers(componentMeta, jsonCmp)
+    expect(jsonCmp.props[0].type).toBe('string, string[]');
+  });
+  it('string union types', () => {
+
+    const componentMeta: ComponentMeta = {
+      membersMeta: {
+        name1: {
+          attribType: {
+            text: `'submit' | 'reset' | 'button'`,
+            optional: false
+          },
+          memberType: MEMBER_TYPE.Prop
+        }
+      }
+    }
+    const jsonCmp = { props: [] }
+    generateJsDocMembers(componentMeta, jsonCmp)
+    expect(jsonCmp.props[0].type).toBe('"submit", "reset", "button"');
+  });
+
+  it('any type', () => {
+    const componentMeta: ComponentMeta = {
+      membersMeta: {
+        name1: {
+          propType: PROP_TYPE.Any,
+          memberType: MEMBER_TYPE.Prop,
+          attribType: {
+            text: '',
+            optional: false
+          },
+        }
+      }
+    }
+    const jsonCmp = { props: [] }
+    generateJsDocMembers(componentMeta, jsonCmp)
+    expect(jsonCmp.props[0].type).toBe('any');
+  });
+
+  it('string type', () => {
+    const componentMeta: ComponentMeta = {
+      membersMeta: {
+        name1: {
+          propType: PROP_TYPE.String,
+          memberType: MEMBER_TYPE.Prop,
+          attribType: {
+            text: '',
+            optional: false
+          },
+        }
+      }
+    }
+
+    const jsonCmp = { props: [] }
+    generateJsDocMembers(componentMeta, jsonCmp)
+    expect(jsonCmp.props[0].type).toBe('string');
+  });
+
+  it('number type', () => {
+    const componentMeta: ComponentMeta = {
+      membersMeta: {
+        name1: {
+          propType: PROP_TYPE.Number,
+          memberType: MEMBER_TYPE.Prop,
+          attribType: {
+            text: '',
+            optional: false
+          },
+        }
+      }
+    }
+
+    const jsonCmp = { props: [] }
+    generateJsDocMembers(componentMeta, jsonCmp)
+    expect(jsonCmp.props[0].type).toBe('number');
+  });
+
+  it('boolean type', () => {
+    const componentMeta: ComponentMeta = {
+      membersMeta: {
+        name1: {
+          propType: PROP_TYPE.Boolean,
+          memberType: MEMBER_TYPE.Prop,
+          attribType: {
+            text: '',
+            optional: false
+          },
+        }
+      }
+    }
+
+    const jsonCmp = { props: [] }
+    generateJsDocMembers(componentMeta, jsonCmp)
+    expect(jsonCmp.props[0].type).toBe('boolean');
+  });
+
+  it('optional attribute', () => {
+    const componentMeta: ComponentMeta = {
+      membersMeta: {
+        name1: {
+          propType: PROP_TYPE.Boolean,
+          memberType: MEMBER_TYPE.Prop,
+          attribType: {
+            text: '',
+            optional: true
+          },
+        }
+      }
+    }
+
+    const jsonCmp = { props: [] }
+    generateJsDocMembers(componentMeta, jsonCmp)
+    expect(jsonCmp.props[0].optional).toBe(true);
+  });
+
+  it('optional attribute', () => {
+    const componentMeta: ComponentMeta = {
+      membersMeta: {
+        name1: {
+          propType: PROP_TYPE.Boolean,
+          memberType: MEMBER_TYPE.PropMutable,
+          attribType: {
+            text: '',
+            optional: true
+          },
+        }
+      }
+    }
+
+    const jsonCmp = { props: [] }
+    generateJsDocMembers(componentMeta, jsonCmp)
+    expect(jsonCmp.props[0].mutable).toBe(true);
+  });
+})

--- a/src/declarations/docs.ts
+++ b/src/declarations/docs.ts
@@ -29,6 +29,7 @@ export interface JsonDocsProp {
   attr?: string;
   reflectToAttr?: boolean;
   docs?: string;
+  optional?: boolean;
 }
 
 


### PR DESCRIPTION
fix #974 

this brings the prop type data from the JSON doc output inline with the auto generated readme types, and adds the new optional token when applicable