### PR TITLE
fix(): ensureDir for backslash folder-separator

### DIFF
--- a/src/utils/in-memory-fs.ts
+++ b/src/utils/in-memory-fs.ts
@@ -407,7 +407,7 @@ export class InMemoryFileSystem implements d.InMemoryFileSystem {
 
     while (true) {
       p = this.path.dirname(p);
-      if (typeof p === 'string' && p.length > 0 && p !== '/' && p.endsWith(':/') === false) {
+      if (typeof p === 'string' && p.length > 0 && p !== '/' && p.endsWith(':/') === false && p.endsWith(':\\') === false) {
         allDirs.push(p);
       } else {
         break;


### PR DESCRIPTION
I was getting a _JavaScript heap out of memory_ when building on my Windows machine. I traced it down to the `ensureDir` function which does not manage to break out of the `while(true)` loop due to `this.path.dirname` returns the string with backslash `\` folder-separators.

Not sure if there are cases where `:/` is relevant on other Windows setups, but I figured it's safer to just check both.