### PR TITLE
fix(runtime): apply hydrated marker as attribute alongside class

### DIFF
--- a/src/cli/task-generate.ts
+++ b/src/cli/task-generate.ts
@@ -170,6 +170,7 @@ describe('${name}', () => {
 
     const element = await page.find('${name}');
     expect(element).toHaveClass('hydrated');
+    expect(element).toHaveAttribute('data-hydrated');
   });
 });
 `;

--- a/src/cli_next/tasks/task-generate.ts
+++ b/src/cli_next/tasks/task-generate.ts
@@ -179,6 +179,7 @@ describe('${name}', () => {
 
     const element = await page.find('${name}');
     expect(element).toHaveClass('hydrated');
+    expect(element).toHaveAttribute('data-hydrated');
   });
 });
 `;

--- a/src/hydrate/runner/render.ts
+++ b/src/hydrate/runner/render.ts
@@ -198,6 +198,7 @@ function finalizeHydrate(win: Window, doc: Document, opts: HydrateFactoryOptions
 
     if (opts.clientHydrateAnnotations) {
       doc.documentElement.classList.add('hydrated');
+      doc.documentElement.dataset.hydrated = "";
     }
 
     if (opts.serializeToHtml) {

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -163,7 +163,7 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
     }));
 
   // visibilityStyle.innerHTML = cmpTags.map(t => `${t}:not(.hydrated)`) + '{display:none}';
-  visibilityStyle.innerHTML = cmpTags + '{visibility:hidden}.hydrated{visibility:inherit}';
+  visibilityStyle.innerHTML = cmpTags + '{visibility:hidden} .hydrated,[data-hydrated]{visibility:inherit}';
   visibilityStyle.setAttribute('data-styles', '');
   head.insertBefore(visibilityStyle, y ? y.nextSibling : head.firstChild);
 

