### PR TITLE
fix(runtime): simplify classlist.add/remove for IE11

### DIFF
--- a/src/runtime/vdom/set-accessor.ts
+++ b/src/runtime/vdom/set-accessor.ts
@@ -18,9 +18,8 @@ export const setAccessor = (elm: HTMLElement, memberName: string, oldValue: any,
   }
   if (BUILD.vdomClass && memberName === 'class') {
     const classList = elm.classList;
-    classList.remove(...parseClassList(oldValue));
-    classList.add(...parseClassList(newValue));
-
+    parseClassList(oldValue).forEach(cls => classList.remove(cls));
+    parseClassList(newValue).forEach(cls => classList.add(cls));
   } else if (BUILD.vdomStyle && memberName === 'style') {
     // update style attribute, css properties and values
     if (BUILD.updatable) {


### PR DESCRIPTION
IE11 unfortunately cannot handle multiple arguments when using HTMLelement.classList.add/remove. This should fix some issues with IE11 errors. Someday the terrible browser will die, till then....

I believe this should fix #1757. 
