### PR TITLE
feat(docs): add @Component jsdoc to json docs

### DIFF
--- a/src/compiler/docs/generate-json-doc.ts
+++ b/src/compiler/docs/generate-json-doc.ts
@@ -6,6 +6,7 @@ import { MEMBER_TYPE, PROP_TYPE } from '../../util/constants';
 export async function generateJsDocComponent(config: d.Config, compilerCtx: d.CompilerCtx, jsonDocs: d.JsonDocs, cmpMeta: d.ComponentMeta, dirPath: string, readmeContent: string) {
   const jsonCmp: d.JsonDocsComponent = {
     tag: cmpMeta.tagNameMeta,
+    docs: getMemberDocumentation(cmpMeta.jsdoc),
     readme: readmeContent || '',
     usage: await generateJsDocsUsages(config, compilerCtx, dirPath),
     props: [],

--- a/src/declarations/docs.ts
+++ b/src/declarations/docs.ts
@@ -8,6 +8,7 @@ export interface JsonDocs {
 export interface JsonDocsComponent {
   tag?: string;
   readme?: string;
+  docs?: string,
   usage?: JsonDocsUsage;
   props?: JsonDocsProp[];
   methods?: JsonDocsMethod[];


### PR DESCRIPTION
Saw someone mention this earlier today on slack, and thought I'd actually prefer writing in the file itself instead of in the readme file to generate documentation from (specifically since i'm using the json output instead to generate docs from later)

if this isn't something you care to have, no worries, just figured I'd throw the PR up in case.  Let me know if there's anything else you'd want to make something like this sensible