--- a/src/runtime/test/before-each.spec.tsx
+++ b/src/runtime/test/before-each.spec.tsx
@@ -34,7 +34,7 @@ describe('newSpecPage, spec testing', () => {
 
   it('renders changes to the name data', async () => {
     expect(root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <mock:shadow-root>
           <div>
             Hello, World! I'm
@@ -43,6 +43,7 @@ describe('newSpecPage, spec testing', () => {
       </cmp-a>
     `);
     expect(root).toHaveClass('hydrated');
+    expect(root).toHaveAttribute('data-hydrated');
     const div = root.shadowRoot.querySelector('div');
     expect(div.textContent).toEqual(`Hello, World! I'm `);
 

--- a/src/runtime/test/hydrate-no-encapsulation.spec.tsx
+++ b/src/runtime/test/hydrate-no-encapsulation.spec.tsx
@@ -22,7 +22,7 @@ describe('hydrate no encapsulation', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
         <p c-id="1.0.0.0" class="hi">
           <!--t.1.1.1.0-->
@@ -42,7 +42,7 @@ describe('hydrate no encapsulation', () => {
     expect(clientHydrated.root['s-cr']['s-cn']).toBe(true);
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
         <p class="hi">
           Hello
@@ -69,7 +69,7 @@ describe('hydrate no encapsulation', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
         <!--t.1.0.0.0-->
         Hello
@@ -87,7 +87,7 @@ describe('hydrate no encapsulation', () => {
     expect(clientHydrated.root['s-cr']['s-cn']).toBe(true);
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
         Hello
       </cmp-a>
@@ -114,7 +114,7 @@ describe('hydrate no encapsulation', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
         <!--t.1.0.0.0-->
         top
@@ -136,7 +136,7 @@ describe('hydrate no encapsulation', () => {
     expect(clientHydrated.root['s-id']).toBe('1');
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
         top
         <p>
@@ -176,9 +176,9 @@ describe('hydrate no encapsulation', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
-        <cmp-b class="hydrated" c-id="1.0.0.0" s-id="2">
+        <cmp-b class="hydrated" data-hydrated c-id="1.0.0.0" s-id="2">
           <!--r.2-->
           <!--o.1.1-->
           <!--s.2.0.0.0.-->
@@ -197,9 +197,9 @@ describe('hydrate no encapsulation', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
-        <cmp-b class="hydrated">
+        <cmp-b class="hydrated" data-hydrated>
           <!--r.2-->
           <!---->
           <!--s.2.0.0.0.-->
@@ -240,9 +240,9 @@ describe('hydrate no encapsulation', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
-        <cmp-b class="hydrated" c-id="1.0.0.0" s-id="2">
+        <cmp-b class="hydrated" data-hydrated c-id="1.0.0.0" s-id="2">
           <!--r.2-->
           <!--o.1.1-->
           <header c-id="2.0.0.0"></header>
@@ -261,9 +261,9 @@ describe('hydrate no encapsulation', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
-        <cmp-b class="hydrated">
+        <cmp-b class="hydrated" data-hydrated>
           <!--r.2-->
           <!---->
           <header></header>
@@ -304,9 +304,9 @@ describe('hydrate no encapsulation', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
-        <cmp-b class="hydrated" c-id="1.0.0.0" s-id="2">
+        <cmp-b class="hydrated" data-hydrated c-id="1.0.0.0" s-id="2">
           <!--r.2-->
           <!--o.1.1-->
           <header c-id="2.0.0.0"></header>
@@ -326,9 +326,9 @@ describe('hydrate no encapsulation', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
-        <cmp-b class="hydrated">
+        <cmp-b class="hydrated" data-hydrated>
           <!--r.2-->
           <!---->
           <header></header>
@@ -376,9 +376,9 @@ describe('hydrate no encapsulation', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
-        <cmp-b class="hydrated" c-id="1.0.0.0" s-id="2">
+        <cmp-b class="hydrated" data-hydrated c-id="1.0.0.0" s-id="2">
           <!--r.2-->
           <!--o.1.1-->
           <!--o.1.3-->
@@ -410,9 +410,9 @@ describe('hydrate no encapsulation', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
-        <cmp-b class="hydrated">
+        <cmp-b class="hydrated" data-hydrated>
           <!--r.2-->
           <!---->
           <!---->

--- a/src/runtime/test/hydrate-prop-types.spec.tsx
+++ b/src/runtime/test/hydrate-prop-types.spec.tsx
@@ -26,7 +26,7 @@ describe('hydrate prop types', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" num="1" s-id="1">
+      <cmp-a class="hydrated" data-hydrated num="1" s-id="1">
         <!--r.1-->
         <!--t.1.0.0.0-->
         101
@@ -44,7 +44,7 @@ describe('hydrate prop types', () => {
     expect(clientHydrated.root['s-cr']['s-cn']).toBe(true);
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" num="1">
+      <cmp-a class="hydrated" data-hydrated num="1">
         <!--r.1-->
         101
       </cmp-a>

--- a/src/runtime/test/hydrate-scoped.spec.tsx
+++ b/src/runtime/test/hydrate-scoped.spec.tsx
@@ -24,7 +24,7 @@ describe('hydrate scoped', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
         <!--o.0.1.-->
         <article c-id="1.0.0.0">
@@ -44,7 +44,7 @@ describe('hydrate scoped', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
         <!---->
         <article>
@@ -75,7 +75,7 @@ describe('hydrate scoped', () => {
       hydrateServerSide: true,
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
         <!--o.0.1.c-->
         <article c-id="1.0.0.0">
@@ -97,7 +97,7 @@ describe('hydrate scoped', () => {
     expect(clientHydrated.root['s-cr']['s-cn']).toBe(true);
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
         <!---->
         <article>
@@ -126,7 +126,7 @@ describe('hydrate scoped', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
         <p c-id="1.0.0.0" class="hi">
           <!--t.1.1.1.0-->
@@ -146,7 +146,7 @@ describe('hydrate scoped', () => {
     expect(clientHydrated.root['s-cr']['s-cn']).toBe(true);
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
         <p class="hi">
           Hello

--- a/src/runtime/test/hydrate-shadow-child.spec.tsx
+++ b/src/runtime/test/hydrate-shadow-child.spec.tsx
@@ -22,7 +22,7 @@ describe('hydrate, shadow child', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
         <p c-id="1.0.0.0">
           <!--t.1.1.1.0-->
@@ -40,7 +40,7 @@ describe('hydrate, shadow child', () => {
     expect(clientHydrated.root['s-id']).toBe('1');
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <mock:shadow-root>
           <p>
             Hello
@@ -78,9 +78,9 @@ describe('hydrate, shadow child', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
-        <cmp-b class="hydrated" c-id="1.0.0.0" s-id="2">
+        <cmp-b class="hydrated" data-hydrated c-id="1.0.0.0" s-id="2">
           <!--r.2-->
           <!--o.1.1.-->
           <!--s.2.0.0.0.-->
@@ -98,9 +98,9 @@ describe('hydrate, shadow child', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
-        <cmp-b class="hydrated">
+        <cmp-b class="hydrated" data-hydrated>
           <mock:shadow-root>
             <slot></slot>
           </mock:shadow-root>
@@ -140,9 +140,9 @@ describe('hydrate, shadow child', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
-        <cmp-b class="hydrated" c-id="1.0.0.0" s-id="2">
+        <cmp-b class="hydrated" data-hydrated c-id="1.0.0.0" s-id="2">
           <!--r.2-->
           <header c-id="2.0.0.0"></header>
           <!--s.2.1.0.1.-->
@@ -158,9 +158,9 @@ describe('hydrate, shadow child', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
-        <cmp-b class="hydrated">
+        <cmp-b class="hydrated" data-hydrated>
           <mock:shadow-root>
             <header></header>
             <slot></slot>
@@ -199,9 +199,9 @@ describe('hydrate, shadow child', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
-        <cmp-b class="hydrated" c-id="1.0.0.0" s-id="2">
+        <cmp-b class="hydrated" data-hydrated c-id="1.0.0.0" s-id="2">
           <!--r.2-->
           <!--t.2.0.0.0-->
           shadow-header
@@ -218,9 +218,9 @@ describe('hydrate, shadow child', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
-        <cmp-b class="hydrated">
+        <cmp-b class="hydrated" data-hydrated>
           <mock:shadow-root>
             shadow-header
             <slot></slot>
@@ -259,9 +259,9 @@ describe('hydrate, shadow child', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
-        <cmp-b class="hydrated" c-id="1.0.0.0" s-id="2">
+        <cmp-b class="hydrated" data-hydrated c-id="1.0.0.0" s-id="2">
           <!--r.2-->
           <!--o.1.1.-->
           <header c-id="2.0.0.0"></header>
@@ -280,9 +280,9 @@ describe('hydrate, shadow child', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
-        <cmp-b class="hydrated">
+        <cmp-b class="hydrated" data-hydrated>
           <mock:shadow-root>
             <header></header>
             <slot></slot>
@@ -323,9 +323,9 @@ describe('hydrate, shadow child', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
-        <cmp-b class="hydrated" c-id="1.0.0.0" s-id="2">
+        <cmp-b class="hydrated" data-hydrated c-id="1.0.0.0" s-id="2">
           <!--r.2-->
           <!--t.2.0.0.0-->
           shadow-header
@@ -345,9 +345,9 @@ describe('hydrate, shadow child', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
-        <cmp-b class="hydrated">
+        <cmp-b class="hydrated" data-hydrated>
           <mock:shadow-root>
             shadow-header
             <footer>
@@ -389,9 +389,9 @@ describe('hydrate, shadow child', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
-        <cmp-b class="hydrated" c-id="1.0.0.0" s-id="2">
+        <cmp-b class="hydrated" data-hydrated c-id="1.0.0.0" s-id="2">
           <!--r.2-->
           <!--o.1.1.-->
           <header c-id="2.0.0.0"></header>
@@ -411,9 +411,9 @@ describe('hydrate, shadow child', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
-        <cmp-b class="hydrated">
+        <cmp-b class="hydrated" data-hydrated>
           <mock:shadow-root>
             <header></header>
             <slot></slot>
@@ -473,9 +473,9 @@ describe('hydrate, shadow child', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
-        <cmp-b class="hydrated" s-id="2">
+        <cmp-b class="hydrated" data-hydrated s-id="2">
           <!--r.2-->
           <!--o.0.1.-->
           <!--o.0.2.-->
@@ -483,7 +483,7 @@ describe('hydrate, shadow child', () => {
             <!--s.2.1.1.0.-->
             <!--t.0.1-->
             cmp-b-top-text
-            <cmp-c class="hydrated" c-id="0.2" s-id="3">
+            <cmp-c class="hydrated" data-hydrated c-id="0.2" s-id="3">
               <!--r.3-->
               <article c-id="3.0.0.0">
                 <!--t.3.1.1.0-->
@@ -503,9 +503,9 @@ describe('hydrate, shadow child', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
-        <cmp-b class="hydrated">
+        <cmp-b class="hydrated" data-hydrated>
           <mock:shadow-root>
             <section>
               <slot></slot>
@@ -514,7 +514,7 @@ describe('hydrate, shadow child', () => {
           <!---->
           cmp-b-top-text
           <!---->
-          <cmp-c class="hydrated">
+          <cmp-c class="hydrated" data-hydrated>
             <mock:shadow-root>
               <article>
                 cmp-c

--- a/src/runtime/test/hydrate-shadow-in-shadow.spec.tsx
+++ b/src/runtime/test/hydrate-shadow-in-shadow.spec.tsx
@@ -34,10 +34,10 @@ describe('hydrate, shadow in shadow', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
         <!--o.0.1.-->
-        <cmp-b class="hydrated" c-id="1.0.0.0" s-id="2">
+        <cmp-b class="hydrated" data-hydrated c-id="1.0.0.0" s-id="2">
           <!--r.2-->
           <!--o.1.1.-->
           <!--s.2.0.0.0.-->
@@ -56,9 +56,9 @@ describe('hydrate, shadow in shadow', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <mock:shadow-root>
-          <cmp-b class="hydrated">
+          <cmp-b class="hydrated" data-hydrated>
             <mock:shadow-root>
               <slot></slot>
             </mock:shadow-root>
@@ -71,7 +71,7 @@ describe('hydrate, shadow in shadow', () => {
       </cmp-a>
     `);
     expect(clientHydrated.root).toEqualLightHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!---->
         light-dom
       </cmp-a>
@@ -106,9 +106,9 @@ describe('hydrate, shadow in shadow', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
-        <cmp-b class="hydrated" c-id="1.0.0.0" s-id="2">
+        <cmp-b class="hydrated" data-hydrated c-id="1.0.0.0" s-id="2">
           <!--r.2-->
           <!--o.1.1.-->
           <!--s.2.0.0.0.-->
@@ -126,9 +126,9 @@ describe('hydrate, shadow in shadow', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <mock:shadow-root>
-          <cmp-b class="hydrated">
+          <cmp-b class="hydrated" data-hydrated>
             <mock:shadow-root>
               <slot></slot>
             </mock:shadow-root>
@@ -169,9 +169,9 @@ describe('hydrate, shadow in shadow', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
-        <cmp-b class="hydrated" c-id="1.0.0.0" s-id="2">
+        <cmp-b class="hydrated" data-hydrated c-id="1.0.0.0" s-id="2">
           <!--r.2-->
           <header c-id="2.0.0.0"></header>
           <!--s.2.1.0.1.-->
@@ -187,9 +187,9 @@ describe('hydrate, shadow in shadow', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
-        <cmp-b class="hydrated">
+        <cmp-b class="hydrated" data-hydrated>
           <mock:shadow-root>
             <header></header>
             <slot></slot>
@@ -228,9 +228,9 @@ describe('hydrate, shadow in shadow', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
-        <cmp-b class="hydrated" c-id="1.0.0.0" s-id="2">
+        <cmp-b class="hydrated" data-hydrated c-id="1.0.0.0" s-id="2">
           <!--r.2-->
           <!--t.2.0.0.0-->
           shadow-header
@@ -247,9 +247,9 @@ describe('hydrate, shadow in shadow', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
-        <cmp-b class="hydrated">
+        <cmp-b class="hydrated" data-hydrated>
           <mock:shadow-root>
             shadow-header
             <slot></slot>
@@ -288,9 +288,9 @@ describe('hydrate, shadow in shadow', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
-        <cmp-b class="hydrated" c-id="1.0.0.0" s-id="2">
+        <cmp-b class="hydrated" data-hydrated c-id="1.0.0.0" s-id="2">
           <!--r.2-->
           <!--o.1.1.-->
           <header c-id="2.0.0.0"></header>
@@ -309,9 +309,9 @@ describe('hydrate, shadow in shadow', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
-        <cmp-b class="hydrated">
+        <cmp-b class="hydrated" data-hydrated>
           <mock:shadow-root>
             <header></header>
             <slot></slot>
@@ -352,9 +352,9 @@ describe('hydrate, shadow in shadow', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
-        <cmp-b class="hydrated" c-id="1.0.0.0" s-id="2">
+        <cmp-b class="hydrated" data-hydrated c-id="1.0.0.0" s-id="2">
           <!--r.2-->
           <!--t.2.0.0.0-->
           shadow-header
@@ -374,9 +374,9 @@ describe('hydrate, shadow in shadow', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
-        <cmp-b class="hydrated">
+        <cmp-b class="hydrated" data-hydrated>
           <mock:shadow-root>
             shadow-header
             <footer>
@@ -418,9 +418,9 @@ describe('hydrate, shadow in shadow', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
-        <cmp-b class="hydrated" c-id="1.0.0.0" s-id="2">
+        <cmp-b class="hydrated" data-hydrated c-id="1.0.0.0" s-id="2">
           <!--r.2-->
           <!--o.1.1.-->
           <header c-id="2.0.0.0"></header>
@@ -440,9 +440,9 @@ describe('hydrate, shadow in shadow', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
-        <cmp-b class="hydrated">
+        <cmp-b class="hydrated" data-hydrated>
           <mock:shadow-root>
             <header></header>
             <slot></slot>

--- a/src/runtime/test/hydrate-shadow-parent.spec.tsx
+++ b/src/runtime/test/hydrate-shadow-parent.spec.tsx
@@ -30,7 +30,7 @@ describe('hydrate, shadow parent', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
         <!--o.0.1.-->
         <div c-id="1.0.0.0">
@@ -50,7 +50,7 @@ describe('hydrate, shadow parent', () => {
     expect(clientHydrated.root['s-id']).toBe('1');
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <mock:shadow-root>
           <div>
             <slot></slot>
@@ -88,7 +88,7 @@ describe('hydrate, shadow parent', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
         <!--o.0.1.-->
         <!--t.1.0.0.0-->
@@ -110,7 +110,7 @@ describe('hydrate, shadow parent', () => {
     expect(clientHydrated.root['s-id']).toBe('1');
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <mock:shadow-root>
           top
           <slot></slot>
@@ -146,7 +146,7 @@ describe('hydrate, shadow parent', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
         <!--t.1.0.0.0-->
         shadow-text
@@ -162,7 +162,7 @@ describe('hydrate, shadow parent', () => {
     expect(clientHydrated.root['s-id']).toBe('1');
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <mock:shadow-root>
           shadow-text
         </mock:shadow-root>
@@ -197,7 +197,7 @@ describe('hydrate, shadow parent', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
         <div c-id="1.0.0.0">
           <!--s.1.1.1.0.-->
@@ -215,7 +215,7 @@ describe('hydrate, shadow parent', () => {
     expect(clientHydrated.root['s-id']).toBe('1');
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <mock:shadow-root>
           <div>
             <slot></slot>
@@ -254,9 +254,9 @@ describe('hydrate, shadow parent', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
-        <cmp-b class="hydrated" c-id="1.0.0.0" s-id="2">
+        <cmp-b class="hydrated" data-hydrated c-id="1.0.0.0" s-id="2">
           <!--r.2-->
           <!--o.1.1-->
           <!--s.2.0.0.0.-->
@@ -274,9 +274,9 @@ describe('hydrate, shadow parent', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <mock:shadow-root>
-          <cmp-b class="hydrated">
+          <cmp-b class="hydrated" data-hydrated>
             <!--r.2-->
             <!---->
             <!--s.2.0.0.0.-->
@@ -286,7 +286,7 @@ describe('hydrate, shadow parent', () => {
       </cmp-a>
     `);
     expect(clientHydrated.root).toEqualLightHtml(`
-      <cmp-a class="hydrated"></cmp-a>
+      <cmp-a class="hydrated" data-hydrated></cmp-a>
     `);
   });
 
@@ -320,7 +320,7 @@ describe('hydrate, shadow parent', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
         <!--o.0.1.-->
         <section c-id="1.0.0.0">
@@ -345,7 +345,7 @@ describe('hydrate, shadow parent', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <mock:shadow-root>
           <section>
             <slot name="start"></slot>
@@ -362,7 +362,7 @@ describe('hydrate, shadow parent', () => {
       </cmp-a>
     `);
     expect(clientHydrated.root).toEqualLightHtml(`
-    <cmp-a class="hydrated">
+    <cmp-a class="hydrated" data-hydrated>
       <!---->
       Title
     </cmp-a>
@@ -412,19 +412,19 @@ describe('hydrate, shadow parent', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <ion-tab-button class="hydrated" s-id="1">
+      <ion-tab-button class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
         <!--o.0.2.-->
         <a c-id="1.0.0.0">
           <!--s.1.1.1.0.-->
-          <ion-badge class="hydrated" c-id="0.2" s-id="2">
+          <ion-badge class="hydrated" data-hydrated c-id="0.2" s-id="2">
             <!--r.2-->
             <!--o.0.4.-->
             <!--s.2.0.0.0.-->
             <!--t.0.4-->
             root-text
           </ion-badge>
-          <ion-ripple-effect class="hydrated" c-id="1.2.1.1" s-id="3">
+          <ion-ripple-effect class="hydrated" data-hydrated c-id="1.2.1.1" s-id="3">
             <!--r.3-->
           </ion-ripple-effect>
         </a>
@@ -439,18 +439,18 @@ describe('hydrate, shadow parent', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <ion-tab-button class="hydrated">
+      <ion-tab-button class="hydrated" data-hydrated>
         <mock:shadow-root>
           <a>
             <slot></slot>
-            <ion-ripple-effect class="hydrated">
+            <ion-ripple-effect class="hydrated" data-hydrated>
               <mock:shadow-root>
               </mock:shadow-root>
             </ion-ripple-effect>
           </a>
         </mock:shadow-root>
         <!---->
-        <ion-badge class="hydrated">
+        <ion-badge class="hydrated" data-hydrated>
           <mock:shadow-root>
             <slot></slot>
           </mock:shadow-root>

--- a/src/runtime/test/hydrate-shadow.spec.tsx
+++ b/src/runtime/test/hydrate-shadow.spec.tsx
@@ -38,9 +38,9 @@ describe('hydrate, shadow', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
-        <cmp-b c-id="1.0.0.0" class="hydrated" s-id="2">
+        <cmp-b c-id="1.0.0.0" class="hydrated" data-hydrated s-id="2">
           <!--r.2-->
           <!--o.1.1.-->
           <article c-id="2.0.0.0">
@@ -59,9 +59,9 @@ describe('hydrate, shadow', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
-        <cmp-b class="hydrated">
+        <cmp-b class="hydrated" data-hydrated>
           <mock:shadow-root>
             <article>
               <slot></slot>
@@ -113,7 +113,7 @@ describe('hydrate, shadow', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
         <!--o.0.2.-->
         <article c-id="1.0.0.0">
@@ -149,7 +149,7 @@ describe('hydrate, shadow', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <mock:shadow-root>
           <article>
             <section>

--- a/src/runtime/test/hydrate-style-element.spec.tsx
+++ b/src/runtime/test/hydrate-style-element.spec.tsx
@@ -20,7 +20,7 @@ describe('hydrate style element', () => {
       hydrateServerSide: true
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated" s-id="1">
+      <cmp-a class="hydrated" data-hydrated s-id="1">
         <!--r.1-->
         <style c-id="1.0.0.0">div { color: red; }</style>
       </cmp-a>
@@ -33,7 +33,7 @@ describe('hydrate style element', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!--r.1-->
         <style>div { color: red; }</style>
       </cmp-a>

--- a/src/runtime/test/hydrated.spec.tsx
+++ b/src/runtime/test/hydrated.spec.tsx
@@ -16,10 +16,10 @@ describe('globals', () => {
       includeAnnotations: true
     });
     const html = page.doc.documentElement;
-    expect(html.classList.contains('hydrated')).toBe(false);
+    expect(html.dataset.hydrated).toBeUndefined();
     await new Promise(resolve => {
       setTimeout(() => {
-        expect(html.classList.contains('hydrated')).toBe(true);
+        expect(html.dataset.hydrated).toEqual('');
         resolve();
       }, 100);
     });
@@ -32,7 +32,7 @@ describe('globals', () => {
       includeAnnotations: true
     });
     const html = page.doc.documentElement;
-    expect(html.classList.contains('hydrated')).toBe(true);
+    expect(html.dataset.hydrated).toEqual('');
   });
 
   it('should hide non hydrated components', async () => {
@@ -47,7 +47,7 @@ describe('globals', () => {
     });
     expect(doc.head.children[0]).toEqualHtml(`
       <style data-styles>
-        cmp-a,cmp-b{visibility:hidden}.hydrated{visibility:inherit}
+        cmp-a,cmp-b{visibility:hidden} .hydrated,[data-hydrated]{visibility:inherit}
       </style>
     `);
   });

--- a/src/runtime/test/lifecycle-sync.spec.tsx
+++ b/src/runtime/test/lifecycle-sync.spec.tsx
@@ -69,10 +69,10 @@ describe('lifecycle sync', () => {
       html: `<cmp-b><cmp-a></cmp-a></cmp-b>`,
     });
     expect(root).toEqualHtml(`
-      <cmp-b class="hydrated">
+      <cmp-b class="hydrated" data-hydrated>
         <!---->
         <div>
-          <cmp-a class="hydrated"></cmp-a>
+          <cmp-a class="hydrated" data-hydrated></cmp-a>
         </div>
       </cmp-b>
     `);

--- a/src/runtime/test/render-vdom.spec.tsx
+++ b/src/runtime/test/render-vdom.spec.tsx
@@ -420,7 +420,7 @@ describe('render-vdom', () => {
     });
 
     expect(root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class="hydrated" data-hydrated>
         <!---->
         <a href="#">Hello</a>
       </cmp-a>
@@ -738,7 +738,7 @@ describe('render-vdom', () => {
         includeAnnotations: true
       });
       expect(root).toEqualHtml(`
-    <cmp-a class="hydrated sc-cmp-a-h sc-cmp-a-s">
+    <cmp-a class="sc-cmp-a-h sc-cmp-a-s hydrated" data-hydrated>
       <svg class="sc-cmp-a"></svg>
     </cmp-a>
     `);
@@ -748,7 +748,7 @@ describe('render-vdom', () => {
       await waitForChanges();
 
       expect(root).toEqualHtml(`
-      <cmp-a class="hydrated sc-cmp-a-h sc-cmp-a-s">
+      <cmp-a class="sc-cmp-a-h sc-cmp-a-s hydrated" data-hydrated>
         <svg class="manual hello sc-cmp-a"></svg>
       </cmp-a>
       `);

--- a/src/runtime/test/scoped.spec.tsx
+++ b/src/runtime/test/scoped.spec.tsx
@@ -41,8 +41,8 @@ describe('scoped', () => {
     });
 
     expect(page.root).toEqualHtml(`
-    <cmp-a class="hydrated sc-cmp-a-h sc-cmp-a-s">
-      <cmp-b class="hydrated sc-cmp-a sc-cmp-b-h sc-cmp-b-s">
+    <cmp-a class="sc-cmp-a-h sc-cmp-a-s hydrated" data-hydrated>
+      <cmp-b class="sc-cmp-a sc-cmp-b-h sc-cmp-b-s hydrated" data-hydrated>
         <!---->
         <div class="sc-cmp-b sc-cmp-b-s">
           <span class="sc-cmp-a">

--- a/src/runtime/test/shadow.spec.tsx
+++ b/src/runtime/test/shadow.spec.tsx
@@ -39,7 +39,7 @@ describe('shadow', () => {
 
 
     expect(page.root).toEqualHtml(`
-    <cmp-a class="hydrated">
+    <cmp-a class="hydrated" data-hydrated>
       <mock:shadow-root>
         <div>
           <slot name=\"start\"></slot>
@@ -62,7 +62,7 @@ describe('shadow', () => {
     </cmp-a>`);
 
     expect(page.root).toEqualLightHtml(`
-    <cmp-a class="hydrated">
+    <cmp-a class="hydrated" data-hydrated>
       <span slot=\"end\">
         End
       </span>
@@ -87,7 +87,7 @@ describe('shadow', () => {
     });
 
     const expected = `
-    <cmp-a class="hydrated sc-cmp-a-h">
+    <cmp-a class="sc-cmp-a-h hydrated" data-hydrated>
       <!---->
       <div class="sc-cmp-a sc-cmp-a-s">
         <span slot=\"start\">

--- a/src/runtime/test/style.spec.tsx
+++ b/src/runtime/test/style.spec.tsx
@@ -21,7 +21,7 @@ describe('style', () => {
       html: `<cmp-a></cmp-a>`,
     });
 
-    expect(root).toHaveClass('hydrated');
+    expect(root).toHaveAttribute('data-hydrated');
     expect(styles.get('CMP-A')).toBe(`div { color: red; }`);
   });
 

--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -193,6 +193,7 @@ export const postUpdateComponent = (hostRef: d.HostRef) => {
       // DOM WRITE!
       // add the css class that this element has officially hydrated
       elm.classList.add(HYDRATED_CLASS);
+      elm.dataset.hydrated = '';
     }
 
     if (BUILD.cmpDidLoad) {
@@ -278,6 +279,7 @@ export const appDidLoad = (who: string) => {
   // we have finish the first big initial render
   if (BUILD.cssAnnotations) {
     doc.documentElement.classList.add(HYDRATED_CLASS);
+    doc.documentElement.dataset.hydrated = '';
   }
   if (!BUILD.hydrateServerSide) {
     plt.$flags$ |= PLATFORM_FLAGS.appLoaded;

--- a/test/end-to-end/src/build-data/build-data.e2e.ts
+++ b/test/end-to-end/src/build-data/build-data.e2e.ts
@@ -11,7 +11,7 @@ describe('build-data e2e', () => {
     });
     const element = await page.find('build-data')
     expect(element).toEqualHtml(`
-      <build-data class="hydrated">
+      <build-data class="hydrated" data-hydrated>
         <p>isDev: true</p>
         <p>isBrowser: true</p>
         <p>isTesting: true</p>

--- a/test/end-to-end/src/car-list/car-list.e2e.ts
+++ b/test/end-to-end/src/car-list/car-list.e2e.ts
@@ -15,7 +15,7 @@ describe('car-list', () => {
 
   it('should work without parameters', async () => {
     expect(elm).toEqualHtml(`
-      <car-list class="hydrated">
+      <car-list class="hydrated" data-hydrated>
         <mock:shadow-root></mock:shadow-root>
       </car-list>
     `);
@@ -36,25 +36,25 @@ describe('car-list', () => {
     await page.waitForChanges();
 
     expect(elm).toEqualHtml(`
-      <car-list class="hydrated">
+      <car-list class="hydrated" data-hydrated>
         <mock:shadow-root>
           <ul>
             <li class="">
-              <car-detail class="hydrated">
+              <car-detail class="hydrated" data-hydrated>
                 <section>
                   1934 Cord Model 812
                 </section>
               </car-detail>
             </li>
             <li class="">
-              <car-detail class="hydrated">
+              <car-detail class="hydrated" data-hydrated>
                 <section>
                   1935 Duesenberg SSJ
                 </section>
               </car-detail>
             </li>
             <li class="">
-              <car-detail class="hydrated">
+              <car-detail class="hydrated" data-hydrated>
                 <section>
                   1938 Alfa Romeo 2900 8c
                 </section>
@@ -70,21 +70,21 @@ describe('car-list', () => {
     expect(elm.shadowRoot).toEqualHtml(`
       <ul>
         <li>
-          <car-detail class="hydrated">
+          <car-detail class="hydrated" data-hydrated>
             <section>
               1934 Cord Model 812
             </section>
           </car-detail>
         </li>
         <li>
-          <car-detail class="hydrated">
+          <car-detail class="hydrated" data-hydrated>
             <section>
               1935 Duesenberg SSJ
             </section>
           </car-detail>
         </li>
         <li>
-          <car-detail class="hydrated">
+          <car-detail class="hydrated" data-hydrated>
             <section>
               1938 Alfa Romeo 2900 8c
             </section>

--- a/test/end-to-end/src/dom-api/dom-api.e2e.ts
+++ b/test/end-to-end/src/dom-api/dom-api.e2e.ts
@@ -12,7 +12,7 @@ describe('dom api e2e tests', () => {
 
     expect(elm).toHaveClass('class-a');
     expect(elm).not.toHaveClass('class-b');
-    expect(elm.className).toBe('class-a hydrated');
+    expect(elm).toHaveAttribute('data-hydrated');
 
     elm.classList.add('class-b', 'class-c');
 
@@ -40,7 +40,8 @@ describe('dom api e2e tests', () => {
     expect(elm.classList.contains('class-c')).toBe(true);
     expect(elm.classList.contains('class-d')).toBe(false);
 
-    expect(elm.className).toBe('class-a hydrated class-b class-c');
+    expect(elm.className).toBe('class-a class-b class-c');
+    expect(elm).toHaveAttribute('data-hydrated');
   });
 
   it('should remove css classes', async () => {
@@ -155,7 +156,7 @@ describe('dom api e2e tests', () => {
     const elm = await page.find('dom-api');
 
     expect(elm).toEqualHtml(`
-      <dom-api class="hydrated">
+      <dom-api class="hydrated" data-hydrated>
         <span data-z="z" class="red green blue" data-a="a">
           dom api
         </span>
@@ -185,13 +186,13 @@ describe('dom api e2e tests', () => {
     await page.waitForChanges();
 
     expect(elm).toEqualHtml(`
-      <dom-api class="hydrated">
+      <dom-api class="hydrated" data-hydrated>
         <div>changed content</div>
       </dom-api>
     `);
 
     expect(elm.outerHTML).toEqualHtml(`
-      <dom-api class="hydrated">
+      <dom-api class="hydrated" data-hydrated>
         <div>changed content</div>
       </dom-api>
     `);
@@ -233,7 +234,7 @@ describe('dom api e2e tests', () => {
     `);
 
     expect(elm).toEqualHtml(`
-      <dom-api class="hydrated">
+      <dom-api class="hydrated" data-hydrated>
         updated text content
       </dom-api>
     `);

--- a/test/end-to-end/src/element-cmp/element-cmp.e2e.ts
+++ b/test/end-to-end/src/element-cmp/element-cmp.e2e.ts
@@ -43,7 +43,7 @@ describe('@Element', () => {
     await page.waitForChanges();
 
     expect(elm).toEqualHtml(`
-      <element-cmp id="my-elm" class="hydrated">
+      <element-cmp id="my-elm" class="hydrated" data-hydrated>
         <div>
           inner content
         </div>


### PR DESCRIPTION
Another pass at addressing https://github.com/ionic-team/stencil/issues/2109 to not break those dependent on the `hydrated` class. We could also hide the attribute bind behind a config and add either the class or the attr; that seems like unnecessary config API bloat at this time, though.