### PR TITLE
Add close event to Dialog

### DIFF
--- a/src/declarations/jsx.ts
+++ b/src/declarations/jsx.ts
@@ -217,6 +217,7 @@ export namespace JSXElements {
   }
 
   export interface DialogHTMLAttributes<T> extends HTMLAttributes<T> {
+    onClose?: (event: Event) => string | void;
     open?: boolean;
     returnValue?: string;
   }

--- a/src/declarations/jsx.ts
+++ b/src/declarations/jsx.ts
@@ -217,7 +217,7 @@ export namespace JSXElements {
   }
 
   export interface DialogHTMLAttributes<T> extends HTMLAttributes<T> {
-    onClose?: (event: Event) => string | void;
+    onClose?: (event: Event) => void;
     open?: boolean;
     returnValue?: string;
   }


### PR DESCRIPTION
I believe that I should be able to do an inline event listener for the close event. Example is the returning value from dialog section https://demo.agektmr.com/dialog/ https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element