### PR TITLE
fix(cli): Update tests in task generator

### DIFF
--- a/src/cli_next/tasks/task-generate.ts
+++ b/src/cli_next/tasks/task-generate.ts
@@ -146,11 +146,22 @@ const getStyleUrlBoilerplate = () =>
  * Get the boilerplate for a spec test.
  */
 const getSpecTestBoilerplate = (tagName: string) =>
-`import { ${toPascalCase(tagName)} } from './${tagName}';
+`import { newSpecPage } from '@stencil/core/testing';
+import { ${toPascalCase(tagName)} } from './${tagName}';
 
 describe('${tagName}', () => {
-  it('builds', () => {
-    expect(new ${toPascalCase(tagName)}()).toBeTruthy();
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [${toPascalCase(tagName)}],
+      html: \`<${tagName}></${tagName}>\`,
+    });
+    expect(page.root).toEqualHtml(\`
+      <${tagName}>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </${tagName}>
+    \`);
   });
 });
 `;


### PR DESCRIPTION
For generated components, this gets the default up to 100% by default.