### PR TITLE
insert style[data-styles] tag after meta[charset] to prevent parsing …

### DIFF
--- a/src/client/loader.ts
+++ b/src/client/loader.ts
@@ -26,7 +26,8 @@ export function init(
     x = doc.createElement('style');
     x.innerHTML = y.join() + '{visibility:hidden}.' + hydratedCssClass + '{visibility:inherit}';
     x.setAttribute('data-styles', '');
-    doc.head.insertBefore(x, doc.head.firstChild);
+    const linkElms = doc.head.querySelectorAll('link[rel="stylesheet"][href]');
+    doc.head.insertBefore(x, linkElms[0]);
   }
 
   createComponentOnReadyPrototype(win, namespace, HTMLElementPrototype);


### PR DESCRIPTION
…errors while behaving right order of styles.

Hi @adamdbradley,

as mentioned a few days ago, I would like to please you to check this litte optimization, whereby the style[data-styles] (and so all the other following) are inserted after the meta[charset] tag, which caused rendering errors.

Thanks, Alex