### PR TITLE
fix(bundling): downgrade `@rollup/plugin-commonjs`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1139,9 +1139,9 @@
       }
     },
     "@rollup/plugin-commonjs": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-14.0.0.tgz",
-      "integrity": "sha512-+PSmD9ePwTAeU106i9FRdc+Zb3XUWyW26mo5Atr2mk82hor8+nPwkztEjFo8/B1fJKfaQDg9aM2bzQkjhi7zOw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-12.0.0.tgz",
+      "integrity": "sha512-8+mDQt1QUmN+4Y9D3yCG8AJNewuTSLYPJVzKKUZ+lGeQrI+bV12Tc5HCyt2WdlnG6ihIL/DPbKRJlB40DX40mw==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.0.8",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "typescript": "3.9.7"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "14.0.0",
+    "@rollup/plugin-commonjs": "12.0.0",
     "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-node-resolve": "8.4.0",
     "@rollup/plugin-replace": "2.3.3",


### PR DESCRIPTION
See https://github.com/rollup/plugins/issues/497#issuecomment-657952505. v13.0.0 broke named exports for __esModule packages. v13.0.1 fixed named exports but broke default exports for __esModule packages. This is still the case in v14.0.0.

The master branch already has a fix (see https://github.com/rollup/plugins/pull/501) but not sure when that's going to be released.

In the meantime we can just downgrade to v12 which didn't have any of these issues.