### PR TITLE
docs: move breaking changes to BREAKING_CHANGES.md

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,3 +1,94 @@
+# Stencil Two
+
+In keeping with [Semver](https://semver.org/), Stencil `2.0.0` was released due to changes in the API (mainly from some updates to the config API). But even though this is a new major version, there are few breaking changes.
+
+## BREAKING CHANGES
+
+While migrating from Stencil One, any changes will be flagged and described by the compiler during development. For the most part, most of the changes are removal of deprecated APIs that have been printing out warning logs for quite some time now
+
+### Opt-in for IE11, Edge 16-18 and Safari 10 Builds
+
+* **config:** update config extra defaults to not build IE11, Edge 16-18 and Safari 10 by default ([363bf59](https://github.com/ionic-team/stencil/commit/363bf59fc9212a771a766c21909263d6c4ccdf18))
+
+A change in Stencil 2 is that the IE11, Edge 16-18 and Safari 10 builds will not be enabled by default. However, the ability to opt-in is still available, and can be enabled by setting each `extras` config flag to `true`. And advantages of this is less runtime within your builds. See the [config.extras docs](https://stenciljs.com/docs/config-extras) for more info.
+
+
+### Opt-in for ES5 and SystemJS Builds
+
+* **config:** do not build es5 by default ([fa67d97](https://github.com/ionic-team/stencil/commit/fa67d97d043d12e0a3af0d868fa1746eb9e3badf))
+
+Just like having to opt-in for IE11, the same goes for opting-in for ES5 and SystemJS builds. For a production build in Stencil 1, it would build both ES2017/ESM files, and ES5/SystemJS files. As of Stencil 2, both dev and prod builds do not create ES5/SystemJS builds. An advantage of this is having faster production builds by not having to also downlevel to es5. See the [buildEs5](https://stenciljs.com/docs/config#buildes5) for more info.
+
+
+### Use `disconnectedCallback()` instead of `componentDidUnload()`
+
+* **componentDidUnload:** use disconnectedCallback instead of componentDidUnload ([4e45862](https://github.com/ionic-team/stencil/commit/4e45862f73609599a7195fcf5c93d9fb39492154))
+
+When Stencil is used within other frameworks, DOM elements may be reused, making it impossible for `componentDidUnload()` to be accurate 100% of the time if it is disconnected, then re-connected, and disconnected again. Instead, `disconnectedCallback()` is the preferred way to always know if a component was disconnected from the DOM.
+
+_Note that the runtime still works for any collections that have been built with componentDidUnload(). However, updates to Stencil 2 will require it's changed to disconnectedCallback()._
+
+
+### Default to `async` task queue
+
+* **taskQueue:** set "async" taskQueue as default ([f3bb121](https://github.com/ionic-team/stencil/commit/f3bb121b8130e0c4e0c344eca7078ce572ad34a5))
+
+Update taskQueue default to "async". Stencil 1 default was "congestionAsync". See [config.taskQueue](https://stenciljs.com/docs/config#taskqueue) for more info.
+
+
+### Restore Stencil 1 defaults
+```ts
+export const config: Config = {
+  buildEs5: 'prod',
+  extras: {
+    cssVarsShim: true,
+    dynamicImportShim: true,
+    safari10: true,
+    shadowDomShim: true,
+  }
+};
+```
+
+
+### dist package.json
+
+To ensure the extensions are built for the future and work with today's bundlers, we've found it best to use `.cjs.js` extension for CommonJS files, and `.js` for ESM files, with the idea that cjs files will no longer be needed some day, and the ESM files are the standard. _(We were using `.mjs` files, but not all of today's tooling and bundlers work well with that extension)._
+
+If you're using the `dist` output target, update the `package.json` in the root of your project, like this:
+
+```diff
+  {
+-    "main": "dist/index.js",
++    "main": "dist/index.cjs.js",
+
+-    "module": "dist/index.mjs",
++    "module": "dist/index.js",
+
+-    "es2015": "dist/esm/index.mjs",
++    "es2015": "dist/esm/index.js",
+
+-    "es2017": "dist/esm/index.mjs",
++    "es2017": "dist/esm/index.js",
+
+-    "jsnext:main": "dist/esm/index.mjs",
++    "jsnext:main": "dist/esm/index.js",
+  }
+```
+
+Additionally the `dist/loader` output directory has renamed its extensions too, but since its `dist/loader/package.json` file is auto-generated, the entries were renamed too. So unless you were referencing the loader files directly you will not have to do external updates.
+
+See the [Output Folder Structure Defaults](https://github.com/ionic-team/stencil/blob/master/src/compiler/output-targets/readme.md) for more info.
+
+
+### NodeJS Update
+
+* **node:** minimum of Node 12.10.0, recommend 14.5.0 or greater ([55331be](https://github.com/ionic-team/stencil/commit/55331be42f311a6e2a4e4f8ac13c01d28dc31613))
+
+With the major release, now's a good time to update the minimum and recommended version of NodeJS.
+
+* [Node Releases](https://nodejs.org/en/about/releases/)
+* [node.green](https://node.green/)
+
 # Stencil One
 
 Most of the updates for the `1.0.0` release involve removing custom APIs, and continuing to leverage web-standards in order to generate future-proof components that scale.

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -89,6 +89,8 @@ With the major release, now's a good time to update the minimum and recommended 
 * [Node Releases](https://nodejs.org/en/about/releases/)
 * [node.green](https://node.green/)
 
+*****
+
 # Stencil One
 
 Most of the updates for the `1.0.0` release involve removing custom APIs, and continuing to leverage web-standards in order to generate future-proof components that scale.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 In keeping with [Semver](https://semver.org/), Stencil `2.0.0` was released due to changes in the API (mainly from some updates to the config API).
 
-But even though this is a new major version, there are few [BREAKING CHANGES](BREAKING_CHANGE.md), and any changes will be flagged and described by the compiler during development. For the most part, most of the changes are removal of deprecated APIs that have been printing out warning logs for quite some time now.
+But even though this is a new major version, there are few [BREAKING CHANGES](BREAKING_CHANGES.md), and any changes will be flagged and described by the compiler during development. For the most part, most of the changes are removal of deprecated APIs that have been printing out warning logs for quite some time now.
 
 
 ### TypeScript 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,91 +28,9 @@
 
 # 🚗 [2.0.0](https://github.com/ionic-team/stencil/compare/v1.17.3...v2.0.0) (2020-08-31)
 
+In keeping with [Semver](https://semver.org/), Stencil `2.0.0` was released due to changes in the API (mainly from some updates to the config API).
 
-In keeping with [Semver](https://semver.org/), Stencil `2.0.0` was released due to changes in the API (mainly from some updates to the config API). But even though this is a new major version, there are few breaking changes, and any changes will be flagged and described by the compiler during development. For the most part, most of the changes are removal of deprecated APIs that have been printing out warning logs for quite some time now.
-
-### Opt-in for IE11, Edge 16-18 and Safari 10 Builds
-
-* **config:** update config extra defaults to not build IE11, Edge 16-18 and Safari 10 by default ([363bf59](https://github.com/ionic-team/stencil/commit/363bf59fc9212a771a766c21909263d6c4ccdf18))
-
-A change in Stencil 2 is that the IE11, Edge 16-18 and Safari 10 builds will not be enabled by default. However, the ability to opt-in is still available, and can be enabled by setting each `extras` config flag to `true`. And advantages of this is less runtime within your builds. See the [config.extras docs](https://stenciljs.com/docs/config-extras) for more info.
-
-
-### Opt-in for ES5 and SystemJS Builds
-
-* **config:** do not build es5 by default ([fa67d97](https://github.com/ionic-team/stencil/commit/fa67d97d043d12e0a3af0d868fa1746eb9e3badf))
-
-Just like having to opt-in for IE11, the same goes for opting-in for ES5 and SystemJS builds. For a production build in Stencil 1, it would build both ES2017/ESM files, and ES5/SystemJS files. As of Stencil 2, both dev and prod builds do not create ES5/SystemJS builds. An advantage of this is having faster production builds by not having to also downlevel to es5. See the [buildEs5](https://stenciljs.com/docs/config#buildes5) for more info.
-
-
-### Use `disconnectedCallback()` instead of `componentDidUnload()`
-
-* **componentDidUnload:** use disconnectedCallback instead of componentDidUnload ([4e45862](https://github.com/ionic-team/stencil/commit/4e45862f73609599a7195fcf5c93d9fb39492154))
-
-When Stencil is used within other frameworks, DOM elements may be reused, making it impossible for `componentDidUnload()` to be accurate 100% of the time if it is disconnected, then re-connected, and disconnected again. Instead, `disconnectedCallback()` is the preferred way to always know if a component was disconnected from the DOM.
-
-_Note that the runtime still works for any collections that have been built with componentDidUnload(). However, updates to Stencil 2 will require it's changed to disconnectedCallback()._
-
-
-### Default to `async` task queue
-
-* **taskQueue:** set "async" taskQueue as default ([f3bb121](https://github.com/ionic-team/stencil/commit/f3bb121b8130e0c4e0c344eca7078ce572ad34a5))
-
-Update taskQueue default to "async". Stencil 1 default was "congestionAsync". See [config.taskQueue](https://stenciljs.com/docs/config#taskqueue) for more info.
-
-
-### Restore Stencil 1 defaults
-```ts
-export const config: Config = {
-  buildEs5: 'prod',
-  extras: {
-    cssVarsShim: true,
-    dynamicImportShim: true,
-    safari10: true,
-    shadowDomShim: true,
-  }
-};
-```
-
-
-### dist package.json
-
-To ensure the extensions are built for the future and work with today's bundlers, we've found it best to use `.cjs.js` extension for CommonJS files, and `.js` for ESM files, with the idea that cjs files will no longer be needed some day, and the ESM files are the standard. _(We were using `.mjs` files, but not all of today's tooling and bundlers work well with that extension)._
-
-If you're using the `dist` output target, update the `package.json` in the root of your project, like this:
-
-```diff
-  {
--    "main": "dist/index.js",
-+    "main": "dist/index.cjs.js",
-
--    "module": "dist/index.mjs",
-+    "module": "dist/index.js",
-
--    "es2015": "dist/esm/index.mjs",
-+    "es2015": "dist/esm/index.js",
-
--    "es2017": "dist/esm/index.mjs",
-+    "es2017": "dist/esm/index.js",
-
--    "jsnext:main": "dist/esm/index.mjs",
-+    "jsnext:main": "dist/esm/index.js",
-  }
-```
-
-Additionally the `dist/loader` output directory has renamed its extensions too, but since its `dist/loader/package.json` file is auto-generated, the entries were renamed too. So unless you were referencing the loader files directly you will not have to do external updates.
-
-See the [Output Folder Structure Defaults](https://github.com/ionic-team/stencil/blob/master/src/compiler/output-targets/readme.md) for more info.
-
-
-### NodeJS Update
-
-* **node:** minimum of Node 12.10.0, recommend 14.5.0 or greater ([55331be](https://github.com/ionic-team/stencil/commit/55331be42f311a6e2a4e4f8ac13c01d28dc31613))
-
-With the major release, now's a good time to update the minimum and recommended version of NodeJS.
-
-* [Node Releases](https://nodejs.org/en/about/releases/)
-* [node.green](https://node.green/)
+But even though this is a new major version, there are few [BREAKING CHANGES](BREAKING_CHANGE.md), and any changes will be flagged and described by the compiler during development. For the most part, most of the changes are removal of deprecated APIs that have been printing out warning logs for quite some time now.
 
 
 ### TypeScript 4


### PR DESCRIPTION
For traceability reason and for those migrating to Stencil Two from One only in a couple of months, in might be easier to find the Stencil Two breaking changes in the related md file of the repo rather in the changelog.

This PR move the breaking changes of Stencil Two to BREAKING_CHANGES.md and link these in the CHANGELOG.md