### PR TITLE
fix(): change autocapitalize types to any to avoid conflicts

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -875,10 +875,10 @@ export namespace JSXBase {
     accept?: string;
     allowdirs?: boolean;
     alt?: string;
-    autoCapitalize?: string;
-    autocapitalize?: string;
-    autoComplete?: string;
-    autocomplete?: string;
+    autoCapitalize?: any;
+    autocapitalize?: any;
+    autoComplete?: any;
+    autocomplete?: any;
     autoFocus?: boolean;
     autofocus?: boolean | string;
     capture?: string; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute

--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -877,8 +877,8 @@ export namespace JSXBase {
     alt?: string;
     autoCapitalize?: any;
     autocapitalize?: any;
-    autoComplete?: any;
-    autocomplete?: any;
+    autoComplete?: string;
+    autocomplete?: string;
     autoFocus?: boolean;
     autofocus?: boolean | string;
     capture?: string; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
@@ -1235,8 +1235,8 @@ export namespace JSXBase {
     vocab?: string;
 
     // Non-standard Attributes
-    autoCapitalize?: string;
-    autocapitalize?: string;
+    autoCapitalize?: any;
+    autocapitalize?: any;
     autoCorrect?: string;
     autocorrect?: string;
     autoSave?: string;


### PR DESCRIPTION
blocks https://github.com/ionic-team/ionic/pull/21464

We are getting a compiler error when trying to specify types for `autocapitalize`. This change comes after discussion with Manu re: what to do about the issue.