### PR TITLE
chore(): update browserslist via autoprefixer + core-js-builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1423,6 +1423,19 @@
       "requires": {
         "@types/browserslist": "*",
         "postcss": "7.x.x"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "7.0.35",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
+          "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        }
       }
     },
     "@types/babel__core": {
@@ -9753,6 +9766,12 @@
       "dev": true,
       "optional": true
     },
+    "nanoid": {
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+      "dev": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -10360,14 +10379,14 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-      "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.2.tgz",
+      "integrity": "sha512-HM1NDNWLgglJPQQMNwvLxgH2KcrKZklKLi/xXYIOaqQB57p/pDWEJNS83PVICYsn1Dg/9C26TiejNr422/ePaQ==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
+        "colorette": "^1.2.1",
+        "nanoid": "^3.1.20",
+        "source-map": "^0.6.1"
       }
     },
     "postcss-value-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2280,24 +2280,48 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "9.8.6",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
-      "integrity": "sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.1.0.tgz",
+      "integrity": "sha512-0/lBNwN+ZUnb5su18NZo5MBIjDaq6boQKZcxwy86Gip/CmXA2zZqUoFQLCNAGI5P25ZWSP2RWdhDJ8osfKEjoQ==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.12.0",
-        "caniuse-lite": "^1.0.30001109",
+        "browserslist": "^4.15.0",
+        "caniuse-lite": "^1.0.30001165",
         "colorette": "^1.2.1",
+        "fraction.js": "^4.0.12",
         "normalize-range": "^0.1.2",
-        "num2fraction": "^1.2.2",
-        "postcss": "^7.0.32",
         "postcss-value-parser": "^4.1.0"
       },
       "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30001112",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001112.tgz",
-          "integrity": "sha512-J05RTQlqsatidif/38aN3PGULCLrg8OYQOlJUKbeYVzC2mGZkZLIztwRlB3MtrfLmawUmjFlNJvy/uhwniIe1Q==",
+        "browserslist": {
+          "version": "4.16.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
+          "integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001165",
+            "colorette": "^1.2.1",
+            "electron-to-chromium": "^1.3.621",
+            "escalade": "^3.1.1",
+            "node-releases": "^1.1.67"
+          }
+        },
+        "electron-to-chromium": {
+          "version": "1.3.633",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.633.tgz",
+          "integrity": "sha512-bsVCsONiVX1abkWdH7KtpuDAhsQ3N3bjPYhROSAXE78roJKet0Y5wznA14JE9pzbwSZmSMAW6KiKYf1RvbTJkA==",
+          "dev": true
+        },
+        "escalade": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+          "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+          "dev": true
+        },
+        "node-releases": {
+          "version": "1.1.67",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
+          "integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==",
           "dev": true
         }
       }
@@ -2724,15 +2748,16 @@
       }
     },
     "browserslist": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.13.0.tgz",
-      "integrity": "sha512-MINatJ5ZNrLnQ6blGvePd/QOz9Xtu+Ne+x29iQSCHfkU5BugKVJwZKn/iiL8UbpIpa3JhviKjz+XxMo0m2caFQ==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
+      "integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001093",
-        "electron-to-chromium": "^1.3.488",
-        "escalade": "^3.0.1",
-        "node-releases": "^1.1.58"
+        "caniuse-lite": "^1.0.30001165",
+        "colorette": "^1.2.1",
+        "electron-to-chromium": "^1.3.621",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.67"
       }
     },
     "bser": {
@@ -2860,9 +2885,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001094",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001094.tgz",
-      "integrity": "sha512-ufHZNtMaDEuRBpTbqD93tIQnngmJ+oBknjvr0IbFympSdtFpAUFmNv4mVKbb53qltxFx0nK3iy32S9AqkLzUNA==",
+      "version": "1.0.30001173",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001173.tgz",
+      "integrity": "sha512-R3aqmjrICdGCTAnSXtNyvWYMK3YtV5jwudbq0T7nN9k4kmE4CBuwPqyJ+KBzepSTh0huivV2gLbSMEzTTmfeYw==",
       "dev": true
     },
     "capture-exit": {
@@ -3881,30 +3906,30 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.2.tgz",
+      "integrity": "sha512-FfApuSRgrR6G5s58casCBd9M2k+4ikuu4wbW6pJyYU7bd9zvFc9qf7vr5xmrZOhT9nn+8uwlH1oRR9jTnFoA3A==",
       "dev": true
     },
     "core-js-builder": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js-builder/-/core-js-builder-3.6.5.tgz",
