### PR TITLE
Add peer dependencies for test related dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,13 @@
     "webpack": "^4.46.0",
     "ws": "7.4.2"
   },
+  "peerDependencies": {
+    "@types/jest": "^26.6.3",
+    "@types/puppeteer": "^5.4.2",
+    "jest": "^26.6.3",
+    "jest-cli": "^26.6.3",
+    "puppeteer": "5.5.0"
+  },
   "engines": {
     "node": ">=12.10.0",
     "npm": ">=6.0.0"


### PR DESCRIPTION
Running `stencil test --spec --e2e` after initializing a project yields:

```txt
[13:37.0]  @stencil/core
[13:37.3]  v2.4.0 📷

[ ERROR ]  Please install missing dev dependencies with either npm or yarn.
           npm install --save-dev @types/jest@26.0.20 jest@26.6.3 jest-cli@26.6.3 @types/puppeteer@5.4.2
           puppeteer@5.5.0
```

At a glance, it seems like this project aims to have 0 dependencies so I did not add it there. Adding it to peer dependencies acknowledges that this should be done earlier on, and is an expected part of the process.