### PR TITLE
fix(dev-server): prevent crash with Safari 15

### DIFF
--- a/src/dev-server/server-web-socket.ts
+++ b/src/dev-server/server-web-socket.ts
@@ -31,6 +31,9 @@ export function createWebSocket(
     ws.isAlive = true;
 
     ws.on('pong', heartbeat);
+
+    // ignore invalid close frames sent by Safari 15
+    ws.on('error', console.error);
   });
 
   const pingInternval = setInterval(() => {


### PR DESCRIPTION
Safari 15 sends an invalid WebSocket close frame when navigating away
from a page. This causes the dev-server to crash.

STENCIL-46