### PR TITLE
feat(cli): [STENCIL-33] Writing and Reading the Ionic config file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@stencil/core",
-      "version": "2.6.0",
+      "version": "2.7.0-0",
       "license": "MIT",
       "bin": {
         "stencil": "bin/stencil"

--- a/src/cli/ionic-config.ts
+++ b/src/cli/ionic-config.ts
@@ -33,11 +33,12 @@ export async function readConfig(): Promise<TelemetryConfig> {
 }
 
 export async function writeConfig(config: TelemetryConfig): Promise<void> {
-	await fs.mkdirp(path.dirname(DEFAULT_CONFIG_DIRECTORY)).then(async () => {
-		return await fs.writeJSON(DEFAULT_CONFIG_DIRECTORY, config, { spaces: '\t' });
-	}).catch(() => {
+	try {
+		await fs.mkdirp(path.dirname(DEFAULT_CONFIG_DIRECTORY))
+		await fs.writeJSON(DEFAULT_CONFIG_DIRECTORY, config, { spaces: '\t' });
+	} catch (error) {
 		console.error(`Stencil Telemetry: couldn't write configuration file to ${DEFAULT_CONFIG_DIRECTORY} - ${error}.`)
-	});
+	};
 }
 
 export async function updateConfig(newOptions: TelemetryConfig): Promise<void> {

--- a/src/cli/ionic-config.ts
+++ b/src/cli/ionic-config.ts
@@ -1,8 +1,8 @@
-import fs from 'fs-extra';
+import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { uuidv4 } from './telemetry/helpers';
+import { readJson, uuidv4 } from './telemetry/helpers';
 
 const CONFIG_FILE = 'config.json';
 export const DEFAULT_CONFIG_DIRECTORY = path.resolve(os.homedir(), '.ionic', CONFIG_FILE);
@@ -14,8 +14,7 @@ export interface TelemetryConfig {
 
 export async function readConfig(): Promise<TelemetryConfig> {
 	try {
-		
-		return await fs.readJson(DEFAULT_CONFIG_DIRECTORY);
+		return await readJson(DEFAULT_CONFIG_DIRECTORY);
 	} catch (e) {
 		if (e.code !== 'ENOENT') {
 			throw e;
@@ -34,8 +33,8 @@ export async function readConfig(): Promise<TelemetryConfig> {
 
 export async function writeConfig(config: TelemetryConfig): Promise<void> {
 	try {
-		await fs.mkdirp(path.dirname(DEFAULT_CONFIG_DIRECTORY))
-		await fs.writeJSON(DEFAULT_CONFIG_DIRECTORY, config, { spaces: '\t' });
+		await fs.promises.mkdir(path.dirname(DEFAULT_CONFIG_DIRECTORY), { recursive: true });
+		await fs.promises.writeFile(DEFAULT_CONFIG_DIRECTORY, JSON.stringify(config))
 	} catch (error) {
 		console.error(`Stencil Telemetry: couldn't write configuration file to ${DEFAULT_CONFIG_DIRECTORY} - ${error}.`)
 	};

--- a/src/cli/ionic-config.ts
+++ b/src/cli/ionic-config.ts
@@ -1,41 +1,40 @@
 import { getCompilerSystem } from './state/stencil-cli-config';
 import { readJson, uuidv4 } from './telemetry/helpers';
 
-const CONFIG_FILE = 'config.json';
-export const DEFAULT_CONFIG_DIRECTORY = (file: boolean = false) => {
-	return getCompilerSystem().resolvePath(`${getCompilerSystem().homeDir()}/.ionic${file ? "/" + CONFIG_FILE : ""}`);
-}
+export const DEFAULT_CONFIG = (file: boolean = false) => {
+  return getCompilerSystem().resolvePath(`${getCompilerSystem().homeDir()}/.ionic${file ? '/config.json' : ''}`);
+};
 
 export interface TelemetryConfig {
-	"telemetry.stencil"?: boolean,
-	"tokens.telemetry"?: string,
+  'telemetry.stencil'?: boolean;
+  'tokens.telemetry'?: string;
 }
 
 export async function readConfig(): Promise<TelemetryConfig> {
-	let config: TelemetryConfig = await readJson(DEFAULT_CONFIG_DIRECTORY(true));
+  let config: TelemetryConfig = await readJson(DEFAULT_CONFIG(true));
 
-	if (!config) {
-		config = {
-			"tokens.telemetry": uuidv4(),
-			"telemetry.stencil": true,
-		};
+  if (!config) {
+    config = {
+      'tokens.telemetry': uuidv4(),
+      'telemetry.stencil': true,
+    };
 
-		await writeConfig(config);
-	}
+    await writeConfig(config);
+  }
 
-	return config;
+  return config;
 }
 
 export async function writeConfig(config: TelemetryConfig): Promise<void> {
-	try {
-		await getCompilerSystem().createDir(DEFAULT_CONFIG_DIRECTORY(), { recursive: true });
-		await getCompilerSystem().writeFile(DEFAULT_CONFIG_DIRECTORY(true), JSON.stringify(config))
-	} catch (error) {
-		console.error(`Stencil Telemetry: couldn't write configuration file to ${DEFAULT_CONFIG_DIRECTORY(true)} - ${error}.`)
-	};
+  try {
+    await getCompilerSystem().createDir(DEFAULT_CONFIG(), { recursive: true });
+    await getCompilerSystem().writeFile(DEFAULT_CONFIG(true), JSON.stringify(config));
+  } catch (error) {
+    console.error(`Stencil Telemetry: couldn't write configuration file to ${DEFAULT_CONFIG(true)} - ${error}.`);
+  }
 }
 
 export async function updateConfig(newOptions: TelemetryConfig): Promise<void> {
-	const config = await readConfig();
-	await writeConfig(Object.assign(config, newOptions));
+  const config = await readConfig();
+  await writeConfig(Object.assign(config, newOptions));
 }

--- a/src/cli/ionic-config.ts
+++ b/src/cli/ionic-config.ts
@@ -1,0 +1,45 @@
+import { readJSON, writeJSON, mkdirp } from '@ionic/utils-fs';
+
+import * as os from 'os';
+import * as path from 'path';
+
+import { uuidv4 } from './telemetry/helpers';
+
+export const CONFIG_FILE = 'config.json';
+export const DEFAULT_CONFIG_DIRECTORY = path.resolve(os.homedir(), '.ionic', CONFIG_FILE);
+
+export interface SystemConfig {
+	"telemetry"?: boolean,
+	"telemetry.stencil"?: boolean,
+	"tokens.telemetry"?: string,
+}
+
+export async function readConfig(): Promise<SystemConfig> {
+	try {
+		return await readJSON(DEFAULT_CONFIG_DIRECTORY);
+	} catch (e) {
+		if (e.code !== 'ENOENT') {
+			throw e;
+		}
+
+		const config: SystemConfig = {
+			"tokens.telemetry": uuidv4(),
+			"telemetry": true,
+			"telemetry.stencil": true,
+		};
+
+		await writeConfig(config);
+
+		return config;
+	}
+}
+
+export async function writeConfig(config: SystemConfig): Promise<void> {
+	await mkdirp(path.dirname(DEFAULT_CONFIG_DIRECTORY));
+	await writeJSON(DEFAULT_CONFIG_DIRECTORY, config, { spaces: '\t' });
+}
+
+export async function updateConfig(newOptions: SystemConfig): Promise<void> {
+	const config = await readConfig();
+	await writeConfig(Object.assign(config, newOptions));
+}

--- a/src/cli/ionic-config.ts
+++ b/src/cli/ionic-config.ts
@@ -1,9 +1,11 @@
 import { getCompilerSystem } from './state/stencil-cli-config';
 import { readJson, uuidv4 } from './telemetry/helpers';
 
-export const DEFAULT_CONFIG = (file: boolean = false) => {
-  return getCompilerSystem().resolvePath(`${getCompilerSystem().homeDir()}/.ionic${file ? '/config.json' : ''}`);
-};
+export const default_config = () =>
+  getCompilerSystem().resolvePath(`${getCompilerSystem().homeDir()}/.ionic/config.json`);
+
+export const default_config_directory = () =>
+  getCompilerSystem().resolvePath(`${getCompilerSystem().homeDir()}/.ionic`);
 
 export interface TelemetryConfig {
   'telemetry.stencil'?: boolean;
@@ -11,7 +13,7 @@ export interface TelemetryConfig {
 }
 
 export async function readConfig(): Promise<TelemetryConfig> {
-  let config: TelemetryConfig = await readJson(DEFAULT_CONFIG(true));
+  let config: TelemetryConfig = await readJson(default_config());
 
   if (!config) {
     config = {
@@ -27,10 +29,10 @@ export async function readConfig(): Promise<TelemetryConfig> {
 
 export async function writeConfig(config: TelemetryConfig): Promise<void> {
   try {
-    await getCompilerSystem().createDir(DEFAULT_CONFIG(), { recursive: true });
-    await getCompilerSystem().writeFile(DEFAULT_CONFIG(true), JSON.stringify(config));
+    await getCompilerSystem().createDir(default_config_directory(), { recursive: true });
+    await getCompilerSystem().writeFile(default_config(), JSON.stringify(config));
   } catch (error) {
-    console.error(`Stencil Telemetry: couldn't write configuration file to ${DEFAULT_CONFIG(true)} - ${error}.`);
+    console.error(`Stencil Telemetry: couldn't write configuration file to ${default_config()} - ${error}.`);
   }
 }
 

--- a/src/cli/ionic-config.ts
+++ b/src/cli/ionic-config.ts
@@ -36,7 +36,7 @@ export async function writeConfig(config: TelemetryConfig): Promise<void> {
 	await fs.mkdirp(path.dirname(DEFAULT_CONFIG_DIRECTORY)).then(async () => {
 		return await fs.writeJSON(DEFAULT_CONFIG_DIRECTORY, config, { spaces: '\t' });
 	}).catch(() => {
-		console.debug(`Couldn't write to ${DEFAULT_CONFIG_DIRECTORY}. `)
+		console.error(`Stencil Telemetry: couldn't write configuration file to ${DEFAULT_CONFIG_DIRECTORY} - ${error}.`)
 	});
 }
 

--- a/src/cli/ionic-config.ts
+++ b/src/cli/ionic-config.ts
@@ -1,11 +1,10 @@
 import { getCompilerSystem } from './state/stencil-cli-config';
 import { readJson, uuidv4 } from './telemetry/helpers';
 
-export const default_config = () =>
+export const defaultConfig = () =>
   getCompilerSystem().resolvePath(`${getCompilerSystem().homeDir()}/.ionic/config.json`);
 
-export const default_config_directory = () =>
-  getCompilerSystem().resolvePath(`${getCompilerSystem().homeDir()}/.ionic`);
+export const defaultConfigDirectory = () => getCompilerSystem().resolvePath(`${getCompilerSystem().homeDir()}/.ionic`);
 
 export interface TelemetryConfig {
   'telemetry.stencil'?: boolean;
@@ -13,7 +12,7 @@ export interface TelemetryConfig {
 }
 
 export async function readConfig(): Promise<TelemetryConfig> {
-  let config: TelemetryConfig = await readJson(default_config());
+  let config: TelemetryConfig = await readJson(defaultConfig());
 
   if (!config) {
     config = {
@@ -29,10 +28,10 @@ export async function readConfig(): Promise<TelemetryConfig> {
 
 export async function writeConfig(config: TelemetryConfig): Promise<void> {
   try {
-    await getCompilerSystem().createDir(default_config_directory(), { recursive: true });
-    await getCompilerSystem().writeFile(default_config(), JSON.stringify(config));
+    await getCompilerSystem().createDir(defaultConfigDirectory(), { recursive: true });
+    await getCompilerSystem().writeFile(defaultConfig(), JSON.stringify(config));
   } catch (error) {
-    console.error(`Stencil Telemetry: couldn't write configuration file to ${default_config()} - ${error}.`);
+    console.error(`Stencil Telemetry: couldn't write configuration file to ${defaultConfig()} - ${error}.`);
   }
 }
 

--- a/src/cli/state/stencil-cli-config.ts
+++ b/src/cli/state/stencil-cli-config.ts
@@ -1,0 +1,107 @@
+import type { Logger, CompilerSystem, ConfigFlags } from "../../declarations";
+export type CoreCompiler = typeof import('@stencil/core/compiler');
+
+export interface StencilCLIConfigArgs {
+	task?: string;
+	args: string[];
+	logger: Logger;
+	sys: CompilerSystem;
+	flags?: ConfigFlags;
+	coreCompiler?: CoreCompiler
+}
+
+export default class StencilCLIConfig {
+
+	static instance: StencilCLIConfig;
+
+	private _args: string[];
+	private _logger: Logger;
+	private _sys: CompilerSystem;
+	private _flags: ConfigFlags;
+	private _task: string;
+	private _coreCompiler: CoreCompiler;
+
+	private constructor (options: StencilCLIConfigArgs) {
+		this._args = options?.args || [];
+		this._logger = options?.logger;
+		this._sys = options?.sys;
+	}
+
+	public static getInstance(options?: StencilCLIConfigArgs): StencilCLIConfig {
+		if (!StencilCLIConfig.instance && !!options) {
+			StencilCLIConfig.instance = new StencilCLIConfig(options);
+		}
+		
+		return StencilCLIConfig.instance;
+	}
+
+	public get logger() {
+		return this._logger
+	}
+	public set logger(logger: Logger) {
+		this._logger = logger;
+	}
+
+
+	public get sys() {
+		return this._sys
+	}
+	public set sys(sys: CompilerSystem) {
+		this._sys = sys;
+	}
+
+
+	public get args() {
+		return this._args
+	}
+	public set args(args: string[]) {
+		this._args = args;
+	}
+
+
+	public get task() {
+		return this._task
+	}
+	public set task(task: string) {
+		this._task = task;
+	}
+
+
+	public get flags() {
+		return this._flags
+	}
+	public set flags(flags: ConfigFlags) {
+		this._flags = flags;
+	}
+
+
+	public get coreCompiler() {
+		return this._coreCompiler
+	}
+	public set coreCompiler(coreCompiler: CoreCompiler) {
+		this._coreCompiler = coreCompiler;
+	}
+}
+
+export function initializeStencilCLIConfig(options: StencilCLIConfigArgs): StencilCLIConfig {
+	return StencilCLIConfig.getInstance(options);
+}
+
+export function getStencilCLIConfig(): StencilCLIConfig {
+	return StencilCLIConfig.getInstance();
+}
+
+export function getCompilerSystem(): CompilerSystem {
+	const stencilCLIConfig = getStencilCLIConfig();
+	return !!stencilCLIConfig && stencilCLIConfig?.sys
+}
+
+export function getLogger(): Logger {
+	const stencilCLIConfig = getStencilCLIConfig();
+	return !!stencilCLIConfig && stencilCLIConfig?.logger
+}
+
+export function getCoreCompiler(): CoreCompiler {
+	const stencilCLIConfig = getStencilCLIConfig();
+	return !!stencilCLIConfig && stencilCLIConfig?.coreCompiler
+}

--- a/src/cli/state/stencil-cli-config.ts
+++ b/src/cli/state/stencil-cli-config.ts
@@ -1,107 +1,98 @@
-import type { Logger, CompilerSystem, ConfigFlags } from "../../declarations";
+import type { Logger, CompilerSystem, ConfigFlags } from '../../declarations';
 export type CoreCompiler = typeof import('@stencil/core/compiler');
 
 export interface StencilCLIConfigArgs {
-	task?: string;
-	args: string[];
-	logger: Logger;
-	sys: CompilerSystem;
-	flags?: ConfigFlags;
-	coreCompiler?: CoreCompiler
+  task?: string;
+  args: string[];
+  logger: Logger;
+  sys: CompilerSystem;
+  flags?: ConfigFlags;
+  coreCompiler?: CoreCompiler;
 }
 
 export default class StencilCLIConfig {
+  static instance: StencilCLIConfig;
 
-	static instance: StencilCLIConfig;
+  private _args: string[];
+  private _logger: Logger;
+  private _sys: CompilerSystem;
+  private _flags: ConfigFlags | undefined;
+  private _task: string | undefined;
+  private _coreCompiler: CoreCompiler | undefined;
 
-	private _args: string[];
-	private _logger: Logger;
-	private _sys: CompilerSystem;
-	private _flags: ConfigFlags;
-	private _task: string;
-	private _coreCompiler: CoreCompiler;
+  private constructor(options: StencilCLIConfigArgs) {
+    this._args = options?.args || [];
+    this._logger = options?.logger;
+    this._sys = options?.sys;
+  }
 
-	private constructor (options: StencilCLIConfigArgs) {
-		this._args = options?.args || [];
-		this._logger = options?.logger;
-		this._sys = options?.sys;
-	}
+  public static getInstance(options?: StencilCLIConfigArgs): StencilCLIConfig {
+    if (!StencilCLIConfig.instance) {
+      StencilCLIConfig.instance = new StencilCLIConfig(options);
+    }
 
-	public static getInstance(options?: StencilCLIConfigArgs): StencilCLIConfig {
-		if (!StencilCLIConfig.instance && !!options) {
-			StencilCLIConfig.instance = new StencilCLIConfig(options);
-		}
-		
-		return StencilCLIConfig.instance;
-	}
+    return StencilCLIConfig.instance;
+  }
 
-	public get logger() {
-		return this._logger
-	}
-	public set logger(logger: Logger) {
-		this._logger = logger;
-	}
+  public get logger() {
+    return this._logger;
+  }
+  public set logger(logger: Logger) {
+    this._logger = logger;
+  }
 
+  public get sys() {
+    return this._sys;
+  }
+  public set sys(sys: CompilerSystem) {
+    this._sys = sys;
+  }
 
-	public get sys() {
-		return this._sys
-	}
-	public set sys(sys: CompilerSystem) {
-		this._sys = sys;
-	}
+  public get args() {
+    return this._args;
+  }
+  public set args(args: string[]) {
+    this._args = args;
+  }
 
+  public get task() {
+    return this._task;
+  }
+  public set task(task: string) {
+    this._task = task;
+  }
 
-	public get args() {
-		return this._args
-	}
-	public set args(args: string[]) {
-		this._args = args;
-	}
+  public get flags() {
+    return this._flags;
+  }
+  public set flags(flags: ConfigFlags) {
+    this._flags = flags;
+  }
 
-
-	public get task() {
-		return this._task
-	}
-	public set task(task: string) {
-		this._task = task;
-	}
-
-
-	public get flags() {
-		return this._flags
-	}
-	public set flags(flags: ConfigFlags) {
-		this._flags = flags;
-	}
-
-
-	public get coreCompiler() {
-		return this._coreCompiler
-	}
-	public set coreCompiler(coreCompiler: CoreCompiler) {
-		this._coreCompiler = coreCompiler;
-	}
+  public get coreCompiler() {
+    return this._coreCompiler;
+  }
+  public set coreCompiler(coreCompiler: CoreCompiler) {
+    this._coreCompiler = coreCompiler;
+  }
 }
 
 export function initializeStencilCLIConfig(options: StencilCLIConfigArgs): StencilCLIConfig {
-	return StencilCLIConfig.getInstance(options);
+  return StencilCLIConfig.getInstance(options);
 }
 
 export function getStencilCLIConfig(): StencilCLIConfig {
-	return StencilCLIConfig.getInstance();
+  return StencilCLIConfig.getInstance();
 }
 
 export function getCompilerSystem(): CompilerSystem {
-	const stencilCLIConfig = getStencilCLIConfig();
-	return !!stencilCLIConfig && stencilCLIConfig?.sys
+  return getStencilCLIConfig().sys;
 }
 
 export function getLogger(): Logger {
-	const stencilCLIConfig = getStencilCLIConfig();
-	return !!stencilCLIConfig && stencilCLIConfig?.logger
+  return getStencilCLIConfig().logger;
 }
 
 export function getCoreCompiler(): CoreCompiler {
-	const stencilCLIConfig = getStencilCLIConfig();
-	return !!stencilCLIConfig && stencilCLIConfig?.coreCompiler
+  return getStencilCLIConfig().coreCompiler;
 }

--- a/src/cli/state/test/stencil-cli-config.spec.ts
+++ b/src/cli/state/test/stencil-cli-config.spec.ts
@@ -1,0 +1,44 @@
+import { createLogger } from '../../../compiler/sys/logger/console-logger';
+import { createSystem } from '../../../compiler/sys/stencil-sys';
+import StencilCLIConfig, { getCompilerSystem, getStencilCLIConfig, initializeStencilCLIConfig, getLogger, getCoreCompiler } from '../stencil-cli-config';
+
+describe('StencilCLIConfig', () => {
+	const config = initializeStencilCLIConfig({
+		sys: createSystem(),
+		args: [],
+		logger: createLogger()
+	})
+
+	it('should behave as a singleton', async () => {
+		const config2 = initializeStencilCLIConfig({
+			sys: createSystem(),
+			args: [],
+			logger: createLogger()
+		})
+
+		expect(config2).toBe(config);
+
+		const config3 = getStencilCLIConfig();
+
+		expect(config3).toBe(config);
+	});
+
+	it('allows updating any item', async () => {
+		config.args = ["nice", "awesome"];
+		expect(config.args).toEqual(["nice", "awesome"]);
+	});
+
+
+	it('getCompilerSystem should return a segment of the singleton', async () => {
+		expect(config.sys).toBe(getCompilerSystem());
+	});
+
+	it('getLogger should return a segment of the singleton', async () => {
+		expect(config.logger).toBe(getLogger());
+	});
+
+	it('getCoreCompiler should return a segment of the singleton', async () => {
+		expect(config.coreCompiler).toBe(getCoreCompiler());
+	});
+
+});

--- a/src/cli/state/test/stencil-cli-config.spec.ts
+++ b/src/cli/state/test/stencil-cli-config.spec.ts
@@ -1,44 +1,48 @@
 import { createLogger } from '../../../compiler/sys/logger/console-logger';
 import { createSystem } from '../../../compiler/sys/stencil-sys';
-import StencilCLIConfig, { getCompilerSystem, getStencilCLIConfig, initializeStencilCLIConfig, getLogger, getCoreCompiler } from '../stencil-cli-config';
+import {
+  getCompilerSystem,
+  getStencilCLIConfig,
+  initializeStencilCLIConfig,
+  getLogger,
+  getCoreCompiler,
+} from '../stencil-cli-config';
 
 describe('StencilCLIConfig', () => {
-	const config = initializeStencilCLIConfig({
-		sys: createSystem(),
-		args: [],
-		logger: createLogger()
-	})
+  const config = initializeStencilCLIConfig({
+    sys: createSystem(),
+    args: [],
+    logger: createLogger(),
+  });
 
-	it('should behave as a singleton', async () => {
-		const config2 = initializeStencilCLIConfig({
-			sys: createSystem(),
-			args: [],
-			logger: createLogger()
-		})
+  it('should behave as a singleton', () => {
+    const config2 = initializeStencilCLIConfig({
+      sys: createSystem(),
+      args: [],
+      logger: createLogger(),
+    });
 
-		expect(config2).toBe(config);
+    expect(config2).toBe(config);
 
-		const config3 = getStencilCLIConfig();
+    const config3 = getStencilCLIConfig();
 
-		expect(config3).toBe(config);
-	});
+    expect(config3).toBe(config);
+  });
 
-	it('allows updating any item', async () => {
-		config.args = ["nice", "awesome"];
-		expect(config.args).toEqual(["nice", "awesome"]);
-	});
+  it('allows updating any item', () => {
+    config.args = ['nice', 'awesome'];
+    expect(config.args).toEqual(['nice', 'awesome']);
+  });
 
+  it('getCompilerSystem should return a segment of the singleton', () => {
+    expect(config.sys).toBe(getCompilerSystem());
+  });
 
-	it('getCompilerSystem should return a segment of the singleton', async () => {
-		expect(config.sys).toBe(getCompilerSystem());
-	});
+  it('getLogger should return a segment of the singleton', () => {
+    expect(config.logger).toBe(getLogger());
+  });
 
-	it('getLogger should return a segment of the singleton', async () => {
-		expect(config.logger).toBe(getLogger());
-	});
-
-	it('getCoreCompiler should return a segment of the singleton', async () => {
-		expect(config.coreCompiler).toBe(getCoreCompiler());
-	});
-
+  it('getCoreCompiler should return a segment of the singleton', () => {
+    expect(config.coreCompiler).toBe(getCoreCompiler());
+  });
 });

--- a/src/cli/telemetry/helpers.ts
+++ b/src/cli/telemetry/helpers.ts
@@ -1,3 +1,5 @@
+import fs from "fs";
+
 interface TerminalInfo {
 	/**
 	 * Whether this is in CI or not.
@@ -42,4 +44,9 @@ export function uuidv4(): string {
 
 		return v.toString(16);
 	});
+}
+
+export async function readJson(path) {
+	const rawdata = await fs.readFileSync(path);
+	return JSON.parse(rawdata.toString());
 }

--- a/src/cli/telemetry/helpers.ts
+++ b/src/cli/telemetry/helpers.ts
@@ -1,4 +1,23 @@
-import { TERMINAL_INFO } from '@ionic/utils-terminal';
+interface TerminalInfo {
+	/**
+	 * Whether this is in CI or not.
+	 */
+	readonly ci: boolean;
+	/**
+	 * Path to the user's shell program.
+	 */
+	readonly shell: string;
+	/**
+	 * Whether the terminal is an interactive TTY or not.
+	 */
+	readonly tty: boolean;
+	/**
+	 * Whether this is a Windows shell or not.
+	 */
+	readonly windows: boolean;
+}
+
+declare const TERMINAL_INFO: TerminalInfo;
 
 export const tryFn = async <T extends (...args: any[]) => Promise<R>, R>(
 	fn: T,
@@ -15,6 +34,7 @@ export const tryFn = async <T extends (...args: any[]) => Promise<R>, R>(
 
 export const isInteractive = (): boolean => TERMINAL_INFO.tty && !TERMINAL_INFO.ci;
 
+// Plucked from https://github.com/ionic-team/capacitor/blob/b893a57aaaf3a16e13db9c33037a12f1a5ac92e0/cli/src/util/uuid.ts
 export function uuidv4(): string {
 	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
 		const r = (Math.random() * 16) | 0;

--- a/src/cli/telemetry/helpers.ts
+++ b/src/cli/telemetry/helpers.ts
@@ -1,0 +1,25 @@
+import { TERMINAL_INFO } from '@ionic/utils-terminal';
+
+export const tryFn = async <T extends (...args: any[]) => Promise<R>, R>(
+	fn: T,
+	...args: any[]
+): Promise<R | null> => {
+	try {
+		return await fn(...args);
+	} catch {
+		// ignore
+	}
+
+	return null;
+};
+
+export const isInteractive = (): boolean => TERMINAL_INFO.tty && !TERMINAL_INFO.ci;
+
+export function uuidv4(): string {
+	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+		const r = (Math.random() * 16) | 0;
+		const v = c == 'x' ? r : (r & 0x3) | 0x8;
+
+		return v.toString(16);
+	});
+}

--- a/src/cli/telemetry/helpers.ts
+++ b/src/cli/telemetry/helpers.ts
@@ -46,7 +46,7 @@ export function uuidv4(): string {
 	});
 }
 
-export async function readJson(path) {
+export async function readJson(path: string) {
 	const rawdata = await fs.readFileSync(path);
 	return JSON.parse(rawdata.toString());
 }

--- a/src/cli/telemetry/helpers.ts
+++ b/src/cli/telemetry/helpers.ts
@@ -1,4 +1,4 @@
-import { getCompilerSystem } from '../state/stencil-cli-config';
+import { getCompilerSystem, getStencilCLIConfig } from '../state/stencil-cli-config';
 
 interface TerminalInfo {
   /**
@@ -27,14 +27,16 @@ export const isInteractive = (object?: TerminalInfo): boolean => {
   const terminalInfo =
     object ||
     Object.freeze({
-      tty: process.stdout.isTTY ? true : false,
+      tty: getCompilerSystem().isTTY() ? true : false,
       ci:
-        ['CI', 'BUILD_ID', 'BUILD_NUMBER', 'BITBUCKET_COMMIT', 'CODEBUILD_BUILD_ARN'].filter(v => !!process.env[v])
-          .length > 0 || process.argv.includes('--ci'),
+        ['CI', 'BUILD_ID', 'BUILD_NUMBER', 'BITBUCKET_COMMIT', 'CODEBUILD_BUILD_ARN'].filter(
+          v => !!getCompilerSystem().getEnvironmentVar(v),
+        ).length > 0 || !!getStencilCLIConfig()?.flags?.ci,
     });
 
   return terminalInfo.tty && !terminalInfo.ci;
 };
+
 // Plucked from https://github.com/ionic-team/capacitor/blob/b893a57aaaf3a16e13db9c33037a12f1a5ac92e0/cli/src/util/uuid.ts
 export function uuidv4(): string {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {

--- a/src/cli/telemetry/helpers.ts
+++ b/src/cli/telemetry/helpers.ts
@@ -19,7 +19,7 @@ interface TerminalInfo {
 	readonly windows: boolean;
 }
 
-declare const TERMINAL_INFO: TerminalInfo;
+export declare const TERMINAL_INFO: TerminalInfo;
 
 export const tryFn = async <T extends (...args: any[]) => Promise<R>, R>(
 	fn: T,
@@ -47,6 +47,6 @@ export function uuidv4(): string {
 }
 
 export async function readJson(path: string) {
-	const rawdata = await fs.promises.readFileSync(path);
+	const rawdata = await fs.promises.readFile(path);
 	return JSON.parse(rawdata.toString());
 }

--- a/src/cli/telemetry/helpers.ts
+++ b/src/cli/telemetry/helpers.ts
@@ -47,6 +47,6 @@ export function uuidv4(): string {
 }
 
 export async function readJson(path: string) {
-	const rawdata = await fs.readFileSync(path);
+	const rawdata = await fs.promises.readFileSync(path);
 	return JSON.parse(rawdata.toString());
 }

--- a/src/cli/telemetry/helpers.ts
+++ b/src/cli/telemetry/helpers.ts
@@ -1,52 +1,51 @@
-import { getCompilerSystem } from '../state/stencil-cli-config'
+import { getCompilerSystem } from '../state/stencil-cli-config';
 
 interface TerminalInfo {
-	/**
-	 * Whether this is in CI or not.
-	 */
-	readonly ci: boolean;
-	/**
-	 * Path to the user's shell program.
-	 */
-	readonly shell: string;
-	/**
-	 * Whether the terminal is an interactive TTY or not.
-	 */
-	readonly tty: boolean;
-	/**
-	 * Whether this is a Windows shell or not.
-	 */
-	readonly windows: boolean;
+  /**
+   * Whether this is in CI or not.
+   */
+  readonly ci: boolean;
+  /**
+   * Whether the terminal is an interactive TTY or not.
+   */
+  readonly tty: boolean;
 }
 
 export declare const TERMINAL_INFO: TerminalInfo;
 
-export const tryFn = async <T extends (...args: any[]) => Promise<R>, R>(
-	fn: T,
-	...args: any[]
-): Promise<R | null> => {
-	try {
-		return await fn(...args);
-	} catch {
-		// ignore
-	}
+export const tryFn = async <T extends (...args: any[]) => Promise<R>, R>(fn: T, ...args: any[]): Promise<R | null> => {
+  try {
+    return await fn(...args);
+  } catch {
+    // ignore
+  }
 
-	return null;
+  return null;
 };
 
-export const isInteractive = (): boolean => TERMINAL_INFO.tty && !TERMINAL_INFO.ci;
+export const isInteractive = (object?: TerminalInfo): boolean => {
+  const terminalInfo =
+    object ||
+    Object.freeze({
+      tty: process.stdout.isTTY ? true : false,
+      ci:
+        ['CI', 'BUILD_ID', 'BUILD_NUMBER', 'BITBUCKET_COMMIT', 'CODEBUILD_BUILD_ARN'].filter(v => !!process.env[v])
+          .length > 0 || process.argv.includes('--ci'),
+    });
 
+  return terminalInfo.tty && !terminalInfo.ci;
+};
 // Plucked from https://github.com/ionic-team/capacitor/blob/b893a57aaaf3a16e13db9c33037a12f1a5ac92e0/cli/src/util/uuid.ts
 export function uuidv4(): string {
-	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
-		const r = (Math.random() * 16) | 0;
-		const v = c == 'x' ? r : (r & 0x3) | 0x8;
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    const r = (Math.random() * 16) | 0;
+    const v = c == 'x' ? r : (r & 0x3) | 0x8;
 
-		return v.toString(16);
-	});
+    return v.toString(16);
+  });
 }
 
 export async function readJson(path: string) {
-	const file = await getCompilerSystem()?.readFile(path);
-	return !!file && JSON.parse(file);
+  const file = await getCompilerSystem().readFile(path);
+  return !!file && JSON.parse(file);
 }

--- a/src/cli/telemetry/helpers.ts
+++ b/src/cli/telemetry/helpers.ts
@@ -1,4 +1,4 @@
-import fs from "fs";
+import { getCompilerSystem } from '../state/stencil-cli-config'
 
 interface TerminalInfo {
 	/**
@@ -47,6 +47,6 @@ export function uuidv4(): string {
 }
 
 export async function readJson(path: string) {
-	const rawdata = await fs.promises.readFile(path);
-	return JSON.parse(rawdata.toString());
+	const file = await getCompilerSystem()?.readFile(path);
+	return !!file && JSON.parse(file);
 }

--- a/src/cli/telemetry/test/helpers.spec.ts
+++ b/src/cli/telemetry/test/helpers.spec.ts
@@ -2,7 +2,7 @@ import { isInteractive, TERMINAL_INFO, tryFn, uuidv4 } from '../helpers';
 
 describe('uuidv4', () => {
 
-	it('should output a UUID', async () => {
+	it('outputs a UUID', async () => {
 		const pattern = new RegExp(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i);
 		const uuid = uuidv4()
 		expect(!!uuid.match(pattern)).toBe(true)

--- a/src/cli/telemetry/test/helpers.spec.ts
+++ b/src/cli/telemetry/test/helpers.spec.ts
@@ -5,7 +5,6 @@ describe('uuidv4', () => {
 	it('should output a UUID', async () => {
 		const pattern = new RegExp(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i);
 		const uuid = uuidv4()
-		expect(typeof uuid).toBe("string")
 		expect(!!uuid.match(pattern)).toBe(true)
 	});
 

--- a/src/cli/telemetry/test/helpers.spec.ts
+++ b/src/cli/telemetry/test/helpers.spec.ts
@@ -1,4 +1,4 @@
-import { tryFn, uuidv4 } from '../helpers';
+import { isInteractive, TERMINAL_INFO, tryFn, uuidv4 } from '../helpers';
 
 describe('uuidv4', () => {
 
@@ -9,6 +9,27 @@ describe('uuidv4', () => {
 	});
 
 });
+
+describe('isInteractive', () => {
+	it('should return false when tty is false', async () => {
+		TERMINAL_INFO = { ci: true, shell: true, tty: false, windows: true };
+		const result = isInteractive();
+		expect(result).toBe(false)
+	});
+
+	it('should return false when ci is true', async () => {
+		TERMINAL_INFO = { ci: true, shell: true, tty: true, windows: true };
+		const result = isInteractive();
+		expect(result).toBe(false)
+	});
+
+	it('should return true when tty is true and ci is false', async () => {
+		TERMINAL_INFO = { ci: false, shell: true, tty: true, windows: true };
+		const result = isInteractive();
+		expect(result).toBe(true)
+	});
+});
+
 
 describe('tryFn', () => {
 

--- a/src/cli/telemetry/test/helpers.spec.ts
+++ b/src/cli/telemetry/test/helpers.spec.ts
@@ -1,0 +1,32 @@
+import { tryFn, uuidv4 } from '../helpers';
+
+describe('uuidv4', () => {
+
+	it('should output a UUID', async () => {
+		const pattern = new RegExp(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i);
+		const uuid = uuidv4()
+		expect(typeof uuid).toBe("string")
+		expect(!!uuid.match(pattern)).toBe(true)
+	});
+
+});
+
+describe('tryFn', () => {
+
+	it('should handle failures correctly', async () => {
+		const result = await tryFn(async () => {
+			throw new Error("Uh oh!")
+		});
+
+		expect(result).toBe(null)
+	});
+
+	it('should handle success correctly', async () => {
+		const result = await tryFn(async () => {
+			return true
+		})
+
+		expect(result).toBe(true)
+	});
+
+});

--- a/src/cli/telemetry/test/helpers.spec.ts
+++ b/src/cli/telemetry/test/helpers.spec.ts
@@ -1,4 +1,7 @@
+import { initializeStencilCLIConfig } from '../../state/stencil-cli-config';
 import { isInteractive, TERMINAL_INFO, tryFn, uuidv4 } from '../helpers';
+import { createSystem } from '../../../compiler/sys/stencil-sys';
+import { mockLogger } from '@stencil/core/testing';
 
 describe('uuidv4', () => {
   it('outputs a UUID', () => {
@@ -9,6 +12,12 @@ describe('uuidv4', () => {
 });
 
 describe('isInteractive', () => {
+  initializeStencilCLIConfig({
+    sys: createSystem(),
+    logger: mockLogger(),
+    args: [],
+  });
+
   it('returns false by default', () => {
     const result = isInteractive();
     expect(result).toBe(false);

--- a/src/cli/telemetry/test/helpers.spec.ts
+++ b/src/cli/telemetry/test/helpers.spec.ts
@@ -27,6 +27,7 @@ describe('tryFn', () => {
 
 		expect(result).toBe(true)
 	});
+
 	it('handles returning false correctly', async () => {
 		const result = await tryFn(async () => {
 			return false;

--- a/src/cli/telemetry/test/helpers.spec.ts
+++ b/src/cli/telemetry/test/helpers.spec.ts
@@ -1,59 +1,57 @@
 import { isInteractive, TERMINAL_INFO, tryFn, uuidv4 } from '../helpers';
 
 describe('uuidv4', () => {
-
-	it('outputs a UUID', async () => {
-		const pattern = new RegExp(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i);
-		const uuid = uuidv4()
-		expect(!!uuid.match(pattern)).toBe(true)
-	});
-
+  it('outputs a UUID', () => {
+    const pattern = new RegExp(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i);
+    const uuid = uuidv4();
+    expect(!!uuid.match(pattern)).toBe(true);
+  });
 });
 
 describe('isInteractive', () => {
-	it('should return false when tty is false', async () => {
-		TERMINAL_INFO = { ci: true, shell: true, tty: false, windows: true };
-		const result = isInteractive();
-		expect(result).toBe(false)
-	});
+  it('returns false by default', () => {
+    const result = isInteractive();
+    expect(result).toBe(false);
+  });
 
-	it('should return false when ci is true', async () => {
-		TERMINAL_INFO = { ci: true, shell: true, tty: true, windows: true };
-		const result = isInteractive();
-		expect(result).toBe(false)
-	});
+  it('returns false when tty is false', () => {
+    const result = isInteractive({ ci: true, tty: false });
+    expect(result).toBe(false);
+  });
 
-	it('should return true when tty is true and ci is false', async () => {
-		TERMINAL_INFO = { ci: false, shell: true, tty: true, windows: true };
-		const result = isInteractive();
-		expect(result).toBe(true)
-	});
+  it('returns false when ci is true', () => {
+    const result = isInteractive({ ci: true, tty: true });
+    expect(result).toBe(false);
+  });
+
+  it('returns true when tty is true and ci is false', () => {
+    const result = isInteractive({ ci: false, tty: true });
+    expect(result).toBe(true);
+  });
 });
 
-
 describe('tryFn', () => {
+  it('handles failures correctly', async () => {
+    const result = await tryFn(async () => {
+      throw new Error('Uh oh!');
+    });
 
-	it('should handle failures correctly', async () => {
-		const result = await tryFn(async () => {
-			throw new Error("Uh oh!")
-		});
+    expect(result).toBe(null);
+  });
 
-		expect(result).toBe(null)
-	});
+  it('handles success correctly', async () => {
+    const result = await tryFn(async () => {
+      return true;
+    });
 
-	it('should handle success correctly', async () => {
-		const result = await tryFn(async () => {
-			return true
-		})
+    expect(result).toBe(true);
+  });
 
-		expect(result).toBe(true)
-	});
+  it('handles returning false correctly', async () => {
+    const result = await tryFn(async () => {
+      return false;
+    });
 
-	it('handles returning false correctly', async () => {
-		const result = await tryFn(async () => {
-			return false;
-		})
-
-		expect(result).toBe(false);
-	});
+    expect(result).toBe(false);
+  });
 });

--- a/src/cli/telemetry/test/helpers.spec.ts
+++ b/src/cli/telemetry/test/helpers.spec.ts
@@ -28,5 +28,11 @@ describe('tryFn', () => {
 
 		expect(result).toBe(true)
 	});
+	it('handles returning false correctly', async () => {
+		const result = await tryFn(async () => {
+			return false;
+		})
 
+		expect(result).toBe(false);
+	});
 });

--- a/src/cli/test/ionic-config.spec.ts
+++ b/src/cli/test/ionic-config.spec.ts
@@ -12,7 +12,6 @@ describe('readConfig', () => {
 
 		const config = await readConfig();
 
-		expect(typeof config).toBe("object");
 		expect(Object.keys(config).join()).toBe("tokens.telemetry,telemetry.stencil");
 	});
 
@@ -23,7 +22,6 @@ describe('readConfig', () => {
 
 		const config = await readConfig();
 
-		expect(typeof config).toBe("object");
 		expect(Object.keys(config).join()).toBe("telemetry.stencil,tokens.telemetry");
 		expect(config['telemetry.stencil']).toBe(true);
 		expect(config['tokens.telemetry']).toBe("12345");

--- a/src/cli/test/ionic-config.spec.ts
+++ b/src/cli/test/ionic-config.spec.ts
@@ -1,6 +1,6 @@
 import { mockLogger } from '@stencil/core/testing';
 import { getCompilerSystem, initializeStencilCLIConfig } from '../state/stencil-cli-config';
-import { readConfig, writeConfig, updateConfig, DEFAULT_CONFIG } from '../ionic-config';
+import { readConfig, writeConfig, updateConfig, default_config } from '../ionic-config';
 import { createSystem } from '../../compiler/sys/stencil-sys';
 
 describe('readConfig', () => {
@@ -11,13 +11,13 @@ describe('readConfig', () => {
   });
 
   it('should create a file if it does not exist', async () => {
-    let result = await getCompilerSystem().stat(DEFAULT_CONFIG(true));
+    let result = await getCompilerSystem().stat(default_config());
 
     if (result.isFile) {
-      await getCompilerSystem().removeFile(DEFAULT_CONFIG(true));
+      await getCompilerSystem().removeFile(default_config());
     }
 
-    result = await getCompilerSystem().stat(DEFAULT_CONFIG(true));
+    result = await getCompilerSystem().stat(default_config());
 
     expect(result.isFile).toBe(false);
 
@@ -29,7 +29,7 @@ describe('readConfig', () => {
   it('should read a file if it exists', async () => {
     await writeConfig({ 'telemetry.stencil': true, 'tokens.telemetry': '12345' });
 
-    let result = await getCompilerSystem().stat(DEFAULT_CONFIG(true));
+    let result = await getCompilerSystem().stat(default_config());
 
     expect(result.isFile).toBe(true);
 
@@ -51,7 +51,7 @@ describe('updateConfig', () => {
   it('should edit a file', async () => {
     await writeConfig({ 'telemetry.stencil': true, 'tokens.telemetry': '12345' });
 
-    let result = await getCompilerSystem().stat(DEFAULT_CONFIG(true));
+    let result = await getCompilerSystem().stat(default_config());
 
     expect(result.isFile).toBe(true);
 

--- a/src/cli/test/ionic-config.spec.ts
+++ b/src/cli/test/ionic-config.spec.ts
@@ -1,6 +1,6 @@
 import { mockLogger } from '@stencil/core/testing';
 import { getCompilerSystem, initializeStencilCLIConfig } from '../state/stencil-cli-config';
-import { readConfig, writeConfig, updateConfig, default_config } from '../ionic-config';
+import { readConfig, writeConfig, updateConfig, defaultConfig } from '../ionic-config';
 import { createSystem } from '../../compiler/sys/stencil-sys';
 
 describe('readConfig', () => {
@@ -11,13 +11,13 @@ describe('readConfig', () => {
   });
 
   it('should create a file if it does not exist', async () => {
-    let result = await getCompilerSystem().stat(default_config());
+    let result = await getCompilerSystem().stat(defaultConfig());
 
     if (result.isFile) {
-      await getCompilerSystem().removeFile(default_config());
+      await getCompilerSystem().removeFile(defaultConfig());
     }
 
-    result = await getCompilerSystem().stat(default_config());
+    result = await getCompilerSystem().stat(defaultConfig());
 
     expect(result.isFile).toBe(false);
 
@@ -29,7 +29,7 @@ describe('readConfig', () => {
   it('should read a file if it exists', async () => {
     await writeConfig({ 'telemetry.stencil': true, 'tokens.telemetry': '12345' });
 
-    let result = await getCompilerSystem().stat(default_config());
+    let result = await getCompilerSystem().stat(defaultConfig());
 
     expect(result.isFile).toBe(true);
 
@@ -51,7 +51,7 @@ describe('updateConfig', () => {
   it('should edit a file', async () => {
     await writeConfig({ 'telemetry.stencil': true, 'tokens.telemetry': '12345' });
 
-    let result = await getCompilerSystem().stat(default_config());
+    let result = await getCompilerSystem().stat(defaultConfig());
 
     expect(result.isFile).toBe(true);
 

--- a/src/cli/test/ionic-config.spec.ts
+++ b/src/cli/test/ionic-config.spec.ts
@@ -1,0 +1,58 @@
+import fs from 'fs-extra';
+import { readConfig, writeConfig, updateConfig, DEFAULT_CONFIG_DIRECTORY } from '../ionic-config';
+
+describe('readConfig', () => {
+
+	it('should create a file if it does not exist', async () => {
+		if (await fs.pathExists(DEFAULT_CONFIG_DIRECTORY)) {
+			fs.rmSync(DEFAULT_CONFIG_DIRECTORY);
+		}
+
+		expect(await fs.pathExists(DEFAULT_CONFIG_DIRECTORY)).toBe(false)
+
+		const config = await readConfig();
+
+		expect(typeof config).toBe("object");
+		expect(Object.keys(config).join()).toBe("tokens.telemetry,telemetry.stencil");
+	});
+
+	it('should read a file if it exists', async () => {
+		await writeConfig({"telemetry.stencil": true, "tokens.telemetry": "12345"})
+
+		expect(await fs.pathExists(DEFAULT_CONFIG_DIRECTORY)).toBe(true)
+
+		const config = await readConfig();
+
+		expect(typeof config).toBe("object");
+		expect(Object.keys(config).join()).toBe("telemetry.stencil,tokens.telemetry");
+		expect(config['telemetry.stencil']).toBe(true);
+		expect(config['tokens.telemetry']).toBe("12345");
+	});
+});
+
+describe('updateConfig', () => {
+
+	it('should edit a file', async () => {
+		await writeConfig({ "telemetry.stencil": true, "tokens.telemetry": "12345" })
+
+		expect(await fs.pathExists(DEFAULT_CONFIG_DIRECTORY)).toBe(true)
+
+		const configPre = await readConfig();
+
+		expect(typeof configPre).toBe("object");
+		expect(Object.keys(configPre).join()).toBe("telemetry.stencil,tokens.telemetry");
+		expect(configPre['telemetry.stencil']).toBe(true);
+		expect(configPre['tokens.telemetry']).toBe("12345");
+
+		await updateConfig({ "telemetry.stencil": false, "tokens.telemetry": "67890" });
+
+		const configPost = await readConfig();
+
+		expect(typeof configPost).toBe("object");
+		// Should keep the previous order
+		expect(Object.keys(configPost).join()).toBe("telemetry.stencil,tokens.telemetry");
+		expect(configPost['telemetry.stencil']).toBe(false);
+		expect(configPost['tokens.telemetry']).toBe("67890");
+	});
+
+});

--- a/src/cli/test/ionic-config.spec.ts
+++ b/src/cli/test/ionic-config.spec.ts
@@ -1,77 +1,75 @@
 import { mockLogger } from '@stencil/core/testing';
 import { getCompilerSystem, initializeStencilCLIConfig } from '../state/stencil-cli-config';
-import { readConfig, writeConfig, updateConfig, DEFAULT_CONFIG_DIRECTORY } from '../ionic-config';
+import { readConfig, writeConfig, updateConfig, DEFAULT_CONFIG } from '../ionic-config';
 import { createSystem } from '../../compiler/sys/stencil-sys';
 
 describe('readConfig', () => {
+  initializeStencilCLIConfig({
+    sys: createSystem(),
+    logger: mockLogger(),
+    args: [],
+  });
 
-	initializeStencilCLIConfig({
-		sys: createSystem(),
-		logger: mockLogger(),
-		args: []
-	});
+  it('should create a file if it does not exist', async () => {
+    let result = await getCompilerSystem().stat(DEFAULT_CONFIG(true));
 
-	it('should create a file if it does not exist', async () => {
-		let result = await getCompilerSystem().stat(DEFAULT_CONFIG_DIRECTORY(true));
+    if (result.isFile) {
+      await getCompilerSystem().removeFile(DEFAULT_CONFIG(true));
+    }
 
-		if (result.isFile) {
-			await getCompilerSystem().removeFile(DEFAULT_CONFIG_DIRECTORY(true))
-		}
+    result = await getCompilerSystem().stat(DEFAULT_CONFIG(true));
 
-		result = await getCompilerSystem().stat(DEFAULT_CONFIG_DIRECTORY(true))
+    expect(result.isFile).toBe(false);
 
-		expect(result.isFile).toBe(false)
+    const config = await readConfig();
 
-		const config = await readConfig();
+    expect(Object.keys(config).join()).toBe('tokens.telemetry,telemetry.stencil');
+  });
 
-		expect(Object.keys(config).join()).toBe("tokens.telemetry,telemetry.stencil");
-	});
+  it('should read a file if it exists', async () => {
+    await writeConfig({ 'telemetry.stencil': true, 'tokens.telemetry': '12345' });
 
-	it('should read a file if it exists', async () => {
-		await writeConfig({ "telemetry.stencil": true, "tokens.telemetry": "12345" })
+    let result = await getCompilerSystem().stat(DEFAULT_CONFIG(true));
 
-		let result = await getCompilerSystem().stat(DEFAULT_CONFIG_DIRECTORY(true));
+    expect(result.isFile).toBe(true);
 
-		expect(result.isFile).toBe(true)
+    const config = await readConfig();
 
-		const config = await readConfig();
-
-		expect(Object.keys(config).join()).toBe("telemetry.stencil,tokens.telemetry");
-		expect(config['telemetry.stencil']).toBe(true);
-		expect(config['tokens.telemetry']).toBe("12345");
-	});
+    expect(Object.keys(config).join()).toBe('telemetry.stencil,tokens.telemetry');
+    expect(config['telemetry.stencil']).toBe(true);
+    expect(config['tokens.telemetry']).toBe('12345');
+  });
 });
 
 describe('updateConfig', () => {
-	initializeStencilCLIConfig({
-		sys: createSystem(),
-		logger: mockLogger(),
-		args: []
-	});
+  initializeStencilCLIConfig({
+    sys: createSystem(),
+    logger: mockLogger(),
+    args: [],
+  });
 
-	it('should edit a file', async () => {
-		await writeConfig({ "telemetry.stencil": true, "tokens.telemetry": "12345" })
+  it('should edit a file', async () => {
+    await writeConfig({ 'telemetry.stencil': true, 'tokens.telemetry': '12345' });
 
-		let result = await getCompilerSystem().stat(DEFAULT_CONFIG_DIRECTORY(true));
+    let result = await getCompilerSystem().stat(DEFAULT_CONFIG(true));
 
-		expect(result.isFile).toBe(true)
+    expect(result.isFile).toBe(true);
 
-		const configPre = await readConfig();
+    const configPre = await readConfig();
 
-		expect(typeof configPre).toBe("object");
-		expect(Object.keys(configPre).join()).toBe("telemetry.stencil,tokens.telemetry");
-		expect(configPre['telemetry.stencil']).toBe(true);
-		expect(configPre['tokens.telemetry']).toBe("12345");
+    expect(typeof configPre).toBe('object');
+    expect(Object.keys(configPre).join()).toBe('telemetry.stencil,tokens.telemetry');
+    expect(configPre['telemetry.stencil']).toBe(true);
+    expect(configPre['tokens.telemetry']).toBe('12345');
 
-		await updateConfig({ "telemetry.stencil": false, "tokens.telemetry": "67890" });
+    await updateConfig({ 'telemetry.stencil': false, 'tokens.telemetry': '67890' });
 
-		const configPost = await readConfig();
+    const configPost = await readConfig();
 
-		expect(typeof configPost).toBe("object");
-		// Should keep the previous order
-		expect(Object.keys(configPost).join()).toBe("telemetry.stencil,tokens.telemetry");
-		expect(configPost['telemetry.stencil']).toBe(false);
-		expect(configPost['tokens.telemetry']).toBe("67890");
-	});
-
+    expect(typeof configPost).toBe('object');
+    // Should keep the previous order
+    expect(Object.keys(configPost).join()).toBe('telemetry.stencil,tokens.telemetry');
+    expect(configPost['telemetry.stencil']).toBe(false);
+    expect(configPost['tokens.telemetry']).toBe('67890');
+  });
 });

--- a/src/cli/test/ionic-config.spec.ts
+++ b/src/cli/test/ionic-config.spec.ts
@@ -1,14 +1,26 @@
-import fs from 'fs-extra';
+import { mockLogger } from '@stencil/core/testing';
+import { getCompilerSystem, initializeStencilCLIConfig } from '../state/stencil-cli-config';
 import { readConfig, writeConfig, updateConfig, DEFAULT_CONFIG_DIRECTORY } from '../ionic-config';
+import { createSystem } from '../../compiler/sys/stencil-sys';
 
 describe('readConfig', () => {
 
+	initializeStencilCLIConfig({
+		sys: createSystem(),
+		logger: mockLogger(),
+		args: []
+	});
+
 	it('should create a file if it does not exist', async () => {
-		if (await fs.pathExists(DEFAULT_CONFIG_DIRECTORY)) {
-			fs.rmSync(DEFAULT_CONFIG_DIRECTORY);
+		let result = await getCompilerSystem().stat(DEFAULT_CONFIG_DIRECTORY(true));
+
+		if (result.isFile) {
+			await getCompilerSystem().removeFile(DEFAULT_CONFIG_DIRECTORY(true))
 		}
 
-		expect(await fs.pathExists(DEFAULT_CONFIG_DIRECTORY)).toBe(false)
+		result = await getCompilerSystem().stat(DEFAULT_CONFIG_DIRECTORY(true))
+
+		expect(result.isFile).toBe(false)
 
 		const config = await readConfig();
 
@@ -16,9 +28,11 @@ describe('readConfig', () => {
 	});
 
 	it('should read a file if it exists', async () => {
-		await writeConfig({"telemetry.stencil": true, "tokens.telemetry": "12345"})
+		await writeConfig({ "telemetry.stencil": true, "tokens.telemetry": "12345" })
 
-		expect(await fs.pathExists(DEFAULT_CONFIG_DIRECTORY)).toBe(true)
+		let result = await getCompilerSystem().stat(DEFAULT_CONFIG_DIRECTORY(true));
+
+		expect(result.isFile).toBe(true)
 
 		const config = await readConfig();
 
@@ -29,11 +43,18 @@ describe('readConfig', () => {
 });
 
 describe('updateConfig', () => {
+	initializeStencilCLIConfig({
+		sys: createSystem(),
+		logger: mockLogger(),
+		args: []
+	});
 
 	it('should edit a file', async () => {
 		await writeConfig({ "telemetry.stencil": true, "tokens.telemetry": "12345" })
 
-		expect(await fs.pathExists(DEFAULT_CONFIG_DIRECTORY)).toBe(true)
+		let result = await getCompilerSystem().stat(DEFAULT_CONFIG_DIRECTORY(true));
+
+		expect(result.isFile).toBe(true)
 
 		const configPre = await readConfig();
 

--- a/src/compiler/sys/stencil-sys.ts
+++ b/src/compiler/sys/stencil-sys.ts
@@ -16,6 +16,7 @@ import type {
 } from '../../declarations';
 import platformPath from 'path-browserify';
 import { basename, dirname, join } from 'path';
+import * as os from 'os'
 import { buildEvents } from '../events';
 import { createLogger } from './logger/console-logger';
 import { createWebWorkerMainController } from './worker/web-worker-main';
@@ -73,6 +74,10 @@ export const createSystem = (c?: { logger?: Logger }) => {
     writeFileSync(dest, readFileSync(src));
     return true;
   };
+
+  const homeDir = () => {
+    return os.homedir();
+  }
 
   const createDirSync = (p: string, opts?: CompilerSystemCreateDirectoryOptions) => {
     p = normalize(p);
@@ -546,6 +551,7 @@ export const createSystem = (c?: { logger?: Logger }) => {
     copyFile,
     createDir,
     createDirSync,
+    homeDir,
     destroy,
     encodeToBase64,
     exit: async exitCode => logger.warn(`exit ${exitCode}`),

--- a/src/compiler/sys/stencil-sys.ts
+++ b/src/compiler/sys/stencil-sys.ts
@@ -16,7 +16,8 @@ import type {
 } from '../../declarations';
 import platformPath from 'path-browserify';
 import { basename, dirname, join } from 'path';
-import * as os from 'os'
+import * as process from 'process';
+import * as os from 'os';
 import { buildEvents } from '../events';
 import { createLogger } from './logger/console-logger';
 import { createWebWorkerMainController } from './worker/web-worker-main';
@@ -75,9 +76,13 @@ export const createSystem = (c?: { logger?: Logger }) => {
     return true;
   };
 
+  const isTTY = (): boolean => {
+    return !!process?.stdout?.isTTY;
+  };
+
   const homeDir = () => {
     return os.homedir();
-  }
+  };
 
   const createDirSync = (p: string, opts?: CompilerSystemCreateDirectoryOptions) => {
     p = normalize(p);
@@ -528,6 +533,10 @@ export const createSystem = (c?: { logger?: Logger }) => {
     return results;
   };
 
+  const getEnvironmentVar = (key: string) => {
+    return process?.env[key];
+  };
+
   const getLocalModulePath = (opts: { rootDir: string; moduleId: string; path: string }) =>
     join(opts.rootDir, 'node_modules', opts.moduleId, opts.path);
 
@@ -552,6 +561,8 @@ export const createSystem = (c?: { logger?: Logger }) => {
     createDir,
     createDirSync,
     homeDir,
+    isTTY,
+    getEnvironmentVar,
     destroy,
     encodeToBase64,
     exit: async exitCode => logger.warn(`exit ${exitCode}`),

--- a/src/compiler/sys/tests/stencil-sys.spec.ts
+++ b/src/compiler/sys/tests/stencil-sys.spec.ts
@@ -135,6 +135,11 @@ describe('stencil system', () => {
     expect(newABCStat.isDirectory).toBe(true);
   });
 
+  it('get home directory', async () => {
+    const homedir = sys.homeDir();
+    expect(typeof homedir).toBe("string")
+  })
+
   it('rename directory, with files/subfolders', async () => {
     await sys.createDir('/x/y/z', { recursive: true });
     await sys.createDir('/x/y/y1-dir', { recursive: true });

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -902,6 +902,7 @@ export interface CompilerSystem {
    * SYNC! Does not throw.
    */
   createDirSync(p: string, opts?: CompilerSystemCreateDirectoryOptions): CompilerSystemCreateDirectoryResults;
+  homeDir(): string;
   /**
    * Each plaform as a different way to dynamically import modules.
    */

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -904,6 +904,10 @@ export interface CompilerSystem {
   createDirSync(p: string, opts?: CompilerSystemCreateDirectoryOptions): CompilerSystemCreateDirectoryResults;
   homeDir(): string;
   /**
+   * Used to determine if the current context of the terminal is TTY.
+   */
+  isTTY(): boolean;
+  /**
    * Each plaform as a different way to dynamically import modules.
    */
   dynamicImport?(p: string): Promise<any>;

--- a/src/sys/deno/deno-sys.ts
+++ b/src/sys/deno/deno-sys.ts
@@ -124,6 +124,9 @@ export function createDenoSys(c: { Deno?: any } = {}) {
       }
       return results;
     },
+    homeDir() {
+      return deno.env.get("HOME")
+    },
     createDirSync(p, opts) {
       const results: CompilerSystemCreateDirectoryResults = {
         basename: basename(p),

--- a/src/sys/deno/deno-sys.ts
+++ b/src/sys/deno/deno-sys.ts
@@ -124,8 +124,11 @@ export function createDenoSys(c: { Deno?: any } = {}) {
       }
       return results;
     },
+    isTTY() {
+      return !!deno?.isatty(deno?.stdout?.rid);
+    },
     homeDir() {
-      return deno.env.get("HOME")
+      return deno.env.get('HOME');
     },
     createDirSync(p, opts) {
       const results: CompilerSystemCreateDirectoryResults = {

--- a/src/sys/node/node-sys.ts
+++ b/src/sys/node/node-sys.ts
@@ -243,6 +243,9 @@ export function createNodeSys(c: { process?: any } = {}) {
         });
       });
     },
+    isTTY() {
+      return !!process?.stdout?.isTTY;
+    },
     readDirSync(p) {
       try {
         return fs.readdirSync(p).map(f => {
@@ -273,8 +276,8 @@ export function createNodeSys(c: { process?: any } = {}) {
     },
     homeDir() {
       try {
-        return os.homedir()
-      } catch (e) { }
+        return os.homedir();
+      } catch (e) {}
       return undefined;
     },
     realpath(p) {

--- a/src/sys/node/node-sys.ts
+++ b/src/sys/node/node-sys.ts
@@ -17,6 +17,7 @@ import { NodeLazyRequire } from './node-lazy-require';
 import { NodeResolveModule } from './node-resolve-module';
 import { NodeWorkerController } from './node-worker-controller';
 import path from 'path';
+import * as os from 'os';
 import type TypeScript from 'typescript';
 
 export function createNodeSys(c: { process?: any } = {}) {
@@ -268,6 +269,12 @@ export function createNodeSys(c: { process?: any } = {}) {
       try {
         return fs.readFileSync(p, 'utf8');
       } catch (e) {}
+      return undefined;
+    },
+    homeDir() {
+      try {
+        return os.homedir()
+      } catch (e) { }
       return undefined;
     },
     realpath(p) {

--- a/src/testing/testing-sys.ts
+++ b/src/testing/testing-sys.ts
@@ -36,6 +36,7 @@ export const createTestingSystem = () => {
 
   sys.access = wrapRead(sys.access);
   sys.accessSync = wrapRead(sys.accessSync);
+  sys.homeDir = wrapRead(sys.homeDir);
   sys.readFile = wrapRead(sys.readFile);
   sys.readFileSync = wrapRead(sys.readFileSync);
   sys.readDir = wrapRead(sys.readDir);


### PR DESCRIPTION
Adds ability to allow writing and reading to the ~/.ionic/config.json file. When reading, if the file doesn't exist, readConfig will automatically create the file. 

Satisfies ADR-2