### PR TITLE
feat(): add forceShadowDom config option - this will disable scoped fallback in IE

### DIFF
--- a/src/client/client-window.ts
+++ b/src/client/client-window.ts
@@ -17,7 +17,11 @@ export const plt: d.PlatformRuntime = {
   rel: (el, eventName, listener, opts) => el.removeEventListener(eventName, listener, opts),
 };
 
-export const supportsShadowDom = (BUILD.shadowDom) ? /*@__PURE__*/(() => !!doc.documentElement.attachShadow)() : false;
+export const supportsShadowDom =
+  BUILD.forceShadowDom ||
+  (BUILD.shadowDom
+    ? /*@__PURE__*/ (() => !!doc.documentElement.attachShadow)()
+    : false);
 
 export const supportsListenerOptions = /*@__PURE__*/(() => {
   let supportsListenerOptions = false;

--- a/src/compiler/browser/build-conditionals-client.ts
+++ b/src/compiler/browser/build-conditionals-client.ts
@@ -56,6 +56,7 @@ export const BUILD: Required<d.Build> = {
   taskQueue: true,
 
   devTools: false,
+  forceShadowDom: false,
   hotModuleReplacement: false,
   isDebug: false,
   isDev: false,

--- a/src/compiler/component-lazy/generate-lazy-app.ts
+++ b/src/compiler/component-lazy/generate-lazy-app.ts
@@ -44,6 +44,7 @@ function getBuildConditionals(config: d.Config, cmps: d.ComponentCompilerMeta[])
   build.cssVarShim = true;
   build.initializeNextTick = true;
   build.taskQueue = true;
+  build.forceShadowDom = config.forceShadowDom || false;
 
   const hasHydrateOutputTargets = config.outputTargets.some(isOutputTargetHydrate);
   build.hydrateClientSide = hasHydrateOutputTargets;

--- a/src/declarations/build-conditionals.ts
+++ b/src/declarations/build-conditionals.ts
@@ -82,6 +82,7 @@ export interface Build extends Partial<BuildFeatures> {
   isDebug?: boolean;
   isDev?: boolean;
   devTools?: boolean;
+  forceShadowDom?: boolean;
   hydrateServerSide?: boolean;
   hydrateClientSide?: boolean;
   lifecycleDOMEvents?: boolean;

--- a/src/declarations/config.ts
+++ b/src/declarations/config.ts
@@ -163,6 +163,12 @@ export interface StencilConfig {
   devMode?: boolean;
 
   /**
+   * Forces Stencil to use shadowDOM and not fallback to scoped on browsers that don't support shadowDOM natively.
+   * This is intended to be used together with a shadowDOM polyfill like @webcomponents/webcomponentsjs
+   */
+  forceShadowDom?: boolean;
+
+  /**
    * Object to provide a custom logger. By default a `logger` is already provided for the
    * platform the compiler is running on, such as NodeJS or a browser.
    */


### PR DESCRIPTION
Hi all,

this might not be the cleanest solution as I guess there's a lot of code being shipped for the scoped fallback even though you disable using it, but it's a quick fix and works together with  @webcomponents/webcomponentsjs.

Related to #2012 and various other IE issues that exist using the scoped fallback.