### PR TITLE
fix(hydrate): don’t run initializeDocumentHydrate on unsupported browsers

### DIFF
--- a/src/runtime/client-hydrate.ts
+++ b/src/runtime/client-hydrate.ts
@@ -235,6 +235,11 @@ const clientHydrate = (
 
 
 export const initializeDocumentHydrate = (node: d.RenderNode, orgLocNodes: Map<string, any>) => {
+  // Make sure the below code isn’t executed in IE11 or Edge
+  // as it’d break prerendered content’s client-side hydration
+  if (!document.documentElement.attachShadow) {
+    return
+  }
   if (node.nodeType === NODE_TYPE.ElementNode) {
     let i = 0;
     for (; i < node.childNodes.length; i++) {


### PR DESCRIPTION
This pull fixes #2068 partly by making the client-side hydration of prerendered content fully work in IE11 and latest Edge versions. 

With this small change `<slot/>` contents aren’t anymore breaking in IE11 and Edge when client-side hydration happens for prerendered content. This does not alter the functionality for Chrome and other modern browsers that support `attachShadow`.