### PR TITLE
Build docs in dev mode

### DIFF
--- a/src/compiler/output-targets/output-docs.ts
+++ b/src/compiler/output-targets/output-docs.ts
@@ -8,9 +8,6 @@ import { generateVscodeDocs } from '../docs/vscode';
 import { outputCustom } from './output-custom';
 
 export async function outputDocs(config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) {
-  if (config.devMode) {
-    return;
-  }
   const docsOutputTargets = config.outputTargets.filter(o => (
     isOutputTargetCustom(o) ||
     isOutputTargetDocsReadme(o) ||


### PR DESCRIPTION
Carries over behavior from 0.x where docs are generated in dev mode as well as prod.

Useful for developing components and making sure docs are up to date in the repo.