### PR TITLE
feat(docs-custom): add config argument

### DIFF
--- a/src/compiler/docs/custom/index.ts
+++ b/src/compiler/docs/custom/index.ts
@@ -9,7 +9,7 @@ export const generateCustomDocs = async (config: d.Config, docsData: d.JsonDocs,
   await Promise.all(
     customOutputTargets.map(async customOutput => {
       try {
-        await customOutput.generator(docsData);
+        await customOutput.generator(docsData, config);
       } catch (e) {
         config.logger.error(`uncaught custom docs error: ${e}`);
       }

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1819,7 +1819,7 @@ export interface OutputTargetDocsJson extends OutputTargetBase {
 export interface OutputTargetDocsCustom extends OutputTargetBase {
   type: 'docs-custom';
 
-  generator: (docs: JsonDocs) => void | Promise<void>;
+  generator: (docs: JsonDocs, config: Config) => void | Promise<void>;
   strict?: boolean;
 }
 


### PR DESCRIPTION
I would like to have access to the logger when using the `docs-custom` output target, at the moment only the `docs` generated by Stencil is given to the `generator` function.

Sending only the logger to `generator` seems a bit weird and since the logger is available on `config` I added that as an argument instead. There might be other stuff on `config` that also could be of use to anyone using the `docs-custom` output target.

If there is another way to do this, please let med know! :slightly_smiling_face: 
I'm also not sure if there is anything else I need to update, all the tests pass at least! :slightly_smiling_face: 