### PR TITLE
Add onToggle property to the DetailsHTMLAttributes interface

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -777,6 +777,7 @@ export namespace JSXBase {
 
   export interface DetailsHTMLAttributes<T> extends HTMLAttributes<T> {
     open?: boolean;
+    onToggle?: (event: Event) => void;
   }
 
   export interface DelHTMLAttributes<T> extends HTMLAttributes<T> {


### PR DESCRIPTION
This PR adds types for the `toggle` [event](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#Events) in `<details>` with the `onToggle` property.

Closes: #2398