### PR TITLE
fix(compiler): warning regex for .ts(x) imports

### DIFF
--- a/src/compiler/rollup-plugins/in-memory-fs-read.ts
+++ b/src/compiler/rollup-plugins/in-memory-fs-read.ts
@@ -64,7 +64,7 @@ export function inMemoryFsRead(config: d.Config, compilerCtx: d.CompilerCtx): Pl
     },
 
     async load(sourcePath: string) {
-      if (/\.tsx?/i.test(sourcePath)) {
+      if (/\.tsx?$/i.test(sourcePath)) {
         this.warn({
           message: `An import was resolved to a Tyepscript file (${sourcePath}) but Rollup treated it as Javascript. You should instead resolve to the absolute path of its transpiled Javascript equivalent (${path.resolve(sourcePath.replace(/\.tsx?/i, '.js'))}).`,
         });


### PR DESCRIPTION
Was just working in that file again and noticed that I forgot the `$` in the regex for that warning message (which I added in #1576).