### PR TITLE
fix(cli): correct import in generated spec tests

### DIFF
--- a/src/cli/tasks/task-generate.ts
+++ b/src/cli/tasks/task-generate.ts
@@ -163,7 +163,7 @@ const getStyleUrlBoilerplate = () =>
  */
 const getSpecTestBoilerplate = (tagName: string) =>
   `import { newSpecPage } from '@stencil/core/testing';
-import { ${toPascalCase(tagName)} } from './${tagName}';
+import { ${toPascalCase(tagName)} } from '../${tagName}';
 
 describe('${tagName}', () => {
   it('renders', async () => {


### PR DESCRIPTION
Since generated tests are now placed in a `tests` folder (baff1dc), the import path had to be adjusted.