### PR TITLE
Make serve openBrowser configurable with open flag

### DIFF
--- a/src/cli/task-serve.ts
+++ b/src/cli/task-serve.ts
@@ -12,7 +12,7 @@ export async function taskServe(process: NodeJS.Process, config: d.Config, flags
   }
 
   config.flags.serve = true;
-  config.devServer.openBrowser = false;
+  config.devServer.openBrowser = flags.open;
   config.devServer.hotReplacement = false;
   config.maxConcurrentWorkers = 1;
 


### PR DESCRIPTION
Allow to pass `--open` flag to serve command to open the Browser