### PR TITLE
fix(runtime): Safari 10.0 hydration solved by dont using performance api

### DIFF
--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -13,7 +13,7 @@ import { createTime, installDevTools } from './profile';
 
 
 export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.CustomElementsDefineOptions = {}) => {
-  if (BUILD.profile) {
+  if (BUILD.profile && performance.mark) {
     performance.mark('st:app:start');
   }
   installDevTools();

--- a/src/runtime/profile.ts
+++ b/src/runtime/profile.ts
@@ -6,7 +6,7 @@ import { HOST_FLAGS } from '@utils';
 let i = 0;
 
 export const createTime = (fnName: string, tagName = '') => {
-  if (BUILD.profile) {
+  if (BUILD.profile && performance.mark) {
     const key = `st:${fnName}:${tagName}:${i++}`;
     // Start
     performance.mark(key);
@@ -19,7 +19,7 @@ export const createTime = (fnName: string, tagName = '') => {
 };
 
 export const uniqueTime = (key: string, measureText: string) => {
-  if (BUILD.profile) {
+  if (BUILD.profile && performance.mark) {
     if (performance.getEntriesByName(key).length === 0) {
       performance.mark(key);
     }

--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -279,7 +279,7 @@ export const appDidLoad = (who: string) => {
     plt.$flags$ |= PLATFORM_FLAGS.appLoaded;
   }
   emitLifecycleEvent(doc, 'appload');
-  if (BUILD.profile) {
+  if (BUILD.profile && performance.measure) {
     performance.measure(`[Stencil] ${NAMESPACE} initial load (by ${who})`, 'st:app:start');
   }
 };


### PR DESCRIPTION
See issue: https://github.com/ionic-team/stencil/issues/2080

This solves the Safari 10.0 iOS hydration.

Because the Performance api in this Safari only has method `now()`.

Cheers