### PR TITLE
Fail the build for reserved members

### DIFF
--- a/src/compiler/transpile/datacollection/reserved-public-members.ts
+++ b/src/compiler/transpile/datacollection/reserved-public-members.ts
@@ -1,10 +1,10 @@
-import * as d  from '../../../declarations';
-import { buildWarn } from '../../util';
+import * as d from '../../../declarations';
+import { buildError } from '../../util';
 
 
 export function validatePublicName(diagnostics: d.Diagnostic[], componentClass: string, memberName: string, decorator: string, memberType: string) {
   if (isReservedMember(memberName)) {
-    const diagnostic = buildWarn(diagnostics);
+    const diagnostic = buildError(diagnostics);
     diagnostic.messageText = [
       `The ${decorator} name "${memberName}" used within the "${componentClass}" class is a reserved public name. `,
       `Please rename the "${memberName}" ${memberType} so it does not conflict with an existing standardized prototype member. `,


### PR DESCRIPTION
I propose that the build should fail if reserved words are used as component props. Currently, a warning is issued, which is too easy to ignore. If this has a potential to cause a real issue, it should be an error.

An alternative would be to create an eslint rule for stencil. Or, if it's really not an issue, perhaps it should not be a warning? Discussion appreciated.