### PR TITLE
docs(breaking) fix @Method await typo

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -219,7 +219,7 @@ That means, developers will be able to call component methods safely without usi
 @Component(...)
 export class Cmp {
   @Method()
-  await doSomething() {
+  async doSomething() {
     console.log('called');
   }
 }


### PR DESCRIPTION
In the breaking changes file there is a function definition that didn't really make sense