### PR TITLE
fix(#2366): rehydrated components added twice

### DIFF
--- a/src/runtime/vdom/vdom-annotations.ts
+++ b/src/runtime/vdom/vdom-annotations.ts
@@ -127,15 +127,20 @@ const insertParentVNodeAnnotations = (hostElm: d.HostElement, vnode: d.VNode) =>
     return;
   }
 
-  const comment = Array.from(parent.childNodes).find(node => {
+  const parentChildNodes: ChildNode[] = Array.from(parent.childNodes);
+
+  const comment: d.RenderNode | undefined = parentChildNodes.find(node => {
     return node.nodeType === NODE_TYPE.CommentNode && (node as d.RenderNode)['s-sr'];
-  });
+  }) as d.RenderNode | undefined;
 
   if (!comment) {
     return;
   }
 
-  (vnode.$elm$ as d.RenderNode).setAttribute(HYDRATE_CHILD_ID, `${(comment as d.RenderNode)['s-host-id']}.${(comment as d.RenderNode)['s-node-id']}.0.1`);
+  // We have got at least the element plus a comment. First element should be indexed with 1, second element with 2, etc.
+  const index: number = parentChildNodes.indexOf(hostElm) - 1;
+
+  (vnode.$elm$ as d.RenderNode).setAttribute(HYDRATE_CHILD_ID, `${comment['s-host-id']}.${comment['s-node-id']}.0.${index}`);
 };
 
 const insertChildVNodeAnnotations = (doc: Document, vnodeChild: d.VNode, cmpData: CmpData, hostId: number, depth: number, index: number) => {

--- a/src/runtime/vdom/vdom-annotations.ts
+++ b/src/runtime/vdom/vdom-annotations.ts
@@ -107,7 +107,35 @@ const insertVNodeAnnotations = (doc: Document, hostElm: d.HostElement, vnode: d.
         insertChildVNodeAnnotations(doc, vnodeChild, cmpData, hostId, depth, index);
       });
     }
+
+    insertParentVNodeAnnotations(hostElm, vnode);
   }
+};
+
+const insertParentVNodeAnnotations = (hostElm: d.HostElement, vnode: d.VNode) => {
+  if (!hostElm || !vnode || !vnode.$elm$) {
+    return;
+  }
+
+  if (hostElm.getAttribute('c-id') !== null) {
+    return;
+  }
+
+  const parent: HTMLElement = hostElm.parentElement;
+
+  if (!parent || !parent.childNodes || parent.childNodes.length <= 0) {
+    return;
+  }
+
+  const comment = Array.from(parent.childNodes).find(node => {
+    return node.nodeType === NODE_TYPE.CommentNode && (node as d.RenderNode)['s-sr'];
+  });
+
+  if (!comment) {
+    return;
+  }
+
+  (vnode.$elm$ as d.RenderNode).setAttribute(HYDRATE_CHILD_ID, `${(comment as d.RenderNode)['s-host-id']}.${(comment as d.RenderNode)['s-node-id']}.0.1`);
 };
 
 const insertChildVNodeAnnotations = (doc: Document, vnodeChild: d.VNode, cmpData: CmpData, hostId: number, depth: number, index: number) => {


### PR DESCRIPTION
### Introduction

This is my suggestion to solve #2366. I am honestly not sure it is the proper solution and would appreciate any hints.

I am also not against that PR being rejected as long as the problem, I communicated in April 2020,  finds  a solution.

Indeed I am not able to upgrade our applications and therefore are kind of blocked  with Stencil v1.8. I would be really happy to upgrade. 

Moreover, I noticed that  prerendering solved would enhance by more  than 10% our load time, therefore, more really more  than in need  and looking forward  to a solution.

### Current behavior:

With prerendering, components are not rehydrated and are added twice to the DOM

### Expected behavior:

Components  are rehydrated with a single instance to the DOM

### Root cause of issue

I mostly tested the issue with the `ion-router`, more precisely noticed the  issue with the `ion-nav` and a "page" (`app-home`) being added twice two the DOM.

I did a comparison with the Stencil router, with which I did not face the issue, and noticed that the root case was the missing component reference (`c-id`).

Concretely, currently these elements would be prerendered as following:

```
<ion-nav s-id=14>
     <!--s.14.0.0.0.-->
     <app-home s-id=15>
```

But if they would be added as following, then the issue would be solved:

```
<ion-nav s-id=14>
     <!--s.14.0.0.0.-->
     <app-home s-id=15 c-id=14.0.0.1>
```

Adding `c-id=14.0.0.1` was the solution here.

A spent some time debugging `vdom-annotation.ts` and figured out that this "missing annotation" was a result of the VDOM representation.

Indeed, if the `ion-nav` is referenced as `parent` of the `app-home`, the contrary was not correct, the `app-home` was not referenced as `child` of the `ion-nav` but its `slot`.

ion-nav element:

```
ion-app
    ion-nav
        slot
```

app-home element:

```
ion-nav
    app-home
         ion-content
```

### Suggestion of solution

As both elements are kind of not fully linked, my idea is to add a post processing to the insertion of the annotation which checks if the node as received a `c-id` and if not, as a a parent which contains a `comment` for the slot. If so, it calculate the `c-id` and adds the attribute

### Conclusion

As I said in my introduction, my solution might not be correct, it of course works out according my tests but you might find some reason why not. In such case, I am not against rejecting this PR, a cool, but would really, really appreciate if we can move forward with prerendering while using the Ionic Router.