### PR TITLE
fix(dev-server): allow web server to be run in Docker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@stencil/core",
-      "version": "2.6.0",
+      "version": "2.7.0-0",
       "license": "MIT",
       "bin": {
         "stencil": "bin/stencil"
@@ -60,7 +60,7 @@
         "mime-db": "^1.46.0",
         "minimatch": "3.0.4",
         "node-fetch": "2.6.1",
-        "open": "8.0.4",
+        "open": "8.2.1",
         "open-in-editor": "2.2.0",
         "parse5": "6.0.1",
         "path-browserify": "^1.0.1",
@@ -8641,9 +8641,9 @@
       }
     },
     "node_modules/open": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.0.4.tgz",
-      "integrity": "sha512-Txc9FOcvjrr5Kv+Zb3w89uKMKiP7wH8mLdYj1xJa+YnhhntEYhbB6cQHjS4O6P+jFwMEzEQVVcpfnu9WkKNuLQ==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.2.1.tgz",
+      "integrity": "sha512-rXILpcQlkF/QuFez2BJDf3GsqpjGKbkUUToAIGo9A0Q6ZkoSGogZJulrUdwRkrAsoQvoZsrjCYt8+zblOk7JQQ==",
       "dev": true,
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
@@ -19701,9 +19701,9 @@
       }
     },
     "open": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.0.4.tgz",
