### PR TITLE
test(e2e): add failing functional component test

### DIFF
--- a/test/end-to-end/src/components.d.ts
+++ b/test/end-to-end/src/components.d.ts
@@ -31,6 +31,8 @@ export namespace Components {
         "methodThatFiresMyDocumentEvent": () => Promise<void>;
         "methodThatFiresMyWindowEvent": (value: number) => Promise<void>;
     }
+    interface FunctionalCmpWrapper {
+    }
     interface ListenCmp {
         "opened": boolean;
     }
@@ -110,6 +112,12 @@ declare global {
         prototype: HTMLEventCmpElement;
         new (): HTMLEventCmpElement;
     };
+    interface HTMLFunctionalCmpWrapperElement extends Components.FunctionalCmpWrapper, HTMLStencilElement {
+    }
+    var HTMLFunctionalCmpWrapperElement: {
+        prototype: HTMLFunctionalCmpWrapperElement;
+        new (): HTMLFunctionalCmpWrapperElement;
+    };
     interface HTMLListenCmpElement extends Components.ListenCmp, HTMLStencilElement {
     }
     var HTMLListenCmpElement: {
@@ -168,6 +176,7 @@ declare global {
         "dom-visible": HTMLDomVisibleElement;
         "element-cmp": HTMLElementCmpElement;
         "event-cmp": HTMLEventCmpElement;
+        "functional-cmp-wrapper": HTMLFunctionalCmpWrapperElement;
         "listen-cmp": HTMLListenCmpElement;
         "method-cmp": HTMLMethodCmpElement;
         "path-alias-cmp": HTMLPathAliasCmpElement;
@@ -206,6 +215,8 @@ declare namespace LocalJSX {
         "onMyDocumentEvent"?: (event: CustomEvent<any>) => void;
         "onMyWindowEvent"?: (event: CustomEvent<number>) => void;
     }
+    interface FunctionalCmpWrapper {
+    }
     interface ListenCmp {
         "opened"?: boolean;
     }
@@ -237,6 +248,7 @@ declare namespace LocalJSX {
         "dom-visible": DomVisible;
         "element-cmp": ElementCmp;
         "event-cmp": EventCmp;
+        "functional-cmp-wrapper": FunctionalCmpWrapper;
         "listen-cmp": ListenCmp;
         "method-cmp": MethodCmp;
         "path-alias-cmp": PathAliasCmp;
@@ -260,6 +272,7 @@ declare module "@stencil/core" {
             "dom-visible": LocalJSX.DomVisible & JSXBase.HTMLAttributes<HTMLDomVisibleElement>;
             "element-cmp": LocalJSX.ElementCmp & JSXBase.HTMLAttributes<HTMLElementCmpElement>;
             "event-cmp": LocalJSX.EventCmp & JSXBase.HTMLAttributes<HTMLEventCmpElement>;
+            "functional-cmp-wrapper": LocalJSX.FunctionalCmpWrapper & JSXBase.HTMLAttributes<HTMLFunctionalCmpWrapperElement>;
             "listen-cmp": LocalJSX.ListenCmp & JSXBase.HTMLAttributes<HTMLListenCmpElement>;
             "method-cmp": LocalJSX.MethodCmp & JSXBase.HTMLAttributes<HTMLMethodCmpElement>;
             "path-alias-cmp": LocalJSX.PathAliasCmp & JSXBase.HTMLAttributes<HTMLPathAliasCmpElement>;

--- a/test/end-to-end/src/functional-cmp/functional-cmp.e2e.ts
+++ b/test/end-to-end/src/functional-cmp/functional-cmp.e2e.ts
@@ -1,0 +1,13 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('Functional Component', () => {
+  it('should pass `undefined` as props param so it can be destructured and have a default value', async () => {
+    const page = await newE2EPage({ html: `
+      <functional-cmp-wrapper></functional-cmp-wrapper>
+    `});
+
+    const div = await page.find('functional-cmp-wrapper >>> div');
+
+    expect(div.textContent).toBe('Hi, my name is Kim Doe.')
+  })
+})

--- a/test/end-to-end/src/functional-cmp/functional-cmp.tsx
+++ b/test/end-to-end/src/functional-cmp/functional-cmp.tsx
@@ -1,0 +1,20 @@
+import { Component, FunctionalComponent, h } from '@stencil/core';
+
+@Component({
+  tag: 'functional-cmp-wrapper',
+  shadow: true,
+})
+export class FunctionalCmpWrapper {
+  render() {
+    return <FunctionalCmp />;
+  }
+}
+
+const FunctionalCmp: FunctionalComponent<FunctionalCmpProps> = ({ first = 'Kim', last = 'Doe' } = {}) => (
+  <div>Hi, my name is {first} {last}.</div>
+);
+
+interface FunctionalCmpProps {
+  first?: string;
+  last?: string;
+}


### PR DESCRIPTION
Adds a functional component that sets `{}` as the default argument for the `props` parameter and uses object destructuring on it.

```tsx
const FnCmp = ({ first = 'Kim', last = 'Doe' } = {}) => <div>Hi, my name is {first} {last}.</div>
```

All props of the functional component are optional, and if none are passed, `null` will be passed as the `props` argument, which will cause a runtime error.

It would be nice if `undefined` was passed at runtime instead of `null` if the node has type `function`, so that default arguments and object destructuring work. Alternatively `{}` (empty object) could be passed so that at least object destructuring works (not sure what makes more sense or if there are performance implications).

---

I believe that here we could change the call

https://github.com/ionic-team/stencil/blob/565d35307dd73009cd3f1e217278b8661dc25a95/src/runtime/vdom/h.ts#L83-L86

to

```ts
nodeName(vnodeData === null ? undefined : vnodeData, vNodeChildren, vdomFnUtils)
```

