### PR TITLE
feat: skip lazyDependencies

### DIFF
--- a/src/cli/task-test.ts
+++ b/src/cli/task-test.ts
@@ -41,7 +41,8 @@ export async function taskTest(config: d.Config) {
     await config.sys.lazyRequire.ensure(
       config.logger,
       config.rootDir,
-      ensureModuleIds
+      ensureModuleIds,
+      config.lazyDependencies
     );
 
     const passed = await testing.runTests();

--- a/src/compiler/output-targets/output-service-workers.ts
+++ b/src/compiler/output-targets/output-service-workers.ts
@@ -16,7 +16,7 @@ export async function outputServiceWorkers(config: d.Config, buildCtx: d.BuildCt
   }
 
   // let's make sure they have what we need from workbox installed
-  await config.sys.lazyRequire.ensure(config.logger, config.rootDir, [WORKBOX_BUILD_MODULE_ID]);
+  await config.sys.lazyRequire.ensure(config.logger, config.rootDir, [WORKBOX_BUILD_MODULE_ID] , true /* Override LazyDependencies user config */);
 
   // we've ensure workbox is installed, so let's require it now
   const workbox: d.Workbox = config.sys.lazyRequire.require(WORKBOX_BUILD_MODULE_ID);

--- a/src/declarations/config.ts
+++ b/src/declarations/config.ts
@@ -176,6 +176,7 @@ export interface StencilConfig {
   tsconfig?: string;
   validateTypes?: boolean;
   watchIgnoredRegex?: RegExp;
+  lazyDependencies? : boolean;
 }
 
 export interface Config extends StencilConfig {

--- a/src/declarations/system.ts
+++ b/src/declarations/system.ts
@@ -81,7 +81,7 @@ export interface Semver {
 
 
 export interface LazyRequire {
-  ensure(logger: d.Logger, fromDir: string, moduleIds: string[]): Promise<void>;
+  ensure(logger: d.Logger, fromDir: string, moduleIds: string[] , lazyDependencies: boolean): Promise<void>;
   require(moduleId: string): any;
   getModulePath(moduleId: string): string;
 }


### PR DESCRIPTION
This PR, has as the main goal allow to activate or deactivate LazyDependencies install, will affect only  testing . The pull request is complementary to Skip Puppeteer Install 

The current Behaviour when you configure `browserExecutablePath` is that `puppeteer-core` is installed instead of `puppeteer`. 

With this PR we can set a new config property called `lazyDependencies: false,`  and all dependencies related to testing aren't installed in the case you already have them installed. 

Advantages : 
- You can customize in your own risk lazy loaded dependencies 
- Save install time if you already had installed testing dependencies even not satisfying stencil config 
- Override dependency versions 

I believe this solves #1693  , at least allow set a custom version for `puppeteer`.

@adamdbradley  please review and ask any changes 👍 

