### PR TITLE
fix(runtime): Do not double render when attaching cloned elements with Shadow DOM turned off #

### DIFF
--- a/src/runtime/initialize-component.ts
+++ b/src/runtime/initialize-component.ts
@@ -123,4 +123,25 @@ export const initializeComponent = async (elm: d.HostElement, hostRef: d.HostRef
   } else {
     schedule();
   }
+
+  // For CLONED components that are re-added to the DOM (like ngIf in AngularJS)
+  // AND do not use shadow-dom, remove all children that are not slot content
+  if (elm.classList.contains('hydrated') && BUILD.slotRelocation && !BUILD.hydrateServerSide && !BUILD.hydrateClientSide) {
+    removeNonSlotNodes(elm);
+  }
+};
+
+const removeNonSlotNodes = (elm: Element) => {
+  Array.from(elm.children)
+  .forEach((node) => {
+    const numChildren = node.children && node.children.length;
+    // ['s-isc'] stands for is-slot-content and is only added to elements that belong to a slot
+    // It is added as an attribute, because arbitrary props get removed when cloning nodes
+    if (node.getAttribute('s-isc') === null && !numChildren) {
+      node.remove();
+    }
+    if (numChildren) {
+      removeNonSlotNodes(node);
+    }
+  });
 };

--- a/src/runtime/test/render-vdom.spec.tsx
+++ b/src/runtime/test/render-vdom.spec.tsx
@@ -880,4 +880,74 @@ describe('render-vdom', () => {
     });
 
   });
