### PR TITLE
fix(e2e): don't use request interception internally

### DIFF
--- a/src/testing/puppeteer/puppeteer-page.ts
+++ b/src/testing/puppeteer/puppeteer-page.ts
@@ -162,7 +162,7 @@ async function e2eSetContent(page: pd.E2EPageInternal, html: string) {
 
   const url = [
     `data:text/html;charset=UTF-8,`,
-    `<script src="${appUrl}"></script>`,
+    `<script type="module" src="${appUrl}"></script>`,
     html
   ];
 

--- a/src/testing/puppeteer/puppeteer-page.ts
+++ b/src/testing/puppeteer/puppeteer-page.ts
@@ -157,7 +157,7 @@ async function e2eSetContent(page: pd.E2EPageInternal, html: string) {
   const appUrl = (process.env as d.E2EProcessEnv).__STENCIL_APP_URL__;
   if (typeof appUrl !== 'string') {
     await closePage(page);
-    return 'invalid e2eSetContent() loader script url';
+    return 'invalid e2eSetContent() app script url';
   }
 
   const url = [

--- a/src/testing/puppeteer/puppeteer-page.ts
+++ b/src/testing/puppeteer/puppeteer-page.ts
@@ -157,30 +157,16 @@ async function e2eSetContent(page: pd.E2EPageInternal, html: string) {
   const appUrl = (process.env as d.E2EProcessEnv).__STENCIL_APP_URL__;
   if (typeof appUrl !== 'string') {
     await closePage(page);
-    return 'invalid e2eSetContent() app script url';
+    return 'invalid e2eSetContent() loader script url';
   }
 
-  const url = (process.env as d.E2EProcessEnv).__STENCIL_BROWSER_URL__;
-  const body = [
-    `<script type="module" src="${appUrl}"></script>`,
+  const url = [
+    `data:text/html;charset=UTF-8,`,
+    `<script src="${appUrl}"></script>`,
     html
-  ].join('\n');
+  ];
 
-  await page.setRequestInterception(true);
-  page.on('request', interceptedRequest => {
-    if (url === interceptedRequest.url()) {
-      interceptedRequest.respond({
-        status: 200,
-        contentType: 'text/html',
-        body: body
-      });
-
-    } else {
-      interceptedRequest.continue();
-    }
-  });
-
-  const rsp = await page._e2eGoto(url);
+  const rsp = await page._e2eGoto(url.join(''));
 
   if (!rsp.ok()) {
     await closePage(page);


### PR DESCRIPTION
I don't have a good understanding of this code, but reverted this back to the way it was done previously - to not use request interception to add the script tag - as `e2eSetContent` throws an exception if a user uses `E2EPage.on('request', handler)`

fixes #1567 