### PR TITLE
update domApi to handle template children automatically

### DIFF
--- a/src/declarations/dom.ts
+++ b/src/declarations/dom.ts
@@ -3,6 +3,7 @@
 export interface DomApi {
   $doc: HTMLDocument;
   $nodeType(node: any): number;
+  $nodeIs<T extends Node>(nodeName: string, node: Node): node is T;
   $createElement<K extends keyof HTMLElementTagNameMap>(tagName: K): HTMLElementTagNameMap[K];
   $createElement(tagName: any): HTMLElement;
   $createElementNS(namespace: string, tagName: any): any;

--- a/src/renderer/dom-api.ts
+++ b/src/renderer/dom-api.ts
@@ -18,6 +18,8 @@ export const createDomApi = (App: AppGlobal, win: any, doc: Document): DomApi =>
     $nodeType: (node: any) =>
       node.nodeType,
 
+    $nodeIs: (nodeName: string, node: Node): node is any => node.nodeName && node.nodeName === nodeName.toUpperCase(),
+
     $createElement: (tagName: any) =>
       doc.createElement(tagName),
 
@@ -29,14 +31,14 @@ export const createDomApi = (App: AppGlobal, win: any, doc: Document): DomApi =>
     $createComment: (data: string) => doc.createComment(data),
 
     $insertBefore: (parentNode: Node, childNode: Node, referenceNode: Node) =>
-      parentNode.insertBefore(childNode, referenceNode),
+      domApi.$nodeIs<HTMLTemplateElement>('TEMPLATE', parentNode) ? parentNode.content.insertBefore(childNode, referenceNode) : parentNode.insertBefore(childNode, referenceNode),
 
     // https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove
     // and it's polyfilled in es5 builds
     $remove: (node: Node) => (node as any).remove(),
 
     $appendChild: (parentNode: Node, childNode: Node) =>
-      parentNode.appendChild(childNode),
+      domApi.$nodeIs<HTMLTemplateElement>('TEMPLATE', parentNode) ? parentNode.content.appendChild(childNode) : parentNode.appendChild(childNode),
 
     $addClass: (elm: Element, cssClass: string) => {
       if (_BUILD_.hasSvg && _BUILD_.es5) {
@@ -60,7 +62,7 @@ export const createDomApi = (App: AppGlobal, win: any, doc: Document): DomApi =>
     },
 
     $childNodes: (node: Node) =>
-      node.childNodes,
+      domApi.$nodeIs<HTMLTemplateElement>('TEMPLATE', node) ? node.content.childNodes : node.childNodes,
 
     $parentNode: (node: Node) =>
       node.parentNode,

--- a/src/renderer/test/dom-api.spec.ts
+++ b/src/renderer/test/dom-api.spec.ts
@@ -20,6 +20,60 @@ describe('dom api', () => {
   });
 
 
+  describe('$nodeIs', () => {
+
+    it('is not case sensitive', () => {
+
+      const r = domApi.$nodeIs('dIv', elm);
+      expect(r).toBe(true);
+    })
+
+    it('is not', () => {
+
+      const r = domApi.$nodeIs('span', elm);
+      expect(r).toBe(false);
+    });
+  });
+
+  describe('$insertBefore', () => {
+
+    it('when inserting child on a template, goes in content fragment', () => {
+
+      const parentElm = doc.createElement('template');
+      const referenceElm = doc.createElement('div');
+      parentElm.content.appendChild(referenceElm);
+
+      domApi.$insertBefore(parentElm, elm, referenceElm);
+      const r = parentElm.content.childNodes[0];
+      expect(r).toBe(elm);
+    });
+  });
+
+  describe('$appendChild', () => {
+
+    it('when appending child on a template, goes in content fragment', () => {
+
+      const parentElm = doc.createElement('template');
+      parentElm.content.appendChild(doc.createElement('div'));
+
+      domApi.$appendChild(parentElm, elm);
+      const r = parentElm.content.childNodes[1];
+      expect(r).toBe(elm);
+    });
+  });
+
+  describe('$childNodes', () => {
+
+    it('returning childNodes from a template', () => {
+
+      const parentElm = doc.createElement('template');
+      parentElm.content.appendChild(elm);
+
+      const r = domApi.$childNodes(parentElm)[0];
+      expect(r).toBe(elm);
+    });
+  });
+
   describe('$parentElement', () => {
 
     it('element w/ parentNode thats is a shadow root should return host', () => {

--- a/src/renderer/vdom/test/patch.spec.ts
+++ b/src/renderer/vdom/test/patch.spec.ts
@@ -891,7 +891,24 @@ describe('renderer', () => {
 
   });
 
-  function prop(name: any) {
+  describe('template elements', () => {
+
+    it('adds children to the content fragment', ()=>{
+      hostElm = domApi.$createElement('my-tag');
+      vnode0 = {};
+      vnode0.elm = hostElm;
+      hostElm = patch(hostElm, vnode0,
+        h('my-tag', null,
+            h('template', null, 'Test Child')
+        )
+      ).elm;
+
+      expect(hostElm.childNodes[0].tagName).toBe('TEMPLATE');
+      expect(hostElm.childNodes[0].content.childNodes[0].textContent).toBe('Test Child');
+    });
+  });
+
+function prop(name: any) {
     return function(obj: any) {
       return obj[name];
     };


### PR DESCRIPTION
changed the domApi to handle template elements children as being in the 'content' property
allows the vdom patch to add nodes to the correct place in this instance

one thing, was wondering if patch should be changed instead?

might be faster as there would be less calls to $nodeIs guard function (new bit)
and feels like I am changing expectations of an $appendChild call

however, do you ever need to have childnodes directly on a template?
also it would require more changes and need to be implemented in anything using domAPI