### PR TITLE
feat(loader): inject static imports that are statically analyzable

### DIFF
--- a/src/client/client-load-module.ts
+++ b/src/client/client-load-module.ts
@@ -16,6 +16,7 @@ export const loadModule = (cmpMeta: d.ComponentRuntimeMeta, hostRef: d.HostRef, 
   if (module) {
     return module[exportName];
   }
+  // staticImportSwitch
   return import(
     /* webpackInclude: /\.entry\.js$/ */
     /* webpackExclude: /\.system\.entry\.js$/ */


### PR DESCRIPTION
This small PR adds static imports to the stencil lazy loader's es5 and esm loader outputs.

The dynamic import expression that stencil's loader `loadModule` function ships with:

```import(`./${bundleId}.entry.js`).then(```

Is not compatible with certain bundlers like vite and parcel. 

Fixes #2827 