### PR TITLE
fix(devserver): expose startupTimeout

### DIFF
--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -421,7 +421,12 @@ export interface StencilDevServerConfig {
    */
   ssr?: boolean;
   /**
-   * If to use the dev server's websocket client or not. Defaults to `true`.
+   * If the dev server fails to start up within the given timout (in milliseconds), the startup will
+   * be canceled. Set to zero to disable the timeout. Defaults to `15000`.
+   */
+  startupTimeout?: number;
+  /**
+   * Whether to use the dev server's websocket client or not. Defaults to `true`.
    */
   websocket?: boolean;
   /**
@@ -440,7 +445,6 @@ export interface DevServerConfig extends StencilDevServerConfig {
   prerenderConfig?: string;
   protocol?: 'http' | 'https';
   srcIndexHtml?: string;
-  startupTimeout?: number;
 }
 
 export interface HistoryApiFallback {

--- a/src/dev-server/index.ts
+++ b/src/dev-server/index.ts
@@ -53,10 +53,10 @@ function startServer(
   const timespan = logger.createTimeSpan(`starting dev server`, true);
 
   const startupTimeout =
-    logger.getLevel() !== 'debug'
+    logger.getLevel() !== 'debug' || devServerConfig.startupTimeout !== 0
       ? setTimeout(() => {
           reject(`dev server startup timeout`);
-        }, devServerConfig.startupTimeout || 15000)
+        }, devServerConfig.startupTimeout ?? 15000)
       : null;
 
   let isActivelyBuilding = false;


### PR DESCRIPTION
Follow-up on #2719 because `startupTimeout` was added to the wrong interface and therefore wasn't exposed to the user.

Also changed it to interpret the value zero as "disable timeout completely", and added a description comment.

Closes #2718.