### PR TITLE
test(prerender): test client component lifecycle order

### DIFF
--- a/test/karma/test-app/prerender-test/karma.spec.ts
+++ b/test/karma/test-app/prerender-test/karma.spec.ts
@@ -1,13 +1,13 @@
-import { setupDomTests } from '../util';
+import { setupDomTests, waitForChanges } from '../util';
 
 describe('prerender', () => {
   const { setupDom, tearDownDom } = setupDomTests(document);
   let app: HTMLElement;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     app = await setupDom('/prerender/index.html');
   });
-  afterAll(tearDownDom);
+  afterEach(tearDownDom);
 
   it('server componentWillLoad Order', () => {
     const elm = app.querySelector('#server-componentWillLoad');
@@ -31,6 +31,32 @@ describe('prerender', () => {
     expect(elm.children[5].textContent.trim()).toBe('CmpC server componentDidLoad');
     expect(elm.children[6].textContent.trim()).toBe('CmpB server componentDidLoad');
     expect(elm.children[7].textContent.trim()).toBe('CmpA server componentDidLoad');
+  });
+  
+  it('client componentWillLoad Order', async () => {
+    await waitForChanges();
+    const elm = app.querySelector('#client-componentWillLoad');
+    expect(elm.children[0].textContent.trim()).toBe('CmpA client componentWillLoad');
+    expect(elm.children[1].textContent.trim()).toBe('CmpD - a1-child client componentWillLoad');
+    expect(elm.children[2].textContent.trim()).toBe('CmpD - a2-child client componentWillLoad');
+    expect(elm.children[3].textContent.trim()).toBe('CmpD - a3-child client componentWillLoad');
+    expect(elm.children[4].textContent.trim()).toBe('CmpD - a4-child client componentWillLoad');
+    expect(elm.children[5].textContent.trim()).toBe('CmpB client componentWillLoad');
+    expect(elm.children[6].textContent.trim()).toBe('CmpC client componentWillLoad');
+    expect(elm.children[7].textContent.trim()).toBe('CmpD - c-child client componentWillLoad');
+  });
+
+  it('client componentDidLoad Order', async () => {
+    await waitForChanges();
+    const elm = app.querySelector('#client-componentDidLoad');
+    expect(elm.children[0].textContent.trim()).toBe('CmpD - a1-child client componentDidLoad');
+    expect(elm.children[1].textContent.trim()).toBe('CmpD - a2-child client componentDidLoad');
+    expect(elm.children[2].textContent.trim()).toBe('CmpD - a3-child client componentDidLoad');
+    expect(elm.children[3].textContent.trim()).toBe('CmpD - a4-child client componentDidLoad');
+    expect(elm.children[4].textContent.trim()).toBe('CmpD - c-child client componentDidLoad');
+    expect(elm.children[5].textContent.trim()).toBe('CmpC client componentDidLoad');
+    expect(elm.children[6].textContent.trim()).toBe('CmpB client componentDidLoad');
+    expect(elm.children[7].textContent.trim()).toBe('CmpA client componentDidLoad');
   });
 
   it('set ssrv', () => {


### PR DESCRIPTION
This PR adds tests for client component lifecycle method order after the components have been prerendered. The test is currently failing in Chrome as described in issue #1261 