### PR TITLE
fix(mock-doc): add hasAttribute to MockCSSStyleDeclaration

### DIFF
--- a/src/mock-doc/css-style-declaration.ts
+++ b/src/mock-doc/css-style-declaration.ts
@@ -55,6 +55,10 @@ export class MockCSSStyleDeclaration {
       }
     });
   }
+
+  hasAttribute() {
+    return false;
+  }
 }
 
 export function createCSSStyleDeclaration() {


### PR DESCRIPTION
Proposed changes:

- add `hasAttribute` implementation to `MockCSSStyleDeclaration`

---

Without this I sometimes run into the following error with `jest@26`:

```
PrettyFormatPluginError: _val$hasAttribute.call is not a functionTypeError: _val$hasAttribute.call is not a function

      at testNode (node_modules/jest-matcher-utils/node_modules/pretty-format/build/plugins/DOMElement.js:32:27)
```

The reason this happens is because the css style declaration is proxied, and the `ProxyHandler`'s get method returns an empty string for unknown properties:

https://github.com/ionic-team/stencil/blob/a1c320bfb83cb20935bd1554597316a788174ec1/src/mock-doc/css-style-declaration.ts#L74

https://github.com/ionic-team/stencil/blob/a1c320bfb83cb20935bd1554597316a788174ec1/src/mock-doc/css-style-declaration.ts#L14-L17

When jest tries to pretty-format, it checks whether the object has a `hasAttribute` property, and if it does, it assumes that it's a function and tries calling it (which fails because the proxy returns a string `''`).

---

My first assumption was that `MockCSSStyleDeclaration` is supposed to be the mock for the `<style>` element, in which case I thought it might also make sense that it extends `MockHTMLElement` so that all element-related methods are implemented. But now I see that this is regarding the `style` attribute, so maybe it makes sense to get this fixed in `pretty-format` instead:

https://github.com/facebook/jest/blob/7430a7824421c122cd07035d800d22e1007408fa/packages/pretty-format/src/plugins/DOMElement.ts#L30

```diff
- val.hasAttribute?.('is');
+ typeof val.hasAttribute === 'function' && val.hasAttribute('is');
```

(`pretty-format` is a bit optimistic here to assume that `hasAttribute` is always callable like this)