### PR TITLE
chore(end-to-end-tests): run 'npm ci' in e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test": "jest",
     "test.analysis": "cd test && npm run build",
     "test.dist": "node scripts --validate-build",
-    "test.end-to-end": "cd test/end-to-end && npm i && npm test && npm run test.dist",
+    "test.end-to-end": "cd test/end-to-end && npm ci && npm test && npm run test.dist",
     "test.jest": "jest",
     "test.karma": "cd test/karma && npm run karma",
     "test.karma.prod": "cd test/karma && npm run karma.prod",


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally ~and any changes were pushed~

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): Backport of https://github.com/ionic-team/stencil/pull/2934


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When developers run `npm run test.end-to-end`, we `cd` to the `test/end-to-end` directory and run `npm i`. These tests are meant to run using Node v12.X (and NPM v6.X), as that's the minimum version of Node that Stencil supports today. Because _development_ for Stencil is done in NPM v7, running this `package.json` script results in the following:

- this changes the format of the `test/end-to-end/package-lock.json` file, which is getting committed in community PRs and needs to be deliberately avoided by the dev team when working on Stencili
- when running in CI, we don't have reproducible NPM installs for this script (since we're not using `npm ci`)

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Run `npm ci` as a part of this script in lieu of `npm i`
- This preserves the lockfile version when developing locally (running `npm ci` with NPM 7 in this directory does not change the lockfile)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I'm also open to changing the lockfile version in this PR as well - 
npm is flexible enough to allow us to upgrade the lockfile, and continue running the end to end tests with Node 12/npm 6.

My real goal is to minimize the amount of churn in community PRs/avoid having to deal with it myself when developing for Stencil. But having reproducible runs of `test.end-to-end` in CI is a great bonus as well.

Long term, we should discuss our e2e testing strategy for multiple versions of Node, keeping the packages in `test/end-to-end/package.json` up to date, etc.
