### PR TITLE
fix(): output preamble in generated files

### DIFF
--- a/src/compiler/optimize/optimize-module.ts
+++ b/src/compiler/optimize/optimize-module.ts
@@ -3,6 +3,7 @@ import { minifyJs } from './minify-js';
 import type { CompilerCtx, Config, Diagnostic, SourceTarget } from '../../declarations';
 import type { CompressOptions, MangleOptions, MinifyOptions } from 'terser';
 import ts from 'typescript';
+import { generatePreamble } from '../../utils/util';
 
 interface OptimizeModuleOptions {
   input: string;
@@ -81,7 +82,10 @@ export const getTerserOptions = (config: Config, sourceTarget: SourceTarget, pre
   const opts: MinifyOptions = {
     ie8: false,
     safari10: !!config.extras.safari10,
-    format: {},
+    format: {
+      comments: /^!/,
+      preamble: generatePreamble(config),
+    },
   };
 
   if (sourceTarget === 'es5') {

--- a/src/compiler/optimize/optimize-module.ts
+++ b/src/compiler/optimize/optimize-module.ts
@@ -3,7 +3,7 @@ import { minifyJs } from './minify-js';
 import type { CompilerCtx, Config, Diagnostic, SourceTarget } from '../../declarations';
 import type { CompressOptions, MangleOptions, MinifyOptions } from 'terser';
 import ts from 'typescript';
-import { generatePreamble } from '../../utils/util';
+import { generatePreamble } from '@utils';
 
 interface OptimizeModuleOptions {
   input: string;

--- a/src/compiler/output-targets/dist-custom-elements-bundle/custom-elements-bundle-types.ts
+++ b/src/compiler/output-targets/dist-custom-elements-bundle/custom-elements-bundle-types.ts
@@ -1,7 +1,7 @@
 import type * as d from '../../../declarations';
 import { isOutputTargetDistCustomElementsBundle } from '../output-utils';
 import { dirname, join, relative } from 'path';
-import { generatePreamble, normalizePath, dashToPascalCase } from '@utils';
+import { normalizePath, dashToPascalCase } from '@utils';
 
 export const generateCustomElementsBundleTypes = async (config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx, distDtsFilePath: string) => {
   const outputTargets = config.outputTargets.filter(isOutputTargetDistCustomElementsBundle);
@@ -18,14 +18,11 @@ const generateCustomElementsTypesOutput = async (
 ) => {
   const customElementsDtsPath = join(outputTarget.dir, 'index.d.ts');
   const componentsDtsRelPath = relDts(outputTarget.dir, distDtsFilePath);
-  const preamble = generatePreamble(config, {
-    suffix: `${config.namespace} custom elements bundle` 
-  });
-  
-  const components = buildCtx.components.filter(m => !m.isCollectionDependency);  
+
+  const components = buildCtx.components.filter(m => !m.isCollectionDependency);
 
   const code = [
-    preamble,
+    `/* ${config.namespace} custom elements bundle */`,
     ``,
     `import type { Components, JSX } from "${componentsDtsRelPath}";`,
     ``,

--- a/src/compiler/output-targets/dist-custom-elements-bundle/custom-elements-bundle-types.ts
+++ b/src/compiler/output-targets/dist-custom-elements-bundle/custom-elements-bundle-types.ts
@@ -1,7 +1,7 @@
 import type * as d from '../../../declarations';
 import { isOutputTargetDistCustomElementsBundle } from '../output-utils';
 import { dirname, join, relative } from 'path';
-import { normalizePath, dashToPascalCase } from '@utils';
+import { generatePreamble, normalizePath, dashToPascalCase } from '@utils';
 
 export const generateCustomElementsBundleTypes = async (config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx, distDtsFilePath: string) => {
   const outputTargets = config.outputTargets.filter(isOutputTargetDistCustomElementsBundle);
@@ -18,11 +18,14 @@ const generateCustomElementsTypesOutput = async (
 ) => {
   const customElementsDtsPath = join(outputTarget.dir, 'index.d.ts');
   const componentsDtsRelPath = relDts(outputTarget.dir, distDtsFilePath);
-
-  const components = buildCtx.components.filter(m => !m.isCollectionDependency);
+  const preamble = generatePreamble(config, {
+    suffix: `${config.namespace} custom elements bundle` 
+  });
+  
+  const components = buildCtx.components.filter(m => !m.isCollectionDependency);  
 
   const code = [
-    `/* ${config.namespace} custom elements bundle */`,
+    preamble,
     ``,
     `import type { Components, JSX } from "${componentsDtsRelPath}";`,
     ``,

--- a/src/compiler/output-targets/dist-custom-elements-bundle/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements-bundle/index.ts
@@ -1,7 +1,7 @@
 import type * as d from '../../../declarations';
 import type { BundleOptions } from '../../bundle/bundle-interface';
 import { bundleOutput } from '../../bundle/bundle-output';
-import { catchError, dashToPascalCase, formatComponentRuntimeMeta, hasError, stringifyRuntimeData } from '@utils';
+import { catchError, dashToPascalCase, formatComponentRuntimeMeta, generatePreamble, hasError, stringifyRuntimeData } from '@utils';
 import { getCustomElementsBuildConditionals } from './custom-elements-build-conditionals';
 import { isOutputTargetDistCustomElementsBundle } from '../output-utils';
 import { join } from 'path';
@@ -59,6 +59,7 @@ const bundleCustomElements = async (
     const build = await bundleOutput(config, compilerCtx, buildCtx, bundleOpts);
     if (build) {
       const rollupOutput = await build.generate({
+        banner: generatePreamble(config),
         format: 'esm',
         sourcemap: config.sourceMap,
         chunkFileNames: outputTarget.externalRuntime || !config.hashFileNames ? '[name].js' : 'p-[hash].js',

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -111,7 +111,7 @@ export const generatePreamble = (config: d.Config, opts: { prefix?: string; suff
     });
   }
 
-  if (preamble.length > 1) {
+  if (preamble.length > 0) {
     preamble = preamble.map(l => ` * ${l}`);
 
     preamble.unshift(`/*!`);
@@ -119,7 +119,7 @@ export const generatePreamble = (config: d.Config, opts: { prefix?: string; suff
 
     return preamble.join('\n');
   }
-
+  
   if (opts.defaultBanner === true) {
     return `/*! ${BANNER} */`;
   }


### PR DESCRIPTION
The preamble config option has been broken for awhile. With this change, `config.preamble` is prepended to the following generated files:

- dist/custom-elements/index.js
- dist/<project>/index.esm.js
- dist/<project>/p-<hash>.entry.js
- dist/<project>/<project>.esm.js
- www/build/index.esm.js
- www/build/p-<hash>.entry.js
- www/build/<project>.esm.js

Fixes #2169