### PR TITLE
fix(runtime): forceUpdate might err in tests when resetting a store

### DIFF
--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -251,6 +251,10 @@ export const postUpdateComponent = (hostRef: d.HostRef) => {
 export const forceUpdate = (ref: any) => {
   if (BUILD.updatable) {
     const hostRef = getHostRef(ref);
+    if (hostRef === undefined) {
+      return false;
+    }
+
     const isConnected = hostRef.$hostElement$.isConnected;
     if (isConnected && (hostRef.$flags$ & (HOST_FLAGS.hasRendered | HOST_FLAGS.isQueuedForUpdate)) === HOST_FLAGS.hasRendered) {
       scheduleUpdate(hostRef, false);


### PR DESCRIPTION
When resetting a store used in the several tests in a same describe
block, an `undefined` `hostRef` is returned and thus, accessing
`$hostElement$` in it raises an error.

This fixes that case.