### PR TITLE
Change constructor creation to avoid CSP problems

### DIFF
--- a/src/client/core-esm.ts
+++ b/src/client/core-esm.ts
@@ -66,7 +66,7 @@ export function defineCustomElement(win: Window, cmpData: d.ComponentHostData | 
 
         if (isNative(win.customElements.define)) {
           // native custom elements supported
-          const createHostConstructor = new Function('w', 'return class extends w.HTMLElement{}');
+          const createHostConstructor = (w) => { return class extends w.HTMLElement{}; };
           HostElementConstructor = createHostConstructor(win);
 
         } else {


### PR DESCRIPTION
Having an strict policy on Content Security Policy (CSP) configuration triggers errors using the 'eval' like function creation