### PR TITLE
fix: export DEFAULT_MODE from host-config to use it in platform-server and to prevent undefined as a bundle id.

### DIFF
--- a/src/compiler/prerender/host-config.ts
+++ b/src/compiler/prerender/host-config.ts
@@ -283,7 +283,7 @@ export function mergeUserHostConfig(userHostConfig: d.HostConfig, hostConfig: d.
 }
 
 
-const DEFAULT_MODE = 'md';
+export const DEFAULT_MODE = 'md';
 const MAX_LINK_REL_PRELOAD_COUNT = 6;
 export const HOST_CONFIG_FILENAME = 'host.config.json';
 

--- a/src/server/platform-server.ts
+++ b/src/server/platform-server.ts
@@ -15,6 +15,7 @@ import { proxyController } from '../core/proxy-controller';
 import { queueUpdate } from '../core/update';
 import { serverAttachStyles, serverInitStyle } from './server-styles';
 import { toDashCase } from '../util/helpers';
+import {DEFAULT_MODE} from "../compiler/prerender/host-config";
 
 
 export function createPlatformServer(
@@ -390,7 +391,7 @@ export function createPlatformServer(
 export function getComponentBundleFilename(cmpMeta: d.ComponentMeta, modeName: string) {
   let bundleId: string = (typeof cmpMeta.bundleIds === 'string') ?
     cmpMeta.bundleIds :
-    ((cmpMeta.bundleIds as d.BundleIds)[modeName] || (cmpMeta.bundleIds as d.BundleIds)[DEFAULT_STYLE_MODE]);
+    ((cmpMeta.bundleIds as d.BundleIds)[modeName] || (cmpMeta.bundleIds as d.BundleIds)[DEFAULT_MODE] || (cmpMeta.bundleIds as d.BundleIds)[DEFAULT_STYLE_MODE]);
 
   if (cmpMeta.encapsulationMeta === ENCAPSULATION.ScopedCss || cmpMeta.encapsulationMeta === ENCAPSULATION.ShadowDom) {
     bundleId += '.sc';


### PR DESCRIPTION
This should fix 

> ENOENT: no such file or directory, open
           '/Users/.../www/build/app/undefined.es5.entry.js' at

of issue [https://github.com/ionic-team/stencil/issues/1144](url). It is uses the very similar logic you've already used when getting bundleIds as array in a different place of an application thus I thought it will be a good idea to stick to this logic.

One more thing - when I was debugging I've noticed that ionic's components are giving me bundleIds for ios and md; Would it be a good idea to take that into notice at some point in time?