### PR TITLE
WIP test: add failing test to demo my lack of understanding re: focus API

### DIFF
--- a/test/example/src/components.d.ts
+++ b/test/example/src/components.d.ts
@@ -57,6 +57,13 @@ export namespace Components {
     'onMyWindowEvent'?: (event: CustomEvent<number>) => void;
   }
 
+  interface FocusCmp {
+    'focusOnOpen': boolean;
+  }
+  interface FocusCmpAttributes extends StencilHTMLAttributes {
+    'focusOnOpen'?: boolean;
+  }
+
   interface ListenCmp {
     'opened': boolean;
   }
@@ -95,6 +102,7 @@ declare global {
     'DomInteraction': Components.DomInteraction;
     'ElementCmp': Components.ElementCmp;
     'EventCmp': Components.EventCmp;
+    'FocusCmp': Components.FocusCmp;
     'ListenCmp': Components.ListenCmp;
     'MethodCmp': Components.MethodCmp;
     'PropCmp': Components.PropCmp;
@@ -109,6 +117,7 @@ declare global {
     'dom-interaction': Components.DomInteractionAttributes;
     'element-cmp': Components.ElementCmpAttributes;
     'event-cmp': Components.EventCmpAttributes;
+    'focus-cmp': Components.FocusCmpAttributes;
     'listen-cmp': Components.ListenCmpAttributes;
     'method-cmp': Components.MethodCmpAttributes;
     'prop-cmp': Components.PropCmpAttributes;
@@ -158,6 +167,12 @@ declare global {
     new (): HTMLEventCmpElement;
   };
 
+  interface HTMLFocusCmpElement extends Components.FocusCmp, HTMLStencilElement {}
+  var HTMLFocusCmpElement: {
+    prototype: HTMLFocusCmpElement;
+    new (): HTMLFocusCmpElement;
+  };
+
   interface HTMLListenCmpElement extends Components.ListenCmp, HTMLStencilElement {}
   var HTMLListenCmpElement: {
     prototype: HTMLListenCmpElement;
@@ -190,6 +205,7 @@ declare global {
     'dom-interaction': HTMLDomInteractionElement
     'element-cmp': HTMLElementCmpElement
     'event-cmp': HTMLEventCmpElement
+    'focus-cmp': HTMLFocusCmpElement
     'listen-cmp': HTMLListenCmpElement
     'method-cmp': HTMLMethodCmpElement
     'prop-cmp': HTMLPropCmpElement
@@ -204,6 +220,7 @@ declare global {
     'dom-interaction': HTMLDomInteractionElement;
     'element-cmp': HTMLElementCmpElement;
     'event-cmp': HTMLEventCmpElement;
+    'focus-cmp': HTMLFocusCmpElement;
     'listen-cmp': HTMLListenCmpElement;
     'method-cmp': HTMLMethodCmpElement;
     'prop-cmp': HTMLPropCmpElement;

--- a/test/example/src/focus/focus-cmp.e2e.ts
+++ b/test/example/src/focus/focus-cmp.e2e.ts
@@ -8,9 +8,9 @@ describe('@Element', () => {
       <focus-cmp focus-on-open="true"></focus-cmp>
     `
     });
-    const elm = await page.find('focus-cmp');
+    const elm = await page.find('focus-cmp button');
     const activeElement = await page.evaluateHandle(
-      () => document.activeElement
+      async () => document.activeElement
     );
     expect(elm).toEqual(activeElement);
   });

--- a/test/example/src/focus/focus-cmp.e2e.ts
+++ b/test/example/src/focus/focus-cmp.e2e.ts
@@ -1,0 +1,17 @@
+import { newE2EPage } from '../../../../dist/testing';
+
+describe('@Element', () => {
+  it('should let me see the active element', async () => {
+    // create a new puppeteer page
+    const page = await newE2EPage({
+      html: `
+      <focus-cmp focus-on-open="true"></focus-cmp>
+    `
+    });
+    const elm = await page.find('focus-cmp');
+    const activeElement = await page.evaluateHandle(
+      () => document.activeElement
+    );
+    expect(elm).toEqual(activeElement);
+  });
+});

--- a/test/example/src/focus/focus-cmp.tsx
+++ b/test/example/src/focus/focus-cmp.tsx
@@ -1,0 +1,22 @@
+import { Component, Prop } from '../../../../dist';
+
+@Component({
+  tag: 'focus-cmp'
+})
+export class Focus {
+  @Prop()
+  focusOnOpen = false;
+  private focusedButton: HTMLButtonElement;
+  componentDidLoad() {
+    if (this.focusOnOpen) {
+      this.focusedButton.focus();
+    }
+  }
+  render() {
+    return (
+      <div>
+        <button ref={el => (this.focusedButton = el)}>Button</button>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
Don't merge as is, but more this is to help me understand how to use the Puppeteer API and compare it against Stencil elements. I figure once it's working, it out I'll update the fork and others could use it as a reference.

My use case is: I have a component with a `focusOnOpen` prop. When set, a part of the template is focused. I'd like to verify this behavior.

What's happening: I've tried a few approaches to do comparisons of the Stencil E2EElement I get with `page.find` and the Puppeteer element I get with `page.evaluateHandle`, but the test hangs when I do any comparisons.

I'm probably using the API wrong, but can't quite figure out what's going on. Any help would be appreciated!