+
+  describe('is slot content attribute', () => {
+    it('should add a `s-isc` attribute', async () => {
+      @Component({ tag: 'comp-a' })
+      class CmpA {
+        render() {
+          return (
+            <Host>
+              <span>Component mark-up</span>
+              <slot></slot>
+            </Host>
+          );
+        }
+      }
+
+      const { waitForChanges, body } = await newSpecPage({
+        components: [CmpA],
+        html: `
+        <comp-a>
+            <div id="slot-content">I am slot content</div>
+        </comp-a>
+      `,
+      });
+
+      const component = body.querySelector('comp-a');
+      body.removeChild(component);
+      body.appendChild(component.cloneNode(true));
+
+      await waitForChanges();
+
+      const span = body.querySelector('span');
+      const slotContent = body.querySelector('#slot-content');
+      expect(span.getAttribute('s-isc')).toBe(null);
+      expect(slotContent.getAttribute('s-isc')).toBe('');
+    });
+
+    it('should not add a `s-isc` attribute with shadow DOM enabled', async () => {
+      @Component({ tag: 'comp-a', shadow: true })
+      class CmpA {
+        render() {
+          return (
+            <Host>
+              <span>Component mark-up</span>
+              <slot></slot>
+            </Host>
+          );
+        }
+      }
+
+      const { waitForChanges, body } = await newSpecPage({
+        components: [CmpA],
+        html: `
+        <comp-a>
+            <div id="slot-content">I am slot content</div>
+        </comp-a>
+      `,
+      });
+
+      const component = body.querySelector('comp-a');
+      body.removeChild(component);
+      body.appendChild(component.cloneNode(true));
+
+      await waitForChanges();
+
+      const span = component.shadowRoot.querySelector('span');
+      const slotContent = body.querySelector('#slot-content');
+      expect(span.getAttribute('s-isc')).toBe(null);
+      expect(slotContent.getAttribute('s-isc')).toBe(null);
+    });
+  });
 });

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -529,6 +529,13 @@ const relocateSlotContent = (
               checkSlotFallbackVisibility = true;
               node['s-sn'] = slotNameAttr;
 
+              // Used in initialize-component.ts
+              // Attributes persist data for cloned elements (like ngIf in AngularJS)
+              // non-native properties such as `node['s-sn']` are lost when cloning
+              if (node.setAttribute) {
+                node.setAttribute('s-isc', '');
+              }
+
               // add to our list of nodes to relocate
               relocateNodes.push({
                 $slotRefNode$: childNode,

--- a/test/karma/test-app/components.d.ts
+++ b/test/karma/test-app/components.d.ts
@@ -60,6 +60,9 @@ export namespace Components {
     'didUnload': number;
     'willLoad': number;
   }
+  interface DomReattachClone {}
+  interface DomReattachCloneDeepSlot {}
+  interface DomReattachCloneHost {}
   interface DynamicCssVariable {}
   interface DynamicImport {
     'update': () => Promise<void>;
@@ -318,6 +321,24 @@ declare global {
   var HTMLDomReattachElement: {
     prototype: HTMLDomReattachElement;
     new (): HTMLDomReattachElement;
+  };
+
+  interface HTMLDomReattachCloneElement extends Components.DomReattachClone, HTMLStencilElement {}
+  var HTMLDomReattachCloneElement: {
+    prototype: HTMLDomReattachCloneElement;
+    new (): HTMLDomReattachCloneElement;
+  };
+
+  interface HTMLDomReattachCloneDeepSlotElement extends Components.DomReattachCloneDeepSlot, HTMLStencilElement {}
+  var HTMLDomReattachCloneDeepSlotElement: {
+    prototype: HTMLDomReattachCloneDeepSlotElement;
+    new (): HTMLDomReattachCloneDeepSlotElement;
+  };
+
+  interface HTMLDomReattachCloneHostElement extends Components.DomReattachCloneHost, HTMLStencilElement {}
+  var HTMLDomReattachCloneHostElement: {
+    prototype: HTMLDomReattachCloneHostElement;
+    new (): HTMLDomReattachCloneHostElement;
   };
 
   interface HTMLDynamicCssVariableElement extends Components.DynamicCssVariable, HTMLStencilElement {}
@@ -825,6 +846,9 @@ declare global {
     'css-variables-shadow-dom': HTMLCssVariablesShadowDomElement;
     'custom-event-root': HTMLCustomEventRootElement;
     'dom-reattach': HTMLDomReattachElement;
+    'dom-reattach-clone': HTMLDomReattachCloneElement;
+    'dom-reattach-clone-deep-slot': HTMLDomReattachCloneDeepSlotElement;
+    'dom-reattach-clone-host': HTMLDomReattachCloneHostElement;
     'dynamic-css-variable': HTMLDynamicCssVariableElement;
     'dynamic-import': HTMLDynamicImportElement;
     'es5-addclass-svg': HTMLEs5AddclassSvgElement;
@@ -955,6 +979,9 @@ declare namespace LocalJSX {
     'didUnload'?: number;
     'willLoad'?: number;
   }
+  interface DomReattachClone {}
+  interface DomReattachCloneDeepSlot {}
+  interface DomReattachCloneHost {}
   interface DynamicCssVariable {}
   interface DynamicImport {}
   interface Es5AddclassSvg {}
@@ -1121,6 +1148,9 @@ declare namespace LocalJSX {
     'css-variables-shadow-dom': CssVariablesShadowDom;
     'custom-event-root': CustomEventRoot;
     'dom-reattach': DomReattach;
+    'dom-reattach-clone': DomReattachClone;
+    'dom-reattach-clone-deep-slot': DomReattachCloneDeepSlot;
+    'dom-reattach-clone-host': DomReattachCloneHost;
     'dynamic-css-variable': DynamicCssVariable;
     'dynamic-import': DynamicImport;
     'es5-addclass-svg': Es5AddclassSvg;
@@ -1230,6 +1260,9 @@ declare module "@stencil/core" {
       'css-variables-shadow-dom': LocalJSX.CssVariablesShadowDom & JSXBase.HTMLAttributes<HTMLCssVariablesShadowDomElement>;
       'custom-event-root': LocalJSX.CustomEventRoot & JSXBase.HTMLAttributes<HTMLCustomEventRootElement>;
       'dom-reattach': LocalJSX.DomReattach & JSXBase.HTMLAttributes<HTMLDomReattachElement>;
+      'dom-reattach-clone': LocalJSX.DomReattachClone & JSXBase.HTMLAttributes<HTMLDomReattachCloneElement>;
+      'dom-reattach-clone-deep-slot': LocalJSX.DomReattachCloneDeepSlot & JSXBase.HTMLAttributes<HTMLDomReattachCloneDeepSlotElement>;
+      'dom-reattach-clone-host': LocalJSX.DomReattachCloneHost & JSXBase.HTMLAttributes<HTMLDomReattachCloneHostElement>;
       'dynamic-css-variable': LocalJSX.DynamicCssVariable & JSXBase.HTMLAttributes<HTMLDynamicCssVariableElement>;
       'dynamic-import': LocalJSX.DynamicImport & JSXBase.HTMLAttributes<HTMLDynamicImportElement>;
       'es5-addclass-svg': LocalJSX.Es5AddclassSvg & JSXBase.HTMLAttributes<HTMLEs5AddclassSvgElement>;

--- a/test/karma/test-app/dom-reattach-clone/angularjs.html
+++ b/test/karma/test-app/dom-reattach-clone/angularjs.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf8">
+<script src="/build/testapp.esm.js" type="module"></script>
+<script src="/build/testapp.js" nomodule></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.6.10/angular.min.js"></script>
+
+<script>
+  angular
+  .module('demo', [])
+  .controller('homeCtrl', homeCtrl);
+
+  function homeCtrl() {
+    var vm = this;
+    vm.visible = true;
+    vm.toggle = () => vm.visible = !vm.visible;
+  }
+</script>
+<body ng-app="demo" ng-controller="homeCtrl as ctrl">
+  <button ng-click="ctrl.toggle()">Toggle</button>
+  <div id="parent" ng-if="ctrl.visible">
+    <dom-reattach-hydrated>
+      <p>Slot content 1</p>
+    </dom-reattach-hydrated>
+  </div>
+</body>

--- a/test/karma/test-app/dom-reattach-clone/cmp-deep-slot.tsx
+++ b/test/karma/test-app/dom-reattach-clone/cmp-deep-slot.tsx
@@ -1,0 +1,19 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'dom-reattach-clone-deep-slot'
+})
+export class DomReattachCloneDeep {
+  render() {
+    return (
+      <div class='wrapper'>
+        <span class="component-mark-up">Component mark-up</span>
+        <div>
+          <section>
+            <slot></slot>
+          </section>
+        </div>
+      </div>
+    )
+  }
+}

--- a/test/karma/test-app/dom-reattach-clone/cmp-host.tsx
+++ b/test/karma/test-app/dom-reattach-clone/cmp-host.tsx
@@ -1,0 +1,15 @@
+import { Component, Host, h } from '@stencil/core';
+
+@Component({
+  tag: 'dom-reattach-clone-host'
+})
+export class DomReattachCloneHost {
+  render() {
+    return (
+      <Host>
+        <span class="component-mark-up">Component mark-up</span>
+        <slot></slot>
+      </Host>
+    )
+  }
+}

--- a/test/karma/test-app/dom-reattach-clone/cmp.tsx
+++ b/test/karma/test-app/dom-reattach-clone/cmp.tsx
@@ -1,0 +1,15 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'dom-reattach-clone'
+})
+export class DomReattachClone {
+  render() {
+    return (
+      <div class='wrapper'>
+        <span class="component-mark-up">Component mark-up</span>
+        <slot></slot>
+      </div>
+    )
+  }
+}

--- a/test/karma/test-app/dom-reattach-clone/index.html
+++ b/test/karma/test-app/dom-reattach-clone/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<meta charset="utf8">
+<script src="/build/testapp.esm.js" type="module"></script>
+<script src="/build/testapp.js" nomodule></script>
+<style>button { display: block }</style>
+<body>
+  <div id="simple-parent">
+    <button
+      onclick="toggle('simple')"
+      id="toggle-simple"
+    >
+      Toggle simple
+    </button>
+    <dom-reattach-clone id="simple">
+      <p>Slot content 1</p>
+    </dom-reattach-clone>
+  </div>
+
+  <div id="deep-parent">
+    <button
+      onclick="toggle('deep')"
+      id="toggle-deep"
+    >
+      Toggle deep
+    </button>
+    <dom-reattach-clone-deep-slot id="deep">
+      <p>Slot content 1</p>
+    </dom-reattach-clone-deep-slot>
+  </div>
+
+  <div id="multiple-parent">
+    <button
+      onclick="toggle('multiple')"
+      id="toggle-multiple"
+    >
+      Toggle multiple
+    </button>
+    <dom-reattach-clone id="multiple">
+      <p>Slot content 1</p>
+      <p>Slot content 2</p>
+      <p>Slot content 3</p>
+    </dom-reattach-clone>
+  </div>
+
+  <div id="host-parent">
+    <button onclick="toggle('host')" id="toggle-host">
+      Toggle host
+    </button>
+    <dom-reattach-clone-host id="host">
+      <p>Slot content 1</p>
+    </dom-reattach-clone-host>
+  </div>
+
+
+  <script>
+    var clones = {};
+
+    function toggle (id) {
+      var element = document.querySelector('#' + id + '.hydrated');
+      var parent = document.querySelector('#' + id + '-parent');
+
+      if (element) {
+        clones[id] = element.cloneNode(true);
+        element.remove();
+      } else {
+        parent.appendChild(clones[id]);
+      }
+    }
+  </script>
+</body>

--- a/test/karma/test-app/dom-reattach-clone/karma.spec.ts
+++ b/test/karma/test-app/dom-reattach-clone/karma.spec.ts
@@ -1,0 +1,39 @@
+import { setupDomTests, waitForChanges } from '../util';
+
+
+fdescribe('dom-reattach-clone', function() {
+  const { setupDom, tearDownDom } = setupDomTests(document);
+  let app: HTMLElement;
+
+  beforeEach(async () => {
+    app = await setupDom('/dom-reattach-clone/index.html');
+    await waitForChanges();
+  });
+  afterEach(tearDownDom);
+
+  const runTest = async (id: string) => {
+    const component = app.querySelector(`#${id}`);
+    const button = app.querySelector(`#toggle-${id}`) as HTMLButtonElement;
+    button.click();
+    await waitForChanges();
+    button.click();
+    await waitForChanges();
+    expect(component.querySelectorAll('.component-mark-up').length).toBe(1);
+  };
+
+  it('should not double render', async () => {
+    await runTest('simple');
+  });
+
+  it('should not double render with deeper slots', async () => {
+    await runTest('deep');
+  });
+
+  it('should not double render with multiple slots', async () => {
+    await runTest('multiple');
+  });
+
+  it('should not double render with Host element', async () => {
+    await runTest('host');
+  });
+});


### PR DESCRIPTION
- In the edge case that we don't use Shadow DOM and have an cloned hydrated component that is (re-)added to the DOM,
make sure that all internal markup is removed, because Stencil will see this component as a new component and will re-add its internal markup as slot content.
This causes perceived double rendering (although technically it is correct) and this commit fixes that by keeping state by adding an 's-isc' attribute. An attribute is needed because the cloning strips off any non-native props such as comp['s-sn'].
- A real world use case where this happens is with AngularJS ng-if directive, fixes #1948