### PR TITLE
fix(jest): change package used to import runCli

### DIFF
--- a/src/testing/jest/jest-runner.ts
+++ b/src/testing/jest/jest-runner.ts
@@ -28,7 +28,7 @@ export async function runJest(config: d.Config, env: d.E2EProcessEnv) {
 
     // run the jest-cli with our data rather than letting the
     // jest-cli parse the args itself
-    const { runCLI } = require('jest-cli');
+    const { runCLI } = require('@jest/core');
     const cliResults = await runCLI(jestArgv, projects);
 
     success = !!cliResults.results.success;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Fixes error 'runJest: TypeError: runCLI is not a function' with Jest 25
Using jest-cli to import runCli breaks in jest@25 and @jest/core must be used instead.
This package started shipping in jest@24.3.0 so its safe to use it as Stencil installs jest@24.9.

Fixes #2168 

#### Testing instructions

- Checkout this branch
- `npm run build`
- `npm link`

On a project that uses Stencil (for example, [stencil-component-starter](https://github.com/ionic-team/stencil-component-starter)), run:
- `npm test`
- Verify there are no errors when using jest@24.9
- `npm install jest@25 jests-cli@25`
- `npm link @stencil/core`
- `npm test`
- Verify there are no errors when using jest@25
