### PR TITLE
feat: Disable the dependencies part of the markdown docs.

### DIFF
--- a/src/compiler/docs/readme/output-docs.ts
+++ b/src/compiler/docs/readme/output-docs.ts
@@ -33,7 +33,7 @@ export const generateReadme = async (config: d.Config, compilerCtx: d.CompilerCt
 
 export const generateMarkdown = (config: d.Config, userContent: string, cmp: d.JsonDocsComponent, cmps: d.JsonDocsComponent[], readmeOutput: d.OutputTargetDocsReadme) => {
   //If the readmeOutput.dependencies is true or undefined the dependencies will be generated.
-  const dependencies = readmeOutput.dependencies === true || readmeOutput.dependencies === undefined ? depsToMarkdown(config, cmp, cmps) : [];
+  const dependencies = readmeOutput.dependencies !== false ? depsToMarkdown(config, cmp, cmps) : [];
   return [
     userContent,
     AUTO_GENERATE_COMMENT,

--- a/src/compiler/docs/readme/output-docs.ts
+++ b/src/compiler/docs/readme/output-docs.ts
@@ -16,7 +16,7 @@ export const generateReadme = async (config: d.Config, compilerCtx: d.CompilerCt
 
   await Promise.all(readmeOutputs.map(async readmeOutput => {
     if (readmeOutput.dir) {
-      const readmeContent = generateMarkdown(config, userContent, docsData, cmps, readmeOutput.footer);
+      const readmeContent = generateMarkdown(config, userContent, docsData, cmps, readmeOutput);
       const relPath = config.sys.path.relative(config.srcDir, docsData.readmePath);
       const absPath = config.sys.path.join(readmeOutput.dir, relPath);
       const results = await compilerCtx.fs.writeFile(absPath, readmeContent);
@@ -31,7 +31,9 @@ export const generateReadme = async (config: d.Config, compilerCtx: d.CompilerCt
   }));
 };
 
-export const generateMarkdown = (config: d.Config, userContent: string, cmp: d.JsonDocsComponent, cmps: d.JsonDocsComponent[], footer: string) => {
+export const generateMarkdown = (config: d.Config, userContent: string, cmp: d.JsonDocsComponent, cmps: d.JsonDocsComponent[], readmeOutput: d.OutputTargetDocsReadme) => {
+  //If the readmeOutput.dependencies is true or undefined the dependencies will be generated.
+  const dependencies = readmeOutput.dependencies === true || readmeOutput.dependencies === undefined ? depsToMarkdown(config, cmp, cmps) : [];
   return [
     userContent,
     AUTO_GENERATE_COMMENT,
@@ -45,10 +47,10 @@ export const generateMarkdown = (config: d.Config, userContent: string, cmp: d.J
     ...slotsToMarkdown(cmp.slots),
     ...partsToMarkdown(cmp.parts),
     ...stylesToMarkdown(cmp.styles),
-    ...depsToMarkdown(config, cmp, cmps),
+    ...dependencies,
     `----------------------------------------------`,
     '',
-    footer,
+    readmeOutput.footer,
     ''
   ].join('\n');
 };

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1152,8 +1152,8 @@ export interface OutputTargetDocsVscode extends OutputTargetBase {
 
 export interface OutputTargetDocsReadme extends OutputTargetBase {
   type: 'docs-readme' | 'docs';
-
   dir?: string;
+  dependencies?: boolean;
   footer?: string;
   strict?: boolean;
 }


### PR DESCRIPTION
I have added a dependencies: boolean property to OutputTargetDocsReadme, this allows the developer to disable the dependencies part of the markdown readme.md file.

If the property is undefined the dependencies will still be rendered.