### PR TITLE
feat(testing): add MockSVGElement

### DIFF
--- a/src/mock-doc/document.ts
+++ b/src/mock-doc/document.ts
@@ -172,7 +172,7 @@ export class MockDocument extends MockHTMLElement {
   }
 
   createElementNS(namespaceURI: string, tagName: string) {
-    const elmNs = new MockElement(this, tagName);
+    const elmNs = createElement(this, tagName);
     elmNs.namespaceURI = namespaceURI;
     return elmNs;
   }

--- a/src/mock-doc/document.ts
+++ b/src/mock-doc/document.ts
@@ -1,5 +1,5 @@
 import { NODE_NAMES, NODE_TYPES } from './constants';
-import { createElement } from './element';
+import { createElement, createElementNS } from './element';
 import { MockDocumentFragment } from './document-fragment';
 import { MockDocumentTypeNode } from './document-type-node';
 import { MockElement, MockHTMLElement, MockTextNode, resetElement } from './node';
@@ -172,7 +172,7 @@ export class MockDocument extends MockHTMLElement {
   }
 
   createElementNS(namespaceURI: string, tagName: string) {
-    const elmNs = createElement(this, tagName);
+    const elmNs = createElementNS(this, tagName);
     elmNs.namespaceURI = namespaceURI;
     return elmNs;
   }

--- a/src/mock-doc/element.ts
+++ b/src/mock-doc/element.ts
@@ -57,6 +57,13 @@ export function createElement(ownerDocument: any, tagName: string) {
   return new MockHTMLElement(ownerDocument, tagName);
 }
 
+export function createElementNS(ownerDocument: any, tagName: string) {
+  if (SVG_TAGS.has(tagName)) {
+    return new MockSVGElement(ownerDocument, tagName);
+  }
+  return new MockElement(ownerDocument, tagName);
+}
+
 // This set is intentionally incomplete. More tags can be added as needed.
 const SVG_TAGS = new Set(['circle', 'line', 'g', 'path', 'svg', 'symbol', 'viewbox']);
 

--- a/src/mock-doc/element.ts
+++ b/src/mock-doc/element.ts
@@ -41,10 +41,10 @@ export function createElement(ownerDocument: any, tagName: string) {
 
     case 'title':
       return new MockTitleElement(ownerDocument);
+  }
 
-    case 'svg':
-    case 'symbol':
-      return new MockElement(ownerDocument, tagName);
+  if (SVG_TAGS.has(tagName)) {
+    return new MockSVGElement(ownerDocument, tagName);
   }
 
   if (ownerDocument != null && tagName.includes('-')) {
@@ -57,6 +57,8 @@ export function createElement(ownerDocument: any, tagName: string) {
   return new MockHTMLElement(ownerDocument, tagName);
 }
 
+// This set is intentionally incomplete. More tags can be added as needed.
+const SVG_TAGS = new Set(['circle', 'line', 'g', 'path', 'svg', 'symbol', 'viewbox']);
 
 class MockAnchorElement extends MockHTMLElement {
   constructor(ownerDocument: any) {
@@ -98,7 +100,6 @@ patchPropAttributes(MockImgElement.prototype, {
   height: Number,
   width: Number
 });
-
 
 class MockInputElement extends MockHTMLElement {
   constructor(ownerDocument: any) {
@@ -197,6 +198,22 @@ class MockScriptElement extends MockHTMLElement {
 patchPropAttributes(MockScriptElement.prototype, {
   type: String
 });
+
+class MockSVGElement extends MockElement {
+  // SVGElement properties and methods
+  get ownerSVGElement(): SVGSVGElement { return null; }
+  get viewportElement(): SVGElement { return null; }
+
+  focus() {/**/}
+  onunload() {/**/}
+
+  // SVGGeometryElement properties and methods
+  get pathLength(): number { return 0; }
+
+  isPointInFill(_pt: DOMPoint): boolean { return false; }
+  isPointInStroke(_pt: DOMPoint): boolean { return false; }
+  getTotalLength(): number { return 0; }
+}
 
 
 export class MockTemplateElement extends MockHTMLElement {

--- a/src/runtime/test/svg-element.spec.tsx
+++ b/src/runtime/test/svg-element.spec.tsx
@@ -1,0 +1,47 @@
+import { Component, h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+describe('SVG element', () => {
+  @Component({ tag: 'cmp-a' })
+  class CmpA {
+    render() {
+      return (
+        <div>
+          <a href="#">Dude!!</a>
+          <svg id="my-svg" viewBox="0 0 100 4" preserveAspectRatio="none">
+            <path id="my-svg-path" d="M 0,2 L 100,2" stroke="#FFEA82" stroke-width="4" fill-opacity="0" />
+          </svg>
+        </div>
+      );
+    }
+  }
+
+  let path: SVGGeometryElement;
+  beforeEach(async () => {
+    const page = await newSpecPage({
+      components: [CmpA],
+      html: `<cmp-a></cmp-a>`
+    });
+    path = page.root.querySelector('#my-svg-path');
+  });
+
+  it('allows read access to the ownerSVGElement property', () => {
+    expect(path.ownerSVGElement).toEqual(null);
+  });
+
+  it('allows read access to the viewportElement property', () => {
+    expect(path.viewportElement).toEqual(null);
+  });
+
+  it('allows access to the getTotalLength() method', () => {
+    expect(path.getTotalLength()).toEqual(0);
+  });
+
+  it('allows access to the isPoingInFill() method', () => {
+    expect(path.isPointInFill()).toEqual(false);
+  });
+
+  it('allows access to the isPoingInStroke() method', () => {
+    expect(path.isPointInStroke()).toEqual(false);
+  });
+});


### PR DESCRIPTION
This change just adds some of the basic APIs and not the whole
set of them. In addition:

- the methods just return some kind of sane default value
- rather than having several sub-classes, everthing is squashed
  into MockSVGElement for simplicity