-      "integrity": "sha512-RXS7ipYfGd/IDlbZTge92kDWmnrxP7LnuEiUqO7FT6dVvEe+lUv032A2Vg9m5NxpfCVdiIK/gR6+OL/NTvO/UQ==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/core-js-builder/-/core-js-builder-3.8.2.tgz",
+      "integrity": "sha512-re/O6zhk7vaV+kuZRzRjM/wzT/Zj5+fNM1vlX6XGmYNYygiXJoWGNZhJA3DdtY6MkWBi2qzKieNT0hRqrR16Eg==",
       "dev": true,
       "requires": {
-        "core-js": "3.6.5",
-        "core-js-compat": "3.6.5",
-        "mkdirp": "^0.5.1",
-        "webpack": "^4.41.5"
+        "core-js": "3.8.2",
+        "core-js-compat": "3.8.2",
+        "mkdirp": ">=0.5.5 <1",
+        "webpack": ">=4.44.2 <5"
       }
     },
     "core-js-compat": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",
-      "integrity": "sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.8.2.tgz",
+      "integrity": "sha512-LO8uL9lOIyRRrQmZxHZFl1RV+ZbcsAkFWTktn5SmH40WgLtSNYN4m4W2v9ONT147PxBY/XrRhrWq8TlvObyUjQ==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.8.5",
+        "browserslist": "^4.16.0",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -4375,9 +4400,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.488",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.488.tgz",
-      "integrity": "sha512-NReBdOugu1yl8ly+0VDtiQ6Yw/1sLjnvflWq0gvY1nfUXU2PbA+1XAVuEb7ModnwL/MfUPjby7e4pAFnSHiy6Q==",
+      "version": "1.3.633",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.633.tgz",
+      "integrity": "sha512-bsVCsONiVX1abkWdH7KtpuDAhsQ3N3bjPYhROSAXE78roJKet0Y5wznA14JE9pzbwSZmSMAW6KiKYf1RvbTJkA==",
       "dev": true
     },
     "elegant-spinner": {
@@ -4502,9 +4527,9 @@
       }
     },
     "escalade": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.1.tgz",
-      "integrity": "sha512-DR6NO3h9niOT+MZs7bjxlj2a1k+POu5RN8CLTPX2+i78bRi9eLe7+0zXgUHMnGXWybYcL61E9hGhPKqedy8tQA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
     },
     "escape-string-regexp": {
@@ -5145,6 +5170,12 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "fraction.js": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.13.tgz",
+      "integrity": "sha512-E1fz2Xs9ltlUp+qbiyx9wmt2n9dRzPsS11Jtdb8D2o+cC7wr9xkkKsVKJuBX0ST+LVS+LhLO+SbLJNtfWcJvXA==",
+      "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -5808,7 +5839,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "handlebars": {
       "version": "4.7.6",
@@ -9852,6 +9884,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -9862,9 +9895,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.58",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.58.tgz",
-      "integrity": "sha512-NxBudgVKiRh/2aPWMgPR7bPTX0VPmGx5QBwCtdHitnqFE5/O8DeBXuIMH1nwNnw/aMo6AjOrpsHzfY3UbUJ7yg==",
+      "version": "1.1.67",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
+      "integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==",
       "dev": true
     },
     "normalize-package-data": {
@@ -9907,12 +9940,6 @@
       "requires": {
         "path-key": "^2.0.0"
       }
-    },
-    "num2fraction": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
-      "dev": true
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -11113,7 +11140,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -12231,7 +12259,8 @@
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
       "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "v8-to-istanbul": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "parse5": "6.0.1",
     "path-browserify": "^1.0.1",
     "pixelmatch": "4.0.2",
-    "postcss": "^7.0.32",
+    "postcss": "^8.2.2",
     "prettier": "^2.2.1",
     "prompts": "2.4.0",
     "puppeteer": "~5.5.0",

--- a/package.json
+++ b/package.json
@@ -77,10 +77,10 @@
     "@types/webpack": "^4.41.25",
     "@types/ws": "^7.4.0",
     "ansi-colors": "4.1.1",
