### PR TITLE
"readonly" in method return causes error

### DIFF
--- a/src/declarations/system.ts
+++ b/src/declarations/system.ts
@@ -75,7 +75,7 @@ export interface Semver {
   lte(v1: string, v2: string): boolean;
   gt(v1: string, v2: string): boolean;
   gte(v1: string, v2: string): boolean;
-  prerelease(v: string): readonly string[] | null;
+  prerelease(v: string): string[] | null;
   satisfies(version: string, range: string): boolean;
 }
 


### PR DESCRIPTION
When generating docs using Typedoc, I'm getting this error:

    node_modules/@stencil/core/dist/declarations/system.d.ts(71) ';' expected.
    node_modules/@stencil/core/dist/declarations/system.d.ts(71) An element access expression should take an argument.
    node_modules/@stencil/core/dist/declarations/system.d.ts(73) Declaration or statement expected.