### PR TITLE
Update jest-runner.ts

### DIFF
--- a/src/testing/jest/jest-runner.ts
+++ b/src/testing/jest/jest-runner.ts
@@ -28,7 +28,7 @@ export async function runJest(config: d.Config, env: d.E2EProcessEnv) {
 
     // run the jest-cli with our data rather than letting the
     // jest-cli parse the args itself
-    const { runCLI } = require('jest-cli');
+    const { runCLI } = require('jest');
     const cliResults = await runCLI(jestArgv, projects);
 
     success = !!cliResults.results.success;


### PR DESCRIPTION
https://github.com/ionic-team/stencil/issues/2168#issuecomment-601044324
fixes the error 
`runJest: TypeError: runCLI is not a function`