### PR TITLE
feat(): add enterkeyhint to HTMLAttributes

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -902,7 +902,6 @@ export namespace JSXBase {
     formtarget?: string;
     height?: number | string;
     indeterminate?: boolean;
-    inputmode?: string;
     list?: string;
     max?: number | string;
     maxLength?: number;
@@ -1215,6 +1214,8 @@ export namespace JSXBase {
     // Unknown
     inputMode?: string;
     inputmode?: string;
+    enterKeyHint?: string;
+    enterkeyhint?: string;
     is?: string;
     radioGroup?: string; // <command>, <menuitem>
     radiogroup?: string;


### PR DESCRIPTION
blocks https://github.com/ionic-team/ionic/pull/21035 https://github.com/ionic-team/ionic/pull/21036

- Adds support for enterkeyhint to all elements
- Removed unneeded inputmode from InputHTMLAttributes since it is global