### PR TITLE
fix(compiler): fix transitive module dependencies in unit tests (#2178)

### DIFF
--- a/src/compiler/transpile.ts
+++ b/src/compiler/transpile.ts
@@ -124,7 +124,8 @@ const transpileJson = (results: TranspileResults) => {
   results.map = { mappings: '' };
 };
 
-const shouldTranspileModule = (ext: string) => ext === 'tsx' || ext === 'ts' || ext === 'jsx' || ext === 'mjs';
+// @todo: could/should this be borrowed from either tsconfig's allowJs or jest config's ?
+const shouldTranspileModule = (ext: string) => ['tsx', 'ts', 'mjs', 'jsx', 'js'].includes(ext);
 
 export const compile = (code: string, opts: any = {}): Promise<any> => {
   console.warn(`compile() deprecated, please use compile() instead`);


### PR DESCRIPTION
This should resolve a few `Cannot use import statement outside a module` errors when spec files are run. 

There's a slightly deeper problem here re: who decides what is a module.  Both typescript and jest can be configured to accept different extensions as module types, but neither configuration is honoured by the stencil compiler when spec files are run.  Perhaps a better fix would be to inspect the `opts` in this helper function to determine which extensions to add here.

Adding `js` to the list of files to compile may introduce potential slowness or problems, as more files will be run through the typescript compiler now.