### PR TITLE
fix(testing): MockResponse404 is not ok

### DIFF
--- a/src/testing/mock-fetch.ts
+++ b/src/testing/mock-fetch.ts
@@ -134,6 +134,7 @@ export const mockFetch = {
 };
 
 class MockResponse404 extends MockResponse {
+  ok = false;
   status = 404;
   statusText = 'Not Found';
   constructor() {


### PR DESCRIPTION
`MockResponse404` extends from `MockResponse` which sets `ok` to `true` by default. However, `ok` should only be `true`, if the status code is within the 2xx range.

Alternatively, we could change the `ok` property of `MockResponse` to a getter:

```
export class MockResponse {
  get ok() {
    return this.status >= 200 && this.status <= 299
  }
}
```

However, by doing that `ok` would be readonly and that is probably a breaking change. 🤔