### PR TITLE
feat(docs): Add documentation output for Shadow Parts

### DIFF
--- a/src/compiler/docs/generate-doc-data.ts
+++ b/src/compiler/docs/generate-doc-data.ts
@@ -48,9 +48,10 @@ const getComponents = async (config: d.Config, compilerCtx: d.CompilerCtx, build
         methods: getMethods(cmp.methods),
         events: getEvents(cmp.events),
         styles: getStyles(cmp),
-        slots: getSlots(cmp.docs.tags)
+        slots: getSlots(cmp.docs.tags),
+        parts: getParts(cmp.docs.tags)
       }));
-    }));
+  }));
 
   return sortBy(flatOne(results), cmp => cmp.tag);
 };
@@ -237,13 +238,19 @@ const getDeprecation = (tags: d.JsonDocsTag[]) => {
 const getSlots = (tags: d.JsonDocsTag[]): d.JsonDocsSlot[] => {
   return sortBy(getNameText('slot', tags)
     .map(([name, docs]) => ({ name, docs }))
-  , a => a.name);
+    , a => a.name);
+};
+
+const getParts = (tags: d.JsonDocsTag[]): d.JsonDocsSlot[] => {
+  return sortBy(getNameText('part', tags)
+    .map(([name, docs]) => ({ name, docs }))
+    , a => a.name);
 };
 
 export const getNameText = (name: string, tags: d.JsonDocsTag[]) => {
   return tags
     .filter(tag => tag.name === name && tag.text)
-    .map(({text}) => {
+    .map(({ text }) => {
       const [namePart, ...rest] = (' ' + text).split(' - ');
       return [
         namePart.trim(),
@@ -259,7 +266,7 @@ const getUserReadmeContent = async (compilerCtx: d.CompilerCtx, readmePath: stri
     if (userContentIndex >= 0) {
       return existingContent.substring(0, userContentIndex);
     }
-  } catch (e) {}
+  } catch (e) { }
   return undefined;
 };
 
@@ -316,7 +323,7 @@ const generateUsages = async (config: d.Config, compilerCtx: d.CompilerCtx, usag
       rtn[key] = usages[key];
     });
 
-  } catch (e) {}
+  } catch (e) { }
 
   return rtn;
 };

--- a/src/compiler/docs/readme/markdown-parts.ts
+++ b/src/compiler/docs/readme/markdown-parts.ts
@@ -1,0 +1,29 @@
+import * as d from '../../../declarations';
+import { MarkdownTable } from './docs-util';
+
+
+export const partsToMarkdown = (parts: d.JsonDocsSlot[]) => {
+	const content: string[] = [];
+	if (parts.length === 0) {
+		return content;
+	}
+
+	content.push(`## Shadow Parts`);
+	content.push(``);
+
+	const table = new MarkdownTable();
+	table.addHeader(['Part', 'Description']);
+
+	parts.forEach(style => {
+		table.addRow([
+			style.name === '' ? '' : `\`"${style.name}"\``,
+			style.docs
+		]);
+	});
+
+	content.push(...table.toMarkdown());
+	content.push(``);
+	content.push(``);
+
+	return content;
+};

--- a/src/compiler/docs/readme/output-docs.ts
+++ b/src/compiler/docs/readme/output-docs.ts
@@ -5,6 +5,7 @@ import { methodsToMarkdown } from './markdown-methods';
 import { usageToMarkdown } from './markdown-usage';
 import { stylesToMarkdown } from './markdown-css-props';
 import { slotsToMarkdown } from './markdown-slots';
+import { partsToMarkdown } from './markdown-parts';
 import { depsToMarkdown } from './markdown-dependencies';
 import { AUTO_GENERATE_COMMENT } from '../../docs/constants';
 
@@ -42,6 +43,7 @@ export const generateMarkdown = (config: d.Config, userContent: string, cmp: d.J
     ...eventsToMarkdown(cmp.events),
     ...methodsToMarkdown(cmp.methods),
     ...slotsToMarkdown(cmp.slots),
+    ...partsToMarkdown(cmp.parts),
     ...stylesToMarkdown(cmp.styles),
     ...depsToMarkdown(config, cmp, cmps),
     `----------------------------------------------`,

--- a/src/declarations/stencil-public-docs.ts
+++ b/src/declarations/stencil-public-docs.ts
@@ -25,6 +25,7 @@ export interface JsonDocsComponent {
   events: JsonDocsEvent[];
   styles: JsonDocsStyle[];
   slots: JsonDocsSlot[];
+  parts: JsonDocsPart[];
   dependents: string[];
   dependencies: string[];
   dependencyGraph: JsonDocsDependencyGraph;
@@ -103,6 +104,11 @@ export interface JsonDocsStyle {
 }
 
 export interface JsonDocsSlot {
+  name: string;
+  docs: string;
+}
+
+export interface JsonDocsPart {
   name: string;
   docs: string;
 }

--- a/test/end-to-end/package.json
+++ b/test/end-to-end/package.json
@@ -6,7 +6,7 @@
   "types": "dist/types/components.d.ts",
   "collection": " dist/collection/collection-manifest.json",
   "scripts": {
-    "build": "node ../../bin/stencil build --next",
+    "build": "node ../../bin/stencil build --next --docs",
     "start": "node ../../bin/stencil build --debug --watch --dev --serve",
     "test": "node ../../bin/stencil test --ci --e2e --spec --screenshot",
     "test.e2e": "node ../../bin/stencil test --e2e",

--- a/test/end-to-end/src/car-list/car-list.tsx
+++ b/test/end-to-end/src/car-list/car-list.tsx
@@ -1,7 +1,11 @@
 import { Component, Event, EventEmitter, Prop, h } from '@stencil/core';
 import { CarData } from './car-data';
 
-
+/**
+ * Component that helps display a list of cars
+ * @slot header - The slot for the header content.
+ * @part car - The shadow part to target to style the car.
+ */
 @Component({
   tag: 'car-list',
   styleUrl: 'car-list.css',


### PR DESCRIPTION
Parse comments for @part and output docs in json and the readme files. From https://github.com/ionic-team/stencil/issues/2121