### PR TITLE
feat(mock-doc): add canvas

### DIFF
--- a/src/mock-doc/element.ts
+++ b/src/mock-doc/element.ts
@@ -44,6 +44,9 @@ export function createElement(ownerDocument: any, tagName: string) {
 
     case 'title':
       return new MockTitleElement(ownerDocument);
+
+    case 'canvas':
+      return new MockCanvasElement(ownerDocument);
   }
 
   if (SVG_TAGS.has(tagName)) {
@@ -294,6 +297,45 @@ class MockTitleElement extends MockHTMLElement {
 }
 
 
+class MockCanvasElement extends MockHTMLElement {
+  constructor(ownerDocument: any) {
+    super(ownerDocument, 'canvas');
+  }
+  getContext() {
+    return {
+      fillRect: function () { },
+      clearRect: function () { },
+      getImageData: function (_: number, __: number, w: number, h: number) {
+        return {
+          data: new Array(w * h * 4)
+        };
+      },
+      putImageData: function () { },
+      createImageData: function (): any[] { return [] },
+      setTransform: function () { },
+      drawImage: function () { },
+      save: function () { },
+      fillText: function () { },
+      restore: function () { },
+      beginPath: function () { },
+      moveTo: function () { },
+      lineTo: function () { },
+      closePath: function () { },
+      stroke: function () { },
+      translate: function () { },
+      scale: function () { },
+      rotate: function () { },
+      arc: function () { },
+      fill: function () { },
+      measureText: function () {
+        return { width: 0 };
+      },
+      transform: function () { },
+      rect: function () { },
+      clip: function () { },
+    }
+  }
+}
 
 function fullUrl(elm: MockElement, attrName: string) {
   const val = elm.getAttribute(attrName) || '';

--- a/src/mock-doc/test/html-parse.spec.ts
+++ b/src/mock-doc/test/html-parse.spec.ts
@@ -212,4 +212,13 @@ describe('parseHtml', () => {
     expect(elm.children[0].attributes.item(0).name).toBe('viewBox');
     expect(elm.children[0].children[0].attributes.item(0).name).toBe('viewBox');
   });
+
+  it('should mock canvas api', () => {
+    const elm = parseHtmlToFragment('<canvas id="canvas" width="300" height="300"></canvas>');
+    const canvas = elm.children[0];    
+    const ctx: CanvasRenderingContext2D = canvas.getContext('2d');
+    expect(elm.children.length).toBe(1);
+    expect(elm.children[0].nodeName).toBe('CANVAS');
+    expect(ctx.getImageData(0, 0, 300, 300).data.length).toBe(300 * 300 * 4);
+  });
 });


### PR DESCRIPTION
As per: #1706, adds a canvas element mock to `mock-doc`, allowing pre-rendering with canvas api usage like `getContext()`.