### PR TITLE
Fix build month in build timestamp

### DIFF
--- a/src/compiler/build/build-ctx.ts
+++ b/src/compiler/build/build-ctx.ts
@@ -185,7 +185,7 @@ function getBuildTimestamp() {
 
   // YYYY-MM-DDThh:mm:ss
   let timestamp = d.getUTCFullYear() + '-';
-  timestamp += ('0' + d.getUTCMonth()).slice(-2) + '-';
+  timestamp += ('0' + (d.getUTCMonth() + 1)).slice(-2) + '-';
   timestamp += ('0' + d.getUTCDate()).slice(-2) + 'T';
   timestamp += ('0' + d.getUTCHours()).slice(-2) + ':';
   timestamp += ('0' + d.getUTCMinutes()).slice(-2) + ':';


### PR DESCRIPTION
Related issue: #1176

Maybe this was intended, but I was going insane checking the build time thinking it was a month old :sweat_smile: