### PR TITLE
chore: add failing (in IE) test demonstrating #1615 (reparenting w/ CSS vars)

### DIFF
--- a/test/karma/test-app/components.d.ts
+++ b/test/karma/test-app/components.d.ts
@@ -124,6 +124,8 @@ export namespace Components {
     'str': string;
     'undef'?: string;
   }
+  interface ReparentStyleNoVars {}
+  interface ReparentStyleWithVars {}
   interface SassCmp {}
   interface ScopedBasic {}
   interface ScopedBasicRoot {}
@@ -492,6 +494,18 @@ declare global {
     new (): HTMLReflectToAttrElement;
   };
 
+  interface HTMLReparentStyleNoVarsElement extends Components.ReparentStyleNoVars, HTMLStencilElement {}
+  var HTMLReparentStyleNoVarsElement: {
+    prototype: HTMLReparentStyleNoVarsElement;
+    new (): HTMLReparentStyleNoVarsElement;
+  };
+
+  interface HTMLReparentStyleWithVarsElement extends Components.ReparentStyleWithVars, HTMLStencilElement {}
+  var HTMLReparentStyleWithVarsElement: {
+    prototype: HTMLReparentStyleWithVarsElement;
+    new (): HTMLReparentStyleWithVarsElement;
+  };
+
   interface HTMLSassCmpElement extends Components.SassCmp, HTMLStencilElement {}
   var HTMLSassCmpElement: {
     prototype: HTMLSassCmpElement;
@@ -771,6 +785,8 @@ declare global {
     'node-globals': HTMLNodeGlobalsElement;
     'node-resolution': HTMLNodeResolutionElement;
     'reflect-to-attr': HTMLReflectToAttrElement;
+    'reparent-style-no-vars': HTMLReparentStyleNoVarsElement;
+    'reparent-style-with-vars': HTMLReparentStyleWithVarsElement;
     'sass-cmp': HTMLSassCmpElement;
     'scoped-basic': HTMLScopedBasicElement;
     'scoped-basic-root': HTMLScopedBasicRootElement;
@@ -927,6 +943,8 @@ declare namespace LocalJSX {
     'str'?: string;
     'undef'?: string;
   }
+  interface ReparentStyleNoVars extends JSXBase.HTMLAttributes<HTMLReparentStyleNoVarsElement> {}
+  interface ReparentStyleWithVars extends JSXBase.HTMLAttributes<HTMLReparentStyleWithVarsElement> {}
   interface SassCmp extends JSXBase.HTMLAttributes<HTMLSassCmpElement> {}
   interface ScopedBasic extends JSXBase.HTMLAttributes<HTMLScopedBasicElement> {}
   interface ScopedBasicRoot extends JSXBase.HTMLAttributes<HTMLScopedBasicRootElement> {}
@@ -1037,6 +1055,8 @@ declare namespace LocalJSX {
     'node-globals': NodeGlobals;
     'node-resolution': NodeResolution;
     'reflect-to-attr': ReflectToAttr;
+    'reparent-style-no-vars': ReparentStyleNoVars;
+    'reparent-style-with-vars': ReparentStyleWithVars;
     'sass-cmp': SassCmp;
     'scoped-basic': ScopedBasic;
     'scoped-basic-root': ScopedBasicRoot;

--- a/test/karma/test-app/reparent-style/index.html
+++ b/test/karma/test-app/reparent-style/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf8">
+<script src="/build/testapp.esm.js" type="module"></script>
+<script src="/build/testapp.js" nomodule></script>
+
+<div class="reparent-container">
+  <reparent-style-with-vars></reparent-style-with-vars>
+  <reparent-style-no-vars></reparent-style-no-vars>
+  <button class="reparent-vars">Reparent (with vars)</button>
+  <button class="reparent-no-vars">Reparent (no vars)</button>
+</div>
+
+<script>
+  var reparentContainer = document.querySelector('.reparent-container');
+  document.querySelector('.reparent-vars').addEventListener('click', function() {
+    var component = document.querySelector('reparent-style-with-vars');
+    reparentContainer.appendChild(component);
+  })
+  document.querySelector('.reparent-no-vars').addEventListener('click', function() {
+    var component = document.querySelector('reparent-style-no-vars');
+    reparentContainer.appendChild(component);
+  })
+</script>

--- a/test/karma/test-app/reparent-style/karma.spec.ts
+++ b/test/karma/test-app/reparent-style/karma.spec.ts
@@ -1,0 +1,39 @@
+import { setupDomTests, waitForChanges } from '../util';
+
+
+describe('reparent behavior (style)', function() {
+  const { setupDom, tearDownDom } = setupDomTests(document);
+  let app: HTMLElement;
+
+  beforeEach(async () => {
+    app = await setupDom('/reparent-style/index.html');
+  });
+  afterEach(tearDownDom);
+
+  it('should have styles applied by default', async () => {
+    const varsContainer = app.querySelector('reparent-style-with-vars');
+    const novarsContainer = app.querySelector('reparent-style-no-vars');
+
+    expect(window.getComputedStyle(varsContainer).backgroundColor).toBe('rgb(0, 0, 255)');
+    expect(window.getComputedStyle(novarsContainer).backgroundColor).toBe('rgb(0, 128, 128)');
+  });
+
+  it('should preserve styles after reparenting a component (no css vars)', async () => {
+    const reparentButton: HTMLButtonElement = app.querySelector('.reparent-no-vars');
+    reparentButton.click();
+    await waitForChanges();
+    const novars = app.querySelector('reparent-style-no-vars');
+    expect(window.getComputedStyle(novars).backgroundColor).toBe('rgb(0, 128, 128)');
+
+  });
+
+  // This test fails in IE!
+  it('should preserve styles after reparenting a component (with css vars)', async () => {
+    const reparentButton: HTMLButtonElement = app.querySelector('.reparent-vars');
+    reparentButton.click();
+    await waitForChanges();
+
+    const vars = app.querySelector('reparent-style-with-vars');
+    expect(window.getComputedStyle(vars).backgroundColor).toBe('rgb(0, 0, 255)');
+  });
+});

--- a/test/karma/test-app/reparent-style/reparent-style-no-vars.css
+++ b/test/karma/test-app/reparent-style/reparent-style-no-vars.css
@@ -1,0 +1,10 @@
+:host {
+  background-color: teal;
+  display: block;
+  padding: 2em;
+}
+
+.css-entry {
+  color: purple;
+  font-weight: bold;
+}

--- a/test/karma/test-app/reparent-style/reparent-style-no-vars.tsx
+++ b/test/karma/test-app/reparent-style/reparent-style-no-vars.tsx
@@ -1,0 +1,12 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'reparent-style-no-vars',
+  styleUrl: 'reparent-style-no-vars.css',
+  shadow: true
+})
+export class ReparentStyleNoVars {
+  render() {
+    return <div class="css-entry">No CSS Variables</div>
+  }
+}

--- a/test/karma/test-app/reparent-style/reparent-style-with-vars.css
+++ b/test/karma/test-app/reparent-style/reparent-style-with-vars.css
@@ -1,0 +1,13 @@
+:root {
+  --custom-color: blue;
+}
+:host {
+  background-color: var(--custom-color, blue);
+  display: block;
+  padding: 2em;
+}
+
+.css-entry {
+  color: purple;
+  font-weight: bold;
+}

--- a/test/karma/test-app/reparent-style/reparent-style-with-vars.tsx
+++ b/test/karma/test-app/reparent-style/reparent-style-with-vars.tsx
@@ -1,0 +1,12 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'reparent-style-with-vars',
+  styleUrl: 'reparent-style-with-vars.css',
+  shadow: true
+})
+export class ReparentStyleWithVars {
+  render() {
+    return <div class="css-entry">With CSS Vars</div>
+  }
+}


