### PR TITLE
fix(client): Test for presence of replace-Method of CSSStyleSheet

### DIFF
--- a/src/client/client-window.ts
+++ b/src/client/client-window.ts
@@ -43,7 +43,7 @@ export const supportsConstructibleStylesheets = BUILD.constructableCSS
   ? /*@__PURE__*/ (() => {
       try {
         new CSSStyleSheet();
-        return true;
+        return typeof (new CSSStyleSheet()).replace === 'function';
       } catch (e) {}
       return false;
     })()


### PR DESCRIPTION
Test for presence of replace-Method of CSSStyleSheet as we rely on this method. Not every browser that implements CSSStyleSheet does also implement CSSStyleSheet.replace()