### PR TITLE
fix(runtime): prevent watchers from prematurely firing in custom elements build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@stencil/core",
-      "version": "2.6.0",
+      "version": "2.7.0-0",
       "license": "MIT",
       "bin": {
         "stencil": "bin/stencil"

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -291,8 +291,8 @@ export interface ConfigExtras {
 
   /**
    * When a component is first attached to the DOM, this setting will wait a single tick before
-   * rendering. This worksaround an Angular issue, where Angular attaches the elements before
-   * settings their initial state, leading to double renders and unnecesary event dispatchs.
+   * rendering. This works around an Angular issue, where Angular attaches the elements before
+   * settings their initial state, leading to double renders and unnecessary event dispatches.
    * Defaults to `false`.
    */
   initializeNextTick?: boolean;

--- a/src/runtime/initialize-component.ts
+++ b/src/runtime/initialize-component.ts
@@ -30,7 +30,7 @@ export const initializeComponent = async (elm: d.HostElement, hostRef: d.HostRef
         throw new Error(`Constructor for "${cmpMeta.$tagName$}#${hostRef.$modeName$}" was not found`);
       }
       if (BUILD.member && !Cstr.isProxied) {
-        // we'eve never proxied this Constructor before
+        // we've never proxied this Constructor before
         // let's add the getters/setters to its prototype before
         // the first time we create an instance of the implementation
         if (BUILD.watchCallback) {
@@ -68,7 +68,8 @@ export const initializeComponent = async (elm: d.HostElement, hostRef: d.HostRef
     } else {
       // sync constructor component
       Cstr = elm.constructor as any;
-      hostRef.$flags$ |= HOST_FLAGS.isWatchReady | HOST_FLAGS.hasInitializedComponent;
+      hostRef.$flags$ |= HOST_FLAGS.hasInitializedComponent;
+      customElements.whenDefined(cmpMeta.$tagName$).then(() => hostRef.$flags$ |= HOST_FLAGS.isWatchReady)
     }
 
     if (BUILD.style && Cstr.style) {

--- a/src/runtime/initialize-component.ts
+++ b/src/runtime/initialize-component.ts
@@ -69,6 +69,9 @@ export const initializeComponent = async (elm: d.HostElement, hostRef: d.HostRef
       // sync constructor component
       Cstr = elm.constructor as any;
       hostRef.$flags$ |= HOST_FLAGS.hasInitializedComponent;
+      // wait for the CustomElementRegistry to mark the component as ready before setting `isWatchReady`. Otherwise,
+      // watchers may fire prematurely if `customElements.get()`/`customElements.whenDefined()` resolves _before_
+      // Stencil has completed instantiating the component.
       customElements.whenDefined(cmpMeta.$tagName$).then(() => hostRef.$flags$ |= HOST_FLAGS.isWatchReady)
     }
 

--- a/src/runtime/runtime-constants.ts
+++ b/src/runtime/runtime-constants.ts
@@ -10,6 +10,7 @@ export const enum PROXY_FLAGS {
 }
 
 export const enum PLATFORM_FLAGS {
+  // designates a node in the DOM as being actively moved by the runtime
   isTmpDisconnected = 1 << 0,
   appLoaded = 1 << 1,
   queueSync = 1 << 2,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/master/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Tests (`npm run test.karma.prod`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using the custom elements build, it's possible that `@Watch` annotated methods will fire before our components are fully instantiated.  This is inconsistent with the lazy load build, as well as the [Stencil documentation](https://stenciljs.com/docs/reactive-data):
> The Watch decorator does not fire when a component initially loads.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Wait until a component is fully instantiated before a `@Watch` method can be fired
  - The ramification here is that watchers fired _before_ fully instantiated will never run
  - With this PR, the behavior will match the behavior in the the lazy load builds today

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

However, folks that are using the custom elements build may see watchers not firing as they expect. So we should either
1) Make this _very_ explicit in the release notes
2) Push this to `v3.0.0-dev` instead

## Testing

Programmatic tests have been pushed to a future story, as the work required to get that wired up is beyond the scope of this effort

### Manual:

#### Replication
- Clone https://github.com/rwaskiewicz/demo-stencil-watch, run `npm ci`
- Serve the lazy loaded bundle (`npm start`)
- Serve the custom elements build (`npm serve`)
- Notice the difference in behavior after 5 seconds:
![Screen Shot 2021-07-20 at 9 43 23 AM](https://user-images.githubusercontent.com/1930213/126334737-ef81ada0-5380-4da0-97c9-a74832da3493.png)

#### What's happening?
For the custom element build, `runTest` is being invoked when the component is ready according to the `CustomElementRegistry`, not according to Stencil. Stencil hasn't finished building the component on its side, but the `@Watch` is fired. 

#### Testing the Fix
- Pull down this branch, run `npm ci && npm run build && npm pack`
- In the directory housing your clone of https://github.com/rwaskiewicz/demo-stencil-watch, `npm i <PATH_TO_STENCIL>/stencil-core-2.7.0-0.tgz`
- Serve the lazy loaded bundle (`npm start`)
- Serve the custom elements build (`npm serve`)
- Note the behavior is the same:
![Screen Shot 2021-07-20 at 9 49 43 AM](https://user-images.githubusercontent.com/1930213/126335535-dc041b47-7740-4d73-ad41-6ae9bb6a9529.png)



## Other information

- Internal ticket: STENCIL-13
