### PR TITLE
fix(type definition): add abbr to ThHTMLAttributes

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1174,6 +1174,7 @@ export namespace JSXBase {
   }
 
   export interface ThHTMLAttributes<T> extends HTMLAttributes<T> {
+    abbr?: string;
     colSpan?: number;
     headers?: string;
     rowSpan?: number;


### PR DESCRIPTION
Fix for Issue #2530
https://www.w3schools.com/tags/tag_th.asp