### PR TITLE
expose getElement to @stencil/core

### DIFF
--- a/src/compiler/transformers/remove-stencil-import.ts
+++ b/src/compiler/transformers/remove-stencil-import.ts
@@ -39,5 +39,6 @@ const KEEP_IMPORTS = new Set([
   'Host',
   'getAssetPath',
   'writeTask',
-  'readTask'
+  'readTask',
+  'getElement'
 ]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,11 @@ export declare function getMode<T = (string | undefined)>(ref: any): T;
 export declare function getAssetPath(path: string): string;
 
 /**
+ * getElement
+ */
+export declare function getElement(ref: any): d.HostElement;
+
+/**
  * writeTask
  */
 export declare function writeTask(task: d.RafCallback): void;


### PR DESCRIPTION
By adding `getElement` to `KEEP_IMPORTS` and exposing it in `src/index.ts`, we'll be able to use `getElement(this)` as an alternative to `@Element()`. The real goal however is not to replace `@Element()`, but that things like decorators will be able to access the host element without requiring additional setup  from the user of the decorator, a setup that's so un-intuitive that you probably have to refer to the documentation.

For example, consider the following decorator:
```ts
export function Lazy(hostProperty: string) {
  return (proto: any, prop: any) => {
    const { componentWillLoad } = proto;

    proto.componentWillLoad = async function() {
      const host = this[hostProperty];
      
      // Setup IntersectionObserver

      return componentWillLoad.call(this);
    }
  };
}
```

Here's how we would have to use this decorator. Note the `@Element()` and the `@Lazy()` argument.
```ts
@Component({})
export class MyComponent {
  @Element() host;

  @Lazy("host")
  lazyCallback() { ... }
}
```

With getElement we could get rid of this extra complexity for the developer that want to use our decorator.

```ts
export function Lazy() {
  return (proto: any, prop: any) => {
    const { componentWillLoad } = proto;

    proto.componentWillLoad = async function() {
      const host = getElement(this);
      
      // Setup IntersectionObserver

      return componentWillLoad.call(this);
    }
  };
}
```

Now it's super simple to use, no setup required.
```ts
@Component({})
export class MyComponent {
  @Lazy()
  lazyCallback() { ... }
}
```