### PR TITLE
fix(polyfill): add proper url base to import shim

### DIFF
--- a/src/compiler/output-targets/dist-lazy/generate-system.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-system.ts
@@ -61,7 +61,7 @@ const getSystemLoader = async (config: d.Config, compilerCtx: d.CompilerCtx, cor
 
     var resourcesUrl = scriptElm ? scriptElm.getAttribute('data-resources-url') || scriptElm.src : '';
     var start = function() {
-      var url = new URL('${corePath}', resourcesUrl);
+      var url = new URL('${corePath}', window.location.href + resourcesUrl);
       System.import(url.href);
     };
 


### PR DESCRIPTION
URL needs absolute address in second part of constructor

This should fix https://github.com/ionic-team/stencil/issues/2397

Hope I found the right place this time ;) 