### PR TITLE
fix(vscode-docs) correctly join repoBaseUrl and component filePath

### DIFF
--- a/src/compiler/docs/vscode/index.ts
+++ b/src/compiler/docs/vscode/index.ts
@@ -1,6 +1,7 @@
 import * as d from '../../../declarations';
 import { getNameText } from '../generate-doc-data';
 import { isOutputTargetDocsVscode } from '../../output-targets/output-utils';
+import { join } from 'path';
 
 export const generateVscodeDocs = async (compilerCtx: d.CompilerCtx, docsData: d.JsonDocs, outputTargets: d.OutputTarget[]) => {
   const vsCodeOutputTargets = outputTargets.filter(isOutputTargetDocsVscode);
@@ -33,7 +34,7 @@ const getReferences = (cmp: d.JsonDocsComponent, repoBaseUrl: string) => {
   if (repoBaseUrl) {
     references.push({
       name: 'Source code',
-      url: repoBaseUrl + cmp.filePath,
+      url: join(repoBaseUrl, cmp.filePath),
     });
   }
   if (references.length > 0) {


### PR DESCRIPTION
Fixes #2362

I wasn't able to run tests locally, as this reference wasn't resolving (file doesn't exist): https://github.com/ionic-team/stencil/blob/92e70fb113efbef03b3bf60d4c3b84ed99e25ad3/jest.config.js#L2

Hopefully no tests break!