### PR DESCRIPTION
👋 

Here's a (failing in IE) test that demonstrates an issue we're seeing with components that use CSS variables when we reparent (move them around) on a page: #1615

Basic idea is, to support tooltips, dropdowns, and other positioned items, it's often helpful to detach an element from its location in the DOM tree, and reattach them to the body of the page. Similar to [portals](https://reactjs.org/docs/portals.html) in React and other frameworks.

What we've noticed is that if the element being moved around:

* is a Stencil component,
* and contains any CSS custom properties,
* and you're running IE11

it loses its `<style>` tag  when it's detached from the DOM, and it never gets styles applied again.

You can see this happen in the `'should preserve styles after reparenting a component (with css vars)'` Karma test in `reparent-style`. In IE this is the initial styling:

![image](https://user-images.githubusercontent.com/389077/59879329-1043a680-9370-11e9-8dc8-8b795ac18edd.png)

And after reparenting:

![image](https://user-images.githubusercontent.com/389077/59879340-19347800-9370-11e9-8c7c-9dd8559a1652.png)

I've been testing this by just opening http://localhost:9876/reparent-style/index.html to see how it behaves.

I *think* this is the last thing keeping us from upgrading to Stencil One; we're stuck on 0.15.2, which doesn't exhibit this behavior.

Let me know if there's anything else I can provide to help reproduce or test this; I know IE11 issues are super-not-fun to work on, but it's the majority of the world we're living in for the next few months.