### PR TITLE
fix(hmr): call all callbacks in build event subscribers

### DIFF
--- a/src/compiler/events.ts
+++ b/src/compiler/events.ts
@@ -14,7 +14,7 @@ export class BuildEvents implements d.BuildEvents {
   subscribe(eventName: 'buildLog', cb: (buildLog: d.BuildLog) => void): Function;
   subscribe(eventName: d.CompilerEventName, cb: Function): Function {
     const evName = getEventName(eventName);
-    const callbacks = this.evCallbacks.get(eventName);
+    const callbacks = this.evCallbacks.get(evName);
 
     if (callbacks == null) {
       this.evCallbacks.set(evName, [cb]);


### PR DESCRIPTION
This fixes an HMR issue where `buildResults` was never sent to the dev-server client because only the most recent `buildFinish` event subscriber was attached.

I think the bug was introduced in https://github.com/ionic-team/stencil/commit/fbbe23260ab95de004e02ab856532bb684c74dcc#diff-06187c875ae567c88cb345d2abd4ea2b.

BTW after applying this fix locally in my project (within `node_modules/@stencil/core/dist/compiler/index.js`), I had some really weird behavior until I cleaned my `.stencil` directory. The only thing that would end up in `components.d.ts` was the last component that I had edited.

Does Stencil auto-clear the `.stencil` folder if the version that the cache was created with is a mismatch (i. e. an older version than the one currently compiling)?