### PR TITLE
chore(event-emitter): fix spelling in err msg

### DIFF
--- a/src/runtime/event-emitter.ts
+++ b/src/runtime/event-emitter.ts
@@ -9,7 +9,7 @@ export const createEvent = (ref: d.RuntimeRef, name: string, flags: number) => {
   return {
     emit: (detail: any) => {
       if (BUILD.isDev && !elm.isConnected) {
-        consoleDevWarn(`The "${name}" event was emitted, but the dispatcher node is not longer connected to the dom.`);
+        consoleDevWarn(`The "${name}" event was emitted, but the dispatcher node is no longer connected to the dom.`);
       }
       return elm.dispatchEvent(
         new (BUILD.hydrateServerSide ? (win as any).CustomEvent : CustomEvent)(name, {


### PR DESCRIPTION
Came across this error during development work: quick spelling fix for the error message