### PR TITLE
fix(compiler): ignore irrelevant emitted files of ts transpiler

### DIFF
--- a/src/compiler/transpile/transpile-module.ts
+++ b/src/compiler/transpile/transpile-module.ts
@@ -56,9 +56,9 @@ export const transpileModule = (config: d.Config, input: string, transformOpts: 
       return normalizePath(fileName) === normalizePath(sourceFilePath) ? sourceFile : undefined;
     },
     writeFile: (name, text) => {
-      if (name.endsWith('.map')) {
+      if (name.endsWith('.js.map')) {
         results.map = text;
-      } else {
+      } else if (name.endsWith('.js')) {
         results.code = text;
       }
     },


### PR DESCRIPTION
Fixes #2211.

Problem was that (at least with the provided lerna mono-repo case) there's more files emitted by the ts program than expected, or they are in a different order. For full details see https://github.com/ionic-team/stencil/issues/2211#issuecomment-589966100.

Not sure this is the most correct solution but all tests pass and it works with our app and app tests.