### PR TITLE
feat(compiler): add check for potential custom element name issue#947

### DIFF
--- a/src/compiler/entries/app-graph.ts
+++ b/src/compiler/entries/app-graph.ts
@@ -142,6 +142,13 @@ function getGraph(buildCtx: d.BuildCtx, allModules: d.ModuleFile[], entryTags: s
       diagnostic.messageText = `unable to find tag "${tag}" while generating component graph`;
       return;
     }
+    const regex = new RegExp(/^[a-z](?:[\-\.0-9_a-z\xB7\xC0-\xD6\xD8-\xF6\xF8-\u037D\u037F-\u1FFF\u200C\u200D\u203F\u2040\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])*-(?:[\-\.0-9_a-z\xB7\xC0-\xD6\xD8-\xF6\xF8-\u037D\u037F-\u1FFF\u200C\u200D\u203F\u2040\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])*$/);
+    if (!regex.test(tag)) {
+      const diagnostic = buildError(buildCtx.diagnostics);
+      diagnostic.messageText = `"${tag}" is an invalid tag name`;
+      return;
+    }
+
     m.cmpMeta.dependencies = (m.cmpMeta.dependencies || []);
 
     const dependencies = m.cmpMeta.dependencies.filter(t => t !== tag).sort();

--- a/src/compiler/entries/app-graph.ts
+++ b/src/compiler/entries/app-graph.ts
@@ -142,13 +142,6 @@ function getGraph(buildCtx: d.BuildCtx, allModules: d.ModuleFile[], entryTags: s
       diagnostic.messageText = `unable to find tag "${tag}" while generating component graph`;
       return;
     }
-    const regex = new RegExp(/^[a-z](?:[\-\.0-9_a-z\xB7\xC0-\xD6\xD8-\xF6\xF8-\u037D\u037F-\u1FFF\u200C\u200D\u203F\u2040\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])*-(?:[\-\.0-9_a-z\xB7\xC0-\xD6\xD8-\xF6\xF8-\u037D\u037F-\u1FFF\u200C\u200D\u203F\u2040\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])*$/);
-    if (!regex.test(tag)) {
-      const diagnostic = buildError(buildCtx.diagnostics);
-      diagnostic.messageText = `"${tag}" is an invalid tag name`;
-      return;
-    }
-
     m.cmpMeta.dependencies = (m.cmpMeta.dependencies || []);
 
     const dependencies = m.cmpMeta.dependencies.filter(t => t !== tag).sort();

--- a/src/compiler/transpile/datacollection/component-decorator.ts
+++ b/src/compiler/transpile/datacollection/component-decorator.ts
@@ -22,6 +22,13 @@ export function getComponentDecoratorMeta(diagnostics: d.Diagnostic[], checker: 
     throw new Error(`tag missing in component decorator: ${JSON.stringify(componentOptions, null, 2)}`);
   }
 
+  const regex = new RegExp(/^[a-z](?:[\-\.0-9_a-z\xB7\xC0-\xD6\xD8-\xF6\xF8-\u037D\u037F-\u1FFF\u200C\u200D\u203F\u2040\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])*-(?:[\-\.0-9_a-z\xB7\xC0-\xD6\xD8-\xF6\xF8-\u037D\u037F-\u1FFF\u200C\u200D\u203F\u2040\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])*$/);
+  if (!regex.test(componentOptions.tag)) {
+   throw new SyntaxError(`"${componentOptions.tag}" is not a valid tag name. Refer to
+   https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name for more info`);
+  }
+
+
   if (node.heritageClauses && node.heritageClauses.some(c => c.token === ts.SyntaxKind.ExtendsKeyword)) {
     throw new Error(`Classes decorated with @Component can not extend from a base class.
   Inherency is temporarily disabled for stencil components.`);

--- a/src/compiler/transpile/datacollection/test/component-decorator.spec.ts
+++ b/src/compiler/transpile/datacollection/test/component-decorator.spec.ts
@@ -115,5 +115,15 @@ describe('component decorator', () => {
         dependencies: []
       });
     });
+    it('should check for invalid component name', () => {
+      const sourceFilePath = path.resolve(__dirname, './fixtures/component-valid-name');
+      gatherMetadata(sourceFilePath, (checker, classNode) => {
+        try {
+          getComponentDecoratorMeta([], checker, classNode);
+        } catch (e) {
+        expect(e).toBeInstanceOf(SyntaxError);
+        }
+      });
+    });
   });
 });

--- a/src/compiler/transpile/datacollection/test/fixtures/component-valid-name.ts
+++ b/src/compiler/transpile/datacollection/test/fixtures/component-valid-name.ts
@@ -1,0 +1,8 @@
+import { Component } from '../../../../../index';
+
+@Component({
+  tag: 'ion_card',
+  scoped: true,
+})
+class IonCard {
+}


### PR DESCRIPTION
This PR will resolve [#947](https://github.com/ionic-team/stencil/issues/947) 
I have added a check for tag name of a custom component as defined [here](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name)
I have taken reference from [here](https://github.com/mathiasbynens/mothereff.in/blob/master/custom-element-name/vendor/is-potential-custom-element-name.js)
I have seen that this issue is listed on-deck on the [project](https://github.com/ionic-team/stencil/projects/1) page. So, I picked it up. This is my first try to contribute code in stencil. Do let me know if there is any correction in this PR or code.