### PR TITLE
docs: add detail to generated event docs

### DIFF
--- a/src/compiler/docs/docs-util.ts
+++ b/src/compiler/docs/docs-util.ts
@@ -157,6 +157,13 @@ interface RowData {
   isHeader?: boolean;
 }
 
+export function getEventDetailType(eventType: d.AttributeTypeInfo) {
+  if (eventType && eventType.text && typeof eventType.text === 'string' && eventType.text !== 'void') {
+    return eventType.text.trim();
+  }
+  return '';
+}
+
 
 export function getMemberDocumentation(jsDoc: d.JsDoc) {
   if (jsDoc && typeof jsDoc.documentation === 'string') {

--- a/src/compiler/docs/generate-json-doc.ts
+++ b/src/compiler/docs/generate-json-doc.ts
@@ -1,5 +1,5 @@
 import * as d from '../../declarations';
-import { getMemberDocumentation, getMethodParameters, getMethodReturns } from './docs-util';
+import { getMemberDocumentation, getMethodParameters, getMethodReturns, getEventDetailType} from './docs-util';
 import { MEMBER_TYPE } from '../../util/constants';
 
 
@@ -114,7 +114,8 @@ function generateJsDocEvents(cmpMeta: d.ComponentMeta, jsonCmp: d.JsonDocsCompon
       bubbles: !!eventMeta.eventBubbles,
       cancelable: !!eventMeta.eventCancelable,
       composed: !!eventMeta.eventComposed,
-      docs: getMemberDocumentation(eventMeta.jsdoc)
+      docs: getMemberDocumentation(eventMeta.jsdoc),
+      detail: getEventDetailType(eventMeta.eventType),
     };
 
     jsonCmp.events.push(eventData);

--- a/src/compiler/docs/markdown-events.ts
+++ b/src/compiler/docs/markdown-events.ts
@@ -1,5 +1,5 @@
 import { EventMeta } from '../../declarations';
-import { MarkdownTable, getMemberDocumentation, isMemberInternal } from './docs-util';
+import { MarkdownTable, getMemberDocumentation, isMemberInternal, getEventDetailType } from './docs-util';
 
 
 export class MarkdownEvents {
@@ -27,11 +27,12 @@ export class MarkdownEvents {
 
     const table = new MarkdownTable();
 
-    table.addHeader(['Event', 'Description']);
+    table.addHeader(['Event', 'Detail', 'Description']);
 
     rows.forEach(row => {
       table.addRow([
         '`' + row.eventName + '`',
+        row.detail,
         row.description
       ]);
     });
@@ -51,6 +52,10 @@ class Row {
 
   get eventName() {
     return this.eventMeta.eventName;
+  }
+
+  get detail() {
+    return getEventDetailType(this.eventMeta.eventType);
   }
 
   get description() {

--- a/src/declarations/docs.ts
+++ b/src/declarations/docs.ts
@@ -56,6 +56,7 @@ export interface JsonDocsEvent {
   cancelable?: boolean;
   composed?: boolean;
   docs?: string;
+  detail?: string;
 }
 
 


### PR DESCRIPTION
fix #1161 

This adds a detail key to the events doc-json and adds a column for Detail to the generated readmes

It does not list void, since this value is used whether the EventEmitter is passed void or no value, where no value may not necessarily be correctly void