### PR TITLE
fix(testing): fix testEnvironment validation

### DIFF
--- a/src/compiler/config/validate-testing.ts
+++ b/src/compiler/config/validate-testing.ts
@@ -80,7 +80,7 @@ export const validateTesting = (config: d.Config, diagnostics: d.Diagnostic[]) =
   }
 
   if (typeof testing.testEnvironment === 'string') {
-    if (!isAbsolute(testing.testEnvironment)) {
+    if (isAbsolute(testing.testEnvironment)) {
       testing.testEnvironment = join(config.configPath, testing.testEnvironment);
     }
   }


### PR DESCRIPTION
Hoping to resolve https://github.com/ionic-team/stencil/issues/2425.

After this change I am able set `testEnvironment` as a node module in `stencil.config.ts`  like "jsdom".