### PR TITLE
System.js build: Fix leaking variables, improve resource resolution logic

### DIFF
--- a/src/compiler/component-lazy/generate-system.ts
+++ b/src/compiler/component-lazy/generate-system.ts
@@ -71,6 +71,9 @@ if (win.__stencil_cssshim) {
 } else {
   start();
 }
+
+// Note: using .call(window) here because the self-executing function needs
+// to be scoped to the window object for the ES6Promise polyfill to work
 }).call(window);
 `;
 }

--- a/src/compiler/component-lazy/generate-system.ts
+++ b/src/compiler/component-lazy/generate-system.ts
@@ -49,7 +49,7 @@ async function getSystemLoader(config: d.Config, corePath: string, includePolyfi
 ${polyfills}
 
 var doc = document;
-var scriptElm = doc.querySelector('script[data-resources-url]');
+var scriptElm = doc.querySelector('script[data-stencil-namespace="${config.fsNamespace}"]') || doc.querySelector('script[data-resources-url]');
 if (!scriptElm) {
   var allScripts = doc.querySelectorAll('script');
   for (var x = allScripts.length - 1; x >= 0; x--) {

--- a/src/compiler/component-lazy/generate-system.ts
+++ b/src/compiler/component-lazy/generate-system.ts
@@ -45,17 +45,21 @@ async function getSystemLoader(config: d.Config, corePath: string, includePolyfi
   const polyfills = includePolyfills ? await getAppBrowserCorePolyfills(config) : '';
   return `
 'use strict';
+(function () {
 ${polyfills}
 
 var doc = document;
-var allScripts = doc.querySelectorAll('script');
-var scriptElm;
-for (var x = allScripts.length - 1; x >= 0; x--) {
-  scriptElm = allScripts[x];
-  if (scriptElm.src || scriptElm.hasAttribute('data-resources-url')) {
-    break;
+var scriptElm = doc.querySelector('script[data-resources-url]');
+if (!scriptElm) {
+  var allScripts = doc.querySelectorAll('script');
+  for (var x = allScripts.length - 1; x >= 0; x--) {
+    scriptElm = allScripts[x];
+    if (scriptElm.src) {
+      break;
+    }
   }
 }
+
 var resourcesUrl = scriptElm ? scriptElm.getAttribute('data-resources-url') || scriptElm.src : '';
 var start = function() {
   var url = new URL('${corePath}', resourcesUrl);
@@ -67,5 +71,6 @@ if (win.__stencil_cssshim) {
 } else {
   start();
 }
+}).call(window);
 `;
 }

--- a/src/compiler/component-lazy/generate-system.ts
+++ b/src/compiler/component-lazy/generate-system.ts
@@ -49,12 +49,12 @@ async function getSystemLoader(config: d.Config, corePath: string, includePolyfi
 ${polyfills}
 
 var doc = document;
-var scriptElm = doc.querySelector('script[data-stencil-namespace="${config.fsNamespace}"]') || doc.querySelector('script[data-resources-url]');
+var scriptElm = doc.querySelector('script[data-stencil-namespace="${config.fsNamespace}"]');
 if (!scriptElm) {
   var allScripts = doc.querySelectorAll('script');
   for (var x = allScripts.length - 1; x >= 0; x--) {
     scriptElm = allScripts[x];
-    if (scriptElm.src) {
+    if (scriptElm.src || scriptElm.hasAttribute('data-resources-url')) {
       break;
     }
   }


### PR DESCRIPTION
- Wraps the polyfills and loading logic inside a self-executing function to avoid leaking variables to the window object. Fixes #1786 
- First looks for a script with `data-stencil-namespace` or `data-resources-url` to resolve the resources url, instead of always using the last script in the DOM. Fixes #1787, fixes #1456 