### PR TITLE
fix(jsx): add referrerPolicy for iframe interface

### DIFF
--- a/src/declarations/jsx.ts
+++ b/src/declarations/jsx.ts
@@ -318,6 +318,7 @@ export namespace JSXBase {
     marginWidth?: number;
     marginwidth?: string | number;
     name?: string;
+    referrerPolicy?: ReferrerPolicy;
     sandbox?: string;
     scrolling?: string;
     seamless?: boolean;


### PR DESCRIPTION
Fixes #2002

Adds a referrerPolicy property to the iframe jsx interface so users are able to define the referrerPolicy on their iframes.