### PR TITLE
feat(cli): add --dry-run flag

### DIFF
--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -162,6 +162,7 @@ const ARG_OPTS = {
     'debug',
     'dev',
     'docs',
+    'dry-run',
     'e2e',
     'es5',
     'headless',

--- a/src/cli/test/parse-flags.spec.ts
+++ b/src/cli/test/parse-flags.spec.ts
@@ -237,6 +237,12 @@ describe('parseFlags', () => {
     expect(flags.docsJson).toBe('some/path/docs.json');
   });
 
+  it('should parse --dry-run', () => {
+    process.argv[2] = '--dry-run';
+    const flags = parseFlags(process);
+    expect(flags.dryRun).toBe(true);
+  });
+
   it('should parse --e2e', () => {
     process.argv[2] = '--e2e';
     const flags = parseFlags(process);

--- a/src/compiler/build/build.ts
+++ b/src/compiler/build/build.ts
@@ -68,8 +68,8 @@ export async function build(config: d.Config, compilerCtx: d.CompilerCtx, buildC
     const cmpRegistry = await generateBundles(config, compilerCtx, buildCtx, entryModules, rawModules);
     if (buildCtx.hasError || !buildCtx.isActiveBuild) return buildCtx.abort();
 
-    // should we write any files?
-    // if we're in diagnostics mode, the answer is no
+    // should we write these files?
+    // if we're in dryRun mode, the answer is no
     if (config.flags.dryRun) return buildCtx.finish();
 
     // generate the app files, such as app.js, app.core.js

--- a/src/compiler/build/build.ts
+++ b/src/compiler/build/build.ts
@@ -47,7 +47,6 @@ export async function build(config: d.Config, compilerCtx: d.CompilerCtx, buildC
     if (buildCtx.hasError || !buildCtx.isActiveBuild) return buildCtx.abort();
 
     let copyTaskPromise: Promise<void>;
-
     if (!config.flags.dryRun) {
       // start copy tasks from the config.copy and component assets
       // but don't wait right now (running in worker)

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -87,24 +87,6 @@ export class Compiler implements d.Compiler {
     return devServer;
   }
 
-  async startDiagnosticServer() {
-    if (this.config.sys.details.runtime !== 'node') {
-      throw new Error(`Diagnostic Server only availabe in node`);
-    }
-
-    // start up the diagnostic server
-    const diagnosticServer = await startDevServerMain(this.config, this.ctx);
-
-    if (diagnosticServer) {
-      // get the browser url to be logged out at the end of the build
-      this.config.devServer.browserUrl = diagnosticServer.browserUrl;
-
-      this.config.logger.debug(`diagnostic server started: ${diagnosticServer.browserUrl}`);
-    }
-
-    return diagnosticServer;
-  }
-
   on(eventName: 'fsChange', cb: (fsWatchResults?: d.FsWatchResults) => void): Function;
   on(eventName: 'buildNoChange', cb: (buildResults: d.BuildNoChangeResults) => void): Function;
   on(eventName: 'buildLog', cb: (buildResults: d.BuildLog) => void): Function;

--- a/src/declarations/config.ts
+++ b/src/declarations/config.ts
@@ -209,6 +209,7 @@ export interface ConfigFlags {
   docs?: boolean;
   docsApi?: string;
   docsJson?: string;
+  dryRun?: boolean;
   e2e?: boolean;
   emulate?: string;
   es5?: boolean;


### PR DESCRIPTION
This PR adds a `--dry-run` flag to `@stencil/cli`.

The `--dry-run` flag is intended to enable `stencil build` to run without actually writing any files to an outputTarget. It is a boolean, defaulting to `false`.

**Usage**
```bash
stencil build --dry-run
```
```bash
stencil build --dev --watch --dry-run
```

**Why?**

This feature is useful for:
- New `@stencil/cli` users
- Users that wish to quickly check for diagnostic errors (particularly Stencil's custom diagnostics)
- Diagnostic tools that wish to run Stencil in the background (in order to integrate Stencil's custom diagnostics into an editor, for example)

Note that this implementation still steps through the entire build process short of writing the generated files. Everything remains in the `inMemoryFs` rather than being written to disk. *Are there any steps that can be skipped to improve build times without sacrificing diagnostic coverage?*

**Alternative Names**
- `--dry`
- `--no-emit`
- `--diagnostics-only`

**See Also**
- [npm install --dry-run](https://docs.npmjs.com/cli/install)
- [typescript getPreEmitDiagnostics](https://github.com/Microsoft/TypeScript/blob/901476fae3064435b48412a189f7120f3bdc9dc4/src/compiler/program.ts#L201)