### PR TITLE
fix(config): nodeResolve config

### DIFF
--- a/src/compiler/component-hydrate/bundle-hydrate-app.ts
+++ b/src/compiler/component-hydrate/bundle-hydrate-app.ts
@@ -33,7 +33,8 @@ export async function bundleHydrateApp(config: d.Config, compilerCtx: d.Compiler
         config.sys.rollup.plugins.emptyJsResolver(),
         config.sys.rollup.plugins.commonjs({
           include: /node_modules/,
-          sourceMap: false
+          sourceMap: false,
+          ...config.commonjs
         }),
         bundleJson(config),
         inMemoryFsRead(config, compilerCtx),

--- a/src/compiler/component-hydrate/bundle-hydrate-app.ts
+++ b/src/compiler/component-hydrate/bundle-hydrate-app.ts
@@ -27,7 +27,8 @@ export async function bundleHydrateApp(config: d.Config, compilerCtx: d.Compiler
         globalScriptsPlugin(config, compilerCtx),
         componentEntryPlugin(config, compilerCtx, buildCtx, build, buildCtx.entryModules),
         config.sys.rollup.plugins.nodeResolve({
-          mainFields: ['collection:main', 'jsnext:main', 'es2017', 'es2015', 'module', 'main']
+          mainFields: ['collection:main', 'jsnext:main', 'es2017', 'es2015', 'module', 'main'],
+          ...config.nodeResolve
         }),
         config.sys.rollup.plugins.emptyJsResolver(),
         config.sys.rollup.plugins.commonjs({


### PR DESCRIPTION
Fixes #1554.

Or is it on purpose that the `nodeResolve` config option wasn't passed into the hydrate-app bundling?