### PR TITLE
Run specs even if file has build warnings

### DIFF
--- a/src/testing/jest/jest-preprocessor.ts
+++ b/src/testing/jest/jest-preprocessor.ts
@@ -13,7 +13,10 @@ export const jestPreprocessor = {
       const opts = Object.assign({}, this.getCompilerOptions(jestConfig.rootDir));
 
       const results = transpile(sourceText, opts, filePath);
-      if (results.diagnostics && results.diagnostics.length > 0) {
+
+      const hasErrors = results.diagnostics.some((diagnostic) => diagnostic.level === 'error');
+
+      if (results.diagnostics && hasErrors) {
         const msg = results.diagnostics.map(formatDiagnostic).join('\n\n');
         throw new Error(msg);
       }


### PR DESCRIPTION
Related issue: #1677

As the jest preprocessor is right now, having any type of output diagnostic (warning, for instance) from the compiler will cause a test case to fail. The way I see it, this should only happen if it's an error, as some warnings are just indications.