### PR TITLE
fix(readme generator): fix path sep on windows

### DIFF
--- a/src/compiler/docs/readme/markdown-dependencies.ts
+++ b/src/compiler/docs/readme/markdown-dependencies.ts
@@ -50,7 +50,7 @@ export function depsToMarkdown(config: d.Config, cmp: d.JsonDocsComponent, cmps:
 function getCmpLink(config: d.Config, from: d.JsonDocsComponent, to: string, cmps: d.JsonDocsComponent[]) {
   const destCmp = cmps.find(c => c.tag === to);
   if (destCmp) {
-    const cmpRelPath = config.sys.path.relative(from.dirPath, destCmp.dirPath);
+    const cmpRelPath = config.sys.path.relative(from.dirPath, destCmp.dirPath).replace(/\\/g,'/');
     return `[${to}](${cmpRelPath})`;
   }
   return to;


### PR DESCRIPTION
fixes #1708 

I was just trying to make some Ionic docs changes and ended up down a rabbit hole. I'm submitting this one line fix in case that's all that needs to be done, but I have only tested it on my own Windows 10 computer and it resolved the issue.