### PR TITLE
fix(mock-doc): make MockAttributeMap iterable

### DIFF
--- a/src/mock-doc/attribute.ts
+++ b/src/mock-doc/attribute.ts
@@ -83,6 +83,10 @@ export class MockAttributeMap {
       }),
     };
   }
+
+  get [Symbol.toStringTag]() {
+    return 'MockAttributeMap';
+  }
 }
 
 function getNamespaceURI(namespaceURI: string) {

--- a/src/mock-doc/attribute.ts
+++ b/src/mock-doc/attribute.ts
@@ -5,14 +5,15 @@ const attrHandler = {
     if (prop in obj) {
       return obj[prop];
     }
-    if (!isNaN(prop as any)) {
+    if (typeof prop !== 'symbol' && !isNaN(prop as any)) {
       return (obj as MockAttributeMap).__items[prop as any];
     }
     return undefined;
   },
 };
 
-export const createAttributeProxy = (caseInsensitive: boolean) => new Proxy(new MockAttributeMap(caseInsensitive), attrHandler);
+export const createAttributeProxy = (caseInsensitive: boolean) =>
+  new Proxy(new MockAttributeMap(caseInsensitive), attrHandler);
 
 export class MockAttributeMap {
   __items: MockAttr[] = [];
@@ -54,7 +55,9 @@ export class MockAttributeMap {
 
   getNamedItemNS(namespaceURI: string, attrName: string) {
     namespaceURI = getNamespaceURI(namespaceURI);
-    return this.__items.find(attr => attr.name === attrName && getNamespaceURI(attr.namespaceURI) === namespaceURI) || null;
+    return (
+      this.__items.find(attr => attr.name === attrName && getNamespaceURI(attr.namespaceURI) === namespaceURI) || null
+    );
   }
 
   removeNamedItem(attr: MockAttr) {
@@ -68,6 +71,17 @@ export class MockAttributeMap {
         break;
       }
     }
+  }
+
+  [Symbol.iterator]() {
+    let i = 0;
+
+    return {
+      next: () => ({
+        done: i === this.length,
+        value: this.item(i++),
+      }),
+    };
   }
 }
 

--- a/src/mock-doc/test/attribute.spec.ts
+++ b/src/mock-doc/test/attribute.spec.ts
@@ -1,12 +1,20 @@
+import { MockAttr, MockAttributeMap } from '../attribute';
 import { MockDocument } from '../document';
 import { MockElement, MockHTMLElement } from '../node';
 import { XLINK_NS } from '../../runtime/runtime-constants';
-import { MockImageElement } from '../element';
 
 describe('attributes', () => {
   let doc: MockDocument;
   beforeEach(() => {
     doc = new MockDocument();
+  });
+
+  it('attribute map is iterable', () => {
+    const map = new MockAttributeMap();
+    const attr = new MockAttr('attr', 'value');
+    map.setNamedItem(attr);
+
+    expect(Array.from(map)[0]).toBe(attr);
   });
 
   it('should get attributes by index', () => {
@@ -67,7 +75,9 @@ describe('attributes', () => {
     expect(element.getAttribute('prop5')).toBe('hola');
     expect(element.getAttribute('prop6')).toBe('');
 
-    expect(element).toEqualHtml(`<div prop1=\"null\" prop2=\"undefined\" prop3=\"0\" prop4=\"1\" prop5=\"hola\" prop6></div>`);
+    expect(element).toEqualHtml(
+      `<div prop1=\"null\" prop2=\"undefined\" prop3=\"0\" prop4=\"1\" prop5=\"hola\" prop6></div>`,
+    );
   });
 
   it('should cast attributeNS values to string', () => {
@@ -86,7 +96,9 @@ describe('attributes', () => {
     expect(element.getAttribute('prop5')).toBe('hola');
     expect(element.getAttribute('prop6')).toBe('');
 
-    expect(element).toEqualHtml(`<div prop1=\"null\" prop2=\"undefined\" prop3=\"0\" prop4=\"1\" prop5=\"hola\" prop6></div>`);
+    expect(element).toEqualHtml(
+      `<div prop1=\"null\" prop2=\"undefined\" prop3=\"0\" prop4=\"1\" prop5=\"hola\" prop6></div>`,
+    );
   });
 
   it('attributes are case insensible in HTMLElement', () => {
@@ -126,7 +138,7 @@ describe('attributes', () => {
   });
 
   it('draggable default value', () => {
-    const div = doc.createElement('div')
+    const div = doc.createElement('div');
     expect(div.draggable).toEqual(false);
 
     const img = doc.createElement('img');


### PR DESCRIPTION
TL;DR Proposed changes:

- implement `[Symbol.iterator]` in `MockAttributeMap` to make it iterable
- implement `get [Symbol.toStringTag]` in `MockAttributeMap`
- don't pass symbols into `isNaN` in attribute proxy
- prettier formatted a couple things

---

When writing E2E tests I ran into different `PrettyFormatPluginError` errors, when Jest would try to pretty-format an `E2EElement` while iterating over its attributes:

```
PrettyFormatPluginError: Cannot read property 'name' of undefinedTypeError: Cannot read property 'name' of undefined
```

or

```
PrettyFormatPluginError: _val$hasAttribute.call is not a functionTypeError: _val$hasAttribute.call is not a function
```

```
at node_modules/jest-matcher-utils/node_modules/pretty-format/build/plugins/DOMElement.js
```

---

This error might only happen in my case because I'm using `jest@26` and I think Stencil still defaults to `jest@25`, but doesn't complain if a higher major version is used cause it's likely compatible.

Anyway, after debugging this for half a day, I figured out that `pretty-format` fails to print the attributes because `MockAttributeMap` is not really iterable but it tries to iterate it (passed into `Array.from`, see [facebook/jest/pretty-format/src/plugins/DOMElement.ts#L87](https://github.com/facebook/jest/blob/7430a7824421c122cd07035d800d22e1007408fa/packages/pretty-format/src/plugins/DOMElement.ts#L87) and [facebook/jest/pretty-format/src/plugins/DOMElement.ts#L87](https://github.com/facebook/jest/blob/7430a7824421c122cd07035d800d22e1007408fa/packages/pretty-format/src/plugins/DOMElement.ts#L92)), and ends up being an Array of `undefined`s (not sure why).

The solution is to add an implementation of `[Symbol.iterator]`. Another symbol that pretty-format tries to access is `Symbol.toStringTag` so I've also implemented that.

---

Also, the attribute proxy uses `isNaN` which breaks when called on a symbol:

```
PrettyFormatPluginError: Cannot convert a Symbol value to a numberTypeError: Cannot convert a Symbol value to a number
        at isNaN (<anonymous>)

      at Object.get (node_modules/@stencil/core/mock-doc/index.cjs:21:10)
          at Proxy.toString (<anonymous>)
          at Array.map (<anonymous>)
```

thus I've added a check for that.