### PR TITLE
fix(polyfills): update baseURI for base w/out href

### DIFF
--- a/src/client/polyfills/dom.js
+++ b/src/client/polyfills/dom.js
@@ -44,7 +44,7 @@ if (typeof document.baseURI !== 'string') {
     configurable: true,
     get: function () {
       var base = document.querySelector('base');
-      if (base) {
+      if (base && base.href) {
         return base.href;
       }
       return document.URL;


### PR DESCRIPTION
Fixes #1994 

If document base tag only has a target, and does not have an href, baseURI polyfill currently returns undefined.  Update the polyfill to check first if base.href has a value, otherwise returns document.URL as normal.