### PR TITLE
fix(events): remove event listeners after lifecycle hook call

### DIFF
--- a/src/core/disconnected.ts
+++ b/src/core/disconnected.ts
@@ -25,12 +25,6 @@ export const disconnectedCallback = (plt: PlatformApi, elm: HostElement, perf: P
     // since we're disconnecting, call all of the JSX ref's with null
     callNodeRefs(plt.vnodeMap.get(elm), true);
 
-    // detatch any event listeners that may have been added
-    // because we're not passing an exact event name it'll
-    // remove all of this element's event, which is good
-    plt.domApi.$removeEventListener(elm);
-    plt.hasListenersMap.delete(elm);
-
     if (_BUILD_.cmpDidUnload) {
       // call instance componentDidUnload
       // if we've created an instance for this
@@ -40,6 +34,12 @@ export const disconnectedCallback = (plt: PlatformApi, elm: HostElement, perf: P
         instance.componentDidUnload();
       }
     }
+
+    // detatch any event listeners that may have been added
+    // because we're not passing an exact event name it'll
+    // remove all of this element's event, which is good
+    plt.domApi.$removeEventListener(elm);
+    plt.hasListenersMap.delete(elm);
 
     // clear CSS var-shim tracking
     if (_BUILD_.cssVarShim && plt.customStyle) {


### PR DESCRIPTION
This PR relocates the removal of a certain elements' event listeners to after its `componentDidUnload` method call.
As stated in [#1218](https://github.com/ionic-team/stencil/issues/1218), when an event is emitted within a component's `componentDidUnload` method, it can no longer be consumed by its listeners.
By moving the `plt.domApi.$removeEventListener(elm)` and `plt.hasListenersMap.delete(elm)` calls to after the `componentDidUnload` call, events fired within `componentDidUnload`  can still be consumed by all listeners. 