### PR TITLE
docs(README): fix syntax highlighting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ Stencil components are plain ES6/TypeScript classes with some decorator metadata
 
 Create new components by creating files with a `.tsx` extension, such as `my-component.tsx`, and place them in `src/components`.
 
-```typescript
+```tsx
 import { Component, Prop, h } from '@stencil/core';
 
 @Component({


### PR DESCRIPTION
A tiny edit to fix the syntax highlighting in the readme example.

Before:
<img width="434" alt="Screen Shot 2020-02-16 at 1 28 54 PM" src="https://user-images.githubusercontent.com/1571918/74613120-6ebc5280-50c0-11ea-8266-e2f73d841761.png">
After:
<img width="437" alt="Screen Shot 2020-02-16 at 1 29 10 PM" src="https://user-images.githubusercontent.com/1571918/74613121-6fed7f80-50c0-11ea-83f9-f2d276b02ba3.png">
