### PR TITLE
fix(runtime): render svg #text nodes

### DIFF
--- a/src/runtime/test/render-vdom.spec.tsx
+++ b/src/runtime/test/render-vdom.spec.tsx
@@ -818,7 +818,9 @@ describe('render-vdom', () => {
                 </svg>
                 <feGaussianBlur class='is-html'>bye</feGaussianBlur>
               </foreignObject>
-              <feGaussianBlur class='is-svg'></feGaussianBlur>
+              <text class='is-svg'>Hello</text>
+              <text class='is-svg'>Bye</text>
+
             </svg>
           );
         }
@@ -856,7 +858,8 @@ describe('render-vdom', () => {
               bye
             </fegaussianblur>
           </foreignObject>
-          <feGaussianBlur class=\"is-svg\"></feGaussianBlur>
+          <text class=\"is-svg\">Hello</text>
+          <text class=\"is-svg\">Bye</text>
         </svg>
       </cmp-a>`);
     });

--- a/src/runtime/test/svg-element.spec.tsx
+++ b/src/runtime/test/svg-element.spec.tsx
@@ -1,7 +1,58 @@
 import { Component, h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
+import { Prop } from '../../declarations';
 
 describe('SVG element', () => {
+  it('should render #text nodes', async () => {
+    @Component({ tag: 'cmp-a' })
+    class CmpA {
+      @Prop() lines: any[] = [1];
+
+      render() {
+        return (
+          <svg viewBox='0 0 100 4'>
+            {this.lines.map((a) => {
+              return [
+                <text>Hola {a}</text>
+              ];
+            })}
+          </svg>
+        );
+      }
+    }
+    const { root, waitForChanges } = await newSpecPage({
+      components: [CmpA],
+      html: `<cmp-a></cmp-a>`
+    });
+    expect(root).toEqualHtml(`
+      <cmp-a>
+        <svg viewBox=\"0 0 100 4\">
+          <text>Hola 1</text>
+        </svg>
+      </cmp-a>
+    `);
+    root.lines = [1, 2];
+    debugger;
+    await waitForChanges();
+    expect(root).toEqualHtml(`
+      <cmp-a>
+        <svg viewBox=\"0 0 100 4\">
+          <text>Hola 1</text>
+          <text>Hola 2</text>
+        </svg>
+      </cmp-a>
+    `);
+
+    // Ensure all SVG elements have the SVG namespace
+    const namespaces = root.querySelectorAll('text')
+      .map((e: any) => e.namespaceURI);
+
+    expect(namespaces).toEqual([
+      'http://www.w3.org/2000/svg',
+      'http://www.w3.org/2000/svg',
+    ]);
+  });
+
   it('should render camelCase attributes', async () => {
     @Component({ tag: 'cmp-a' })
     class CmpA {

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -368,19 +368,26 @@ export const patch = (oldVNode: d.VNode, newVNode: d.VNode) => {
   const elm = newVNode.$elm$ = oldVNode.$elm$;
   const oldChildren = oldVNode.$children$;
   const newChildren = newVNode.$children$;
+  const tag = newVNode.$tag$;
+  const text = newVNode.$text$;
   let defaultHolder: Comment;
 
-  if (BUILD.svg) {
-    // test if we're rendering an svg element, or still rendering nodes inside of one
-    // only add this to the when the compiler sees we're using an svg somewhere
-    isSvgMode = newVNode.$tag$ === 'svg' ? true : (newVNode.$tag$ === 'foreignObject' ? false : isSvgMode);
-  }
+  if (!BUILD.vdomText || text === null) {
 
-  if (!BUILD.vdomText || newVNode.$text$ === null) {
+    if (BUILD.svg) {
+      // test if we're rendering an svg element, or still rendering nodes inside of one
+      // only add this to the when the compiler sees we're using an svg somewhere
+      isSvgMode = (tag === 'svg')
+        ? true
+        : (tag === 'foreignObject')
+          ? false
+          : isSvgMode;
+    }
+
     // element node
 
     if (BUILD.vdomAttribute || BUILD.reflect) {
-      if (BUILD.slot && newVNode.$tag$ === 'slot') {
+      if (BUILD.slot && tag === 'slot') {
         // minifier will clean this up
 
       } else {
@@ -409,18 +416,18 @@ export const patch = (oldVNode: d.VNode, newVNode: d.VNode) => {
       removeVnodes(oldChildren, 0, oldChildren.length - 1);
     }
 
+    if (BUILD.svg && isSvgMode && tag === 'svg') {
+      isSvgMode = false;
+    }
+
   } else if (BUILD.vdomText && BUILD.slotRelocation && (defaultHolder = (elm['s-cr'] as any))) {
     // this element has slotted content
-    defaultHolder.parentNode.textContent = newVNode.$text$;
+    defaultHolder.parentNode.textContent = text;
 
-  } else if (BUILD.vdomText && oldVNode.$text$ !== newVNode.$text$) {
+  } else if (BUILD.vdomText && oldVNode.$text$ !== text) {
     // update the text content for the text only vnode
     // and also only if the text is different than before
-    elm.data = newVNode.$text$;
-  }
-
-  if (BUILD.svg && isSvgMode && newVNode.$tag$ === 'svg') {
-    isSvgMode = false;
+    elm.data = text;
   }
 };
 

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -373,9 +373,6 @@ export const patch = (oldVNode: d.VNode, newVNode: d.VNode) => {
   if (BUILD.svg) {
     // test if we're rendering an svg element, or still rendering nodes inside of one
     // only add this to the when the compiler sees we're using an svg somewhere
-    isSvgMode = elm && elm.parentNode &&
-                ((elm as any) as SVGElement).ownerSVGElement !== undefined;
-
     isSvgMode = newVNode.$tag$ === 'svg' ? true : (newVNode.$tag$ === 'foreignObject' ? false : isSvgMode);
   }
 


### PR DESCRIPTION
Text nodes inside `<svg>` are possible, look at the `<text>` tag:
```
<svg>
  <text>Message</text>
</svg>
``` 

`#text` nodes are not SVG elements and their `ownerSVGElement` is undefined, however that does not mean the vdom render left the SVG, so `isSvgMode` should still be true after rendering a text node.

This breaks SVG rendering after the first `#text` node