### PR TITLE
Fix taskQueue: "immediate" rendering nothing

### DIFF
--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -28,7 +28,7 @@ export const scheduleUpdate = (hostRef: d.HostRef, isInitialLoad: boolean) => {
   // has already fired off its lifecycle update then
   // fire off the initial update
   const dispatch = () => dispatchHooks(hostRef, isInitialLoad);
-  return BUILD.taskQueue ? writeTask(dispatch) : dispatch;
+  return BUILD.taskQueue ? writeTask(dispatch) : dispatch();
 };
 
 const dispatchHooks = (hostRef: d.HostRef, isInitialLoad: boolean) => {


### PR DESCRIPTION
With `taskQueue: "async"` and `"congestedAsync"` `scheduleUpdate` calls `writeTask`, passing it the `dispatch` callback. `writeTask` calls the passed in dispatch callback in `process.nextTick`

Before this change, when the taskQueue: was set to `immediate`, the dispatch callback was never called. Resulting in no components rendering in the DOM.

Fixes https://github.com/ionic-team/stencil/issues/2491