### PR TITLE
chore(ci): add github actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ on:
 jobs:
   build_and_test:
     strategy:
+      fail-fast: false # turn off for testing
       matrix:
         node: [8, 10, 12]
         os: ['ubuntu-latest', 'windows-latest', 'macOS-latest']

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,17 +12,6 @@ on:
       - 'types'
       - 'package.json'
 
-  pull_request:
-    paths:
-      - '.github/workflows/*'
-      - 'bin/*'
-      - 'screenshot'
-      - 'scripts'
-      - 'src'
-      - 'test'
-      - 'types'
-      - 'package.json'
-
 jobs:
   build_and_test:
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false # turn off for testing
       matrix:
-        node: [8, 10, 12]
+        node: [10, 12]
         os: ['ubuntu-latest', 'windows-latest', 'macOS-latest']
 
     name: Node ${{ matrix.node }} on ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,60 @@
+name: Build & Test
+
+on:
+  push:
+    paths:
+      - '.github/workflows/*'
+      - 'bin/*'
+      - 'screenshot'
+      - 'scripts'
+      - 'src'
+      - 'test'
+      - 'types'
+      - 'package.json'
+
+  pull_request:
+    paths:
+      - '.github/workflows/*'
+      - 'bin/*'
+      - 'screenshot'
+      - 'scripts'
+      - 'src'
+      - 'test'
+      - 'types'
+      - 'package.json'
+
+jobs:
+  build_and_test:
+    strategy:
+      matrix:
+        node: [8, 10, 12]
+        os: ['ubuntu-latest', 'windows-latest', 'macOS-latest']
+
+    name: Node ${{ matrix.node }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Use Node.js ${{ matrix.node }}.x
+        uses: actions/setup-node@v1
+        with:
+          version: ${{ matrix.node }}.x
+
+      - name: install
+        run: npm install
+
+      - name: build
+        run: npm run build -- --ci
+
+      - name: test dist
+        run: npm run test.dist && npm run test.testing
+
+      - name: test end-to-end
+        run: npm run test.end-to-end -- --ci
+
+      - name: test jest
+        run: npm run test.jest -- --maxWorkers=1
+
+      - name: test sys-node
+        run: npm run test.sys.node


### PR DESCRIPTION
This runs everything except the karma test, because I'm not yet sure how to setup browserstack.

The matrix is set up to cross-test Node.js versions 10 and 12 on Ubuntu, macOS and Windows each.

All the tests are run within the same job, which means the indiviual tests (i. e. dist, end-to-end, jest, etc) don't run in parallel. This can be split into multiple jobs, however I'm not yet sure how well that works with respect to the matrix setup.

It's by default set to cancel all the matrix tests if any of them fails ([`strategy.fail-fast`](https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast)), which I turned off.