### PR TITLE
feat(puppeteer): allow specification of Chrome executable

### DIFF
--- a/src/declarations/testing.ts
+++ b/src/declarations/testing.ts
@@ -104,6 +104,11 @@ export interface TestingConfig {
   browserArgs?: string[];
 
   /**
+   * Path to a Chromium or Chrome executable to run instead of the bundled Chromium.
+   */
+  browserExecutablePath?: string;
+
+  /**
    * Whether to run browser e2e tests in headless mode. Defaults to true.
    */
   browserHeadless?: boolean;

--- a/src/testing/puppeteer/puppeteer-browser.ts
+++ b/src/testing/puppeteer/puppeteer-browser.ts
@@ -31,6 +31,10 @@ export async function startPuppeteerBrowser(config: d.Config) {
     slowMo: config.testing.browserSlowMo
   };
 
+  if (config.testing.browserExecutablePath) {
+    launchOpts.executablePath = config.testing.browserExecutablePath;
+  }
+
   const browser = await puppeteer.launch(launchOpts);
 
   env.__STENCIL_BROWSER_WS_ENDPOINT__ = browser.wsEndpoint();


### PR DESCRIPTION
In some environments (such as behind corporate proxies) it's difficult to download Chromium with Puppeteer.

There are a handful of environment variables to prevent Puppeteer from downloading Chromium during the install: https://pptr.dev/#?product=Puppeteer&version=v1.8.0&show=api-environment-variables

When configured this way, there needs to be a way to launch Puppeteer against the system Chrome (or another Chromium install). This adds a config option, which can get passed into `puppeteer.launch()`