### PR TITLE
feat(e2e) add remote chrome support for puppeteer

### DIFF
--- a/src/declarations/testing.ts
+++ b/src/declarations/testing.ts
@@ -376,6 +376,11 @@ export interface TestingConfig extends JestConfig {
   browserExecutablePath?: string;
 
   /**
+   * Url of remote Chrome instance to use instead of local Chrome.
+   */
+  browserWSEndpoint?: string;
+
+  /**
    * Whether to run browser e2e tests in headless mode. Defaults to true.
    */
   browserHeadless?: boolean;

--- a/src/testing/puppeteer/puppeteer-browser.ts
+++ b/src/testing/puppeteer/puppeteer-browser.ts
@@ -36,7 +36,14 @@ export async function startPuppeteerBrowser(config: d.Config) {
     launchOpts.executablePath = config.testing.browserExecutablePath;
   }
 
-  const browser = await puppeteer.launch(launchOpts);
+  let browser;
+  if (config.testing.browserWSEndpoint) {
+    let connectOpts: puppeteer.ConnectOptions = launchOpts;
+    connectOpts.browserWSEndpoint = config.testing.browserWSEndpoint;
+    browser = await puppeteer.connect(connectOpts);
+  } else {
+    browser = await puppeteer.launch(launchOpts);
+  }
 
   env.__STENCIL_BROWSER_WS_ENDPOINT__ = browser.wsEndpoint();
 


### PR DESCRIPTION
Add browserWSEndpoint option to testing config.

When used it may require that the devServer address be set in the config if the stencil test runner is invoked from a different host than the chrome instance, such as when running in a docker environment.

We need this functionality at Big Cartel to run e2e tests in our containerized env since Alpine Linux doesn't support the Chromium version automatically downloaded by Puppeteer. All our browser based testing runs in an instance of [browserless](https://github.com/joelgriffith/browserless) running the tagged version of Chrome needed for the version of puppeteer that Stencil depends on for e2e tests.