### PR TITLE
fix(bundle): use newer rollup commonjs plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "postcss": "7.0.11",
     "puppeteer": "~1.11.0",
     "rollup": "1.1.0",
-    "rollup-plugin-commonjs": "9.2.0",
+    "rollup-plugin-commonjs": "^9.2.1",
     "rollup-plugin-json": "^3.1.0",
     "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-node-resolve": "4.0.0",


### PR DESCRIPTION
`rollup-plugin-commonjs@9.2.1` fixes an upstream issue that caused a build error when conflicting packages exist and preferBuiltins is unset.

Closes #1326.