-      "integrity": "sha512-Txc9FOcvjrr5Kv+Zb3w89uKMKiP7wH8mLdYj1xJa+YnhhntEYhbB6cQHjS4O6P+jFwMEzEQVVcpfnu9WkKNuLQ==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.2.1.tgz",
+      "integrity": "sha512-rXILpcQlkF/QuFez2BJDf3GsqpjGKbkUUToAIGo9A0Q6ZkoSGogZJulrUdwRkrAsoQvoZsrjCYt8+zblOk7JQQ==",
       "dev": true,
       "requires": {
         "define-lazy-prop": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "mime-db": "^1.46.0",
     "minimatch": "3.0.4",
     "node-fetch": "2.6.1",
-    "open": "8.0.4",
+    "open": "8.2.1",
     "open-in-editor": "2.2.0",
     "parse5": "6.0.1",
     "path-browserify": "^1.0.1",


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/master/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Tests (`npm run test.karma.prod`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

When running the Stencil web server in a Docker container using v2.5.0+, the server fails to start up.

Fixes: #2930 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- upgrade open package to include changes in https://github.com/sindresorhus/open/compare/v8.0.5...v8.0.6
  - allows xdg_open to be called correctly when running a dev-server in the context of a Docker container

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

### Replication
- Ensure you don't have anything running on port 3333
- Clone https://github.com/maxkarkowski/stencil-docker, run `npm ci`
- Build the Docker container and attempt to start it: `npm run build && npm run docker:build && npm run docker:start`
- Observe the container ID returned at the end of the command. Example:
```
> stencil-docker-cypress@0.0.1 docker:start
> docker run -dp 3333:3333 getting-started

de672f60a62bf02b37b8e2850aa9d89da709f9a30055fa465fad7afc48364a7f
```
-  Look at the logs for the container `docker logs de672f60a62bf02b37b8e2850aa9d89da709f9a30055fa465fad7afc48364a7f`
```
$ docker logs de672f60a62bf02b37b8e2850aa9d89da709f9a30055fa465fad7afc48364a7f

> stencil-docker-cypress@0.0.1 start
> stencil build --dev --watch --serve

[00:11.3]  @stencil/core
[00:11.4]  v2.6.0 📟

[ ERROR ]  stderr: node:events:371 throw er; // Unhandled 'error' event ^
           Error: spawn xdg-open ENOENT at Process.ChildProcess._handle.onexit
           (node:internal/child_process:282:19) at onErrorNT
           (node:internal/child_process:480:16) at processTicksAndRejections
           (node:internal/process/task_queues:83:21) Emitted 'error' event on
           ChildProcess instance at: at Process.ChildProcess._handle.onexit
           (node:internal/child_process:288:12) at onErrorNT
           (node:internal/child_process:480:16) at processTicksAndRejections
           (node:internal/process/task_queues:83:21) { errno: -2, code:
           'ENOENT', syscall: 'spawn xdg-open', path: 'xdg-open', spawnargs: [
           'http://localhost:3333/~dev-server-init' ] } undefined

[00:12.0]  build, stencil-docker-cypress, dev mode, started ...
node:events:371
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
    at ChildProcess.target._send (node:internal/child_process:849:20)
    at ChildProcess.target.send (node:internal/child_process:722:19)
    at receiveFromMain (/usr/src/app/node_modules/@stencil/core/dev-server/index.js:48:27)
    at Object.emit [as callback] (/usr/src/app/node_modules/@stencil/core/dev-server/index.js:142:17)
    at Object.emit (/usr/src/app/node_modules/@stencil/core/compiler/stencil.js:1746:14)
    at BuildContext.start (/usr/src/app/node_modules/@stencil/core/compiler/stencil.js:13233:29)
    at onBuild (/usr/src/app/node_modules/@stencil/core/compiler/stencil.js:61986:14)
    at Object.tsWatchHost.afterProgramCreate (/usr/src/app/node_modules/@stencil/core/compiler/stencil.js:61871:11)
    at H (/usr/src/app/node_modules/@stencil/core/compiler/stencil.js:8525:2077692)
    at Object.e.createWatchProgram (/usr/src/app/node_modules/@stencil/core/compiler/stencil.js:8525:2076330)
Emitted 'error' event on ChildProcess instance at:
    at node:internal/child_process:853:39
    at processTicksAndRejections (node:internal/process/task_queues:78:11) {
  errno: -32,
  code: 'EPIPE',
  syscall: 'write'
}
```

### What's happening?
`xdg-open` is failing to open in a Dockerized linux environment.  This was a regression in v8.0.0 of `open`, and fixed in v8.0.6. 

I was able to pin down the commit in which Stencil introduced this to the commit 0208698cf994a5ed611a2d950faa4e268e5de137

### Testing the Fix
- Ensure you don't have anything running on port 3333
- Pull down this branch, run `npm ci && npm run build && npm pack`
- In the directory housing your clone of https://github.com/maxkarkowski/stencil-docker, `npm i <PATH_TO_STENCIL>/stencil-core-2.7.0-0.tgz`
- Build the Docker container and attempt to start it: `npm run build && npm run docker:build && npm run docker:start`
- Observe the container ID returned at the end of the command. Example:
```
> stencil-docker-cypress@0.0.1 docker:start
> docker run -dp 3333:3333 getting-started

f6dfdefb310068bb6706d1584cc1153c13c2628645284e26e12dd2bfe18869d4
```
-  Look at the logs for the container `docker logs f6dfdefb310068bb6706d1584cc1153c13c2628645284e26e12dd2bfe18869d4`
```
docker logs f6dfdefb310068bb6706d1584cc1153c13c2628645284e26e12dd2bfe18869d4

> stencil-docker-cypress@0.0.1 start
> stencil build --dev --watch --serve

[06:42.6]  @stencil/core
[06:42.7]  [LOCAL DEV] 🍾
[06:43.3]  build, stencil-docker-cypress, dev mode, started ...
[06:43.3]  transpile started ...
[06:44.0]  transpile finished in 632 ms
[06:44.0]  copy started ...
[06:44.0]  generate lazy started ...
[06:44.0]  copy finished (0 files) in 16 ms
[06:44.2]  generate lazy finished in 286 ms
[06:44.3]  build finished, watching for changes... in
           943 ms

[06:44.3]  http://localhost:3333/
```
- Navigate to localhost:3333 and see the page load
- Spin down the container `docker stop f6dfdefb310068bb6706d1584cc1153c13c2628645284e26e12dd2bfe18869d4`

## Other information

- Internal ticket: STENCIL-42
