### PR TITLE
mock-doc: Add getComputedStyle

### DIFF
--- a/src/mock-doc/window.ts
+++ b/src/mock-doc/window.ts
@@ -173,5 +173,26 @@ export class MockWindow {
   set CustomEvent(value: any) {
     this._MockCustomEvent = value;
   }
-
+  getComputedStyle(_: any) {
+    return {
+      cssText: '',
+      length: 0,
+      parentRule: null,
+      getPropertyPriority(): any {
+        return null;
+      },
+      getPropertyValue(): any {
+        return '';
+      },
+      item(): any {
+        return null;
+      },
+      removeProperty(): any {
+        return null;
+      },
+      setProperty(): any {
+        return null;
+      }
+    } as any;
+  }
 }


### PR DESCRIPTION
As noted in Slack - we've got a few instances where we need `getComputedStyle` even in our unit tests. This stubs out the API good enough to pull a few out of the e2e bucket.