### PR TITLE
fix(rollup): Add `preserveSymLinks: true` to rollup config (#2840)

### DIFF
--- a/src/compiler/bundle/bundle-output.ts
+++ b/src/compiler/bundle/bundle-output.ts
@@ -120,6 +120,7 @@ export const getRollupOptions = (
     treeshake: getTreeshakeOption(config, bundleOpts),
     inlineDynamicImports: bundleOpts.inlineDynamicImports,
     preserveEntrySignatures: bundleOpts.preserveEntrySignatures ?? 'strict',
+    preserveSymlinks: true,
 
     onwarn: createOnWarnFn(buildCtx.diagnostics),
 


### PR DESCRIPTION
Adding `preserveSymlinks: true` to rollup config, fixes relative imports from symlinked files.
I can't see any negative impact of this, all tests pass and works in local projects. 
If it is an issue, can make it configurable. 

fixes #2840 