### PR TITLE
feat(docs): support param and returns jsdoc tags

### DIFF
--- a/src/compiler/docs/docs-util.ts
+++ b/src/compiler/docs/docs-util.ts
@@ -157,3 +157,31 @@ export function getMemberDocumentation(jsDoc: d.JsDoc) {
   }
   return '';
 }
+
+export function getMemberType(jsDoc: d.JsDoc) {
+  if (jsDoc && typeof jsDoc.type === "string") {
+    return jsDoc.type.trim();
+  }
+  return "";
+}
+
+export function getMethodParameters({ parameters }: d.JsDoc): d.JsonDocMethodParameter[] {
+  if (parameters) {
+    return parameters.map(({ name, type, documentation }) => ({
+      name,
+      type,
+      docs: documentation
+    }));
+  }
+  return [];
+}
+
+export function getMethodReturns({ returns }: d.JsDoc): d.JsonDocsMethodReturn {
+  if (returns) {
+    return {
+      type: returns.type,
+      docs: returns.documentation
+    };
+  }
+  return null;
+}

--- a/src/compiler/docs/generate-json-doc.ts
+++ b/src/compiler/docs/generate-json-doc.ts
@@ -1,5 +1,5 @@
 import * as d from '../../declarations';
-import { getMemberDocumentation } from './docs-util';
+import { getMemberDocumentation, getMethodParameters, getMethodReturns } from './docs-util';
 import { MEMBER_TYPE, PROP_TYPE } from '../../util/constants';
 
 
@@ -104,7 +104,9 @@ function generateJsDocMembers(cmpMeta: d.ComponentMeta, jsonCmp: d.JsonDocsCompo
     } else if (memberMeta.memberType === MEMBER_TYPE.Method) {
       jsonCmp.methods.push({
         name: memberName,
-        docs: getMemberDocumentation(memberMeta.jsdoc)
+        docs: getMemberDocumentation(memberMeta.jsdoc),
+        returns: getMethodReturns(memberMeta.jsdoc),
+        parameters: getMethodParameters(memberMeta.jsdoc)
       });
     }
   });

--- a/src/compiler/docs/markdown-methods.ts
+++ b/src/compiler/docs/markdown-methods.ts
@@ -1,5 +1,5 @@
 import * as d from '../../declarations';
-import { MarkdownTable, getMemberDocumentation } from './docs-util';
+import { MarkdownTable, getMemberDocumentation, getMemberType, getMethodParameters, getMethodReturns } from './docs-util';
 
 
 export class MarkdownMethods {
@@ -28,19 +28,37 @@ export class MarkdownMethods {
       return 0;
     });
 
-    const table = new MarkdownTable();
-
-    table.addHeader(['Method', 'Description']);
-
     rows.forEach(row => {
-      table.addRow([
-        '`' + row.methodName + '`',
-        row.description
-      ]);
+      content.push(`### ${row.signature}`);
+      content.push(``);
+      content.push(row.description);
+      content.push(``);
+
+      if (row.parameters.length > 0) {
+        const parmsTable = new MarkdownTable();
+
+        parmsTable.addHeader(['Name', 'Type', 'Description']);
+
+        row.parameters.forEach(({ name, type, docs }) => {
+          parmsTable.addRow(['`' + name + '`', '`' + type + '`', docs]);
+        });
+
+        content.push(`#### Parameters`);
+        content.push(``);
+        content.push(...parmsTable.toMarkdown());
+        content.push(``);
+      }
+
+      if (row.returns) {
+        content.push(`#### Returns`);
+        content.push(``);
+        content.push(`Type: \`${row.returns.type}\``);
+        content.push(``);
+        content.push(row.returns.docs);
+        content.push(``);
+      }
     });
 
-    content.push(...table.toMarkdown());
-    content.push(``);
     content.push(``);
 
     return content;
@@ -56,4 +74,16 @@ class Row {
     return getMemberDocumentation(this.memberMeta.jsdoc);
   }
 
+  get signature() {
+    const type = getMemberType(this.memberMeta.jsdoc);
+    return '`' + this.methodName + type + '`';
+  }
+
+  get parameters() {
+    return getMethodParameters(this.memberMeta.jsdoc);
+  }
+
+  get returns() {
+    return getMethodReturns(this.memberMeta.jsdoc);
+  }
 }

