### PR TITLE
docs(changelog): example to restore 1.x defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Update taskQueue default to "async". Stencil 1 default was "congestionAsync". Se
 ### Restore Stencil 1 defaults
 ```ts
 export const config: Config = {
-  buildEs5: true,
+  buildEs5: 'prod',
   extras: {
     cssVarsShim: true,
     dynamicImportShim: true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,20 @@ _Note that the runtime still works for any collections that have been built with
 Update taskQueue default to "async". Stencil 1 default was "congestionAsync". See [config.taskQueue](https://stenciljs.com/docs/config#taskqueue) for more info.
 
 
+### Restore Stencil 1 defaults
+```ts
+export const config: Config = {
+  buildEs5: true,
+  extras: {
+    cssVarsShim: true,
+    dynamicImportShim: true,
+    safari10: true,
+    shadowDomShim: true,
+  }
+};
+```
+
+
 ### NodeJS Update
 
 * **node:** minimum node 12.10.0, recommend 14.5.0 ([55331be](https://github.com/ionic-team/stencil/commit/55331be42f311a6e2a4e4f8ac13c01d28dc31613))


### PR DESCRIPTION
Add a section to make it easy for devs to restore their Stencil 1 defaults. I'm not really sure about `taskQueue` though. The goal is to make it easy for people to do the upgrade easy without breaking, but changing the `taskQueue` isn't a breaking change and so I didn't want to suggest it here. Feel free to overrule me on that though :)