### PR TITLE
chore!(testing) remove puppeteer v5 typings

### DIFF
--- a/src/testing/puppeteer/puppeteer-declarations.ts
+++ b/src/testing/puppeteer/puppeteer-declarations.ts
@@ -1,39 +1,11 @@
 import type { EventInitDict, EventSpy, ScreenshotDiff, ScreenshotOptions } from '@stencil/core/internal';
 import type {
   ClickOptions,
-  HTTPResponse as PuppeteerHTTPResponse,
+  HTTPResponse,
   Page,
   ScreenshotOptions as PuppeteerScreenshotOptions,
   WaitForOptions,
 } from 'puppeteer';
-
-/**
- * This type helps with declaration merging as a part of Stencil's migration from Puppeteer v5.4.3 to v10.0.0. In
- * v5.4.3, `HttpResponse` was an interface whereas v10.0.0 declares it as a class. It is redeclared here to help teams
- * migrate to a newer minor version of Stencil without requiring a Puppeteer upgrade/major version of Stencil. This type
- * should be removed as a part of the Stencil 3.0 release.
- */
-export type HTTPResponse = PuppeteerHTTPResponse;
-
-/**
- * These types help with declaration merging as a part of Stencil's migration from Puppeteer v5.4.3 to v10.0.0. In
- * v10.0.0, `WaitForOptions` is a renamed version of `NavigationOptions` from v5.4.3, who has had its type hierarchy
- * flattened.
- *
- * See {@link https://github.com/DefinitelyTyped/DefinitelyTyped/blob/8290e943f6b398acf39ee1b2e486824144e15bc8/types/puppeteer/index.d.ts#L605-L622}
- * for the v5.4.3 types.
- *
- * These types are redeclared here to help teams migrate to a newer minor version of Stencil without requiring a
- * Puppeteer upgrade/major version of Stencil. These type additions should be removed as a part of the Stencil 3.0
- * release.
- */
-declare module "puppeteer" {
-  type LifeCycleEvent = 'load' | 'domcontentloaded' | 'networkidle0' | 'networkidle2';
-  interface WaitForOptions {
-    timeout?: number;
-    waitUntil?: LifeCycleEvent | LifeCycleEvent[];
-  }
-}
 
 /**
  * This type was once exported by Puppeteer, but has since moved to an object literal in (Puppeteer’s) native types.


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally ~and any changes were pushed~

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Removes the puppeteer v5 typings that are currently in the Stencil 2.X codeline


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We added backwards compatible Puppeteer typings for Stencil 2.X (https://github.com/ionic-team/stencil/pull/2939/files). When syncing the `master` to the `v3.0.0-dev` branch, they were added inadvertently (since we did this a little out of order - committing to the `v3.0.0-dev` branch before `master`)

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- remove typings for puppeteer v5, which are not expected to be  supported in v3.0.0 at this time

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

At this time, we expect consumers to upgrade to Puppeteer v10.0.0 for Stencil v3.0.0

## Testing

In addition to running our testing suite, I ran `npm run build && npm pack`, then installed the tarball on a local application that I spun up fresh with `npm init stencil`. I modified an `e2e.ts` file to verify the dev experience/typings we working as expected:

![Screen Shot 2021-06-30 at 4 36 57 PM](https://user-images.githubusercontent.com/1930213/124027910-6452de00-d9c1-11eb-8f08-a168d714e958.png)
