### PR TITLE
Update readme.md / Fixed Typo in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ npm init stencil
 
 [Stencil](https://stenciljs.com/) is a simple compiler for generating Web Components and progressive web apps (PWA). Stencil was built by the [Ionic Framework](http://ionicframework.com/) team for its next generation of performant mobile and desktop Web Components.
 
-Stencil combines the best concepts of the most popular frontend frameworks into a compile-time rather than run-time tool. It takes TypeScript, JSX, a tiny virtual DOM layer, efficient one-way data binding, an asynchronous rendering pipeline (similar to React Fiber), and lazy-loading out of the box, and generates 100% standards-based Web Components that runs on both [modern browsers and legacy browsers](#browser-support) back to Internet Explorer 11.
+Stencil combines the best concepts of the most popular frontend frameworks into a compile-time rather than run-time tool. It takes TypeScript, JSX, a tiny virtual DOM layer, efficient one-way data binding, an asynchronous rendering pipeline (similar to React Fiber), and lazy-loading out of the box, and generates 100% standards-based Web Components that run on both [modern browsers and legacy browsers](#browser-support) back to Internet Explorer 11.
 
 Stencil components are just Web Components, so they work in any major framework or with no framework at all. In many cases, Stencil can be used as a drop in replacement for traditional frontend frameworks given the capabilities now available in the browser, though using it as such is certainly not required.
 


### PR DESCRIPTION
Fixed "runs" to "run".

The verb refers to "web components" which is plural, so the correct form is "run" and not "runs". 
See: https://www.quora.com/What-is-the-third-form-of-the-word-run

Cheers