### PR TITLE
bug(MockLocation): store href for getter usage

### DIFF
--- a/src/mock-doc/location.ts
+++ b/src/mock-doc/location.ts
@@ -28,6 +28,7 @@ export class MockLocation {
     this.username = url.username;
     this.password = url.password;
     this.origin = url.origin;
+    this._href = value;
   }
 
   assign(_url: string) {


### PR DESCRIPTION
Fixes https://github.com/ionic-team/stencil/issues/1401