### PR TITLE
Improve docs instead of warning

### DIFF
--- a/src/runtime/set-value.ts
+++ b/src/runtime/set-value.ts
@@ -32,16 +32,6 @@ export const setValue = (ref: d.RuntimeRef, propName: string, newVal: any, cmpMe
           '\nOld value',
           oldVal,
         );
-      } else if (hostRef.$flags$ & HOST_FLAGS.devOnDidLoad) {
-        consoleDevWarn(
-          `The state/prop "${propName}" changed during "componentDidLoad()", this triggers extra re-renders, try to setup on "componentWillLoad()"`,
-          '\nElement',
-          elm,
-          '\nNew value',
-          newVal,
-          '\nOld value',
-          oldVal,
-        );
       }
     }
 


### PR DESCRIPTION
```
The state/prop "${propName}" changed during "componentDidLoad()",
this triggers extra re-renders, try to setup on "componentWillLoad()"
```

I think this warning is too much. There are use cases where it's legitimate to update the state *within* `componentDidLoad()`.

I agree upon the potential dangers and that the dev *must* be informed about this, but IMHO it's the doc that should do so (rather than the compiler). This is why I propose to remove the warning and improve the docs instead, see: https://github.com/ionic-team/stencil-site/pull/749.

Here's a pseudo code example of when it *does* make sense to update the state within `componentDidLoad()`. Because only `componentDidLoad()` knows when its children are fully rendered.

This is only *one* example, I'm sure there are many others.

```
<my-tabs>
  <my-tabs-item>Tab 1</my-tabs-item>
  <my-tabs-item>Tab 2</my-tabs-item>
</my-tabs>
```

```
// my-tabs.tsx

@State() activeTabMarker = "0px"

componentDidLoad() {
  // All tab items are now rendered

  this.activeTabMarker = this.getActiveTabLeft() + this.getActiveTabWidth() // leads to a warning
}

render() {
  <div>
    <div class="active-tab-marker" style={this.activeTabMarker} />

    <slot />
  </div>
}
```