### PR TITLE
fix(): remove `ValueChange` XUL event

### DIFF
--- a/src/compiler/transformers/decorators-to-static/event-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/event-decorator.ts
@@ -123,7 +123,6 @@ const DOM_EVENT_NAMES: Set<string> = new Set(
     'SVGScroll',
     'SVGUnload',
     'SVGZoom',
-    'ValueChange',
     'abort',
     'afterprint',
     'afterscriptexecute',


### PR DESCRIPTION
`ValueChange` is not a DOM event, but a XUL event: https://developer.mozilla.org/en-US/docs/Archive/Mozilla/XUL/Events/ValueChange.

So this event can be removed so web components can define their own `valueChange` event emitters.