### PR TITLE
Fix CSS compilation for multiple styleURLs (Close #2432)

### DIFF
--- a/src/compiler/style/css-imports.ts
+++ b/src/compiler/style/css-imports.ts
@@ -126,6 +126,7 @@ export const getCssImports = async (config: d.Config, compilerCtx: d.CompilerCtx
   const importeeExt = filePath.split('.').pop().toLowerCase();
 
   let r: RegExpExecArray;
+  const IMPORT_RE = /(@import)\s+(url\()?\s?(.*?)\s?\)?([^;]*);?/gi;
   while ((r = IMPORT_RE.exec(styleText))) {
     const cssImportData: d.CssImportData = {
       srcImport: r[0],
@@ -167,8 +168,6 @@ export const getCssImports = async (config: d.Config, compilerCtx: d.CompilerCtx
 
   return imports;
 };
-
-const IMPORT_RE = /(@import)\s+(url\()?\s?(.*?)\s?\)?([^;]*);?/gi;
 
 export const isCssNodeModule = (url: string) => url.startsWith('~');
 


### PR DESCRIPTION
This PR fixes compilation of multiple CSS files as documented in #2432
They underlying issue was with the stateful nature of the RegEx `exec` command when using the `g` flag. Moving it into the closure of the function makes sure it's reset for each file, fixing the problem.

I have a [test comparing the contents](https://github.com/alex-ketch/stenciljs-postcss-import-issue/blob/master/src/components/app-root/app-root.spec.ts) of the compiled files in the reproduction fork here, but I haven't found a good way to test for it in this repo.

Exporting and testing the `updateCssImports` function works until it tries to read the file contents at [`compilerCtx.fs.readFile`](https://github.com/ionic-team/stencil/blob/master/src/compiler/style/css-imports.ts#L104), where the `mockCompilerCtx` seems to return `undefined` for the file contents.

Could you advise on how you'd like to see this PR proceed please @adamdbradley or @manucorporat?
Thanks!