### PR TITLE
fix(fs-watch): always rebuild sw when --serviceWorker flag

### DIFF
--- a/src/compiler/fs-watch/fs-watch-rebuild.ts
+++ b/src/compiler/fs-watch/fs-watch-rebuild.ts
@@ -46,7 +46,7 @@ export function generateBuildFromFsWatch(config: d.Config, compilerCtx: d.Compil
   // figure out if any changed files were index.html files
   buildCtx.hasIndexHtmlChanges = hasIndexHtmlChanges(config, buildCtx);
 
-  buildCtx.hasServiceWorkerChanges = hasServiceWorkerChanges(config, buildCtx);
+  buildCtx.hasServiceWorkerChanges = hasServiceWorkerChanges(config);
 
   // we've got watch results, which means this is a rebuild!!
   buildCtx.isRebuild = true;

--- a/src/compiler/service-worker/generate-sw.ts
+++ b/src/compiler/service-worker/generate-sw.ts
@@ -109,7 +109,7 @@ async function canSkipGenerateSW(config: d.Config, compilerCtx: d.CompilerCtx, b
     return true;
   }
 
-  const hasServiceWorkerChanged = hasServiceWorkerChanges(config, buildCtx);
+  const hasServiceWorkerChanged = hasServiceWorkerChanges(config);
   if ((compilerCtx.hasSuccessfulBuild && buildCtx.appFileBuildCount === 0 && !hasServiceWorkerChanged) || hasError(buildCtx.diagnostics)) {
     // no need to rebuild index.html if there were no app file changes
     return true;

--- a/src/compiler/util.ts
+++ b/src/compiler/util.ts
@@ -2,14 +2,10 @@ import * as d from '../declarations';
 import { BANNER } from '../util/constants';
 
 
-export function hasServiceWorkerChanges(config: d.Config, buildCtx: d.BuildCtx) {
-  if (config.devMode && !config.flags.serviceWorker) {
-    return false;
-  }
-  const wwwServiceOutputs = (config.outputTargets as d.OutputTargetWww[]).filter(o => o.type === 'www' && o.serviceWorker && o.serviceWorker.swSrc);
-  return wwwServiceOutputs.some(outputTarget => {
-    return buildCtx.filesChanged.some(fileChanged => config.sys.path.basename(fileChanged).toLowerCase() === config.sys.path.basename(outputTarget.serviceWorker.swSrc).toLowerCase());
-  });
+export function hasServiceWorkerChanges(config: d.Config) {
+  // treat as if service worker always has changes if devMode and serviceworker flag is true
+  // this allows precache revision values to be regenerated
+  return !(config.devMode && !config.flags.serviceWorker);
 }
 
 /**


### PR DESCRIPTION
Always rebuild service worker when --serviceworker flag is used. This allows precache revision values to be regenerated