### PR TITLE
feat(compiler): warn about typescript imports

### DIFF
--- a/src/compiler/rollup-plugins/in-memory-fs-read.ts
+++ b/src/compiler/rollup-plugins/in-memory-fs-read.ts
@@ -1,8 +1,8 @@
 import * as d from '../../declarations';
 import { normalizePath } from '@utils';
+import { Plugin } from 'rollup';
 
-
-export function inMemoryFsRead(config: d.Config, compilerCtx: d.CompilerCtx) {
+export function inMemoryFsRead(config: d.Config, compilerCtx: d.CompilerCtx): Plugin {
   const path = config.sys.path;
   return {
     name: 'inMemoryFsRead',
@@ -28,8 +28,8 @@ export function inMemoryFsRead(config: d.Config, compilerCtx: d.CompilerCtx) {
       // 1. load(importee)
       let accessData = await compilerCtx.fs.accessData(importee);
       if (accessData.exists && accessData.isFile) {
-          // exact importee file path exists
-          return importee;
+        // exact importee file path exists
+        return importee;
       }
 
       // 2. load(importee.js)
@@ -64,6 +64,12 @@ export function inMemoryFsRead(config: d.Config, compilerCtx: d.CompilerCtx) {
     },
 
     async load(sourcePath: string) {
+      if (/\.tsx?/i.test(sourcePath)) {
+        this.warn({
+          message: `An import was resolved to a Tyepscript file (${sourcePath}) but Rollup treated it as Javascript. You should instead resolve to the absolute path of its transpiled Javascript equivalent (${path.resolve(sourcePath.replace(/\.tsx?/i, '.js'))}).`,
+        });
+      }
+
       return compilerCtx.fs.readFile(sourcePath);
     }
   };


### PR DESCRIPTION
Throws a warning if an importee is resolved to a typescript file, and lets the user know how to resolve to the equivalent javascript file instead. Note that the error message in the screenshot wouldn't appear if the content of `src/helpers/utils.ts` was valid javascript (it would just be treated as JS, even though the file has a `.ts` extension).

Not sure whether it's ok that I used the `Plugin` interface from `rollup` instead of `../../interfaces`, but the one in interfaces is pretty out of date (I think it's from the time before rollup version 1).

![image](https://user-images.githubusercontent.com/3410759/58556801-2781ef00-821d-11e9-9ed8-fc1684669e3c.png)

