### PR TITLE
chore(): refactor angular output target

### DIFF
--- a/src/compiler/output-targets/output-angular.ts
+++ b/src/compiler/output-targets/output-angular.ts
@@ -113,7 +113,7 @@ export class ${tagNameAsPascal} {`];
   lines.push(`  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;`);
-  if(hasOutputs){
+  if (hasOutputs) {
     lines.push(`    proxyOutputs(this, this.el, ['${outputs.join(`', '`)}']);`);
   }
   lines.push(`  }`);
@@ -202,8 +202,8 @@ export const proxyMethods = (Cmp: any, methods: string[]) => {
 };
 
 export const proxyOutputs = (instance: any, el: any, events: string[]) => {
-   events.forEach(eventName => instance[eventName] = fromEvent(el, eventName));
- }
+  events.forEach(eventName => instance[eventName] = fromEvent(el, eventName));
+}
 
 // tslint:disable-next-line: only-arrow-functions
 export function ProxyCmp(opts: { inputs?: any; methods?: any }) {

--- a/src/compiler/output-targets/output-angular.ts
+++ b/src/compiler/output-targets/output-angular.ts
@@ -207,7 +207,7 @@ export const proxyOutputs = (instance: any, el: any, events: string[]) => {
 
 // tslint:disable-next-line: only-arrow-functions
 export function ProxyCmp(opts: { inputs?: any; methods?: any }) {
-  return (cls: any) => {
+  const decorator =  function(cls: any){
     if (opts.inputs) {
       proxyInputs(cls, opts.inputs);
     }
@@ -216,6 +216,7 @@ export function ProxyCmp(opts: { inputs?: any; methods?: any }) {
     }
     return cls;
   };
+  return decorator;
 }
 `;
 


### PR DESCRIPTION
👋 

This PR refactors the compiler's angular output target to use a Directive instead of proxy functions.

### Why

With recent updates to Angular's build tool (the buildOptimizer specifically) `proxyInput` and `proxyMethods` would be dropped from the final output since they are not part of a component. This would break tests in ionic's angular test setup.

### Changes proposed

Instead of using proxy functions, we use a decorator to decorate the component with the logic needed.

```ts
export function ProxyCmp(opts: { inputs?: any; outputs?: any; methods?: any }) {
  return (cls: any) => {
    if (opts.inputs) {
      proxyInputs(cls, opts.inputs);
    }
    if (opts.methods) {
      proxyMethods(cls, opts.methods);
    }
    if (opts.outputs) {
      proxyOutputs(cls, cls.el, opts.outputs);
    }
    return cls;
  };
}
```

During a build, the output would be 

```ts
export declare interface IonContent extends Components.IonContent {}
@ProxyCmp({inputs: ['color', 'forceOverscroll', 'fullscreen', 'scrollEvents', 'scrollX', 'scrollY'], outputs: ['ionScrollStart', 'ionScroll', 'ionScrollEnd'], 'methods': ['getScrollElement', 'scrollToTop', 'scrollToBottom', 'scrollByPoint', 'scrollToPoint']})
@Component({ selector: 'ion-content', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['color', 'forceOverscroll', 'fullscreen', 'scrollEvents', 'scrollX', 'scrollY'] })
export class IonContent {
  ionScrollStart!: EventEmitter<CustomEvent>;
  ionScroll!: EventEmitter<CustomEvent>;
  ionScrollEnd!: EventEmitter<CustomEvent>;
  protected el: HTMLElement;
  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
    c.detach();
    this.el = r.nativeElement;
  }
}
```

This currently just reuses the existing logic in place, but can be optimized in the future when part of the DS plugins.


A similar PR was made against the DS plugins here 
https://github.com/ionic-team/stencil-ds-plugins/pull/12