### PR TITLE
#1843 partially fix excludeSrc/includeSrc problem

### DIFF
--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -63,6 +63,7 @@ export interface StencilConfig {
    * @deprecated Use the "exclude" option in "tsconfig.json"
    */
   excludeSrc?: string[];
+  exclude?: string[];
 
   /**
    * Stencil is traditionally used to compile many components into an app,
@@ -229,10 +230,13 @@ export interface StencilConfig {
   testing?: TestingConfig;
   maxConcurrentWorkers?: number;
   preamble?: string;
+
   /**
    * @deprecated Use the "include" option in "tsconfig.json"
    */
   includeSrc?: string[];
+  include?: string[];
+  
   rollupPlugins?: { before?: any[]; after?: any[] };
 
   entryComponentsHint?: string[];


### PR DESCRIPTION
Partially fixes #1843. src/compiler/config/validate-config.ts displays error:

    "excludeSrc" is deprecated, use the "exclude" option in tsconfig.json

but tslinting in editor still expects "includeSrc". I guess tthat since these were deprecated, the new values should also have been added... (as was already done with "setupFilesAfterEnv")?

It still, however, appears to include excluded files in the "dist" folder.