### PR TITLE
Immutable props fix (fixes #2433)

### DIFF
--- a/src/runtime/test/prop-warnings.spec.tsx
+++ b/src/runtime/test/prop-warnings.spec.tsx
@@ -1,0 +1,92 @@
+import { Component, Prop, Method, h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+describe('prop', () => {
+  const spy = jest.spyOn(console, 'warn').mockImplementation();
+
+  afterEach(() => spy.mockReset());
+  afterAll(() => spy.mockRestore());
+
+  it('should show warning when immutable prop is mutated', async () => {
+    @Component({ tag: 'cmp-a' })
+    class CmpA {
+      @Prop() a = 1;
+
+      @Method()
+      async update() {
+        this.a = 2;
+      }
+
+      render() {
+        return `${this.a}`;
+      }
+    }
+
+    const { root, waitForChanges } = await newSpecPage({
+      components: [CmpA],
+      html: `<cmp-a></cmp-a>`,
+    });
+
+    expect(root).toEqualHtml('<cmp-a>1</cmp-a>');
+
+    await root.update();
+    await waitForChanges();
+
+    expect(root).toEqualHtml('<cmp-a>2</cmp-a>');
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toMatch(/@Prop\(\) "[A-Za-z-]+" on <[A-Za-z-]+> is immutable/);
+  });
+
+  it('should not show warning when mutable prop is mutated', async () => {
+    @Component({ tag: 'cmp-a' })
+    class CmpA {
+      @Prop({ mutable: true }) a = 1;
+
+      @Method()
+      async update() {
+        this.a = 2;
+      }
+
+      render() {
+        return `${this.a}`;
+      }
+    }
+
+    const { root, waitForChanges } = await newSpecPage({
+      components: [CmpA],
+      html: `<cmp-a></cmp-a>`,
+    });
+
+    expect(root).toEqualHtml('<cmp-a>1</cmp-a>');
+
+    await root.update();
+    await waitForChanges();
+
+    expect(root).toEqualHtml('<cmp-a>2</cmp-a>');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should not show warning when immutable prop is mutated from parent', async () => {
+    @Component({ tag: 'cmp-a' })
+    class CmpA {
+      @Prop() a = 1;
+
+      render() {
+        return `${this.a}`;
+      }
+    }
+
+    const { root, waitForChanges } = await newSpecPage({
+      components: [CmpA],
+      html: `<cmp-a></cmp-a>`,
+    });
+
+    expect(root).toEqualHtml('<cmp-a>1</cmp-a>');
+
+    root.a = 2;
+    await waitForChanges();
+
+    expect(root).toEqualHtml('<cmp-a>2</cmp-a>');
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/testing/platform/testing-log.ts
+++ b/src/testing/platform/testing-log.ts
@@ -14,12 +14,13 @@ export const consoleDevError = (...e: any[]) => {
   caughtErrors.push(new Error(e.join(', ')));
 };
 
-export const consoleDevWarn = (..._: any[]) => {
-  /* noop for testing */
+export const consoleDevWarn = (args: any) => {
+  // log warnings so we can spy on them when testing
+  console.warn(args);
 };
 
 export const consoleDevInfo = (..._: any[]) => {
   /* noop for testing */
 };
 
-export const setErrorHandler = (handler: d.ErrorHandler) => customError = handler;
+export const setErrorHandler = (handler: d.ErrorHandler) => (customError = handler);


### PR DESCRIPTION
This fixes [a longstanding bug](https://github.com/ionic-team/stencil/issues/2433) where the warning for immutable prop changes doesn't get shown. It also adds tests to ensure the warning is emitted at the correct times.

Side note: this will probably confuse people once it gets merged because a lot of projects are likely changing props without the `{ mutable: true }` flag. I've already noticed a few in Stencil Router. 😆 