### PR TITLE
Fix chunk URL determination in IE11

### DIFF
--- a/src/compiler/component-lazy/generate-lazy-app.ts
+++ b/src/compiler/component-lazy/generate-lazy-app.ts
@@ -145,7 +145,7 @@ function getLegacyLoader(config: d.Config) {
   scriptElm.src = url + '/${namespace}.js';
   warn.push(scriptElm.outerHTML);
 
-  scriptElm.setAttribute('data-stencil-namespace', ${namespace});
+  scriptElm.setAttribute('data-stencil-namespace', '${namespace}');
   doc.head.appendChild(scriptElm);
 
   console.warn(warn.join('\\n'));

--- a/src/compiler/component-lazy/generate-lazy-app.ts
+++ b/src/compiler/component-lazy/generate-lazy-app.ts
@@ -143,8 +143,10 @@ function getLegacyLoader(config: d.Config) {
   scriptElm = doc.createElement('script');
   scriptElm.setAttribute('nomodule', '');
   scriptElm.src = url + '/${namespace}.js';
-  doc.head.appendChild(scriptElm);
   warn.push(scriptElm.outerHTML);
+
+  scriptElm.setAttribute('data-stencil-namespace', ${namespace});
+  doc.head.appendChild(scriptElm);
 
   console.warn(warn.join('\\n'));
 


### PR DESCRIPTION
By setting a 'data-stencil-namespace' attribute on the generated legacy script tag before adding that to the DOM, the script will correctly detect the base URL of the chunks that need to be loaded.

This fixes an issue in IE11 where using the 'old' method of integrating a Stencil components library (by adding a single <script> tag) did not work. The `namespace` part of the chunk URLs was missing.