### PR TITLE
feat(mock-doc): add Element

### DIFF
--- a/src/mock-doc/global.ts
+++ b/src/mock-doc/global.ts
@@ -58,6 +58,7 @@ const WINDOW_PROPS = [
   'CSS',
   'CustomEvent',
   'Event',
+  'Element',
   'HTMLElement',
   'KeyboardEvent'
 ];

--- a/src/mock-doc/window.ts
+++ b/src/mock-doc/window.ts
@@ -12,6 +12,7 @@ import { URL } from 'url';
 
 
 const historyMap = new WeakMap<MockWindow, MockHistory>();
+const elementCstrMap = new WeakMap<MockWindow, any>();
 const htmlElementCstrMap = new WeakMap<MockWindow, any>();
 const localStorageMap = new WeakMap<MockWindow, MockStorage>();
 const locMap = new WeakMap<MockWindow, MockLocation>();
@@ -178,6 +179,21 @@ export class MockWindow {
   }
   set history(hsty: any) {
     historyMap.set(this, hsty);
+  }
+
+  get Element() {
+    let ElementCstr = elementCstrMap.get(this);
+    if (ElementCstr == null) {
+      const ownerDocument = this.document;
+      ElementCstr = class extends MockElement {
+        constructor() {
+          super(ownerDocument, '');
+          throw (new Error('Illegal constructor: cannot construct Element'));
+        }
+      };
+      elementCstrMap.set(this, ElementCstr);
+    }
+    return ElementCstr;
   }
 
   get HTMLElement() {
@@ -421,6 +437,7 @@ export function resetWindow(win: Window) {
 
     historyMap.delete(win as any);
     htmlElementCstrMap.delete(win as any);
+    elementCstrMap.delete(win as any);
     localStorageMap.delete(win as any);
     locMap.delete(win as any);
     navMap.delete(win as any);

--- a/src/runtime/test/element.spec.tsx
+++ b/src/runtime/test/element.spec.tsx
@@ -1,13 +1,10 @@
 import { Component, Element, Method } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 
-
 describe('element', () => {
-
-  it('event normal ionChange event', async () => {
-    @Component({ tag: 'cmp-a'})
+  it('allows the class to be set', async () => {
+    @Component({ tag: 'cmp-a' })
     class CmpA {
-
       @Element() el: HTMLElement;
 
       @Method()
@@ -18,7 +15,7 @@ describe('element', () => {
     // @ts-ignore
     const page = await newSpecPage({
       components: [CmpA],
-      html: `<cmp-a></cmp-a>`,
+      html: `<cmp-a></cmp-a>`
     });
 
     expect(page.root).toEqualHtml(`
@@ -32,5 +29,4 @@ describe('element', () => {
       <cmp-a class="new-class"></cmp-a>
     `);
   });
-
 });

--- a/src/runtime/test/globals.spec.tsx
+++ b/src/runtime/test/globals.spec.tsx
@@ -28,4 +28,24 @@ describe('globals', () => {
     });
   });
 
+  it('allows access to the Element prototype', async () => {
+    @Component({ tag: 'cmp-el' })
+    class CmpEl {
+      // @ts-ignore
+      private proto: any;
+
+      constructor() {
+        this.proto = Element.prototype;
+      }
+    }
+
+    const page = await newSpecPage({
+      components: [CmpEl],
+      html: `<cmp-el></cmp-el>`
+    });
+
+    expect(page.root).toEqualHtml(`
+      <cmp-el></cmp-el>
+    `);
+  });
 });


### PR DESCRIPTION
Customer needs to have `Element` on `MockWindow`.

The customer's tests fail when they try to test a Stencil component that itself uses `tippy.js`. Here is where it is failing with a ReferenceError because `Element` is not found, so that is essentially what I am trying to duplicate in the test w/o actually including `tippy.js`.

Here is the LOC in tippy.js that results in the failure in the Stencil component unit test:

https://github.com/atomiks/tippyjs/blob/8b23e4a51452b89ca9a54731bb499eac4cc2920e/src/ponyfills.ts#L3

This PR adds `Element` to `MockWindow` in order to facilitate these tests.