### PR TITLE
feat(build): configure watch exclude extensions

### DIFF
--- a/src/compiler/build/watch-build.ts
+++ b/src/compiler/build/watch-build.ts
@@ -157,7 +157,7 @@ const watchSrcDirectory = async (config: d.Config, compilerCtx: d.CompilerCtx) =
   const srcFiles = await compilerCtx.fs.readdir(config.srcDir, {
     recursive: true,
     excludeDirNames: ['.cache', '.git', '.github', '.stencil', '.vscode', 'node_modules'],
-    excludeExtensions: [
+    excludeExtensions: config.watchExcludeExtensions || [
       '.md',
       '.markdown',
       '.txt',

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -2410,7 +2410,3 @@ export interface CliInitOptions {
   logger: Logger;
   sys: CompilerSystem;
 }
-
-export interface WatchConfig {
-  excludeExtensions?: string[];
-}

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -228,6 +228,11 @@ export interface StencilConfig {
   watchIgnoredRegex?: RegExp | RegExp[];
   excludeUnusedDependencies?: boolean;
   stencilCoreResolvedId?: string;
+
+  /**
+   * Set file extensions that should be ignored during watch mode.
+   */
+  watchExcludeExtensions?: string[];
 }
 
 export interface ConfigExtras {
@@ -2404,4 +2409,8 @@ export interface CliInitOptions {
   args: string[];
   logger: Logger;
   sys: CompilerSystem;
+}
+
+export interface WatchConfig {
+  excludeExtensions?: string[];
 }


### PR DESCRIPTION
Make excluded extensions for watch task configurable.

See: https://github.com/ionic-team/stencil/issues/2886

