### PR TITLE
Update *?worker declaration

### DIFF
--- a/src/declarations/stencil-ext-modules.d.ts
+++ b/src/declarations/stencil-ext-modules.d.ts
@@ -25,7 +25,9 @@ declare module '*.vert' {
 
 declare module '*?worker' {
   export const worker: Worker;
-  export const fileName: string;
+  export const workerMsgId: string;
+  export const workerName: string;
+  export const workerPath: string;
 }
 
 declare module '*?format=url' {


### PR DESCRIPTION
`*?worker` declaration is outdated / doesnt match current behaviour.

Updated declaration based on `import * as worker from './worker.worker.ts?worker;`

![image](https://user-images.githubusercontent.com/11861797/100461744-7dad4800-30c9-11eb-9929-23d659111824.png)

and https://stenciljs.com/docs/web-workers#advanced-cases