### PR TITLE
Update link to puppeteer's key names

### DIFF
--- a/src/testing/puppeteer/puppeteer-declarations.ts
+++ b/src/testing/puppeteer/puppeteer-declarations.ts
@@ -336,7 +336,7 @@ export interface E2EElement {
    * text option can be specified to force an input event to be generated.
    * Note: Modifier keys DO effect `elementHandle.press`. Holding down Shift
    * will type the text in upper case.
-   * Key names: https://github.com/GoogleChrome/puppeteer/blob/master/lib/USKeyboardLayout.js
+   * Key names: https://github.com/puppeteer/puppeteer/blob/main/src/common/USKeyboardLayout.ts
    */
   press(key: string, options?: { text?: string; delay?: number }): Promise<void>;
 


### PR DESCRIPTION
Recently I was working on setting up a test and wasn't sure if the key I needed pass was named 'Enter' or 'Return'. As I dug into the E2EElement interface and was reading about the press method, I found a link to the Keys that puppeteer supports. I've updated the comment to use the new link as the old one was 404ing.