### PR TITLE
fix(import): use arrow fn instead of Function

### DIFF
--- a/src/client/import-shims.ts
+++ b/src/client/import-shims.ts
@@ -44,7 +44,7 @@ export const patchBrowser = async (): Promise<d.CustomElementsDefineOptions> => 
 export const patchDynamicImport = (base: string) => {
   const importFunctionName = getDynamicImportFunction(NAMESPACE);
   try {
-    (win as any)[importFunctionName] = new Function('w', 'return import(w);');
+    (win as any)[importFunctionName] = (w: string) => import(w);
   } catch (e) {
     const moduleMap = new Map<string, any>();
     (win as any)[importFunctionName] = (src: string) => {


### PR DESCRIPTION
This PR fix issue #1765 .
It seems that sometimes (After a refresh and if DevTools is close), Chrome was using the wrong function when importing. 
This is weird and i can't explain why so if anyone has an explanation, i'll take it.

Another working solution was to use another variable name across components instead of 'w', i found it less elegant.
