### PR TITLE
fix(compiler): document CSS variables in the MD file even if 'docs-json' is not set

### DIFF
--- a/src/compiler/plugin/plugin.ts
+++ b/src/compiler/plugin/plugin.ts
@@ -2,7 +2,7 @@ import * as d from '../../declarations';
 import { catchError } from '@utils';
 import { PluginCtx, PluginTransformResults } from '../../declarations/plugin';
 import { parseCssImports } from '../style/css-imports';
-import { DOCS_README, DOCS, DOCS_JSON, DOCS_CUSTOM, DOCS_VSCODE } from 'output-targets/output-utils';
+import { DOCS_README, DOCS, DOCS_JSON, DOCS_CUSTOM, DOCS_VSCODE } from '../output-targets/output-utils';
 
 
 export async function runPluginResolveId(pluginCtx: PluginCtx, importee: string) {

--- a/src/compiler/plugin/plugin.ts
+++ b/src/compiler/plugin/plugin.ts
@@ -2,6 +2,7 @@ import * as d from '../../declarations';
 import { catchError } from '@utils';
 import { PluginCtx, PluginTransformResults } from '../../declarations/plugin';
 import { parseCssImports } from '../style/css-imports';
+import { DOCS_README, DOCS, DOCS_JSON, DOCS_CUSTOM, DOCS_VSCODE } from 'output-targets/output-utils';
 
 
 export async function runPluginResolveId(pluginCtx: PluginCtx, importee: string) {
@@ -88,7 +89,7 @@ export async function runPluginTransforms(config: d.Config, compilerCtx: d.Compi
     // when the entry file is a .css file (not .scss)
     // do this BEFORE transformations on css files
     const shouldParseCssDocs = (cmp != null && config.outputTargets.some(o => {
-      return o.type === 'docs' || o.type === 'docs-json' || o.type === 'docs-custom';
+      return o.type === DOCS || o.type === DOCS_README || o.type === DOCS_JSON || o.type === DOCS_CUSTOM || o.type === DOCS_VSCODE;
     }));
 
     if (shouldParseCssDocs && cmp != null) {
@@ -145,7 +146,7 @@ export async function runPluginTransforms(config: d.Config, compilerCtx: d.Compi
     // files into one file like we did for raw .css files.
     // do this AFTER transformations on non-css files
     const shouldParseCssDocs = (cmp != null && config.outputTargets.some(o => {
-      return o.type === 'docs' || o.type === 'docs-json' || o.type === 'docs-custom';
+      return o.type === DOCS || o.type === DOCS_README || o.type === DOCS_JSON || o.type === DOCS_CUSTOM || o.type === DOCS_VSCODE;
     }));
 
     if (shouldParseCssDocs && cmp != null) {


### PR DESCRIPTION
Documenting CSS variables did not work if `--docs-json` was not set (they did not appear in the markdown file).

I added `docs-readme` and` docs-vscode` (not sure what this flag does, you might want to remove it) to the shouldParseCssDocs checks.