### PR TITLE
feat: integrating firefox e2e testing

### DIFF
--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1507,6 +1507,12 @@ export interface TestingConfig extends JestConfig {
    * Amount of time in milliseconds to wait before a screenshot is taken.
    */
   waitBeforeScreenshot?: number;
+
+
+  /**
+   * Browser to be launched when running e2e tests.
+   */
+  product?: 'chrome' | 'firefox';
 }
 
 export interface EmulateConfig {

--- a/src/testing/puppeteer/puppeteer-browser.ts
+++ b/src/testing/puppeteer/puppeteer-browser.ts
@@ -41,6 +41,7 @@ export async function startPuppeteerBrowser(config: Config) {
     headless: config.testing.browserHeadless,
     devtools: config.testing.browserDevtools,
     slowMo: config.testing.browserSlowMo,
+    product: config.testing.product
   };
 
   if (config.testing.browserExecutablePath) {
@@ -55,7 +56,6 @@ export async function startPuppeteerBrowser(config: Config) {
     : puppeteer.launch({
         ...launchOpts,
       }));
-
   env.__STENCIL_BROWSER_WS_ENDPOINT__ = browser.wsEndpoint();
 
   config.logger.debug(`puppeteer browser wsEndpoint: ${env.__STENCIL_BROWSER_WS_ENDPOINT__}`);


### PR DESCRIPTION
At this moment the support for puppeteer firefox integration still experimental but looks promising so far. I made that test can run on firefox. It opens the browser is very buggy!!

