### PR TITLE
fix(dev-mode) always add dist-types

### DIFF
--- a/src/compiler/config/outputs/validate-dist.ts
+++ b/src/compiler/config/outputs/validate-dist.ts
@@ -44,6 +44,13 @@ export const validateDist = (config: d.Config, userOutputs: d.OutputTarget[]) =>
       file: join(lazyDir, `${config.fsNamespace}.css`),
     });
 
+    outputs.push({
+      type: DIST_TYPES,
+      dir: distOutputTarget.dir,
+      typesDir: distOutputTarget.typesDir,
+      empty: distOutputTarget.empty,
+    });
+
     if (config.buildDist) {
       if (distOutputTarget.collectionDir) {
         outputs.push({
@@ -59,13 +66,6 @@ export const validateDist = (config: d.Config, userOutputs: d.OutputTarget[]) =>
           copy: [...distOutputTarget.copy, { src: '**/*.svg' }, { src: '**/*.js' }],
         });
       }
-
-      outputs.push({
-        type: DIST_TYPES,
-        dir: distOutputTarget.dir,
-        typesDir: distOutputTarget.typesDir,
-        empty: distOutputTarget.empty,
-      });
 
       const esmDir = join(distOutputTarget.dir, 'esm');
       const esmEs5Dir = config.buildEs5 ? join(distOutputTarget.dir, 'esm-es5') : undefined;


### PR DESCRIPTION
With the help of @simonhaenisch I could find the reason why https://github.com/ionic-team/stencil/issues/2349 is happening. 

It is because here https://github.com/ionic-team/stencil/blob/4c70fdd2c418a1419c8c30bd585d4a081100b28b/src/compiler/config/outputs/validate-dist.ts#L47

the `buildDist` is `false` and the output target `DIST_TYPES` is not added in dev-mode. It is however needed later on.

This causes this condition to return false:
https://github.com/ionic-team/stencil/blob/63595bc540db9aa85295f5a8dc8738beb2a37611/src/compiler/transpile/ts-config.ts#L8

and `declaration` becomes `false` - which is not allowed in combination with `composite: true`.

I first tried to tackle it via this line by removing the `devMode` condition but it seems too related to other (global) decisions you've made maybe:
https://github.com/ionic-team/stencil/blob/253894d3ea154c0471e1345ad79fea3e708121d5/src/compiler/config/validate-config.ts#L52

So my solution is to always add the output target `DIST_TYPES` no matter the mode (dev or prod).

This is a huge blocker for us - would love to find a solution!
