### PR TITLE
fix(runtime): Add regex to clear multiple spaces and line breaks in classList.

### DIFF
--- a/src/runtime/test/render-vdom.spec.tsx
+++ b/src/runtime/test/render-vdom.spec.tsx
@@ -97,6 +97,30 @@ describe('render-vdom', () => {
     `);
   });
 
+  it('should add classes', async () => {
+    @Component({ tag: 'cmp-a'})
+    class CmpA {
+      render() {
+        return <div class={
+          ` class1
+              class2
+              class3 `}
+        >Hello VDOM</div>;
+      }
+    }
+
+    const { body, waitForChanges } = await newSpecPage({
+      components: [CmpA]
+    });
+
+    body.innerHTML = `<cmp-a></cmp-a>`;
+    await waitForChanges();
+
+    expect(body).toEqualHtml(`
+      <cmp-a><div class="class1 class2 class3">Hello VDOM</div></cmp-a>
+    `);
+  });
+
   it('should error when reusing vnodes', async () => {
 
     @Component({ tag: 'cmp-a' })

--- a/src/runtime/test/render-vdom.spec.tsx
+++ b/src/runtime/test/render-vdom.spec.tsx
@@ -110,11 +110,9 @@ describe('render-vdom', () => {
     }
 
     const { body, waitForChanges } = await newSpecPage({
-      components: [CmpA]
+      components: [CmpA],
+      html: `<cmp-a></cmp-a>`
     });
-
-    body.innerHTML = `<cmp-a></cmp-a>`;
-    await waitForChanges();
 
     expect(body).toEqualHtml(`
       <cmp-a><div class="class1 class2 class3">Hello VDOM</div></cmp-a>

--- a/src/runtime/vdom/set-accessor.ts
+++ b/src/runtime/vdom/set-accessor.ts
@@ -120,7 +120,5 @@ export const setAccessor = (elm: HTMLElement, memberName: string, oldValue: any,
   }
 };
 
-const parseClassList = (value: string | undefined | null): string[] => {
-  value = value ? value.trim().replace(/\s+/g, ' ') : value;
-  return (!value) ? [] : value.split(' ');
-};
+const parseClassList = (value: string | undefined | null): string[] =>
+  (!value) ? [] : value.trim().split(/\s+/);

--- a/src/runtime/vdom/set-accessor.ts
+++ b/src/runtime/vdom/set-accessor.ts
@@ -120,5 +120,7 @@ export const setAccessor = (elm: HTMLElement, memberName: string, oldValue: any,
   }
 };
 
-const parseClassList = (value: string | undefined | null): string[] =>
-  (!value) ? [] : value.split(' ').filter(c => c);
+const parseClassList = (value: string | undefined | null): string[] => {
+  value = value ? value.trim().replace(/\s+/g, ' ') : value;
+  return (!value) ? [] : value.split(' ');
+};

--- a/src/runtime/vdom/set-accessor.ts
+++ b/src/runtime/vdom/set-accessor.ts
@@ -121,4 +121,4 @@ export const setAccessor = (elm: HTMLElement, memberName: string, oldValue: any,
 };
 
 const parseClassList = (value: string | undefined | null): string[] =>
-  (!value) ? [] : value.trim().split(/\s+/);
+  (!value) ? [] : value.split(/\s+/).filter(c => c);

--- a/src/runtime/vdom/test/set-accessor.spec.ts
+++ b/src/runtime/vdom/test/set-accessor.spec.ts
@@ -660,6 +660,11 @@ describe('setAccessor for standard html elements', () => {
         '  class1 class2',
         'new class4', false, 0);
       expect(elm).toHaveClasses(['class3', 'new', 'class4']);
+
+      setAccessor(elm, 'class', undefined, `class1
+              class2
+       class3  `, false, 0);
+      expect(elm).toHaveClasses(['class1', 'class2', 'class3']);
     });
 
     it('should not add any classes', () => {
@@ -675,6 +680,9 @@ describe('setAccessor for standard html elements', () => {
 
       setAccessor(elm, 'class', undefined, undefined, false, 0);
       expect(elm).toHaveClasses([]);
+
+      setAccessor(elm, 'class', '', `\n      \n      \n     `, false, 0);
+      expect(elm).toHaveClasses([]);
     });
 
     it('should remove classes', () => {
@@ -683,6 +691,10 @@ describe('setAccessor for standard html elements', () => {
 
       setAccessor(elm, 'class', 'icon', 'icon2', false, 0);
       expect(elm).toHaveClasses(['ion-color', 'icon2']);
+
+      setAccessor(elm, 'class', `icon
+           ion-color`, 'icon2', false, 0);
+      expect(elm).toHaveClasses(['icon2']);
     });
 
     it('should not have duplicated classes', () => {


### PR DESCRIPTION
I figured out that when you are using template strings and it has line breaks the last fix does not cover this case properly, I did change the approach to use a regex to clear the extra spaces and line breaks from classList value.

it should fix #1757 