### PR TITLE
Make serve command launch root url

### DIFF
--- a/src/cli/task-serve.ts
+++ b/src/cli/task-serve.ts
@@ -14,6 +14,7 @@ export async function taskServe(process: NodeJS.Process, config: d.Config, flags
   config.flags.serve = true;
   config.devServer.openBrowser = flags.open;
   config.devServer.hotReplacement = false;
+  config.devServer.initialLoadUrl = '/';
   config.maxConcurrentWorkers = 1;
 
   config.devServer.root = process.cwd();

--- a/src/dev-server/start-server-worker.ts
+++ b/src/dev-server/start-server-worker.ts
@@ -26,7 +26,7 @@ export async function startDevServerWorker(process: NodeJS.Process, devServerCon
     sendMsg(process, {
       serverStated: {
         browserUrl: getBrowserUrl(devServerConfig.protocol, devServerConfig.address, devServerConfig.port, devServerConfig.baseUrl, '/'),
-        initialLoadUrl: getBrowserUrl(devServerConfig.protocol, devServerConfig.address, devServerConfig.port, devServerConfig.baseUrl, DEV_SERVER_INIT_URL)
+        initialLoadUrl: getBrowserUrl(devServerConfig.protocol, devServerConfig.address, devServerConfig.port, devServerConfig.baseUrl, devServerConfig.initialLoadUrl || DEV_SERVER_INIT_URL)
       }
     });
 


### PR DESCRIPTION
Set the `initialLoadUrl` to `'/'` when using serve command and make the server use it if configured instead of the default `DEV_SERVER_INIT_URL` 