### PR TITLE
fix(mock-doc): set hostname when location is updated

### DIFF
--- a/src/mock-doc/location.ts
+++ b/src/mock-doc/location.ts
@@ -20,6 +20,7 @@ export class MockLocation implements Location {
     this._href = url.href;
     this.protocol = url.protocol;
     this.host = url.host;
+    this.hostname = url.hostname;
     this.port = url.port;
     this.pathname = url.pathname;
     this.search = url.search;

--- a/src/mock-doc/test/location.spec.ts
+++ b/src/mock-doc/test/location.spec.ts
@@ -1,0 +1,95 @@
+import { MockWindow } from '../window';
+
+describe('location.href', () => {
+  let win: MockWindow;
+  beforeEach(() => {
+    win = new MockWindow(`
+      <html>
+        <head>
+        </head>
+      </head>
+      `);
+    win.location.href = "http://stencil:secret@stenciljs.com:3000/path/to/page?var=var#hash"
+  });
+
+  it('window.location.href', () => {
+    expect(win.location.href).toBe("http://stencil:secret@stenciljs.com:3000/path/to/page?var=var#hash");
+  });
+  it('window.location.protocol', () => {
+    expect(win.location.protocol).toBe("http:");
+  });
+  it('window.location.host', () => {
+    expect(win.location.host).toBe("stenciljs.com:3000");
+  });
+  it('window.location.hostname', () => {
+    expect(win.location.hostname).toBe("stenciljs.com");
+  });
+  it('window.location.port', () => {
+    expect(win.location.port).toBe("3000");
+  });
+  it('window.location.pathname', () => {
+    expect(win.location.pathname).toBe("/path/to/page");
+  });
+  it('window.location.search', () => {
+    expect(win.location.search).toBe("?var=var");
+  });
+  it('window.location.hash', () => {
+    expect(win.location.hash).toBe("#hash");
+  });
+  it('window.location.username', () => {
+    expect(win.location.username).toBe("stencil");
+  });
+  it('window.location.password', () => {
+    expect(win.location.password).toBe("secret");
+  });
+  it('window.location.origin', () => {
+    expect(win.location.origin).toBe("http://stenciljs.com:3000");
+  });
+});
+
+describe('location', () => {
+  let win: MockWindow;
+  beforeEach(() => {
+    win = new MockWindow(`
+      <html>
+        <head>
+        </head>
+      </head>
+      `);
+    win.location = "http://stencil:secret@stenciljs.com:3000/path/to/page?var=var#hash"
+  });
+
+  it('window.location.href', () => {
+    expect(win.location.href).toBe("http://stencil:secret@stenciljs.com:3000/path/to/page?var=var#hash");
+  });
+  it('window.location.protocol', () => {
+    expect(win.location.protocol).toBe("http:");
+  });
+  it('window.location.host', () => {
+    expect(win.location.host).toBe("stenciljs.com:3000");
+  });
+  it('window.location.hostname', () => {
+    expect(win.location.hostname).toBe("stenciljs.com");
+  });
+  it('window.location.port', () => {
+    expect(win.location.port).toBe("3000");
+  });
+  it('window.location.pathname', () => {
+    expect(win.location.pathname).toBe("/path/to/page");
+  });
+  it('window.location.search', () => {
+    expect(win.location.search).toBe("?var=var");
+  });
+  it('window.location.hash', () => {
+    expect(win.location.hash).toBe("#hash");
+  });
+  it('window.location.username', () => {
+    expect(win.location.username).toBe("stencil");
+  });
+  it('window.location.password', () => {
+    expect(win.location.password).toBe("secret");
+  });
+  it('window.location.origin', () => {
+    expect(win.location.origin).toBe("http://stenciljs.com:3000");
+  });
+});


### PR DESCRIPTION
The hostname was not updated when a new href is set on the window location, it looks like this was an oversight, this commit makes it so the hostname is populated like everything else.

chore(test): add test for MockLocation behaviour

Closes #2688 