### PR TITLE
feat(testing): add collectCoverageFrom jest parameter

### DIFF
--- a/src/testing/jest/jest-config.ts
+++ b/src/testing/jest/jest-config.ts
@@ -55,6 +55,9 @@ export function buildJestConfig(config: d.Config) {
   if (isString(stencilConfigTesting.collectCoverage)) {
     jestConfig.collectCoverage = stencilConfigTesting.collectCoverage;
   }
+  if (Array.isArray(stencilConfigTesting.collectCoverageFrom)) {
+    jestConfig.collectCoverageFrom = stencilConfigTesting.collectCoverageFrom;
+  }
   if (isString(stencilConfigTesting.coverageDirectory)) {
     jestConfig.coverageDirectory = stencilConfigTesting.coverageDirectory;
   }

--- a/src/testing/jest/test/jest-config.spec.ts
+++ b/src/testing/jest/test/jest-config.spec.ts
@@ -132,4 +132,20 @@ describe('jest-config', () => {
     const parsedConfig = JSON.parse(jestArgv.config) as d.JestConfig;
     expect(parsedConfig.rootDir).toBe(rootDir);
   });
+
+  it('set jestArgv config collectCoverageFrom', () => {
+    const rootDir = path.resolve('/');
+    const args = ['test'];
+    const config = mockConfig();
+    config.rootDir = rootDir;
+    config.flags = parseFlags(args, config.sys);
+    config.testing = {
+      collectCoverageFrom: ['**/*.+(ts|tsx)'],
+    };
+
+    const jestArgv = buildJestArgv(config);
+    const parsedConfig = JSON.parse(jestArgv.config) as d.JestConfig;
+    expect(parsedConfig.collectCoverageFrom).toHaveLength(1);
+    expect(parsedConfig.collectCoverageFrom[0]).toBe('**/*.+(ts|tsx)');
+  });
 });


### PR DESCRIPTION
Hi!

This PR allows us to collect the code coverage from other not tested code files, adding the *collectCoverageFrom* jest parameter.

Resolves #2557 