### PR TITLE
fix: add ref attribute to SlotAttributes

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -711,6 +711,7 @@ export namespace JSXBase {
 
   export interface SlotAttributes {
     name?: string;
+    ref?: any;
     slot?: string;
     onSlotchange?: (event: Event) => void;
   }


### PR DESCRIPTION
Quick PR to enable `ref` on slots:

```html
<slot ref={el => this.mySlot = el} />
```