### PR TITLE
fix(css-shim): skip 'Data URLs' when fixing relative urls

### DIFF
--- a/src/client/polyfills/css-shim/load-link-styles.ts
+++ b/src/client/polyfills/css-shim/load-link-styles.ts
@@ -61,7 +61,7 @@ export function hasCssVariables(css: string) {
 }
 
 // This regexp find all url() usages with relative urls
-const CSS_URL_REGEXP = /url[\s]*\([\s]*['"]?(?![http|/])([^\'\"\)]*)[\s]*['"]?\)[\s]*/gim;
+const CSS_URL_REGEXP = /url[\s]*\([\s]*['"]?(?!(?:https?|data)\:|\/)([^\'\"\)]*)[\s]*['"]?\)[\s]*/gim;
 
 export function hasRelativeUrls(css: string) {
   CSS_URL_REGEXP.lastIndex = 0;

--- a/src/client/polyfills/css-shim/test/init-css-shim.spec.ts
+++ b/src/client/polyfills/css-shim/test/init-css-shim.spec.ts
@@ -105,6 +105,16 @@ describe('hasRelativeUrls', () => {
     expect(hasRelativeUrls(text)).toBe(false);
   });
 
+  it('false for absolute https urls', () => {
+    const text = `
+      div {
+        background-image: url('https://example.com/mytestimage.jpg');
+      }
+    `;
+
+    expect(hasRelativeUrls(text)).toBe(false);
+  });
+
   it('true for relative urls', () => {
     const text = `
       div {
@@ -169,5 +179,37 @@ describe('fixRelativeUrls', () => {
       }
     `);
   });
+
+  it('should transform prepend relative urls contains data folder with base path', () => {
+    const text = `
+      div {
+        background-image: url('data/images/mytestimage.jpg');
+      }
+    `;
+
+    expect(fixRelativeUrls(text, '/assets/css/styles.css')).toBe(`
+      div {
+        background-image: url('/assets/css/data/images/mytestimage.jpg');
+      }
+    `);
+  });
+
+  it.each([
+    'data:,ABC123',
+    'data:text/plain,ABC123',
+    'data:text/plain;base64,ABC123'
+  ])('should keep data url', (dataURL) => {
+    const text = `
+      div {
+        background-image: url('${dataURL}');
+      }
+    `;
+
+    expect(fixRelativeUrls(text, '/assets/css/styles.css')).toBe(`
+      div {
+        background-image: url('${dataURL}');
+      }
+    `);
+  })
 
 });


### PR DESCRIPTION
This PR is addressed to https://github.com/ionic-team/stencil/issues/1860

When all relative paths in url() in styles are replacing to absolute. We need to make sure that "data urls" will be omitted. 
As the regular expression had to be updated I had to also update an "http" protocol an added optional 's' to make sure that 'http' and 'https' are included.