### PR TITLE
Add config flag for preventing script inlining

### DIFF
--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -19,6 +19,27 @@ describe('validation', () => {
     };
   });
 
+  describe('allowInlineScripts', () => {
+
+    it('set allowInlineScripts true', () => {
+      config.allowInlineScripts = true;
+      validateConfig(config);
+      expect(config.allowInlineScripts).toBe(true);
+    });
+
+    it('set allowInlineScripts false', () => {
+      config.allowInlineScripts = false;
+      validateConfig(config);
+      expect(config.allowInlineScripts).toBe(false);
+    });
+
+    it('default allowInlineScripts true', () => {
+      validateConfig(config);
+      expect(config.allowInlineScripts).toBe(true);
+    });
+
+  });
+
 
   describe('enableCache', () => {
 

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -108,6 +108,7 @@ export function validateConfig(config: d.Config): { config: d.Config, diagnostic
 
   setBooleanConfig(config, 'generateDocs', 'docs', false);
   setBooleanConfig(config, 'enableCache', 'cache', true);
+  setBooleanConfig(config, 'allowInlineScripts', null, true);
 
   if (!Array.isArray(config.includeSrc)) {
     config.includeSrc = DEFAULT_INCLUDES.map(include => {

--- a/src/compiler/html/inline-esm-import.ts
+++ b/src/compiler/html/inline-esm-import.ts
@@ -25,7 +25,7 @@ export async function optimizeEsmImport(config: d.Config, compilerCtx: d.Compile
 
   // If the script is too big, instead of inlining, we hash the file and change
   // the <script> to the new location
-  if (content.length > MAX_JS_INLINE_SIZE) {
+  if (config.allowInlineScripts !== false && content.length > MAX_JS_INLINE_SIZE) {
     const hashedFile = await generateHashedCopy(config, compilerCtx, entryPath);
     if (hashedFile) {
       const hashedPath = config.sys.path.join(resourcesUrl, hashedFile);

--- a/src/compiler/html/inline-esm-import.ts
+++ b/src/compiler/html/inline-esm-import.ts
@@ -25,7 +25,7 @@ export async function optimizeEsmImport(config: d.Config, compilerCtx: d.Compile
 
   // If the script is too big, instead of inlining, we hash the file and change
   // the <script> to the new location
-  if (config.allowInlineScripts !== false && content.length > MAX_JS_INLINE_SIZE) {
+  if (config.allowInlineScripts && content.length > MAX_JS_INLINE_SIZE) {
     const hashedFile = await generateHashedCopy(config, compilerCtx, entryPath);
     if (hashedFile) {
       const hashedPath = config.sys.path.join(resourcesUrl, hashedFile);

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -6,6 +6,11 @@ export * from './stencil-public-docs';
  */
 export interface StencilConfig {
   /**
+   * By default, Stencil will attempt to optimize small scripts by inlining them in HTML. Setting 
+   * this flag to `false` will prevent this optimization and keep all scripts separate from HTML.
+   */
+  allowInlineScripts?: boolean;
+  /**
    * By default, Stencil will use the appropriate config to automatically prefix css. For example,
    * developers can write modern and standard css properties, such as "transform", and Stencil
    * will automatically add in the prefixed version, such as "-webkit-transform". To disable


### PR DESCRIPTION
We have some projects where we rely on script tags being in a certain place in the DOM. The stencil compiler moves these around when it inlines scripts. This flag would allow us to prevent inlining and keep script tags where we expect them to be in the HTML file.