### PR TITLE
 fix(declarations): rollup plugin interface

### DIFF
--- a/src/compiler/plugin/plugin.ts
+++ b/src/compiler/plugin/plugin.ts
@@ -10,7 +10,7 @@ export async function runPluginResolveId(pluginCtx: PluginCtx, importee: string)
 
     if (typeof plugin.resolveId === 'function') {
       try {
-        const results = plugin.resolveId(importee, null, pluginCtx);
+        const results = plugin.resolveId.bind(null)(importee, null, pluginCtx);
 
         if (results != null) {
           if (typeof (results as any).then === 'function') {
@@ -40,7 +40,7 @@ export async function runPluginLoad(pluginCtx: PluginCtx, id: string) {
 
     if (typeof plugin.load === 'function') {
       try {
-        const results = plugin.load(id, pluginCtx);
+        const results = plugin.load.bind(null)(id, pluginCtx);
 
         if (results != null) {
           if (typeof (results as any).then === 'function') {
@@ -103,7 +103,7 @@ export async function runPluginTransforms(config: d.Config, compilerCtx: d.Compi
     if (typeof plugin.transform === 'function') {
       try {
         let pluginTransformResults: PluginTransformResults | string;
-        const results = plugin.transform(transformResults.code, transformResults.id, pluginCtx);
+        const results = plugin.transform.bind(null)(transformResults.code, transformResults.id, pluginCtx);
 
         if (results != null) {
           if (typeof (results as any).then === 'function') {

--- a/src/declarations/config.ts
+++ b/src/declarations/config.ts
@@ -105,7 +105,7 @@ export interface StencilConfig {
    * By default, Stencil does not come with Sass or PostCss support.
    * However, either can be added using the plugin array.
    */
-  plugins?: any[];
+  plugins?: d.Plugin[];
 
   /**
    * The srcDir config specifies the directory which should contain the source typescript files

--- a/src/declarations/plugin.ts
+++ b/src/declarations/plugin.ts
@@ -4,7 +4,7 @@ import {
   Plugin as RollupPlugin,
   PluginContext as RollupPluginContext,
   ResolveIdHook,
-  TransformHook
+  TransformSourceDescription
 } from 'rollup';
 
 export interface Plugin extends RollupPlugin {
@@ -36,10 +36,10 @@ export interface Plugin extends RollupPlugin {
 
 type LoadHookReturnType = ReturnType<LoadHook>;
 type ResolveIdHookReturnType = ReturnType<ResolveIdHook>;
-type TransformHookReturnType = ReturnType<TransformHook> | Promise<PluginTransformResults>;
+type TransformHookReturnType = Promise<TransformResult> | TransformResult;
+type TransformResult = string | null | undefined | PluginTransformResults;
 
-export interface PluginTransformResults {
-  code: string;
+export interface PluginTransformResults extends TransformSourceDescription {
   id?: string;
 }
 

--- a/src/declarations/plugin.ts
+++ b/src/declarations/plugin.ts
@@ -10,11 +10,15 @@ import {
 export interface Plugin extends RollupPlugin {
   /**
    * Defines a custom loader. Returning `null` defers to other `load` functions (and eventually the default behavior of loading from the file system).
+   *
+   * @see https://rollupjs.org/guide/en#hooks
    */
   load?(this: RollupPluginContext, id: string, pluginContext?: PluginCtx): LoadHookReturnType;
 
   /**
    * Defines a custom resolver. A resolver can be useful for e.g. locating third-party dependencies. Returning `null` defers to other `resolveId` functions and eventually the default resolution behavior; returning `false` signals that source should be treated as an external module and not included in the bundle. If this happens for a relative import, the id will be renormalized the same way as when the `external` option is used.
+   *
+   * @see https://rollupjs.org/guide/en#hooks
    */
   resolveId?(
     this: RollupPluginContext,
@@ -25,6 +29,8 @@ export interface Plugin extends RollupPlugin {
 
   /**
    * Can be used to transform individual modules.
+   *
+   * @see https://rollupjs.org/guide/en#hooks
    */
   transform?(
     this: RollupPluginContext,

--- a/src/declarations/plugin.ts
+++ b/src/declarations/plugin.ts
@@ -1,16 +1,45 @@
 import * as d from '.';
+import {
+  LoadHook,
+  Plugin as RollupPlugin,
+  PluginContext as RollupPluginContext,
+  ResolveIdHook,
+  TransformHook
+} from 'rollup';
 
+export interface Plugin extends RollupPlugin {
+  /**
+   * Defines a custom loader. Returning `null` defers to other `load` functions (and eventually the default behavior of loading from the file system).
+   */
+  load?(this: RollupPluginContext, id: string, pluginContext?: PluginCtx): LoadHookReturnType;
 
-export interface Plugin {
-  name?: string;
-  pluginType?: string;
-  load?: (id: string, context: PluginCtx) => Promise<string> | string;
-  resolveId?: (importee: string, importer: string, context: PluginCtx) => Promise<string> | string;
-  transform?: (sourceText: string, id: string, context: PluginCtx) => Promise<PluginTransformResults> | PluginTransformResults | string;
+  /**
+   * Defines a custom resolver. A resolver can be useful for e.g. locating third-party dependencies. Returning `null` defers to other `resolveId` functions and eventually the default resolution behavior; returning `false` signals that source should be treated as an external module and not included in the bundle. If this happens for a relative import, the id will be renormalized the same way as when the `external` option is used.
+   */
+  resolveId?(
+    this: RollupPluginContext,
+    importee: string,
+    importer: string,
+    pluginContext?: PluginCtx,
+  ): ResolveIdHookReturnType;
+
+  /**
+   * Can be used to transform individual modules.
+   */
+  transform?(
+    this: RollupPluginContext,
+    code: string,
+    id: string,
+    pluginContext?: PluginCtx,
+  ): TransformHookReturnType;
 }
 
+type LoadHookReturnType = ReturnType<LoadHook>;
+type ResolveIdHookReturnType = ReturnType<ResolveIdHook>;
+type TransformHookReturnType = ReturnType<TransformHook> | Promise<PluginTransformResults>;
+
 export interface PluginTransformResults {
-  code?: string;
+  code: string;
   id?: string;
 }
 


### PR DESCRIPTION
Fixes the `Plugin` interface.

The old one was quite out of sync with the actual Rollup types, which made it a bit inconvenient to write custom plugins for Stencil.

Basically what I'm doing is extending rollup's `Plugin` interface, by adding the additional `pluginContext` parameter (required by certain stencil rollup plugins) to the signature of each of the three hooks.

The hook descriptions were taken from https://rollupjs.org/guide/en#hooks.
