### PR TITLE
Add missing 'at' attribute to LinkHTMLAttributes

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -955,6 +955,7 @@ export namespace JSXBase {
   }
 
   export interface LinkHTMLAttributes<T> extends HTMLAttributes<T> {
+    as?: string;
     href?: string;
     hrefLang?: string;
     hreflang?: string;


### PR DESCRIPTION
`as` Attribute: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#Attributes