### PR TITLE
fix(vdom): Hide fallback slot when content is entered

### DIFF
--- a/src/runtime/vdom/test/scoped-slot.spec.tsx
+++ b/src/runtime/vdom/test/scoped-slot.spec.tsx
@@ -755,4 +755,26 @@ describe('scoped slot', () => {
     // expect(root.firstElementChild.firstElementChild.children[1].firstElementChild.children[1].nodeName).toBe('GOAT');
     // expect(root.firstElementChild.firstElementChild.children[1].firstElementChild.children[1].textContent).toBe('hey goat!');
   });
+
+  it('should hide the slot\'s fallback content when slot content passed in', async() => {
+    @Component({ tag: 'fallback-test', scoped: true })
+    class FallbackSlotTest {
+      render() {
+        return (
+          <div>
+            <slot>
+              <p>Fallback Content</p>
+            </slot>
+          </div>
+        );
+      }
+    }
+    const { root } = await newSpecPage({
+      components: [FallbackSlotTest],
+      html: `<fallback-test><span>Content</span></fallback-test>`,
+    });
+
+    expect(root.firstElementChild.children[1].nodeName).toBe('SLOT-FB');
+    expect(root.firstElementChild.children[1]).toHaveAttribute('hidden');
+  });
 });

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -418,24 +418,22 @@ const updateFallbackSlotVisibility = (elm: d.RenderNode) => {
         childNode.hidden = false;
 
         for (j = 0; j < ilen; j++) {
-          if (childNodes[j]['s-hn'] !== childNode['s-hn']) {
-            // this sibling node is from a different component
-            nodeType = childNodes[j].nodeType;
+          // this sibling node is from a different component
+          nodeType = childNodes[j].nodeType;
 
-            if (slotNameAttr !== '') {
-              // this is a named fallback slot node
-              if (nodeType === NODE_TYPE.ElementNode && slotNameAttr === childNodes[j].getAttribute('slot')) {
-                childNode.hidden = true;
-                break;
-              }
-            } else {
-              // this is a default fallback slot node
-              // any element or text node (with content)
-              // should hide the default fallback slot node
-              if (nodeType === NODE_TYPE.ElementNode || (nodeType === NODE_TYPE.TextNode && childNodes[j].textContent.trim() !== '')) {
-                childNode.hidden = true;
-                break;
-              }
+          if (slotNameAttr !== '') {
+            // this is a named fallback slot node
+            if (nodeType === NODE_TYPE.ElementNode && slotNameAttr === childNodes[j].getAttribute('slot')) {
+              childNode.hidden = true;
+              break;
+            }
+          } else {
+            // this is a default fallback slot node
+            // any element or text node (with content)
+            // should hide the default fallback slot node
+            if (nodeType === NODE_TYPE.ElementNode || (nodeType === NODE_TYPE.TextNode && childNodes[j].textContent.trim() !== '')) {
+              childNode.hidden = true;
+              break;
             }
           }
         }


### PR DESCRIPTION
Since version 1.8.7 slotted content shows both the fallback content and the inserted content. When shadow is unavailable and it is using scoped slots.

Originally the tests passed because there didn't seem to be a test case on this scenario. In this PR we have added an additional test case to check the attribute of the slot and removed the conditional that prevented the hidden attribute from being added.

This seems to relate to issue https://github.com/ionic-team/stencil/issues/2307 which although was closed does not seem to be fixed.