### PR TITLE
fix(e2e): wait for idle network

### DIFF
--- a/src/testing/puppeteer/puppeteer-page.ts
+++ b/src/testing/puppeteer/puppeteer-page.ts
@@ -120,7 +120,7 @@ async function e2eGoTo(page: pd.E2EPageInternal, url: string) {
 
   const fullUrl = browserUrl + url.substring(1);
 
-  const rsp = await page._e2eGoto(fullUrl);
+  const rsp = await page._e2eGoto(fullUrl, { waitUntil: 'networkidle0' });
 
   if (!rsp.ok()) {
     await closePage(page);
@@ -180,7 +180,7 @@ async function e2eSetContent(page: pd.E2EPageInternal, html: string) {
     }
   });
 
-  const rsp = await page._e2eGoto(url);
+  const rsp = await page._e2eGoto(url, { waitUntil: 'networkidle0' });
 
   if (!rsp.ok()) {
     await closePage(page);


### PR DESCRIPTION
Sometimes when taking screenshots some of the images has not finished loading. This commit will wait for the network to become idle - indicating that all resources has been loaded - before continuing.