### PR TITLE
fix: set script crossorigin=use-credentials for better Safari support

### DIFF
--- a/src/client/loader.ts
+++ b/src/client/loader.ts
@@ -69,7 +69,7 @@ export function init(
     // let's do this!
     x.src = resourcesUrl + appCore;
     x.setAttribute('type', 'module');
-    x.setAttribute('crossorigin', true);
+    x.setAttribute('crossorigin', 'use-credentials');
   }
 
   x.setAttribute('data-resources-url', resourcesUrl);


### PR DESCRIPTION
This PR sets the `crossorigin` attribute of the `<script type="module">` loader to `use-credentials`.

This solves an issue as described in this Slack thread: https://stencil-worldwide.slack.com/archives/C79EANFL7/p1536127733000100

Essentially, when compiled Stencil files are loaded from a server that uses session cookies to protect resources, they fail to load in Safari on macOS and iOS. This appears to happen because the current `crossorigin=true` attribute does not pass session cookies through on Safari.

Demo of the differing `crossorigin` behaviors here: https://protected-stencil.herokuapp.com/

The code for this demo is here; it's an Express app that [403s for any JS files](https://github.com/mattdsteele/protected-stencil-demo/blob/master/app.js#L14) that don't contain a cookie: https://github.com/mattdsteele/protected-stencil-demo

A few files are being loaded to demonstrate the varying cross-origin behavior:

* `no-co.js` - fails in Chrome & Safari
* `co-true.js` - fails in Safari, passes in Chrome
* `co-usecredentials` - passes in Safari and Chrome
* `mycomponent.js` - Stencil component built with current compiler - fails in Safari, passes in Chrome
* `myfixedcomponent.js` - Stencil component built with PR - passes in both Chrome & Safari

From what I can tell, the [spec](https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attributes) only allows for "anonymous" or "use-credentials", not `true`, which is probably why the behavior is different.