### PR TITLE
feat(types): add support for JSX required props

### DIFF
--- a/src/compiler/docs/test/markdown-props.spec.ts
+++ b/src/compiler/docs/test/markdown-props.spec.ts
@@ -9,7 +9,8 @@ describe('markdown props', () => {
     const row = new PropRow('name', {
       attribType: {
         text: `(AlertButton | string)[]`,
-        optional: false
+        optional: false,
+        required: false,
       },
       jsdoc: {
         type: '(AlertButton | string)[]'

--- a/src/compiler/transpile/datacollection/event-decorator.ts
+++ b/src/compiler/transpile/datacollection/event-decorator.ts
@@ -22,7 +22,8 @@ export function getEventDecoratorMeta(diagnostics: d.Diagnostic[], checker: ts.T
         if (genericType) {
           metadata.eventType = {
             text: genericType.getText(),
-            optional: false
+            optional: false,
+            required: false,
           };
           if (ts.isTypeReferenceNode(genericType)) {
             metadata.eventType.typeReferences = getAttributeTypeInfo(member, sourceFile);

--- a/src/compiler/transpile/datacollection/method-decorator.ts
+++ b/src/compiler/transpile/datacollection/method-decorator.ts
@@ -52,6 +52,7 @@ export function getMethodDecoratorMeta(config: d.Config, diagnostics: d.Diagnost
         attribType: {
           text: typeString,
           optional: false,
+          required: false,
           typeReferences: {
             ...methodReturnTypes,
             ...getAttributeTypeInfo(member, sourceFile)

--- a/src/compiler/transpile/datacollection/prop-decorator.ts
+++ b/src/compiler/transpile/datacollection/prop-decorator.ts
@@ -38,7 +38,7 @@ export function getPropDecoratorMeta(diagnostics: d.Diagnostic[], checker: ts.Ty
 
         memberData.memberType = getMemberType(propOptions);
         memberData.attribName = getAttributeName(propOptions, memberName);
-        memberData.attribType = getAttribType(diagnostics, sourceFile, prop);
+        memberData.attribType = getAttribType(diagnostics, sourceFile, prop, memberName);
         memberData.reflectToAttrib = getReflectToAttr(propOptions);
         memberData.propType = propTypeFromTSType(type);
         memberData.jsdoc = serializeSymbol(checker, symbol);
@@ -92,7 +92,7 @@ function getReflectToAttr(propOptions: d.PropOptions) {
 }
 
 
-function getAttribType(diagnostics: d.Diagnostic[], sourceFile: ts.SourceFile, prop: ts.PropertyDeclaration) {
+function getAttribType(diagnostics: d.Diagnostic[], sourceFile: ts.SourceFile, prop: ts.PropertyDeclaration, memberName: string) {
   let attribType: d.AttributeTypeInfo;
 
   // If the @Prop() attribute does not have a defined type then infer it
@@ -108,11 +108,13 @@ function getAttribType(diagnostics: d.Diagnostic[], sourceFile: ts.SourceFile, p
 
     attribType = {
       text: attribTypeText,
+      required: prop.exclamationToken !== undefined && memberName !== 'mode',
       optional: prop.questionToken !== undefined
     };
   } else {
     attribType = {
       text: prop.type.getText(),
+      required: prop.exclamationToken !== undefined && memberName !== 'mode',
       optional: prop.questionToken !== undefined,
       typeReferences: getAttributeTypeInfo(prop.type, sourceFile)
     };

--- a/src/compiler/transpile/datacollection/test/component.spec.ts
+++ b/src/compiler/transpile/datacollection/test/component.spec.ts
@@ -134,6 +134,7 @@ describe('component', () => {
             'attribType': {
               'text': 'string',
               'optional': false,
+              'required': false,
               'typeReferences': {}
             },
             'jsdoc': {
@@ -158,6 +159,7 @@ describe('component', () => {
             'attribType': {
               'text': 'ActionSheetButton[]',
               'optional': false,
+              'required': false,
               'typeReferences': {
                 'ActionSheetButton': {
                   'referenceLocation': 'local',
@@ -183,6 +185,7 @@ describe('component', () => {
             'attribType': {
               'text': 'string',
               'optional': false,
+              'required': false,
               'typeReferences': {}
             },
             'jsdoc': {
@@ -203,6 +206,7 @@ describe('component', () => {
             'attribType': {
               'text': 'boolean',
               'optional': false,
+              'required': false,
               'typeReferences': {}
             },
             'jsdoc': {
@@ -220,6 +224,7 @@ describe('component', () => {
             'attribType': {
               'text': 'AnimationBuilder',
               'optional': false,
+              'required': false,
               'typeReferences': {
                 'AnimationBuilder': {
                   'referenceLocation': 'global',
@@ -241,6 +246,7 @@ describe('component', () => {
             'attribType': {
               'text': 'AnimationBuilder',
               'optional': false,
+              'required': false,
               'typeReferences': {
                 'AnimationBuilder': {
                   'referenceLocation': 'global',
@@ -265,6 +271,7 @@ describe('component', () => {
             'attribType': {
               'text': 'string',
               'optional': false,
+              'required': false,
               'typeReferences': {}
             },
             'jsdoc': {
@@ -282,6 +289,7 @@ describe('component', () => {
             'attribType': {
               'text': 'string',
               'optional': false,
+              'required': false,
               'typeReferences': {}
             },
             'jsdoc': {

--- a/src/compiler/transpile/datacollection/test/fixtures/prop-example.ts
+++ b/src/compiler/transpile/datacollection/test/fixtures/prop-example.ts
@@ -37,4 +37,8 @@ class ActionSheet {
   @Prop() enabled?: boolean | string;
 
   @Prop() color?: Color;
+
+  @Prop() mode!: string;
+
+  @Prop() required!: string;
 }

--- a/src/compiler/transpile/datacollection/test/method-decorator.spec.ts
+++ b/src/compiler/transpile/datacollection/test/method-decorator.spec.ts
@@ -27,6 +27,7 @@ describe('method decorator', () => {
         attribType: {
           text: '(opts?: any) => any',
           optional: false,
+          required: false,
           typeReferences: {
             ActionSheet: {
               referenceLocation: 'global',
@@ -84,6 +85,7 @@ describe('method decorator', () => {
         attribType: {
           text: '(opts?: ActionSheetOptions) => any',
           optional: false,
+          required: false,
           typeReferences: {
             ActionSheetOptions: {
               referenceLocation: 'local',
@@ -134,6 +136,7 @@ describe('method decorator', () => {
         attribType: {
           text: '(opts?: t.CoreContext) => any',
           optional: false,
+          required: false,
           typeReferences: {
             Promise: {
               referenceLocation: 'global',

--- a/src/compiler/transpile/datacollection/test/prop-decorator.spec.ts
+++ b/src/compiler/transpile/datacollection/test/prop-decorator.spec.ts
@@ -19,6 +19,7 @@ describe('props decorator', () => {
         attribType: {
           text: '(_) => Promise<OtherThing>',
           optional: false,
+          required: false,
           typeReferences: {
             OtherThing: {
               importReferenceLocation: '../../../../../index',
@@ -44,6 +45,7 @@ describe('props decorator', () => {
         attribType: {
           text: 'string',
           optional: false,
+          required: false,
           typeReferences: {}
         },
         jsdoc: {
@@ -61,6 +63,7 @@ describe('props decorator', () => {
         attribType: {
           text: 'number',
           optional: false,
+          required: false,
         },
         jsdoc: {
           documentation: '',
@@ -77,6 +80,7 @@ describe('props decorator', () => {
         attribType: {
           text: 'number',
           optional: true,
+          required: false,
           typeReferences: {}
         },
         jsdoc: {
@@ -94,6 +98,7 @@ describe('props decorator', () => {
         attribType: {
           text: `'auto' | 'manual'`,
           optional: true,
+          required: false,
           typeReferences: {}
         },
         jsdoc: {
@@ -111,6 +116,7 @@ describe('props decorator', () => {
         attribType: {
           text: `number | number[]`,
           optional: true,
+          required: false,
           typeReferences: {}
         },
         jsdoc: {
@@ -128,6 +134,7 @@ describe('props decorator', () => {
         attribType: {
           text: `boolean | string`,
           optional: true,
+          required: false,
           typeReferences: {}
         },
         jsdoc: {
@@ -145,6 +152,7 @@ describe('props decorator', () => {
         attribType: {
           text: `Color`,
           optional: true,
+          required: false,
           typeReferences: {
             Color: {
               referenceLocation: 'global'
@@ -156,6 +164,42 @@ describe('props decorator', () => {
           name: 'color',
           tags: [],
           type: `"primary" | "secondary"`,
+        },
+        memberType: MEMBER_TYPE.Prop,
+        propType: PROP_TYPE.String,
+        reflectToAttrib: false
+      },
+      mode: {
+        attribName: 'mode',
+        attribType: {
+          text: `string`,
+          optional: false,
+          required: false,
+          typeReferences: {}
+        },
+        jsdoc: {
+          documentation: '',
+          name: 'mode',
+          tags: [],
+          type: `string`,
+        },
+        memberType: MEMBER_TYPE.Prop,
+        propType: PROP_TYPE.String,
+        reflectToAttrib: false
+      },
+      required: {
+        attribName: 'required',
+        attribType: {
+          text: `string`,
+          optional: false,
+          required: true,
+          typeReferences: {}
+        },
+        jsdoc: {
+          documentation: '',
+          name: 'required',
+          tags: [],
+          type: `string`,
         },
         memberType: MEMBER_TYPE.Prop,
         propType: PROP_TYPE.String,

--- a/src/declarations/component.ts
+++ b/src/declarations/component.ts
@@ -81,6 +81,7 @@ export interface AttributeTypeReferences {
 export interface AttributeTypeInfo {
   text: string;
   optional: boolean;
+  required: boolean;
   typeReferences?: AttributeTypeReferences;
 }
 


### PR DESCRIPTION
```
@Prop() required!: string;
@Prop() optional?: string;
@Prop() alsoOptional = 'defaultValue';
```
and we could reflect that in the JSX types

Use cases:
- ion-tab, ion-tab-button  (both need the “tab” prop)
- ion-router and stencil-router: (path and component props)
- many others

<img width="716" alt="screenshot 2018-11-01 at 13 17 52" src="https://user-images.githubusercontent.com/127379/47874392-fb7fc600-de13-11e8-8f30-0649f5181ac6.png">
