### PR TITLE
feat(e2e): expose page.url() method

### DIFF
--- a/src/testing/puppeteer/puppeteer-declarations.ts
+++ b/src/testing/puppeteer/puppeteer-declarations.ts
@@ -10,7 +10,7 @@ export interface NewE2EPageOptions {
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 type PuppeteerPage = Omit<puppeteer.Page,
-'bringToFront' | 'browser' | 'screenshot' | 'close' | 'emulate' | 'emulateMedia' | 'frames' | 'goBack' | 'goForward' | 'isClosed' | 'mainFrame' | 'pdf' | 'reload' | 'target' | 'title' | 'url' | 'viewport' | 'waitForNavigation' | 'screenshot' | 'workers' | 'addListener' | 'prependListener' | 'prependOnceListener' | 'removeListener' | 'removeAllListeners' | 'setMaxListeners' | 'getMaxListeners' | 'listeners' | 'rawListeners' | 'emit' | 'eventNames' | 'listenerCount' | '$x' | 'waitForXPath'
+'bringToFront' | 'browser' | 'screenshot' | 'close' | 'emulate' | 'emulateMedia' | 'frames' | 'goBack' | 'goForward' | 'isClosed' | 'mainFrame' | 'pdf' | 'reload' | 'target' | 'title' | 'viewport' | 'waitForNavigation' | 'screenshot' | 'workers' | 'addListener' | 'prependListener' | 'prependOnceListener' | 'removeListener' | 'removeAllListeners' | 'setMaxListeners' | 'getMaxListeners' | 'listeners' | 'rawListeners' | 'emit' | 'eventNames' | 'listenerCount' | '$x' | 'waitForXPath'
 >;
 
 


### PR DESCRIPTION
This removes `url` from the omitted entries on the `PuppeteerPage` type.

Closes #1220.

---

BTW I believe `goto` should be added to the omitted list, because `goTo` is exposed instead? Found it kind of confusing to have two goto methods...

**Edit:** just checked and `goTo` doesn't actually work?

```
TypeError: page.goTo is not a function
```