### PR TITLE
fix(testing): SpecPage is not exported

### DIFF
--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,4 +1,4 @@
-
+export { SpecPage } from '../declarations';
 export { createJestPuppeteerEnvironment } from './jest/jest-environment';
 export { createTestRunner } from './jest/jest-runner';
 export { E2EElement, E2EPage } from './puppeteer/puppeteer-declarations';


### PR DESCRIPTION
SpecPage type is only exported from the declarations file making its import different than E2EPage.

```
import { SpecPage } from '@stencil/core/dist/declarations'
import { newSpecPage } from '@stencil/core/testing'

let page: SpecPage
```


```
import { E2EPage, newE2EPage } from '@stencil/core/testing'

let page: E2EPage
```

Resolves #1656