### PR TITLE
feat(cli): [STENCIL-12] Adding Telemetry and CLI features. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/graceful-fs": "^4.1.5",
         "@types/inquirer": "^7.3.1",
         "@types/is-glob": "^4.0.1",
-        "@types/jest": "^26.0.21",
+        "@types/jest": "^26.0.24",
         "@types/listr": "^0.14.2",
         "@types/mime-types": "^2.1.0",
         "@types/node": "^14.14.35",
@@ -1233,9 +1233,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "26.0.21",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.21.tgz",
-      "integrity": "sha512-ab9TyM/69yg7eew9eOwKMUmvIZAKEGZYlq/dhe5/0IMUd/QLJv5ldRMdddSn+u22N13FP3s5jYyktxuBwY0kDA==",
+      "version": "26.0.24",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
+      "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
       "dev": true,
       "dependencies": {
         "jest-diff": "^26.0.0",
@@ -13668,9 +13668,9 @@
       }
     },
     "@types/jest": {
-      "version": "26.0.21",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.21.tgz",
-      "integrity": "sha512-ab9TyM/69yg7eew9eOwKMUmvIZAKEGZYlq/dhe5/0IMUd/QLJv5ldRMdddSn+u22N13FP3s5jYyktxuBwY0kDA==",
+      "version": "26.0.24",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
+      "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
       "dev": true,
       "requires": {
         "jest-diff": "^26.0.0",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "test.testing": "node scripts/test/validate-testing.js",
     "test.sys.node": "echo test.sys.node",
     "test.prod": "npm run test.dist && npm run test.end-to-end && npm run test.jest && npm run test.karma && npm run test.sys.node && npm run test.testing",
-    "test.watch": "jest --watch",
-    "watch-tests": "jest --watch"
+    "test.watch": "jest --watch"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "15.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "test.testing": "node scripts/test/validate-testing.js",
     "test.sys.node": "echo test.sys.node",
     "test.prod": "npm run test.dist && npm run test.end-to-end && npm run test.jest && npm run test.karma && npm run test.sys.node && npm run test.testing",
-    "test.watch": "jest --watch"
+    "test.watch": "jest --watch",
+    "watch-tests": "jest --watch"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "15.1.0",

--- a/src/cli/ionic-config.ts
+++ b/src/cli/ionic-config.ts
@@ -26,16 +26,20 @@ export async function readConfig(): Promise<TelemetryConfig> {
   return config;
 }
 
-export async function writeConfig(config: TelemetryConfig): Promise<void> {
+export async function writeConfig(config: TelemetryConfig): Promise<boolean> {
+  let result = false;
   try {
     await getCompilerSystem().createDir(defaultConfigDirectory(), { recursive: true });
     await getCompilerSystem().writeFile(defaultConfig(), JSON.stringify(config));
+    result = true;
   } catch (error) {
     console.error(`Stencil Telemetry: couldn't write configuration file to ${defaultConfig()} - ${error}.`);
   }
+
+  return result;
 }
 
-export async function updateConfig(newOptions: TelemetryConfig): Promise<void> {
+export async function updateConfig(newOptions: TelemetryConfig): Promise<boolean> {
   const config = await readConfig();
-  await writeConfig(Object.assign(config, newOptions));
+  return await writeConfig(Object.assign(config, newOptions));
 }

--- a/src/cli/ionic-config.ts
+++ b/src/cli/ionic-config.ts
@@ -1,8 +1,10 @@
 import { getCompilerSystem } from './state/stencil-cli-config';
 import { readJson, uuidv4, UUID_REGEX } from './telemetry/helpers';
 
+export const isTest = () => process.env.JEST_WORKER_ID !== undefined
+
 export const defaultConfig = () =>
-  getCompilerSystem().resolvePath(`${getCompilerSystem().homeDir()}/.ionic/config.json`);
+  getCompilerSystem().resolvePath(`${getCompilerSystem().homeDir()}/.ionic/${isTest() ? "tmp-config.json" : "config.json"}`);
 
 export const defaultConfigDirectory = () => getCompilerSystem().resolvePath(`${getCompilerSystem().homeDir()}/.ionic`);
 
@@ -23,7 +25,7 @@ export async function readConfig(): Promise<TelemetryConfig> {
     await writeConfig(config);
   } else if (!!config && !config['tokens.telemetry'].match(UUID_REGEX)) {
     const newUuid = uuidv4();
-    await writeConfig(Object.assign(config, { 'tokens.telemetry': newUuid }));
+    await writeConfig({...config, 'tokens.telemetry': newUuid });
     config['tokens.telemetry'] = newUuid;
   }
 

--- a/src/cli/ionic-config.ts
+++ b/src/cli/ionic-config.ts
@@ -30,7 +30,7 @@ export async function writeConfig(config: TelemetryConfig): Promise<boolean> {
   let result = false;
   try {
     await getCompilerSystem().createDir(defaultConfigDirectory(), { recursive: true });
-    await getCompilerSystem().writeFile(defaultConfig(), JSON.stringify(config));
+    await getCompilerSystem().writeFile(defaultConfig(), JSON.stringify(config, null, 2));
     result = true;
   } catch (error) {
     console.error(`Stencil Telemetry: couldn't write configuration file to ${defaultConfig()} - ${error}.`);

--- a/src/cli/ionic-config.ts
+++ b/src/cli/ionic-config.ts
@@ -1,5 +1,5 @@
 import { getCompilerSystem } from './state/stencil-cli-config';
-import { readJson, uuidv4 } from './telemetry/helpers';
+import { readJson, uuidv4, UUID_REGEX } from './telemetry/helpers';
 
 export const defaultConfig = () =>
   getCompilerSystem().resolvePath(`${getCompilerSystem().homeDir()}/.ionic/config.json`);
@@ -21,6 +21,10 @@ export async function readConfig(): Promise<TelemetryConfig> {
     };
 
     await writeConfig(config);
+  } else if (!!config && !config['tokens.telemetry'].match(UUID_REGEX)) {
+    const newUuid = uuidv4();
+    await writeConfig(Object.assign(config, { 'tokens.telemetry': newUuid }));
+    config['tokens.telemetry'] = newUuid;
   }
 
   return config;

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -39,16 +39,16 @@ export const run = async (init: CliInitOptions) => {
       sys.applyGlobalPatch(sys.getCurrentDirectory());
     }
 
-    if (task === 'help' || flags.help) {
-      taskHelp({ sys, logger });
-      return;
-    }
-
     // Update singleton with modifications
     stencilCLIConfig.logger = logger;
     stencilCLIConfig.task = task;
     stencilCLIConfig.sys = sys;
     stencilCLIConfig.flags = flags;
+
+    if (task === 'help' || flags.help) {
+      taskHelp();
+      return;
+    }
 
     startupLog(logger, task);
 
@@ -128,14 +128,6 @@ export const runTask = async (coreCompiler: CoreCompiler, config: Config, task: 
   config.outputTargets = config.outputTargets || [];
 
   switch (task) {
-    case 'telemetry':
-      await taskTelemetry();
-      break;
-
-    case 'help':
-      taskHelp(config);
-      break;
-
     case 'build':
       await taskBuild(coreCompiler, config);
       break;
@@ -149,12 +141,20 @@ export const runTask = async (coreCompiler: CoreCompiler, config: Config, task: 
       await taskGenerate(coreCompiler, config);
       break;
 
+    case 'help':
+      taskHelp();
+      break;
+
     case 'prerender':
       await taskPrerender(coreCompiler, config);
       break;
 
     case 'serve':
       await taskServe(config);
+      break;
+
+    case 'telemetry':
+      await taskTelemetry();
       break;
 
     case 'test':
@@ -167,7 +167,7 @@ export const runTask = async (coreCompiler: CoreCompiler, config: Config, task: 
 
     default:
       config.logger.error(`${config.logger.emoji('❌ ')}Invalid stencil command, please see the options below:`);
-      taskHelp(config);
+      taskHelp();
       return config.sys.exit(1);
   }
 };

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -15,7 +15,6 @@ import { taskServe } from './task-serve';
 import { taskTest } from './task-test';
 import { initializeStencilCLIConfig } from './state/stencil-cli-config';
 import { taskTelemetry } from './task-telemetry';
-
 import { telemetryAction } from './telemetry/telemetry';
 
 export const run = async (init: CliInitOptions) => {

--- a/src/cli/state/stencil-cli-config.ts
+++ b/src/cli/state/stencil-cli-config.ts
@@ -1,4 +1,4 @@
-import type { Logger, CompilerSystem, ConfigFlags } from '../../declarations';
+import type { Logger, CompilerSystem, ConfigFlags, LoadConfigResults, Config } from '../../declarations';
 export type CoreCompiler = typeof import('@stencil/core/compiler');
 
 export interface StencilCLIConfigArgs {
@@ -8,6 +8,7 @@ export interface StencilCLIConfigArgs {
   sys: CompilerSystem;
   flags?: ConfigFlags;
   coreCompiler?: CoreCompiler;
+  validatedConfig?: LoadConfigResults;
 }
 
 export default class StencilCLIConfig {
@@ -19,11 +20,14 @@ export default class StencilCLIConfig {
   private _flags: ConfigFlags | undefined;
   private _task: string | undefined;
   private _coreCompiler: CoreCompiler | undefined;
+  private _validatedConfig: LoadConfigResults | undefined;
 
   private constructor(options: StencilCLIConfigArgs) {
     this._args = options?.args || [];
     this._logger = options?.logger;
     this._sys = options?.sys;
+    this._flags = options?.flags || undefined;
+    this._validatedConfig = options?.validatedConfig || undefined;
   }
 
   public static getInstance(options?: StencilCLIConfigArgs): StencilCLIConfig {
@@ -74,6 +78,13 @@ export default class StencilCLIConfig {
   }
   public set coreCompiler(coreCompiler: CoreCompiler) {
     this._coreCompiler = coreCompiler;
+  }
+
+  public get validatedConfig() {
+    return this._validatedConfig;
+  }
+  public set validatedConfig(validatedConfig: LoadConfigResults) {
+    this._validatedConfig = validatedConfig;
   }
 }
 

--- a/src/cli/state/stencil-cli-config.ts
+++ b/src/cli/state/stencil-cli-config.ts
@@ -38,6 +38,10 @@ export default class StencilCLIConfig {
     return StencilCLIConfig.instance;
   }
 
+  public resetInstance() {
+    delete StencilCLIConfig.instance;
+  }
+
   public get logger() {
     return this._logger;
   }

--- a/src/cli/state/stencil-cli-config.ts
+++ b/src/cli/state/stencil-cli-config.ts
@@ -1,4 +1,4 @@
-import type { Logger, CompilerSystem, ConfigFlags, LoadConfigResults, Config } from '../../declarations';
+import type { Logger, CompilerSystem, ConfigFlags, LoadConfigResults } from '../../declarations';
 export type CoreCompiler = typeof import('@stencil/core/compiler');
 
 export interface StencilCLIConfigArgs {

--- a/src/cli/task-build.ts
+++ b/src/cli/task-build.ts
@@ -4,6 +4,7 @@ import { runPrerenderTask } from './task-prerender';
 import { startCheckVersion, printCheckVersionResults } from './check-version';
 import { startupCompilerLog } from './logs';
 import { taskWatch } from './task-watch';
+import { telemetryBuildFinishedAction } from './telemetry/telemetry';
 
 export const taskBuild = async (coreCompiler: CoreCompiler, config: Config) => {
   if (config.flags.watch) {
@@ -22,6 +23,8 @@ export const taskBuild = async (coreCompiler: CoreCompiler, config: Config) => {
 
     const compiler = await coreCompiler.createCompiler(config);
     const results = await compiler.build();
+
+    await telemetryBuildFinishedAction(results, { config, sys: config.sys, logger: config.logger });
 
     await compiler.destroy();
 

--- a/src/cli/task-build.ts
+++ b/src/cli/task-build.ts
@@ -24,7 +24,7 @@ export const taskBuild = async (coreCompiler: CoreCompiler, config: Config) => {
     const compiler = await coreCompiler.createCompiler(config);
     const results = await compiler.build();
 
-    await telemetryBuildFinishedAction(results, { config, sys: config.sys, logger: config.logger });
+    await telemetryBuildFinishedAction(results);
 
     await compiler.destroy();
 

--- a/src/cli/task-help.ts
+++ b/src/cli/task-help.ts
@@ -1,9 +1,9 @@
-import type { Config } from '../declarations';
+import { getCompilerSystem, getLogger } from './state/stencil-cli-config';
 import { taskTelemetry } from './task-telemetry';
 
-export const taskHelp = async (config: Config) => {
-  const logger = config.logger;
-  const sys = config.sys;
+export const taskHelp = async () => {
+  const logger = getLogger();
+  const sys = getCompilerSystem();
 
   const prompt = logger.dim(sys.details.platform === 'windows' ? '>' : '$');
 

--- a/src/cli/task-help.ts
+++ b/src/cli/task-help.ts
@@ -5,12 +5,12 @@ export const taskHelp = async (config: Config) => {
   const logger = config.logger;
   const sys = config.sys;
 
-  const p = logger.dim(sys.details.platform === 'windows' ? '>' : '$');
+  const prompt = logger.dim(sys.details.platform === 'windows' ? '>' : '$');
 
   console.log(`
   ${logger.bold('Build:')} ${logger.dim('Build components for development or production.')}
 
-    ${p} ${logger.green('stencil build [--dev] [--watch] [--prerender] [--debug]')}
+    ${prompt} ${logger.green('stencil build [--dev] [--watch] [--prerender] [--debug]')}
 
       ${logger.cyan('--dev')} ${logger.dim('.............')} Development build
       ${logger.cyan('--watch')} ${logger.dim('...........')} Rebuild when files update
@@ -25,7 +25,7 @@ export const taskHelp = async (config: Config) => {
 
   ${logger.bold('Test:')} ${logger.dim('Run unit and end-to-end tests.')}
 
-    ${p} ${logger.green('stencil test [--spec] [--e2e]')}
+    ${prompt} ${logger.green('stencil test [--spec] [--e2e]')}
 
       ${logger.cyan('--spec')} ${logger.dim('............')} Run unit tests with Jest
       ${logger.cyan('--e2e')} ${logger.dim('.............')} Run e2e tests with Puppeteer
@@ -33,19 +33,21 @@ export const taskHelp = async (config: Config) => {
 
   ${logger.bold('Generate:')} ${logger.dim('Bootstrap components.')}
 
-    ${p} ${logger.green('stencil generate')} or ${logger.green('stencil g')}
+    ${prompt} ${logger.green('stencil generate')} or ${logger.green('stencil g')}
 
 `);
-  
-  await taskTelemetry(config);
+
+  await taskTelemetry();
 
   console.log(`
   ${logger.bold('Examples:')}
 
-  ${p} ${logger.green('stencil build --dev --watch --serve')}
-  ${p} ${logger.green('stencil build --prerender')}
-  ${p} ${logger.green('stencil test --spec --e2e')}
-  ${p} ${logger.green('stencil generate')}
-  ${p} ${logger.green('stencil g my-component')}
-`)
+  
+  ${prompt} ${logger.green('stencil build --dev --watch --serve')}
+  ${prompt} ${logger.green('stencil build --prerender')}
+  ${prompt} ${logger.green('stencil test --spec --e2e')}
+  ${prompt} ${logger.green('stencil telemetry on')}
+  ${prompt} ${logger.green('stencil generate')}
+  ${prompt} ${logger.green('stencil g my-component')}
+`);
 };

--- a/src/cli/task-help.ts
+++ b/src/cli/task-help.ts
@@ -1,6 +1,10 @@
-import type { CompilerSystem, Logger } from '../declarations';
+import type { Config } from '../declarations';
+import { taskTelemetry } from './task-telemetry';
 
-export const taskHelp = (sys: CompilerSystem, logger: Logger) => {
+export const taskHelp = async (config: Config) => {
+  const logger = config.logger;
+  const sys = config.sys;
+
   const p = logger.dim(sys.details.platform === 'windows' ? '>' : '$');
 
   console.log(`
@@ -31,14 +35,17 @@ export const taskHelp = (sys: CompilerSystem, logger: Logger) => {
 
     ${p} ${logger.green('stencil generate')} or ${logger.green('stencil g')}
 
+`);
+  
+  await taskTelemetry(config);
 
+  console.log(`
   ${logger.bold('Examples:')}
 
-    ${p} ${logger.green('stencil build --dev --watch --serve')}
-    ${p} ${logger.green('stencil build --prerender')}
-    ${p} ${logger.green('stencil test --spec --e2e')}
-    ${p} ${logger.green('stencil generate')}
-    ${p} ${logger.green('stencil g my-component')}
-
-`);
+  ${p} ${logger.green('stencil build --dev --watch --serve')}
+  ${p} ${logger.green('stencil build --prerender')}
+  ${p} ${logger.green('stencil test --spec --e2e')}
+  ${p} ${logger.green('stencil generate')}
+  ${p} ${logger.green('stencil g my-component')}
+`)
 };

--- a/src/cli/task-telemetry.ts
+++ b/src/cli/task-telemetry.ts
@@ -12,7 +12,7 @@ export const taskTelemetry = async () => {
   const THANK_YOU = `Thank you for helping to make Stencil better! 💖`;
   const ENABLED_MESSAGE = `${logger.green('Enabled')}. ${THANK_YOU}\n\n`;
   const DISABLED_MESSAGE = `${logger.red('Disabled')}\n`;
-  let hasTelemetry = await checkTelemetry();
+  const hasTelemetry = await checkTelemetry();
 
   if (isEnabling) {
     const result = await enableTelemetry();

--- a/src/cli/task-telemetry.ts
+++ b/src/cli/task-telemetry.ts
@@ -11,7 +11,7 @@ export const taskTelemetry = async () => {
   )}`;
   const THANK_YOU = `Thank you for helping to make Stencil better! 💖`;
   const ENABLED_MESSAGE = `${logger.green('Enabled')}. ${THANK_YOU}\n\n`;
-  const DISABLED_MESSAGE = `${logger.red('Disabled')}\n`;
+  const DISABLED_MESSAGE = `${logger.red('Disabled')}\n\n`;
   const hasTelemetry = await checkTelemetry();
 
   if (isEnabling) {

--- a/src/cli/task-telemetry.ts
+++ b/src/cli/task-telemetry.ts
@@ -1,0 +1,36 @@
+import type { Config} from '../declarations';
+import { checkTelemetry, disableTelemetry, enableTelemetry } from './telemetry/telemetry';
+
+export const taskTelemetry = async (config: Config) => {
+  const p = config.logger.dim(config.sys.details.platform === 'windows' ? '>' : '$');
+  const logger = config.logger;
+  const isEnabling = config.flags.args.includes("on");
+  const isDisabling = config.flags.args.includes("off");
+  const INFORMATION = `Opt in or our of telemetry. Information about the data we collect is available on our website: ${logger.bold('https://stenciljs.com/telemetry')}`
+  const THANK_YOU = `Thank you for helping to make Stencil better! 💖`;
+  const ENABLED_MESSAGE = `${logger.green('Enabled')}. ${THANK_YOU}\n\n`;
+  const DISABLED_MESSAGE = `${logger.red('Disabled')}\n`;
+  let hasTelemetry = await checkTelemetry();
+
+  if (isEnabling) {
+    await enableTelemetry()
+    console.log(`\n  ${logger.bold('Telemetry is now ') + ENABLED_MESSAGE}`)
+    return;
+  }
+
+  if (isDisabling) {
+    await disableTelemetry()
+    console.log(`\n  ${logger.bold('Telemetry is now ') + DISABLED_MESSAGE}`)
+    return;
+  }
+
+  console.log(`  ${logger.bold('Telemetry:')} ${logger.dim(INFORMATION)}`)
+
+  console.log(`\n  ${logger.bold('Status')}: ${hasTelemetry ? ENABLED_MESSAGE : DISABLED_MESSAGE}`)
+
+  console.log(`    ${p} ${logger.green('stencil telemetry [off|on]')}
+
+        ${logger.cyan('off')} ${logger.dim('.............')} Disable sharing anonymous usage data
+        ${logger.cyan('on')} ${logger.dim('..............')} Enable sharing anonymous usage data
+  `);
+};

--- a/src/cli/task-telemetry.ts
+++ b/src/cli/task-telemetry.ts
@@ -1,34 +1,40 @@
-import type { Config} from '../declarations';
+import { getCompilerSystem, getLogger, getStencilCLIConfig } from './state/stencil-cli-config';
 import { checkTelemetry, disableTelemetry, enableTelemetry } from './telemetry/telemetry';
 
-export const taskTelemetry = async (config: Config) => {
-  const p = config.logger.dim(config.sys.details.platform === 'windows' ? '>' : '$');
-  const logger = config.logger;
-  const isEnabling = config.flags.args.includes("on");
-  const isDisabling = config.flags.args.includes("off");
-  const INFORMATION = `Opt in or our of telemetry. Information about the data we collect is available on our website: ${logger.bold('https://stenciljs.com/telemetry')}`
+export const taskTelemetry = async () => {
+  const logger = getLogger();
+  const prompt = logger.dim(getCompilerSystem().details.platform === 'windows' ? '>' : '$');
+  const isEnabling = getStencilCLIConfig().flags.args.includes('on');
+  const isDisabling = getStencilCLIConfig().flags.args.includes('off');
+  const INFORMATION = `Opt in or our of telemetry. Information about the data we collect is available on our website: ${logger.bold(
+    'https://stenciljs.com/telemetry',
+  )}`;
   const THANK_YOU = `Thank you for helping to make Stencil better! 💖`;
   const ENABLED_MESSAGE = `${logger.green('Enabled')}. ${THANK_YOU}\n\n`;
   const DISABLED_MESSAGE = `${logger.red('Disabled')}\n`;
   let hasTelemetry = await checkTelemetry();
 
   if (isEnabling) {
-    await enableTelemetry()
-    console.log(`\n  ${logger.bold('Telemetry is now ') + ENABLED_MESSAGE}`)
+    const result = await enableTelemetry();
+    result
+      ? console.log(`\n  ${logger.bold('Telemetry is now ') + ENABLED_MESSAGE}`)
+      : console.log(`Something went wrong when enabling Telemetry.`);
     return;
   }
 
   if (isDisabling) {
-    await disableTelemetry()
-    console.log(`\n  ${logger.bold('Telemetry is now ') + DISABLED_MESSAGE}`)
+    const result = await disableTelemetry();
+    result
+      ? console.log(`\n  ${logger.bold('Telemetry is now ') + DISABLED_MESSAGE}`)
+      : console.log(`Something went wrong when disabling Telemetry.`);
     return;
   }
 
-  console.log(`  ${logger.bold('Telemetry:')} ${logger.dim(INFORMATION)}`)
+  console.log(`  ${logger.bold('Telemetry:')} ${logger.dim(INFORMATION)}`);
 
-  console.log(`\n  ${logger.bold('Status')}: ${hasTelemetry ? ENABLED_MESSAGE : DISABLED_MESSAGE}`)
+  console.log(`\n  ${logger.bold('Status')}: ${hasTelemetry ? ENABLED_MESSAGE : DISABLED_MESSAGE}`);
 
-  console.log(`    ${p} ${logger.green('stencil telemetry [off|on]')}
+  console.log(`    ${prompt} ${logger.green('stencil telemetry [off|on]')}
 
         ${logger.cyan('off')} ${logger.dim('.............')} Disable sharing anonymous usage data
         ${logger.cyan('on')} ${logger.dim('..............')} Enable sharing anonymous usage data

--- a/src/cli/telemetry/helpers.ts
+++ b/src/cli/telemetry/helpers.ts
@@ -51,3 +51,11 @@ export async function readJson(path: string) {
   const file = await getCompilerSystem().readFile(path);
   return !!file && JSON.parse(file);
 }
+
+export function hasDebug() {
+  return process.argv.includes('--debug');
+}
+
+export function hasVerbose() {
+  return process.argv.includes('--verbose') && hasDebug();
+}

--- a/src/cli/telemetry/helpers.ts
+++ b/src/cli/telemetry/helpers.ts
@@ -37,6 +37,8 @@ export const isInteractive = (object?: TerminalInfo): boolean => {
   return terminalInfo.tty && !terminalInfo.ci;
 };
 
+export const UUID_REGEX = new RegExp(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i);
+
 // Plucked from https://github.com/ionic-team/capacitor/blob/b893a57aaaf3a16e13db9c33037a12f1a5ac92e0/cli/src/util/uuid.ts
 export function uuidv4(): string {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {

--- a/src/cli/telemetry/helpers.ts
+++ b/src/cli/telemetry/helpers.ts
@@ -53,9 +53,9 @@ export async function readJson(path: string) {
 }
 
 export function hasDebug() {
-  return process.argv.includes('--debug');
+  return getStencilCLIConfig().flags.debug;
 }
 
 export function hasVerbose() {
-  return process.argv.includes('--verbose') && hasDebug();
+  return getStencilCLIConfig().flags.verbose && hasDebug();
 }

--- a/src/cli/telemetry/shouldTrack.ts
+++ b/src/cli/telemetry/shouldTrack.ts
@@ -3,8 +3,8 @@ import { checkTelemetry } from './telemetry';
 
 /**
  * Used to determine if tracking should occur.
- * @param ci boolean
- * @returns boolean
+ * @param ci whether or not the process is running in a Continuous Integration (CI) environment
+ * @returns true if telemetry should be sent, false otherwise
  */
 export async function shouldTrack(ci?: boolean) {
   return !ci && isInteractive() && (await checkTelemetry());

--- a/src/cli/telemetry/shouldTrack.ts
+++ b/src/cli/telemetry/shouldTrack.ts
@@ -1,0 +1,11 @@
+import { isInteractive } from './helpers';
+import { checkTelemetry } from './telemetry';
+
+/**
+ * Used to determine if tracking should occur.
+ * @param ci boolean
+ * @returns boolean
+ */
+export async function shouldTrack(ci?: boolean) {
+  return !ci && isInteractive() && (await checkTelemetry());
+}

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -52,7 +52,6 @@ export interface TrackableData {
 /**
  * Used to within taskBuild to provide the component_count property.
  * @param result The results of a compiler build.
- * @returns void
  */
 export async function telemetryBuildFinishedAction(result: CompilerBuildResults) {
   const { sys, flags, logger, validatedConfig } = getStencilCLIConfig();

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -17,7 +17,7 @@ export interface Metric {
 
 /**
  * Used for deeper understanding of how people are using certain output targets
- **/
+ */
 interface OutputTargetOptions {
   serviceWorker?: boolean;
 }

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -1,7 +1,7 @@
-import { tryFn, hasDebug, readJson, hasVerbose } from './helpers';
+import { tryFn, hasDebug, readJson, hasVerbose, uuidv4 } from './helpers';
 import { shouldTrack } from './shouldTrack';
 import { CompilerBuildResults, Config, PackageJsonData, TaskCommand } from 'src/declarations';
-import { readConfig, updateConfig } from '../ionic-config';
+import { readConfig, updateConfig, writeConfig } from '../ionic-config';
 import { isObject } from '@utils';
 import { getCompilerSystem, getCoreCompiler, getStencilCLIConfig } from '../state/stencil-cli-config';
 

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -120,7 +120,7 @@ export async function getActiveTargets(): Promise<string[]> {
 export const prepareData = async (duration_ms: number, component_count: number = undefined): Promise<TrackableData> => {
   const { flags, sys } = getStencilCLIConfig();
   const { typescript, rollup } = getCoreCompiler()?.versions || { typescript: 'unknown', rollup: 'unknown' };
-  const packages = await getInstalledPackages() || [];
+  const packages = await getInstalledPackages();
   const targets = await getActiveTargets();
   const yarn = isUsingYarn()
   const stencil = getCoreCompiler()?.version || 'unknown';

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -285,6 +285,10 @@ async function sendTelemetry(data: any) {
  */
 export async function checkTelemetry(): Promise<boolean> {
   const config = await readConfig();
+  if (config['telemetry.stencil'] === undefined) {
+    config['telemetry.stencil'] = true;
+    await writeConfig(config);
+  }
   return config['telemetry.stencil'];
 }
 

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -154,7 +154,7 @@ export async function telemetryAction(action?: TelemetryCallback) {
 }
 
 function isUsingYarn() {
-  return getCompilerSystem().getEnvironmentVar('npm_execpath').includes('yarn');
+  return getCompilerSystem().getEnvironmentVar('npm_execpath')?.includes('yarn') || false;
 }
 
 async function getActiveTargets(config: Config): Promise<string[][] | OutputTargetOptions[][]> {

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -1,0 +1,293 @@
+import { tryFn, isInteractive, hasDebug, readJson, hasVerbose } from './helpers';
+import { CompilerBuildResults, CompilerSystem, Config, Logger, PackageJsonData } from 'src/declarations';
+import { parseFlags } from '../parse-flags';
+import { loadCoreCompiler } from '../load-compiler';
+import { readConfig, updateConfig } from '../ionic-config';
+import { isObject } from '@utils';
+import { getCompilerSystem } from '../state/stencil-cli-config';
+
+export interface CommandMetricData {
+  // app_id: string;
+  command: string;
+  arguments: string;
+  options: string;
+  duration: number;
+  error: string | null;
+  node_version: string;
+  // os: string;
+}
+
+export interface Metric<N extends string, D> {
+  name: N;
+  timestamp: string;
+  source: 'stencil_cli';
+  value: D;
+}
+
+// Used for deeper understanding on how people are using certain output targets
+interface OutputTargetOptions {
+  serviceWorker?: boolean;
+}
+
+type TelemetryCallback = (...args: any[]) => void | Promise<void>;
+
+export interface TrackableData {
+  command?: string;
+  yarn?: boolean;
+  session_id?: string;
+  component_count?: number;
+  arguments?: string[];
+  targets?: string[][] | OutputTargetOptions[][];
+  task?: string;
+  duration?: number;
+  packages?: string[];
+  telemetry?: boolean;
+  os_name: string;
+  os_version: string;
+  cpu_model: string;
+  typescript: string;
+  rollup: string;
+  system: string;
+  build: string;
+  stencil: string;
+}
+
+export interface telemetryActionArgs {
+  args?: string[];
+  sys?: CompilerSystem;
+  logger?: Logger;
+  buildResults?: Logger;
+  config?: Config;
+  action?: TelemetryCallback;
+}
+
+// Used to within taskBuild to signal out with the componentCount integer.
+export async function telemetryBuildFinishedAction(result: CompilerBuildResults, args: telemetryActionArgs) {
+  const { sys, config, logger } = args;
+  const tracking = await shouldTrack(!!config.flags.ci);
+
+  if (!tracking) {
+    return;
+  }
+
+  const details = sys.details;
+  const session_id = await getTelemetryToken();
+  const packages = await getInstalledPackages();
+  const targets = await getActiveTargets(config);
+  const coreCompiler = await loadCoreCompiler(sys);
+  const versions = coreCompiler.versions;
+  const component_count = Object.keys(result.componentGraph).length;
+
+  const data: TrackableData = {
+    session_id,
+    yarn: isUsingYarn(),
+    duration: result.duration,
+    component_count,
+    targets,
+    packages: packages || [],
+    arguments: config.flags.args,
+    task: config.flags.task,
+    stencil: coreCompiler.version,
+    system: `${sys.name} ${sys.version}`,
+    os_name: details.platform,
+    os_version: details.release,
+    cpu_model: `${details.cpuModel}`,
+    build: `${result.buildId}`,
+    typescript: versions.typescript,
+    rollup: versions.rollup,
+  };
+
+  await sendMetric('stencil_cli_command', data);
+  logger.debug(`${logger.blue('Telemetry')}: ${logger.gray(JSON.stringify(data))}`);
+}
+
+export async function telemetryAction(options: telemetryActionArgs) {
+  const { args, sys, logger, config, action } = options;
+  const tracking = await shouldTrack(!!config.flags.ci);
+
+  const coreCompiler = await loadCoreCompiler(sys);
+  const details = sys.details;
+  const versions = coreCompiler.versions;
+  const flags = parseFlags(args, sys);
+  let duration = undefined;
+  let error: any;
+
+  if (action) {
+    const start = new Date();
+
+    try {
+      await action();
+    } catch (e) {
+      error = e;
+    }
+
+    const end = new Date();
+    duration = end.getTime() - start.getTime();
+  }
+
+  // We'll get componentCount details inside the taskBuild, so let's not send two messages.
+  if (!tracking || (flags.task == 'build' && !flags.args.includes('--watch'))) {
+    return;
+  }
+
+  const session_id = await getTelemetryToken();
+  const packages = await getInstalledPackages();
+  const targets = await getActiveTargets(config);
+
+  const data: TrackableData = {
+    session_id,
+    yarn: isUsingYarn(),
+    duration,
+    targets,
+    packages: packages || [],
+    arguments: flags.args,
+    task: flags.task,
+    stencil: coreCompiler.version,
+    system: `${sys.name} ${sys.version}`,
+    os_name: details.platform,
+    os_version: details.release,
+    cpu_model: `${details.cpuModel}`,
+    build: coreCompiler.buildId,
+    typescript: versions.typescript,
+    rollup: versions.rollup,
+  };
+
+  await sendMetric('stencil_cli_command', data);
+  logger.debug(`${logger.blue('Telemetry')}: ${logger.gray(JSON.stringify(data))}`);
+
+  if (error) {
+    throw error;
+  }
+}
+
+function isUsingYarn() {
+  return process.env.npm_execpath.includes('yarn');
+}
+
+async function getActiveTargets(config: Config): Promise<string[][] | OutputTargetOptions[][]> {
+  return (config.outputTargets as any[]).map(target => {
+    let outputTargetSettings: OutputTargetOptions = {};
+
+    if (target.type === 'www') {
+      outputTargetSettings.serviceWorker = isObject(target?.serviceWorker);
+    }
+
+    return [target.type, outputTargetSettings];
+  });
+}
+
+async function getInstalledPackages() {
+  try {
+    // Read package.json and package-lock.json
+    const appRootDir = process.cwd();
+
+    const packageJson: PackageJsonData = await tryFn(
+      readJson,
+      getCompilerSystem().resolvePath(appRootDir + '/package.json'),
+    );
+    const packageLockJson: any = await tryFn(
+      readJson,
+      getCompilerSystem().resolvePath(appRootDir + '/package-lock.json'),
+    );
+
+    const packages = Object.entries({
+      ...packageJson.devDependencies,
+      ...packageJson.dependencies,
+    });
+
+    // Collect packages only in the stencil, ionic, or capacitor org's:
+    // https://www.npmjs.com/org/stencil
+    const ionicPackages = packages.filter(
+      ([k]) => k.startsWith('@stencil/') || k.startsWith('@ionic/') || k.startsWith('@capacitor/'),
+    );
+
+    // Original method, but cross reference with package-lock.json, don't consider yarn.
+    const versions = packageLockJson
+      ? ionicPackages.map(
+          ([k, v]) =>
+            `${k}@${packageLockJson.dependencies[k].version || packageLockJson.devDependencies[k].version || v}`,
+        )
+      : ionicPackages.map(([k, v]) => `${k}@${v}`);
+
+    return versions;
+  } catch (err) {
+    hasDebug() && console.error(err);
+    return [];
+  }
+}
+
+export async function shouldTrack(ci: boolean) {
+  return (await checkTelemetry()) && !ci && isInteractive();
+}
+
+export async function getTelemetryToken() {
+  const config = await readConfig();
+  return config['tokens.telemetry'];
+}
+
+export async function checkTelemetry() {
+  const config = await readConfig();
+  return config['telemetry.stencil'];
+}
+
+export async function enableTelemetry() {
+  await updateConfig({ 'telemetry.stencil': true });
+}
+
+export async function disableTelemetry() {
+  await updateConfig({ 'telemetry.stencil': false });
+}
+
+/**
+ * If telemetry is enabled, send a metric via IPC to a forked process for uploading.
+ */
+export async function sendMetric<D>(name: string, data: D): Promise<void> {
+  const message: Metric<string, D> = {
+    name,
+    timestamp: new Date().toISOString(),
+    source: 'stencil_cli',
+    value: data,
+  };
+
+  await sendTelemetry({ type: 'telemetry', message });
+}
+
+export async function sendTelemetry(data: any) {
+  try {
+    const now = new Date().toISOString();
+
+    const { request } = getCompilerSystem();
+
+    // This request is only made if telemetry is on.
+    const req = request(
+      {
+        hostname: 'api.ionicjs.com',
+        port: 443,
+        path: '/events/metrics',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+      (response: any) => {
+        hasVerbose() &&
+          console.debug('Sent %O metric to events service (status: %O)', data.message.name, response.statusCode);
+
+        if (response.statusCode !== 204) {
+          response.on('data', (chunk: any) => {
+            hasVerbose() && console.debug('Bad response from events service. Request body: %O', chunk.toString());
+          });
+        }
+      },
+    );
+
+    const body = {
+      metrics: [data.message],
+      sent_at: now,
+    };
+
+    req.end(JSON.stringify(body));
+  } catch (e) {
+    hasVerbose() && console.debug('Telemetry request failed', e);
+  }
+}

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -238,6 +238,10 @@ export async function sendMetric(name: string, value: TrackableData): Promise<vo
  */
 async function getTelemetryToken() {
   const config = await readConfig();
+  if (config['tokens.telemetry'] === undefined) {
+    config['tokens.telemetry'] = uuidv4();
+    await writeConfig(config);
+  }
   return config['tokens.telemetry'];
 }
 

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -1,47 +1,45 @@
-import { tryFn, isInteractive, hasDebug, readJson, hasVerbose } from './helpers';
-import { CompilerBuildResults, CompilerSystem, Config, Logger, PackageJsonData } from 'src/declarations';
-import { parseFlags } from '../parse-flags';
+import { tryFn, hasDebug, readJson, hasVerbose } from './helpers';
+import { shouldTrack } from './shouldTrack';
+import { CompilerBuildResults, Config, PackageJsonData, TaskCommand } from 'src/declarations';
 import { loadCoreCompiler } from '../load-compiler';
 import { readConfig, updateConfig } from '../ionic-config';
 import { isObject } from '@utils';
-import { getCompilerSystem } from '../state/stencil-cli-config';
+import { getCompilerSystem, getCoreCompiler, getStencilCLIConfig } from '../state/stencil-cli-config';
 
-export interface CommandMetricData {
-  // app_id: string;
-  command: string;
-  arguments: string;
-  options: string;
-  duration: number;
-  error: string | null;
-  node_version: string;
-  // os: string;
-}
-
-export interface Metric<N extends string, D> {
-  name: N;
+/**
+ * Used as the object sent to the server. Value is the data tracked.
+ */
+export interface Metric {
+  name: string;
   timestamp: string;
   source: 'stencil_cli';
-  value: D;
+  value: TrackableData;
 }
 
-// Used for deeper understanding on how people are using certain output targets
+/**
+ * Used for deeper understanding of how people are using certain output targets
+ **/
 interface OutputTargetOptions {
   serviceWorker?: boolean;
 }
 
+/**
+ * The task to run in order to collect the duration data point.
+ */
 type TelemetryCallback = (...args: any[]) => void | Promise<void>;
 
+/**
+ * The model for the data that's tracked.
+ */
 export interface TrackableData {
-  command?: string;
-  yarn?: boolean;
-  session_id?: string;
+  yarn: boolean;
+  session_id: string;
   component_count?: number;
-  arguments?: string[];
-  targets?: string[][] | OutputTargetOptions[][];
-  task?: string;
-  duration?: number;
-  packages?: string[];
-  telemetry?: boolean;
+  arguments: string[];
+  targets: string[][] | OutputTargetOptions[][];
+  task: TaskCommand;
+  duration_ms: number;
+  packages: string[];
   os_name: string;
   os_version: string;
   cpu_model: string;
@@ -52,19 +50,14 @@ export interface TrackableData {
   stencil: string;
 }
 
-export interface telemetryActionArgs {
-  args?: string[];
-  sys?: CompilerSystem;
-  logger?: Logger;
-  buildResults?: Logger;
-  config?: Config;
-  action?: TelemetryCallback;
-}
-
-// Used to within taskBuild to signal out with the componentCount integer.
-export async function telemetryBuildFinishedAction(result: CompilerBuildResults, args: telemetryActionArgs) {
-  const { sys, config, logger } = args;
-  const tracking = await shouldTrack(!!config.flags.ci);
+/**
+ * Used to within taskBuild to provide the component_count property.
+ * @param result The results of a compiler build.
+ * @returns void
+ */
+export async function telemetryBuildFinishedAction(result: CompilerBuildResults) {
+  const { sys, flags, logger, validatedConfig } = getStencilCLIConfig();
+  const tracking = await shouldTrack(!!flags?.ci);
 
   if (!tracking) {
     return;
@@ -73,26 +66,25 @@ export async function telemetryBuildFinishedAction(result: CompilerBuildResults,
   const details = sys.details;
   const session_id = await getTelemetryToken();
   const packages = await getInstalledPackages();
-  const targets = await getActiveTargets(config);
-  const coreCompiler = await loadCoreCompiler(sys);
-  const versions = coreCompiler.versions;
+  const targets = await getActiveTargets(validatedConfig.config);
+  const versions = getCoreCompiler()?.versions || { typescript: 'unknown', rollup: 'unknown' };
   const component_count = Object.keys(result.componentGraph).length;
 
   const data: TrackableData = {
     session_id,
     yarn: isUsingYarn(),
-    duration: result.duration,
+    duration_ms: result.duration,
     component_count,
     targets,
     packages: packages || [],
-    arguments: config.flags.args,
-    task: config.flags.task,
-    stencil: coreCompiler.version,
+    arguments: flags.args,
+    task: flags.task,
+    stencil: getCoreCompiler()?.version || 'unknown',
     system: `${sys.name} ${sys.version}`,
     os_name: details.platform,
     os_version: details.release,
     cpu_model: `${details.cpuModel}`,
-    build: `${result.buildId}`,
+    build: getCoreCompiler()?.buildId || 'unknown',
     typescript: versions.typescript,
     rollup: versions.rollup,
   };
@@ -101,14 +93,17 @@ export async function telemetryBuildFinishedAction(result: CompilerBuildResults,
   logger.debug(`${logger.blue('Telemetry')}: ${logger.gray(JSON.stringify(data))}`);
 }
 
-export async function telemetryAction(options: telemetryActionArgs) {
-  const { args, sys, logger, config, action } = options;
-  const tracking = await shouldTrack(!!config.flags.ci);
+/**
+ * A function to wrap a compiler task function around. Will send telemetry if, and only if, the machine allows.
+ * @param action A Promise-based function to call in order to get the duration of any given command.
+ * @returns void
+ */
+export async function telemetryAction(action?: TelemetryCallback) {
+  const { sys, flags, logger, validatedConfig } = getStencilCLIConfig();
+  const tracking = await shouldTrack(!!flags.ci);
 
-  const coreCompiler = await loadCoreCompiler(sys);
   const details = sys.details;
-  const versions = coreCompiler.versions;
-  const flags = parseFlags(args, sys);
+  const versions = getCoreCompiler()?.versions || { typescript: 'unknown', rollup: 'unknown' };
   let duration = undefined;
   let error: any;
 
@@ -132,22 +127,22 @@ export async function telemetryAction(options: telemetryActionArgs) {
 
   const session_id = await getTelemetryToken();
   const packages = await getInstalledPackages();
-  const targets = await getActiveTargets(config);
+  const targets = await getActiveTargets(validatedConfig.config);
 
   const data: TrackableData = {
     session_id,
     yarn: isUsingYarn(),
-    duration,
+    duration_ms: duration,
     targets,
     packages: packages || [],
     arguments: flags.args,
     task: flags.task,
-    stencil: coreCompiler.version,
+    stencil: getCoreCompiler()?.version || 'unknown',
     system: `${sys.name} ${sys.version}`,
     os_name: details.platform,
     os_version: details.release,
     cpu_model: `${details.cpuModel}`,
-    build: coreCompiler.buildId,
+    build: getCoreCompiler()?.buildId || 'unknown',
     typescript: versions.typescript,
     rollup: versions.rollup,
   };
@@ -176,6 +171,10 @@ async function getActiveTargets(config: Config): Promise<string[][] | OutputTarg
   });
 }
 
+/**
+ * Reads package-lock.json and package.json files in order to cross references the dependencies and devDependencies properties. Pull the current installed version of each package under the @stencil, @ionic, and @capacitor scopes.
+ * @returns string[]
+ */
 async function getInstalledPackages() {
   try {
     // Read package.json and package-lock.json
@@ -185,15 +184,21 @@ async function getInstalledPackages() {
       readJson,
       getCompilerSystem().resolvePath(appRootDir + '/package.json'),
     );
+
     const packageLockJson: any = await tryFn(
       readJson,
       getCompilerSystem().resolvePath(appRootDir + '/package-lock.json'),
     );
 
+    // They don't have a package.json for some reason? Eject button.
+    if (!!packageJson) {
+      return [];
+    }
+
     const packages = Object.entries({
       ...packageJson.devDependencies,
       ...packageJson.dependencies,
-    });
+    }) as [string, string][];
 
     // Collect packages only in the stencil, ionic, or capacitor org's:
     // https://www.npmjs.com/org/stencil
@@ -201,11 +206,14 @@ async function getInstalledPackages() {
       ([k]) => k.startsWith('@stencil/') || k.startsWith('@ionic/') || k.startsWith('@capacitor/'),
     );
 
-    // Original method, but cross reference with package-lock.json, don't consider yarn.
     const versions = packageLockJson
       ? ionicPackages.map(
           ([k, v]) =>
-            `${k}@${packageLockJson.dependencies[k].version || packageLockJson.devDependencies[k].version || v}`,
+            `${k}@${
+              (packageLockJson?.dependencies[k] as { version: string })?.version ??
+              (packageLockJson?.devDependencies[k] as { version: string })?.version ??
+              v
+            }`,
         )
       : ionicPackages.map(([k, v]) => `${k}@${v}`);
 
@@ -216,43 +224,34 @@ async function getInstalledPackages() {
   }
 }
 
-export async function shouldTrack(ci: boolean) {
-  return (await checkTelemetry()) && !ci && isInteractive();
-}
-
-export async function getTelemetryToken() {
-  const config = await readConfig();
-  return config['tokens.telemetry'];
-}
-
-export async function checkTelemetry() {
-  const config = await readConfig();
-  return config['telemetry.stencil'];
-}
-
-export async function enableTelemetry() {
-  await updateConfig({ 'telemetry.stencil': true });
-}
-
-export async function disableTelemetry() {
-  await updateConfig({ 'telemetry.stencil': false });
-}
-
 /**
  * If telemetry is enabled, send a metric via IPC to a forked process for uploading.
  */
-export async function sendMetric<D>(name: string, data: D): Promise<void> {
-  const message: Metric<string, D> = {
+export async function sendMetric(name: string, value: TrackableData): Promise<void> {
+  const message: Metric = {
     name,
     timestamp: new Date().toISOString(),
     source: 'stencil_cli',
-    value: data,
+    value,
   };
 
   await sendTelemetry({ type: 'telemetry', message });
 }
 
-export async function sendTelemetry(data: any) {
+/**
+ * Used to read the ~/.ionic/config.json file's tokens.telemetry property.
+ * @returns string
+ */
+async function getTelemetryToken() {
+  const config = await readConfig();
+  return config['tokens.telemetry'];
+}
+
+/**
+ * Issues a request to the telemetry server.
+ * @param data Data to be tracked
+ */
+async function sendTelemetry(data: any) {
   try {
     const now = new Date().toISOString();
 
@@ -290,4 +289,27 @@ export async function sendTelemetry(data: any) {
   } catch (e) {
     hasVerbose() && console.debug('Telemetry request failed', e);
   }
+}
+
+/**
+ * Checks if telemetry is enabled
+ * @returns boolean
+ */
+export async function checkTelemetry(): Promise<boolean> {
+  const config = await readConfig();
+  return config['telemetry.stencil'];
+}
+
+/**
+ * Writes to the config file, enabling telemetry for this machine.
+ */
+export async function enableTelemetry(): Promise<boolean> {
+  return await updateConfig({ 'telemetry.stencil': true });
+}
+
+/**
+ * Writes to the config file, disabling telemetry for this machine.
+ */
+export async function disableTelemetry(): Promise<boolean> {
+  return await updateConfig({ 'telemetry.stencil': false });
 }

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -55,7 +55,7 @@ export interface TrackableData {
  */
 export async function telemetryBuildFinishedAction(result: CompilerBuildResults) {
   const { sys, flags, logger, validatedConfig } = getStencilCLIConfig();
-  const tracking = await shouldTrack(!!flags?.ci);
+  const tracking = await shouldTrack(flags.ci);
 
   if (!tracking) {
     return;
@@ -193,10 +193,10 @@ async function getInstalledPackages() {
       return [];
     }
 
-    const packages = Object.entries({
+    const packages: [string, string][] = Object.entries({
       ...packageJson.devDependencies,
       ...packageJson.dependencies,
-    }) as [string, string][];
+    });
 
     // Collect packages only in the stencil, ionic, or capacitor org's:
     // https://www.npmjs.com/org/stencil
@@ -207,11 +207,7 @@ async function getInstalledPackages() {
     const versions = packageLockJson
       ? ionicPackages.map(
           ([k, v]) =>
-            `${k}@${
-              (packageLockJson?.dependencies[k] as { version: string })?.version ??
-              (packageLockJson?.devDependencies[k] as { version: string })?.version ??
-              v
-            }`,
+            `${k}@${packageLockJson?.dependencies[k]?.version ?? packageLockJson?.devDependencies[k]?.version ?? v}`,
         )
       : ionicPackages.map(([k, v]) => `${k}@${v}`);
 
@@ -237,7 +233,7 @@ export async function sendMetric(name: string, value: TrackableData): Promise<vo
 }
 
 /**
- * Used to read the ~/.ionic/config.json file's tokens.telemetry property.
+ * Used to read the config file's tokens.telemetry property.
  * @returns string
  */
 async function getTelemetryToken() {
@@ -280,8 +276,8 @@ async function sendTelemetry(data: any) {
 }
 
 /**
- * Checks if telemetry is enabled
- * @returns boolean
+ * Checks if telemetry is enabled on this machine
+ * @returns true if telemetry is enabled, false otherwise
  */
 export async function checkTelemetry(): Promise<boolean> {
   const config = await readConfig();
@@ -290,6 +286,7 @@ export async function checkTelemetry(): Promise<boolean> {
 
 /**
  * Writes to the config file, enabling telemetry for this machine.
+ * @returns true if writing the file was successful, false otherwise
  */
 export async function enableTelemetry(): Promise<boolean> {
   return await updateConfig({ 'telemetry.stencil': true });
@@ -297,6 +294,7 @@ export async function enableTelemetry(): Promise<boolean> {
 
 /**
  * Writes to the config file, disabling telemetry for this machine.
+ * @returns true if writing the file was successful, false otherwise
  */
 export async function disableTelemetry(): Promise<boolean> {
   return await updateConfig({ 'telemetry.stencil': false });

--- a/src/cli/telemetry/test/helpers.spec.ts
+++ b/src/cli/telemetry/test/helpers.spec.ts
@@ -1,7 +1,56 @@
-import { initializeStencilCLIConfig } from '../../state/stencil-cli-config';
-import { isInteractive, TERMINAL_INFO, tryFn, uuidv4 } from '../helpers';
+import { getStencilCLIConfig, initializeStencilCLIConfig } from '../../state/stencil-cli-config';
+import { isInteractive, TERMINAL_INFO, tryFn, uuidv4, hasDebug, hasVerbose } from '../helpers';
 import { createSystem } from '../../../compiler/sys/stencil-sys';
 import { mockLogger } from '@stencil/core/testing';
+
+describe('hasDebug', () => {
+  it('Returns true when a flag is passed', () => {
+    getStencilCLIConfig().flags = {
+      debug: true,
+      verbose: false,
+    };
+
+    expect(hasDebug()).toBe(true);
+  });
+
+  it('Returns false when a flag is not passed', () => {
+    getStencilCLIConfig().flags = {
+      debug: false,
+      verbose: false,
+    };
+
+    expect(hasDebug()).toBe(false);
+  });
+});
+
+describe('hasVerbose', () => {
+  it('Returns true when both flags are passed', () => {
+    getStencilCLIConfig().flags = {
+      debug: true,
+      verbose: true,
+    };
+
+    expect(hasVerbose()).toBe(true);
+  });
+
+  it('Returns false when the verbose flag is passed, and debug is not', () => {
+    getStencilCLIConfig().flags = {
+      debug: false,
+      verbose: true,
+    };
+
+    expect(hasVerbose()).toBe(false);
+  });
+
+  it('Returns false when the flag is not passed', () => {
+    getStencilCLIConfig().flags = {
+      debug: false,
+      verbose: false,
+    };
+
+    expect(hasVerbose()).toBe(false);
+  });
+});
 
 describe('uuidv4', () => {
   it('outputs a UUID', () => {

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -1,0 +1,78 @@
+import { initializeStencilCLIConfig } from '../../state/stencil-cli-config';
+import * as telemetry from '../telemetry';
+import * as shouldTrack from '../shouldTrack';
+import { createSystem } from '../../../compiler/sys/stencil-sys';
+import { mockLogger } from '@stencil/core/testing';
+import { LoadConfigResults } from '../../../internal';
+
+describe('telemetryBuildFinishedAction', () => {
+  initializeStencilCLIConfig({
+    sys: createSystem(),
+    logger: mockLogger(),
+    flags: { ci: false },
+    validatedConfig: { config: { outputTargets: [] } } as LoadConfigResults,
+    args: [],
+  });
+
+  it('issues a network request when complete', async () => {
+    const spyShouldTrack = jest.spyOn(shouldTrack, 'shouldTrack');
+    spyShouldTrack.mockReturnValue(
+      new Promise(resolve => {
+        resolve(true);
+      }),
+    );
+
+    await telemetry.telemetryBuildFinishedAction({ componentGraph: [] });
+    expect(spyShouldTrack).toHaveBeenCalled();
+
+    spyShouldTrack.mockRestore();
+  });
+});
+
+describe('telemetryAction', () => {
+  it('issues a network request when no async function is passed', async () => {
+    const spyShouldTrack = jest.spyOn(shouldTrack, 'shouldTrack');
+    spyShouldTrack.mockReturnValue(
+      new Promise(resolve => {
+        resolve(true);
+      }),
+    );
+
+    await telemetry.telemetryAction(() => {});
+    expect(spyShouldTrack).toHaveBeenCalled();
+
+    spyShouldTrack.mockRestore();
+  });
+
+  it('issues a network request when passed async function is complete', async () => {
+    const spyShouldTrack = jest.spyOn(shouldTrack, 'shouldTrack');
+    spyShouldTrack.mockReturnValue(
+      new Promise(resolve => {
+        resolve(true);
+      }),
+    );
+
+    await telemetry.telemetryAction(async () => {
+      new Promise(resolve => {
+        setTimeout(() => {
+          resolve(true);
+        }, 1000);
+      });
+    });
+
+    expect(spyShouldTrack).toHaveBeenCalled();
+
+    spyShouldTrack.mockRestore();
+  });
+});
+
+describe('checkTelemetry', () => {
+  it('will read from a file', async () => {
+    await telemetry.enableTelemetry();
+    expect(await telemetry.checkTelemetry()).toBe(true);
+    await telemetry.disableTelemetry();
+    expect(await telemetry.checkTelemetry()).toBe(false);
+    await telemetry.enableTelemetry();
+    expect(await telemetry.checkTelemetry()).toBe(true);
+  });
+});

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -112,18 +112,18 @@ describe('hasAppTarget', () => {
     expect(telemetry.hasAppTarget()).toBe(true)
   });
 
-  it('Result is correct when outputTargets contains www with serviceWorker', () => {
+  it('Result is correct when outputTargets contains www with baseUrl', () => {
     getStencilCLIConfig().validatedConfig = { config: { outputTargets: [{ type: "www", baseUrl: "https://example.com" }] } } as LoadConfigResults
     expect(telemetry.hasAppTarget()).toBe(true)
   });
 
-  it('Result is correct when outputTargets contains www with serviceWorker', () => {
+  it('Result is correct when outputTargets contains www with serviceWorker and baseUrl', () => {
     getStencilCLIConfig().validatedConfig = { config: { outputTargets: [{ type: "www", baseUrl: "https://example.com", serviceWorker: { swDest: "./tmp" } }] } } as LoadConfigResults
     expect(telemetry.hasAppTarget()).toBe(true)
   });
 });
 
-describe('hasAppTarget', () => {
+describe('prepareData', () => {
 
   beforeEach(() => {
     getStencilCLIConfig()?.resetInstance();

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -1,4 +1,4 @@
-import { initializeStencilCLIConfig } from '../../state/stencil-cli-config';
+import { getStencilCLIConfig, initializeStencilCLIConfig } from '../../state/stencil-cli-config';
 import * as telemetry from '../telemetry';
 import * as shouldTrack from '../shouldTrack';
 import { createSystem } from '../../../compiler/sys/stencil-sys';
@@ -76,3 +76,132 @@ describe('checkTelemetry', () => {
     expect(await telemetry.checkTelemetry()).toBe(true);
   });
 });
+
+describe('hasAppTarget', () => {
+
+  beforeEach(() => {
+    getStencilCLIConfig()?.resetInstance();
+
+    initializeStencilCLIConfig({
+      sys: createSystem(),
+      logger: mockLogger(),
+      flags: { ci: false },
+      validatedConfig: { config: { outputTargets: [] } } as LoadConfigResults,
+      args: [],
+    });
+  });
+
+
+  it('Result is correct when outputTargets are empty', () => {
+    getStencilCLIConfig().validatedConfig = { config: { outputTargets: [] } } as LoadConfigResults
+    expect(telemetry.hasAppTarget()).toBe(false)
+  });
+
+  it('Result is correct when outputTargets contains www with no baseUrl or serviceWorker', () => {
+    getStencilCLIConfig().validatedConfig = { config: { outputTargets: [{ type: "www" }] } } as LoadConfigResults;
+    expect(telemetry.hasAppTarget()).toBe(false)
+  });
+
+  it('Result is correct when outputTargets contains www with default baseUrl value', () => {
+    getStencilCLIConfig().validatedConfig = { config: { outputTargets: [{ type: "www", baseUrl: "/" }] } } as LoadConfigResults;
+    expect(telemetry.hasAppTarget()).toBe(false)
+  });
+
+  it('Result is correct when outputTargets contains www with serviceWorker', () => {
+    getStencilCLIConfig().validatedConfig = { config: { outputTargets: [{ type: "www", serviceWorker: { swDest: "./tmp" }, }] } } as LoadConfigResults
+    expect(telemetry.hasAppTarget()).toBe(true)
+  });
+
+  it('Result is correct when outputTargets contains www with serviceWorker', () => {
+    getStencilCLIConfig().validatedConfig = { config: { outputTargets: [{ type: "www", baseUrl: "https://example.com" }] } } as LoadConfigResults
+    expect(telemetry.hasAppTarget()).toBe(true)
+  });
+
+  it('Result is correct when outputTargets contains www with serviceWorker', () => {
+    getStencilCLIConfig().validatedConfig = { config: { outputTargets: [{ type: "www", baseUrl: "https://example.com", serviceWorker: { swDest: "./tmp" } }] } } as LoadConfigResults
+    expect(telemetry.hasAppTarget()).toBe(true)
+  });
+});
+
+describe('hasAppTarget', () => {
+
+  beforeEach(() => {
+    getStencilCLIConfig()?.resetInstance();
+
+    initializeStencilCLIConfig({
+      sys: createSystem(),
+      logger: mockLogger(),
+      flags: { ci: false },
+      validatedConfig: { config: { outputTargets: [] } } as LoadConfigResults,
+      args: [],
+    });
+  });
+  
+  it('provides an object', async () => {
+    const data = await telemetry.prepareData(1000);
+    expect(data).toEqual({
+      "arguments": undefined,
+      "build": "unknown",
+      "component_count": undefined,
+      "cpu_model": "",
+      "duration_ms": 1000,
+      "has_app_pwa_config": false,
+      "os_name": "",
+      "os_version": "",
+      "packages": [],
+      "rollup": "unknown",
+      "stencil": "unknown",
+      "system": "in-memory __VERSION:STENCIL__",
+      "targets": [],
+      "task": undefined,
+      "typescript": "unknown",
+      "yarn": false
+    })
+  })
+
+  it('updates when there is a PWA config', async () => {
+    getStencilCLIConfig().validatedConfig = { config: { outputTargets: [{ type: "www", baseUrl: "https://example.com", serviceWorker: {swDest: "./tmp" } }] } } as LoadConfigResults
+    const data = await telemetry.prepareData(1000);
+    expect(data).toEqual({
+      "arguments": undefined,
+      "build": "unknown",
+      "component_count": undefined,
+      "cpu_model": "",
+      "duration_ms": 1000,
+      "has_app_pwa_config": true,
+      "os_name": "",
+      "os_version": "",
+      "packages": [],
+      "rollup": "unknown",
+      "stencil": "unknown",
+      "system": "in-memory __VERSION:STENCIL__",
+      "targets": ["www"],
+      "task": undefined,
+      "typescript": "unknown",
+      "yarn": false
+    })
+  })
+
+  it('updates when there is a component count passed in', async () => {
+    getStencilCLIConfig().validatedConfig = { config: { outputTargets: [{ type: "www", baseUrl: "https://example.com", serviceWorker: {swDest: "./tmp" } }] } } as LoadConfigResults
+    const data = await telemetry.prepareData(1000, 12);
+    expect(data).toEqual({
+      "arguments": undefined,
+      "build": "unknown",
+      "component_count": 12,
+      "cpu_model": "",
+      "duration_ms": 1000,
+      "has_app_pwa_config": true,
+      "os_name": "",
+      "os_version": "",
+      "packages": [],
+      "rollup": "unknown",
+      "stencil": "unknown",
+      "system": "in-memory __VERSION:STENCIL__",
+      "targets": ["www"],
+      "task": undefined,
+      "typescript": "unknown",
+      "yarn": false
+    })
+  })
+})

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -67,7 +67,7 @@ describe('telemetryAction', () => {
 });
 
 describe('checkTelemetry', () => {
-  it('will read from a file', async () => {
+  it('will read and write from a file, returning the correct status', async () => {
     await telemetry.enableTelemetry();
     expect(await telemetry.checkTelemetry()).toBe(true);
     await telemetry.disableTelemetry();

--- a/src/compiler/sys/stencil-sys.ts
+++ b/src/compiler/sys/stencil-sys.ts
@@ -25,6 +25,7 @@ import { HAS_WEB_WORKER, IS_BROWSER_ENV, IS_WEB_WORKER_ENV } from './environment
 import { isRootPath, normalizePath } from '@utils';
 import { resolveModuleIdAsync } from './resolve/resolve-module-async';
 import { version } from '../../version';
+import { request } from 'https';
 
 export const createSystem = (c?: { logger?: Logger }) => {
   const logger = c && c.logger ? c.logger : createLogger();
@@ -583,6 +584,7 @@ export const createSystem = (c?: { logger?: Logger }) => {
     realpathSync,
     removeDestory,
     rename,
+    request,
     resolvePath,
     removeDir,
     removeDirSync,

--- a/src/compiler/sys/stencil-sys.ts
+++ b/src/compiler/sys/stencil-sys.ts
@@ -25,7 +25,6 @@ import { HAS_WEB_WORKER, IS_BROWSER_ENV, IS_WEB_WORKER_ENV } from './environment
 import { isRootPath, normalizePath } from '@utils';
 import { resolveModuleIdAsync } from './resolve/resolve-module-async';
 import { version } from '../../version';
-import { request } from 'https';
 
 export const createSystem = (c?: { logger?: Logger }) => {
   const logger = c && c.logger ? c.logger : createLogger();
@@ -506,6 +505,8 @@ export const createSystem = (c?: { logger?: Logger }) => {
     return results;
   };
 
+  const fetch = global.fetch;
+
   const writeFile = async (p: string, data: string) => writeFileSync(p, data);
 
   const tmpDirSync = () => '/.tmp';
@@ -584,7 +585,7 @@ export const createSystem = (c?: { logger?: Logger }) => {
     realpathSync,
     removeDestory,
     rename,
-    request,
+    fetch,
     resolvePath,
     removeDir,
     removeDirSync,

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -540,7 +540,8 @@ export type TaskCommand =
   | 'prerender'
   | 'serve'
   | 'test'
-  | 'version';
+  | 'version'
+  | 'telemetry';
 
 export type PageReloadStrategy = 'hmr' | 'pageReload' | null;
 
@@ -1034,6 +1035,12 @@ export interface CompilerSystem {
    */
   removeFileSync(p: string): CompilerSystemRemoveFileResults;
   setupCompiler?: (c: { ts: any }) => void;
+
+  /**
+   * Returns a fetch request
+   */
+  request(url: any, options: any, callback?: any): any;
+
   /**
    * Always returns an object. Does not throw. Check for "error" property if there's an error.
    */

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1037,12 +1037,6 @@ export interface CompilerSystem {
   setupCompiler?: (c: { ts: any }) => void;
 
   /**
-   * Returns a fetch request
-   */
-  request(options: Object, callback?: (args: unknown) => any): any;
-  request(url: string, options: Object, callback?: (args: unknown) => any): any;
-
-  /**
    * Always returns an object. Does not throw. Check for "error" property if there's an error.
    */
   stat(p: string): Promise<CompilerFsStats>;

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -539,9 +539,9 @@ export type TaskCommand =
   | 'info'
   | 'prerender'
   | 'serve'
+  | 'telemetry'
   | 'test'
-  | 'version'
-  | 'telemetry';
+  | 'version';
 
 export type PageReloadStrategy = 'hmr' | 'pageReload' | null;
 
@@ -1039,7 +1039,8 @@ export interface CompilerSystem {
   /**
    * Returns a fetch request
    */
-  request(url: any, options: any, callback?: any): any;
+  request(options: Object, callback?: (args: unknown) => any): any;
+  request(url: string, options: Object, callback?: (args: unknown) => any): any;
 
   /**
    * Always returns an object. Does not throw. Check for "error" property if there's an error.

--- a/src/sys/deno/deno-sys.ts
+++ b/src/sys/deno/deno-sys.ts
@@ -289,6 +289,7 @@ export function createDenoSys(c: { Deno?: any } = {}) {
     exit: async exitCode => {
       deno.exit(exitCode);
     },
+    fetch,
     getCompilerExecutingPath() {
       return stencilExePath;
     },

--- a/src/sys/node/node-sys.ts
+++ b/src/sys/node/node-sys.ts
@@ -100,8 +100,7 @@ export function createNodeSys(c: { process?: any } = {}) {
       opts.window.FetchError = (global as any).FetchError;
     },
     fetch: (input: any, init: any) => {
-      const nodeFetch =
-        typeof global.fetch !== 'function' ? require(path.join(__dirname, 'node-fetch.js')) : global.fetch;
+      const nodeFetch = require(path.join(__dirname, 'node-fetch.js'));
 
       if (typeof input === 'string') {
         // fetch(url) w/ url string

--- a/src/sys/node/node-sys.ts
+++ b/src/sys/node/node-sys.ts
@@ -100,7 +100,8 @@ export function createNodeSys(c: { process?: any } = {}) {
       opts.window.FetchError = (global as any).FetchError;
     },
     fetch: (input: any, init: any) => {
-      const nodeFetch = require(path.join(__dirname, 'node-fetch.js'));
+      const nodeFetch =
+        typeof global.fetch !== 'function' ? require(path.join(__dirname, 'node-fetch.js')) : global.fetch;
 
       if (typeof input === 'string') {
         // fetch(url) w/ url string

--- a/src/sys/node/node-sys.ts
+++ b/src/sys/node/node-sys.ts
@@ -99,6 +99,19 @@ export function createNodeSys(c: { process?: any } = {}) {
       opts.window.Response = global.Response;
       opts.window.FetchError = (global as any).FetchError;
     },
+    fetch: (input: any, init: any) => {
+      const nodeFetch = require(path.join(__dirname, 'node-fetch.js'));
+
+      if (typeof input === 'string') {
+        // fetch(url) w/ url string
+        const urlStr = new URL(input).href;
+        return nodeFetch.fetch(urlStr, init);
+      } else {
+        // fetch(Request) w/ request object
+        input.url = new URL(input.url).href;
+        return nodeFetch.fetch(input, init);
+      }
+    },
     checkVersion,
     copyFile(src, dst) {
       return new Promise(resolve => {


### PR DESCRIPTION
Adds Telemetry options to the CLI. Try it out by running any of these commands in your linked project:

`npx stencil telemetry`
`npx stencil telemetry on|off`

The debug flag will print the telemetry results, e.g:
`npx stencil generate a-component --debug --verbose`

Satisfies ADR-1