### PR TITLE
fix: prevent broken stylesheet being added to DOM

### DIFF
--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -152,7 +152,7 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
     }),
   );
 
-  if (BUILD.hydratedClass || BUILD.hydratedAttribute) {
+  if (cmpTags.length && (BUILD.hydratedClass || BUILD.hydratedAttribute)) {
     visibilityStyle.innerHTML = cmpTags + HYDRATED_CSS;
     visibilityStyle.setAttribute('data-styles', '');
     head.insertBefore(visibilityStyle, metaCharset ? metaCharset.nextSibling : head.firstChild);


### PR DESCRIPTION
Our component library is being loaded by Jest and we have several pages 
that don't include any Stencil components but still seem to load the script 
that adds the hydrated styles. This leads to the 'HYDRATED_CSS' being
added to the page on its own, which is invalid as it begins with '{'

Checking for the 'cmpTags' length prevents this from happening

For reference, the error shown is:
```bash
  console.error
    Error: Could not parse CSS stylesheet
        at exports.createStylesheet (/node_modules/jsdom/lib/jsdom/living/helpers/stylesheets.js:35:21)
        at HTMLStyleElementImpl._updateAStyleBlock (/node_modules/jsdom/lib/jsdom/living/nodes/HTMLStyleElement-impl.js:68:5)
        at HTMLStyleElementImpl._attach (/node_modules/jsdom/lib/jsdom/living/nodes/HTMLStyleElement-impl.js:19:12)
        at HTMLHeadElementImpl._insert (/node_modules/jsdom/lib/jsdom/living/nodes/Node-impl.js:845:14)
        at HTMLHeadElementImpl._preInsert (/node_modules/jsdom/lib/jsdom/living/nodes/Node-impl.js:768:10)
        at HTMLHeadElementImpl.insertBefore (/node_modules/jsdom/lib/jsdom/living/nodes/Node-impl.js:605:17)
        at HTMLHeadElement.insertBefore (/node_modules/jsdom/lib/jsdom/living/generated/Node.js:370:60)
        at Object.bootstrapLazy (/node_modules/PRIVATE/dist/cjs/index-d7cb340b.js:1265:14)
        at /node_modules/PRIVATE/dist/cjs/loader.cjs.js:17:16
        at processTicksAndRejections (internal/process/task_queues.js:93:5) {visibility:hidden}.hydrated{visibility:inherit}
```

It attempts to add this to the DOM
```html
<style>
{visibility:hidden}.hydrated{visibility:inherit}
</style>
```

It's possibly also worth mentioning that this fixes the symptom and there may be an underlying issue causing `cmpTags` to be empty in the first place (either in my app code or Stencil) but this at least prevents the error 

It might be worth investigating and throwing an error / not doing _other things_ if `cmpTags` is empty?