### PR TITLE
Every JSX element should have a "key"

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1141,7 +1141,6 @@ export namespace JSXBase {
   export interface HTMLAttributes<T = HTMLElement> extends DOMAttributes<T> {
     // vdom specific
     innerHTML?: string;
-    key?: string | number;
 
     // Standard HTML Attributes
     accessKey?: string;
@@ -1472,6 +1471,9 @@ export namespace JSXBase {
   }
 
   export interface DOMAttributes<T = Element> {
+    // vdom specific
+    key?: string | number;
+                              
     ref?: (elm?: T) => void;
     slot?: string;
 


### PR DESCRIPTION
Fixes:

<svg key={...} /> // Property 'key' does not exist on type 'SVGAttributes<SVGElement>'.ts(2322)