### PR TITLE
fix(polyfill): add proper url base to import shim

### DIFF
--- a/src/client/import-shims.ts
+++ b/src/client/import-shims.ts
@@ -100,7 +100,7 @@ const patchDynamicImport = (base: string, orgScriptElm: HTMLScriptElement) => {
     // basically this code is for old Edge, v18 and below
     const moduleMap = new Map<string, any>();
     (win as any)[importFunctionName] = (src: string) => {
-      const url = new URL(src, base).href;
+      const url = new URL(src, win.location.href + base).href;
       let mod = moduleMap.get(url);
       if (!mod) {
         const script = doc.createElement('script');


### PR DESCRIPTION
This fixes this issue: https://github.com/ionic-team/stencil/issues/2397
that is based on an invalid URL scheme (second parameter of constructor needs to be an absolute path if the src is relative).