### PR TITLE
fix(jest): correctly set coverageThreshold

### DIFF
--- a/src/testing/jest/jest-config.ts
+++ b/src/testing/jest/jest-config.ts
@@ -58,7 +58,7 @@ export function buildJestConfig(config: d.Config) {
   if (isString(stencilConfigTesting.coverageDirectory)) {
     jestConfig.coverageDirectory = stencilConfigTesting.coverageDirectory;
   }
-  if (isString(stencilConfigTesting.coverageThreshold)) {
+  if (stencilConfigTesting.coverageThreshold) {
     jestConfig.coverageThreshold = stencilConfigTesting.coverageThreshold;
   }
   if (isString(stencilConfigTesting.globalSetup)) {


### PR DESCRIPTION
`coverageThreshold` was never being set in `jestConfig` as it is an object

See https://jestjs.io/docs/en/configuration.html#coveragethreshold-object

Note: https://stenciljs.com/docs/testing-config doesn't mention anything about it being a special option so if it _should_ be a string then the docs need updating instead of merging this PR.

I also tried using `JSON.stringify` to set it but that just made Jest fall over with:
```
[ ERROR ]  runJest: ● Validation Error:   Option
           "coverageThreshold" must be of type:  object  but
           instead received:  string   Example:  {
            "coverageThreshold": {  "global": {  "branches":
           50,  "functions": 100,  "lines": 100,
           "statements": 100  }  }  }
           Configuration Documentation:  https://jestjs.io/docs/configuration.html
```