-    "autoprefixer": "9.8.6",
+    "autoprefixer": "^10.1.0",
     "concurrently": "^5.3.0",
     "conventional-changelog-cli": "^2.1.1",
-    "core-js-builder": "~3.6.5",
+    "core-js-builder": "~3.8.2",
     "css": "^3.0.0",
     "dts-bundle-generator": "~5.3.0",
     "execa": "4.1.0",
@@ -138,5 +138,6 @@
     "custom elements",
     "pwa",
     "progressive web app"
-  ]
+  ],
+  "dependencies": {}
 }

--- a/src/testing/jest/jest-environment.ts
+++ b/src/testing/jest/jest-environment.ts
@@ -27,7 +27,7 @@ export function createJestPuppeteerEnvironment() {
 
       const page = await newBrowserPage(this.browser);
       this.pages.push(page);
-      const env: E2EProcessEnv = process.env;
+      const env: E2EProcessEnv = process.env as E2EProcessEnv;
       if (typeof env.__STENCIL_DEFAULT_TIMEOUT__ === 'string') {
         page.setDefaultTimeout(parseInt(env.__STENCIL_DEFAULT_TIMEOUT__, 10));
       }

--- a/src/testing/jest/jest-setup-test-framework.ts
+++ b/src/testing/jest/jest-setup-test-framework.ts
@@ -1,4 +1,5 @@
 import type * as d from '@stencil/core/internal';
+import type { E2EProcessEnv } from '@stencil/core/internal';
 import { BUILD, Env } from '@app-data';
 import { expectExtend } from '../matchers';
 import { setupGlobal, teardownGlobal } from '@stencil/core/mock-doc';
@@ -49,7 +50,7 @@ export function jestSetupTestFramework() {
 
   global.screenshotDescriptions = new Set();
 
-  const env: d.E2EProcessEnv = process.env;
+  const env: d.E2EProcessEnv = process.env as E2EProcessEnv;
 
   if (typeof env.__STENCIL_DEFAULT_TIMEOUT__ === 'string') {
     const time = parseInt(env.__STENCIL_DEFAULT_TIMEOUT__, 10);

--- a/src/testing/puppeteer/puppeteer-browser.ts
+++ b/src/testing/puppeteer/puppeteer-browser.ts
@@ -6,7 +6,7 @@ export async function startPuppeteerBrowser(config: Config) {
     return null;
   }
 
-  const env: E2EProcessEnv = process.env;
+  const env: E2EProcessEnv = process.env as E2EProcessEnv;
   const puppeteerDep = config.testing.browserExecutablePath ? 'puppeteer-core' : 'puppeteer';
 
   const puppeteerModulePath = config.sys.lazyRequire.getModulePath(config.rootDir, puppeteerDep);
@@ -68,7 +68,7 @@ export async function connectBrowser() {
   // a web socket is because jest probably has us
   // in a different thread, this is also why this
   // uses process.env for data
-  const env: E2EProcessEnv = process.env;
+  const env: E2EProcessEnv = process.env as E2EProcessEnv;
 
   const wsEndpoint = env.__STENCIL_BROWSER_WS_ENDPOINT__;
   if (!wsEndpoint) {

--- a/src/testing/puppeteer/puppeteer-page.ts
+++ b/src/testing/puppeteer/puppeteer-page.ts
@@ -21,7 +21,7 @@ import { initPageScreenshot } from './puppeteer-screenshot';
 
 declare const global: JestEnvironmentGlobal;
 
-const env: E2EProcessEnv = process.env;
+const env: E2EProcessEnv = process.env as E2EProcessEnv;
 export async function newE2EPage(opts: NewE2EPageOptions = {}): Promise<E2EPage> {
   if (!global.__NEW_TEST_PAGE__) {
     throw new Error(`newE2EPage() is only available from E2E tests, and ran with the --e2e cmd line flag.`);

--- a/src/testing/testing.ts
+++ b/src/testing/testing.ts
@@ -41,7 +41,7 @@ export const createTesting = async (config: Config): Promise<Testing> => {
         return false;
       }
 
-      env = process.env;
+      env = process.env as E2EProcessEnv;
 
       if (opts.e2e) {
         msg.push('e2e');


### PR DESCRIPTION
Fixes #2784

Note that this includes some major version bumps:

- autoprefixer: 9.8.6 => 10.0.1
- postcss: 7.0.32 => 8.2.2