### PR TITLE
fix(vite-suport): add /* @vite-ignore */ to suppress warnings

### DIFF
--- a/src/client/client-load-module.ts
+++ b/src/client/client-load-module.ts
@@ -20,6 +20,7 @@ export const loadModule = (cmpMeta: d.ComponentRuntimeMeta, hostRef: d.HostRef, 
     /* webpackInclude: /\.entry\.js$/ */
     /* webpackExclude: /\.system\.entry\.js$/ */
     /* webpackMode: "lazy" */
+    /* @vite-ignore */
     `./${bundleId}.entry.js${BUILD.hotModuleReplacement && hmrVersionId ? '?s-hmr=' + hmrVersionId : ''}`
   ).then(importedModule => {
     if (!BUILD.hotModuleReplacement) {


### PR DESCRIPTION
Hello Stencil Team

We have a [corporate UI-Library](https://baloise-ui-library.now.sh/) build with Stencil and want to use it with Vue 3 and [Vite](https://vitejs.dev/). However, the vite runner always throughs the following warning during local development (`npm run dev`).

<img width="1719" alt="Screenshot 2021-03-22 at 07 27 15" src="https://user-images.githubusercontent.com/6384499/111948839-0bc99600-8ae0-11eb-8583-6c9f1ab61ce7.png">

To suppress this warning we have to use `/* @vite-ignore */` comment inside the import() call.
I would really appreciate if you consider my changes. 🙂

By the way I really like the work you have than with stencil ❤️ 

Thank you
