### PR TITLE
feat(test): Add two event detail jest matchers

### DIFF
--- a/src/declarations/testing.ts
+++ b/src/declarations/testing.ts
@@ -83,6 +83,18 @@ declare global {
       toHaveReceivedEventDetail(eventDetail: any): void;
 
       /**
+       * When given an EventSpy, checks the first event has
+       * received the correct custom event `detail` data.
+       */
+      toHaveFirstReceivedEventDetail(eventDetail: any): void;
+
+      /**
+       * When given an EventSpy, checks the event at an index
+       * has received the correct custom event `detail` data.
+       */
+      toHaveNthReceivedEventDetail(index: number, eventDetail: any): void;
+
+      /**
        * Used to evaluate the results of `compareScreenshot()`, such as
        * `expect(compare).toMatchScreenshot()`. The `allowableMismatchedRatio`
        * value from the testing config is used by default if

--- a/src/testing/matchers/events.ts
+++ b/src/testing/matchers/events.ts
@@ -70,3 +70,63 @@ export function toHaveReceivedEventDetail(eventSpy: d.EventSpy, eventDetail: any
     pass: pass,
   };
 }
+
+export function toHaveFirstReceivedEventDetail(eventSpy: d.EventSpy, eventDetail: any) {
+  if (!eventSpy) {
+    throw new Error(`toHaveFirstReceivedEventDetail event spy is null`);
+  }
+
+  if (typeof (eventSpy as any).then === 'function') {
+    throw new Error(`event spy must be a resolved value, not a promise, before it can be tested`);
+  }
+
+  if (!eventSpy.eventName) {
+    throw new Error(`toHaveFirstReceivedEventDetail did not receive an event spy`);
+  }
+
+  if (!eventSpy.firstEvent) {
+    throw new Error(`event "${eventSpy.eventName}" was not received`);
+  }
+
+  const pass = deepEqual(eventSpy.firstEvent.detail, eventDetail);
+
+  expect(eventSpy.lastEvent.detail).toEqual(eventDetail);
+
+  return {
+    message: () => `expected event "${eventSpy.eventName}" detail to ${pass ? 'not ' : ''}equal`,
+    pass: pass,
+  };
+}
+
+export function toHaveNthReceivedEventDetail(eventSpy: d.EventSpy, index: number, eventDetail: any) {
+  if (!eventSpy) {
+    throw new Error(`toHaveNthReceivedEventDetail event spy is null`);
+  }
+
+  if (typeof (eventSpy as any).then === 'function') {
+    throw new Error(`event spy must be a resolved value, not a promise, before it can be tested`);
+  }
+
+  if (!eventSpy.eventName) {
+    throw new Error(`toHaveNthReceivedEventDetail did not receive an event spy`);
+  }
+
+  if (!eventSpy.firstEvent) {
+    throw new Error(`event "${eventSpy.eventName}" was not received`);
+  }
+
+  const event = eventSpy.events[index];
+
+  if (!event) {
+    throw new Error(`event at index ${index} was not received`);
+  }
+
+  const pass = deepEqual(event.detail, eventDetail);
+
+  expect(event.detail).toEqual(eventDetail);
+
+  return {
+    message: () => `expected event "${eventSpy.eventName}" detail to ${pass ? 'not ' : ''}equal`,
+    pass: pass,
+  };
+}

--- a/src/testing/matchers/index.ts
+++ b/src/testing/matchers/index.ts
@@ -1,5 +1,5 @@
 import { toEqualAttribute, toEqualAttributes, toHaveAttribute } from './attributes';
-import { toHaveReceivedEvent, toHaveReceivedEventDetail, toHaveReceivedEventTimes } from './events';
+import { toHaveReceivedEvent, toHaveReceivedEventDetail, toHaveReceivedEventTimes, toHaveFirstReceivedEventDetail, toHaveNthReceivedEventDetail } from './events';
 import { toEqualHtml, toEqualLightHtml } from './html';
 import { toEqualText } from './text';
 import { toHaveClass, toHaveClasses, toMatchClasses } from './class-list';
@@ -19,5 +19,7 @@ export const expectExtend = {
   toHaveReceivedEvent,
   toHaveReceivedEventDetail,
   toHaveReceivedEventTimes,
+  toHaveFirstReceivedEventDetail,
+  toHaveNthReceivedEventDetail,
   toMatchScreenshot
 };


### PR DESCRIPTION
Resolves #2046 

`toHaveFirstReceivedEventDetail` is like `toHaveReceivedEventDetail` except
it checks the `firstEvent` instead of always the `lastEvent`.

`toHaveNthReceviedEventDetail` is like the others except you specify an
index so that you can check other events that aren't the first and last
events in an easy way. This is like jest's [`toHaveBeenNthCalledWith`](https://jestjs.io/docs/en/expect#tohavebeennthcalledwithnthcall-arg1-arg2-)
matcher.