### PR TITLE
fix(lifecycle): using css-in-js with no styles causes FOUC

### DIFF
--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -132,11 +132,8 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
       }
     }));
 
-
-  if (BUILD.style) {
-    // visibilityStyle.innerHTML = cmpTags.map(t => `${t}:not(.hydrated)`) + '{display:none}';
-    visibilityStyle.innerHTML = cmpTags + '{visibility:hidden}.hydrated{visibility:inherit}';
-    visibilityStyle.setAttribute('data-styles', '');
-    head.insertBefore(visibilityStyle, y ? y.nextSibling : head.firstChild);
-  }
+  // visibilityStyle.innerHTML = cmpTags.map(t => `${t}:not(.hydrated)`) + '{display:none}';
+  visibilityStyle.innerHTML = cmpTags + '{visibility:hidden}.hydrated{visibility:inherit}';
+  visibilityStyle.setAttribute('data-styles', '');
+  head.insertBefore(visibilityStyle, y ? y.nextSibling : head.firstChild);
 };

--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -139,7 +139,7 @@ export const postUpdateComponent = (elm: d.HostElement, hostRef: d.HostRef, ance
     if (!(hostRef.$flags$ & HOST_FLAGS.hasLoadedComponent)) {
       hostRef.$flags$ |= HOST_FLAGS.hasLoadedComponent;
 
-      if (BUILD.lazyLoad && BUILD.style && BUILD.cssAnnotations) {
+      if (BUILD.lazyLoad && BUILD.cssAnnotations) {
         // DOM WRITE!
         // add the css class that this element has officially hydrated
         elm.classList.add(HYDRATED_CLASS);


### PR DESCRIPTION
Noticed an issue where hydrated styles were not being applied and causing a flash of unstyled content in my components. Since I use css-in-js and none of the built in styling mechanisms, Stencil was not blocking rendering until styles were applied.