### PR TITLE
Feature: Add in extraSrcDirs

### DIFF
--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -102,6 +102,23 @@ describe('validation', () => {
       ]);
     });
 
+    it('should add extraSrcDirs globs', () => {
+        config.extraSrcDirs = ['one', 'a/two', '../b/three'];
+        validateConfig(config, [], false);
+        const normalizedIncludeSrc = config.includeSrc.map(x => normalizePath(x));
+        expect(normalizedIncludeSrc).toEqual([
+          '/User/some/path/src/**/*.ts',
+          '/User/some/path/src/**/*.tsx',
+          '/User/some/path/one/**/*.ts',
+          '/User/some/path/a/two/**/*.ts',
+          '/User/some/b/three/**/*.ts',
+          '/User/some/path/one/**/*.tsx',
+          '/User/some/path/a/two/**/*.tsx',
+          '/User/some/b/three/**/*.tsx'
+        ]);
+      });
+
+
     it('should default exclude glob', () => {
       validateConfig(config, [], false);
       expect(config.excludeSrc).toEqual(['/User/some/path/src/**/test/**']);

--- a/src/compiler/config/test/validate-paths.spec.ts
+++ b/src/compiler/config/test/validate-paths.spec.ts
@@ -152,6 +152,25 @@ describe('validatePaths', () => {
     expect(path.isAbsolute(config.srcDir)).toBe(true);
   });
 
+  it('should skip extraSrcDirs when not present', () => {
+    validateConfig(config, [], false);
+    expect(config.extraSrcDirs).toBe(undefined);
+  });
+
+  it('should set extraSrcDirs and convert to absolute path', () => {
+    config.extraSrcDirs = ['one', 'a/two', '../b/three'];
+    validateConfig(config, [], false);
+    expect(path.basename(config.extraSrcDirs[0])).toBe('one');
+    expect(path.isAbsolute(config.extraSrcDirs[0])).toBe(true);
+
+    expect(path.basename(config.extraSrcDirs[1])).toBe('two');
+    expect(path.isAbsolute(config.extraSrcDirs[1])).toBe(true);
+
+    expect(path.basename(config.extraSrcDirs[2])).toBe('three');
+    expect(path.isAbsolute(config.extraSrcDirs[2])).toBe(true);
+  });
+
+
   it('should convert globalScript to absolute path, if a globalScript property was provided', () => {
     config.globalScript = path.join('src', 'global', 'index.ts');
     validateConfig(config, [], false);

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -115,6 +115,16 @@ export function validateConfig(config: d.Config, diagnostics: d.Diagnostic[], se
     });
   }
 
+  if (config.extraSrcDirs) {
+    const extraIncludeSrcs = new Array<string>();
+    DEFAULT_INCLUDES.forEach(include => {
+        config.extraSrcDirs.forEach(srcDir => {
+            extraIncludeSrcs.push(config.sys.path.join(srcDir, include));
+        });
+    });
+    config.includeSrc = [...config.includeSrc.slice(0), ...extraIncludeSrcs.slice(0)];
+  }
+
   if (!Array.isArray(config.excludeSrc)) {
     config.excludeSrc = DEFAULT_EXCLUDES.map(include => {
       return config.sys.path.join(config.srcDir, include);

--- a/src/compiler/config/validate-paths.ts
+++ b/src/compiler/config/validate-paths.ts
@@ -27,6 +27,15 @@ export function validatePaths(config: Config) {
   }
   config.srcDir = normalizePath(config.srcDir);
 
+  if (config.extraSrcDirs) {
+    for (let i = 0; i < config.extraSrcDirs.length; i++) {
+      if (!path.isAbsolute(config.extraSrcDirs[i])) {
+          config.extraSrcDirs[i] = path.join(config.rootDir, config.extraSrcDirs[i]);
+      }
+      config.extraSrcDirs[i] = normalizePath(config.extraSrcDirs[i]);
+    }
+  }
+
   setStringConfig(config, 'cacheDir', DEFAULT_CACHE_DIR);
   if (!path.isAbsolute(config.cacheDir)) {
     config.cacheDir = path.join(config.rootDir, config.cacheDir);

--- a/src/declarations/config.ts
+++ b/src/declarations/config.ts
@@ -63,6 +63,11 @@ export interface StencilConfig {
   excludeSrc?: string[];
 
   /**
+   * Use to specify directories that exist outside of the src dir.  These are optional
+   */
+  extraSrcDirs?: Array<string>;
+
+  /**
    * Stencil is traditionally used to compile many components into an app,
    * and each component comes with its own compartmentalized styles.
    * However, it's still common to have styles which should be "global" across all components and the website.


### PR DESCRIPTION
**Feature**: Add in the ability to specify extraSrc Dirs
**Reason**: This allows for external src dependencies that can be brought into the src.  This is useful for developers using aliased paths and MonoRepos (like NX)