### PR TITLE
chore(github): add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ionic-team/stencil


### PR DESCRIPTION
- add initial codeowners file, where the entire stencil team assumes uniform ownership of the repo