### PR TITLE
feat (Puppeteer): Added devtools option in puppeteer.launch

### DIFF
--- a/src/declarations/testing.ts
+++ b/src/declarations/testing.ts
@@ -391,6 +391,12 @@ export interface TestingConfig extends JestConfig {
   browserSlowMo?: number;
 
   /**
+   * Whether to auto-open a DevTools panel for each tab.
+   * If this option is true, the headless option will be set false
+   */
+  browserDevtools?: boolean;
+
+  /**
    * Array of browser emulations to be using during e2e tests. A full e2e
    * test is ran for each emulation.
    */

--- a/src/testing/puppeteer/puppeteer-browser.ts
+++ b/src/testing/puppeteer/puppeteer-browser.ts
@@ -21,6 +21,10 @@ export async function startPuppeteerBrowser(config: d.Config) {
     config.logger.debug(`puppeteer args: ${config.testing.browserArgs.join(' ')}`);
   }
 
+  if (typeof config.testing.browserDevtools === 'boolean') {
+    config.logger.debug(`puppeteer devtools: ${config.testing.browserDevtools}`);
+  }
+
   if (typeof config.testing.browserSlowMo === 'number') {
     config.logger.debug(`puppeteer slowMo: ${config.testing.browserSlowMo}`);
   }
@@ -29,6 +33,7 @@ export async function startPuppeteerBrowser(config: d.Config) {
     ignoreHTTPSErrors: true,
     args: config.testing.browserArgs,
     headless: config.testing.browserHeadless,
+    devtools: config.testing.browserDevtools,
     slowMo: config.testing.browserSlowMo
   };
 


### PR DESCRIPTION
NOTE: I closed my previous PR to make the change in Stencil One :)

Puppeteer launch api: https://github.com/GoogleChrome/puppeteer/blob/v1.13.0/docs/api.md#puppeteerlaunchoptions