### PR TITLE
fix(compiler): normalizePath result from fs.realpathSync

### DIFF
--- a/src/compiler/sys/modules/fs.ts
+++ b/src/compiler/sys/modules/fs.ts
@@ -1,6 +1,7 @@
 import type * as d from '../../../declarations';
 import { basename } from 'path';
 import { promisify } from './util';
+import { normalizePath } from '@utils';
 
 export interface FsObj {
   __sys: d.CompilerSystem;
@@ -111,7 +112,7 @@ export const realpathSync = (fs.realpathSync = (p: string) => {
   if (results.error) {
     throw results.error;
   }
-  return results.path;
+  return normalizePath(results.path);
 });
 
 export const statSync = (fs.statSync = (p: string) => {


### PR DESCRIPTION
This fixes a windows specific issue when resolving modules due to path formatting ([discovered investigating this](https://github.com/ionic-team/stencil/issues/2610)).

In my case when resolving the uuid package, it was looking for:

```json
"C:\\Development\\stencil-node-resolve-issue\\node_modules\\uuid\\dist\\esm-node\\index.js"
```

against:

```json
{
  "./dist/md5.js": "C:/Development/stencil-node-resolve-issue/node_modules/uuid/dist/md5-browser.js",
  "C:/Development/stencil-node-resolve-issue/node_modules/uuid/dist/md5.js": "C:/Development/stencil-node-resolve-issue/node_modules/uuid/dist/md5-browser.js",
  "./dist/rng.js": "C:/Development/stencil-node-resolve-issue/node_modules/uuid/dist/rng-browser.js",
  "C:/Development/stencil-node-resolve-issue/node_modules/uuid/dist/rng.js": "C:/Development/stencil-node-resolve-issue/node_modules/uuid/dist/rng-browser.js",
  "./dist/sha1.js": "C:/Development/stencil-node-resolve-issue/node_modules/uuid/dist/sha1-browser.js",
  "C:/Development/stencil-node-resolve-issue/node_modules/uuid/dist/sha1.js": "C:/Development/stencil-node-resolve-issue/node_modules/uuid/dist/sha1-browser.js",
  "./dist/esm-node/index.js": "C:/Development/stencil-node-resolve-issue/node_modules/uuid/dist/esm-browser/index.js",
  "C:/Development/stencil-node-resolve-issue/node_modules/uuid/dist/esm-node/index.js": "C:/Development/stencil-node-resolve-issue/node_modules/uuid/dist/esm-browser/index.js",
}
```

which failed and it ended up using the esm-node version instead of the esm-browser version.

Adding normalizePath to the result of fs.realpathSync fixed the issue for me - though there may be a better place to do this.