--- a/src/compiler/transpile/datacollection/method-decorator.ts
+++ b/src/compiler/transpile/datacollection/method-decorator.ts
@@ -21,6 +21,7 @@ export function getMethodDecoratorMeta(config: d.Config, diagnostics: d.Diagnost
 
       const flags = ts.TypeFormatFlags.WriteArrowStyleSignature;
       const returnType = checker.getReturnTypeOfSignature(methodSignature);
+      const jsDocReturnTag = ts.getJSDocReturnTag(member);
       const typeString = checker.signatureToString(
         methodSignature,
         classNode,
@@ -56,7 +57,16 @@ export function getMethodDecoratorMeta(config: d.Config, diagnostics: d.Diagnost
             ...getAttributeTypeInfo(member, sourceFile)
           }
         },
-        jsdoc: serializeSymbol(checker, symbol)
+        jsdoc: {
+          ...serializeSymbol(checker, symbol),
+          returns: {
+            type: checker.typeToString(returnType),
+            documentation: jsDocReturnTag ? jsDocReturnTag.comment : ""
+          },
+          parameters: methodSignature.parameters.map(parmSymbol =>
+            serializeSymbol(checker, parmSymbol)
+          )
+        }
       };
 
 

--- a/src/compiler/transpile/datacollection/test/fixtures/method-example.ts
+++ b/src/compiler/transpile/datacollection/test/fixtures/method-example.ts
@@ -18,6 +18,7 @@ class ActionSheet {
   /**
    * Create method for something
    * @param opts action sheet options
+   * @returns action sheet
    */
   @Method()
   create(opts?: ActionSheetOptions): Promise<ActionSheet> {

--- a/src/compiler/transpile/datacollection/test/method-decorator.spec.ts
+++ b/src/compiler/transpile/datacollection/test/method-decorator.spec.ts
@@ -42,6 +42,17 @@ describe('method decorator', () => {
         jsdoc: {
           documentation: 'Create method for something',
           name: 'create',
+          parameters: [
+            {
+              documentation: "action sheet options", 
+              name: "opts", 
+              type: "any"
+            }
+          ], 
+          returns: {
+            documentation: "action sheet", 
+            type: "any"
+          },
           type: '(opts?: any) => any',
         }
       }
@@ -73,6 +84,17 @@ describe('method decorator', () => {
         jsdoc: {
           documentation: 'Create method for something',
           name: 'create',
+          parameters: [
+            {
+              documentation: "action sheet options", 
+              name: "opts", 
+              type: "ActionSheetOptions"
+            }
+          ], 
+          returns: {
+            documentation: "", 
+            type: "any"
+          },
           type: '(opts?: ActionSheetOptions) => any',
         }
       }
@@ -101,6 +123,17 @@ describe('method decorator', () => {
         jsdoc: {
           documentation: 'Create method for something',
           name: 'create',
+          parameters: [
+            {
+              documentation: "action sheet options",
+              name: "opts",
+              type: "CoreContext"
+            }
+          ], 
+          returns: {
+            documentation: "", 
+            type: "any"
+          },
           type: '(opts?: CoreContext) => any'
         }
       }

--- a/src/declarations/component.ts
+++ b/src/declarations/component.ts
@@ -165,6 +165,11 @@ export interface JsDoc {
   name: string;
   documentation: string;
   type: string;
+  parameters?: JsDoc[];
+  returns?: {
+    type: string;
+    documentation: string;
+  };
 }
 
 

--- a/src/declarations/docs.ts
+++ b/src/declarations/docs.ts
@@ -35,8 +35,20 @@ export interface JsonDocsProp {
 export interface JsonDocsMethod {
   name: string;
   docs?: string;
+  returns?: JsonDocsMethodReturn;
+  parameters?: JsonDocMethodParameter[];
 }
 
+export interface JsonDocsMethodReturn {
+  type?: string;
+  docs?: string;
+}
+
+export interface JsonDocMethodParameter {
+  name?: string;
+  type?: string;
+  docs?: string;
+}
 
 export interface JsonDocsEvent {
   event: string;


### PR DESCRIPTION
fix #954 

This adds support for the param and returns JsDoc tags, used when documenting methods.
Both the md and json files generation was updated to support these tags.
