### PR TITLE
fix: fix an issue in the custom elements bundle where if you set a property on an element programatically before it was upgraded it would shadow the accessors and therefore break any watchers as well. See https://developers.google.com/web/fundamentals/web-components/best-practices\#lazy-properties

### DIFF
--- a/src/runtime/connected-callback.ts
+++ b/src/runtime/connected-callback.ts
@@ -68,7 +68,7 @@ export const connectedCallback = (elm: d.HostElement) => {
 
       // Lazy properties
       // https://developers.google.com/web/fundamentals/web-components/best-practices#lazy-properties
-      if (BUILD.prop && BUILD.lazyLoad && !BUILD.hydrateServerSide && cmpMeta.$members$) {
+      if (BUILD.prop && !BUILD.hydrateServerSide && cmpMeta.$members$) {
         Object.entries(cmpMeta.$members$).map(([memberName, [memberFlags]]) => {
           if (memberFlags & MEMBER_FLAGS.Prop && elm.hasOwnProperty(memberName)) {
             const value = (elm as any)[memberName];

--- a/src/runtime/proxy-component.ts
+++ b/src/runtime/proxy-component.ts
@@ -63,8 +63,8 @@ export const proxyComponent = (Cstr: d.ComponentConstructor, cmpMeta: d.Componen
         plt.jmp(() => {
           const propName = attrNameToPropName.get(attrName);
 
-          // the attr changed callback runs prior to the connected callback where we have logic that also
-          // has similar logic in it to support lazy properties so if we attempt to unshadow in both places
+          // the attr changed callback runs prior to Stencil's connectedCallback, which may also attempt to
+          //  unshadow lazy properties. If we attempt to unshadow in both places
           // to cover the case where an attr was set inline on the non-upgrade element and then the property
           // was programatically set which will be handled here or the case where the attr was not set in
           // which case the connectedCallback will catch and unshadow.

--- a/src/runtime/proxy-component.ts
+++ b/src/runtime/proxy-component.ts
@@ -83,8 +83,8 @@ export const proxyComponent = (Cstr: d.ComponentConstructor, cmpMeta: d.Componen
           //      cutsomElements.define('my-component', MyComponent);
           //    </script>
           //  ```
-          //  In this case if we do not unshadow here and use the value of the shadowing property attributeChangedCallback
-          //  will be called with `newValue = "some-value"` and will set the shadowed property (this.someAttribute = "another-value"
+          //  In this case if we do not unshadow here and use the value of the shadowing property, attributeChangedCallback
+          //  will be called with `newValue = "some-value"` and will set the shadowed property (this.someAttribute = "another-value")
           //  to the value that was set inline i.e. "some-value" from above example and when
           //  the connectedCallback attempts to unshadow it will use "some-value" as the intial value rather than "another-value"
           //

--- a/src/runtime/proxy-component.ts
+++ b/src/runtime/proxy-component.ts
@@ -65,7 +65,7 @@ export const proxyComponent = (Cstr: d.ComponentConstructor, cmpMeta: d.Componen
 
           // the attr changed callback runs prior to Stencil's connectedCallback, which may also attempt to
           //  unshadow lazy properties. If we attempt to unshadow in both places
-          // to cover the case where an attr was set inline on the non-upgrade element and then the property
+          // to cover the case where an attr was set inline on the non-upgraded element and then the property
           // was programatically set which will be handled here or the case where the attr was not set in
           // which case the connectedCallback will catch and unshadow.
           // https://developers.google.com/web/fundamentals/web-components/best-practices#lazy-properties

--- a/src/runtime/proxy-component.ts
+++ b/src/runtime/proxy-component.ts
@@ -66,7 +66,7 @@ export const proxyComponent = (Cstr: d.ComponentConstructor, cmpMeta: d.Componen
           // the attr changed callback runs prior to Stencil's connectedCallback, which may also attempt to
           //  unshadow lazy properties. If we attempt to unshadow in both places
           // to cover the case where an attr was set inline on the non-upgraded element and then the property
-          // was programatically set which will be handled here or the case where the attr was not set in
+          // was programmatically set which will be handled here or the case where the attr was not set in
           // which case the connectedCallback will catch and unshadow.
           // https://developers.google.com/web/fundamentals/web-components/best-practices#lazy-properties
           // we should think about whether or not we actually want to be reflecting the attributes to properties

--- a/src/runtime/proxy-component.ts
+++ b/src/runtime/proxy-component.ts
@@ -85,7 +85,7 @@ export const proxyComponent = (Cstr: d.ComponentConstructor, cmpMeta: d.Componen
           //  ```
           //  In this case if we do not unshadow here and use the value of the shadowing property, attributeChangedCallback
           //  will be called with `newValue = "some-value"` and will set the shadowed property (this.someAttribute = "another-value")
-          //  to the value that was set inline i.e. "some-value" from above example and when
+          //  to the value that was set inline i.e. "some-value" from above example. When
           //  the connectedCallback attempts to unshadow it will use "some-value" as the intial value rather than "another-value"
           //
           //  The case where the attribute was NOT set inline but was not set programmatically shall be handled/unshadowed


### PR DESCRIPTION
This fixes an issue in the custom elements bundle where if you set a property on an element before it is upgraded it will forever shadow the accessors and therefore Watchers will no longer fire.

This is related to and potentially fixes #2456 

The approach here is to check if the element `hasOwnProperty` in the `connectedCallback` and unshadow that property and restore the value that was shadowing the accessors by using the setter to reset the value. This is the best practice described here: https://developers.google.com/web/fundamentals/web-components/best-practices#lazy-properties

We were already doing this but only for the lazy loaded bundle. This PR does it for both.

I also had to add logic to the `attributeChangedCallback` because if fires before the `connectedCallback` event and we set the property there so if it's shadowed we end up setting the shadowed property with the original stale value that was set inline. I believe we should thing about moving the logic to set the property outside of `attributeChangedCallback` as is the best practice described here: https://developers.google.com/web/fundamentals/web-components/best-practices#avoid-reentrancy however that seemed like a bit of a can of worms and outside the scope of this fix. 

I've only tested this fix against the custom elements build so I would like to double check it against the lazy build before we merge.