### PR TITLE
fix (compiler) Fix race condition between writing app.esm.js and optimizeEsmImport

### DIFF
--- a/src/compiler/output-targets/index.ts
+++ b/src/compiler/output-targets/index.ts
@@ -32,12 +32,12 @@ export const generateOutputTargets = async (
     outputCustomElements(config, compilerCtx, buildCtx),
     outputHydrateScript(config, compilerCtx, buildCtx),
     outputLazyLoader(config, compilerCtx),
-    outputLazy(config, compilerCtx, buildCtx),
-    outputWww(config, compilerCtx, buildCtx),
+    outputLazy(config, compilerCtx, buildCtx)
   ]);
 
   // must run after all the other outputs
-  // since it validates files were created
+  // since it validates or uses files that were created
+  await outputWww(config, compilerCtx, buildCtx);
   await outputDocs(config, compilerCtx, buildCtx);
   await outputTypes(config, compilerCtx, buildCtx);
 

--- a/src/compiler/output-targets/index.ts
+++ b/src/compiler/output-targets/index.ts
@@ -32,7 +32,7 @@ export const generateOutputTargets = async (
     outputCustomElements(config, compilerCtx, buildCtx),
     outputHydrateScript(config, compilerCtx, buildCtx),
     outputLazyLoader(config, compilerCtx),
-    outputLazy(config, compilerCtx, buildCtx)
+    outputLazy(config, compilerCtx, buildCtx),
   ]);
 
   // must run after all the other outputs


### PR DESCRIPTION
Background
-----------

I've been investigating an issue where I was getting differing builds between my local build and my CI build (Netlify). 

Specifically I was seeing that locally the `<script type="module" src="/build/app.esm.js"></script>` tag was being re-written to the hashed version e.g. `<script type="module" src="/build/p-703da46a.js" data-stencil data-resources-url="/build/" data-stencil-namespace="app"></script>` - which is what I wanted. But on Netlify the app.esm.js src was remaining in the output index.html file, which was causing me service-worker/caching problems (see below).

Similar things have been reported https://github.com/ionic-team/stencil/issues/2659, https://github.com/ionic-team/stencil/issues/2687 and https://github.com/ionic-team/stencil/issues/1631.

Issue
-----

In the compiler, the `optimizeEsmImport` function is responsible for finding the app.esm.js file and replacing it with the hashed file name.

On stepping through the code I found that when `optimizeEsmImport` was being called, it was failing to find the content of the `entryPath` and so not replacing the script src attribute. 

Looking at `generateOutputTargets` I could see that `outputLazy` (which is responsible for writing the app.esm.js file) and `outputWww` (which writes the index.html, and calls `optimizeEsmImport`) were being run in a big Promise.all([]) so are basically racing against each other, with no guarantee that one will finish before the other (unless there is some other subtle system I haven't seen where one of those promises will wait for another).

So the fix was just to move the `outputWww` until after the Promise.all, in exactly the same way that `outputDocs` and `outputTypes` need to run afterwards.

Side Note - Service Workers
#####################

I'd just like to note that when the above behaviour does occur - i.e. you end up with the `app.esm.js` src in your final index.html, it's a total nightmare for PWAs and service workers. For starters the `app.esm.js` file is globIgnored by the service worker config, so the PWA is totally broken to start with in an offline scenario as the main entry module isn't (pre)cached. If you write a custom service worker that does precache the app.esm.js, that's better but there is no cache busting / hashing of that file, so as soon as you deploy a new build to e.g. Netlify (which wipes out all the previous .entry.js files) again your app is broken because your now old app.esm.js file is requesting files that no longer exist.