### PR TITLE
feat: Improve error msg with effective config attributes name

### DIFF
--- a/src/compiler/copy/config-copy-tasks.ts
+++ b/src/compiler/copy/config-copy-tasks.ts
@@ -148,7 +148,7 @@ export function getDestAbsPath(config: d.Config, src: string, destAbsPath: strin
   }
 
   if (config.sys.path.isAbsolute(src)) {
-    throw new Error(`copy task, "to" property must exist if "from" property is an absolute path: ${src}`);
+    throw new Error(`copy task, "dest" property must exist if "src" property is an absolute path: ${src}`);
   }
 
   return config.sys.path.join(destAbsPath, src);


### PR DESCRIPTION
Improve error msg:

```
[ ERROR ]  copy task, "to" property must exist if "from" property is an absolute path:
```

to

```
[ ERROR ]  copy task, "dest" property must exist if "src" property is an absolute path:
```

as the attributes' names in the Stencil config are dest/src and not to/from
