### PR TITLE
feat(rollup): configuration option for symlinks in rollup build

### DIFF
--- a/src/compiler/bundle/bundle-output.ts
+++ b/src/compiler/bundle/bundle-output.ts
@@ -120,6 +120,7 @@ export const getRollupOptions = (
     treeshake: getTreeshakeOption(config, bundleOpts),
     inlineDynamicImports: bundleOpts.inlineDynamicImports,
     preserveEntrySignatures: bundleOpts.preserveEntrySignatures ?? 'strict',
+    preserveSymlinks: config.rollupConfig.inputOptions.preserveSymlinks ?? undefined,
 
     onwarn: createOnWarnFn(buildCtx.diagnostics),
 

--- a/src/compiler/config/test/validate-rollup-config.spec.ts
+++ b/src/compiler/config/test/validate-rollup-config.spec.ts
@@ -1,4 +1,5 @@
 import type * as d from '@stencil/core/declarations';
+import { RollupInputOptions, RollupOutputOptions } from '@stencil/core/declarations';
 import { validateRollupConfig } from '../validate-rollup-config';
 
 describe('validateStats', () => {
@@ -82,5 +83,62 @@ describe('validateStats', () => {
         },
       },
     });
+  });
+
+  describe('input properties validation', () => {
+    const testInputOptions: Required<RollupInputOptions> = {
+      context: 'window',
+      moduleContext: {},
+      preserveSymlinks: true,
+      treeshake: false,
+    };
+
+    for (const property of Object.keys(testInputOptions)) {
+      const value = testInputOptions[property as keyof RollupInputOptions];
+
+      it(`should pass through the valid inputOption '${property}'`, () => {
+        config.rollupConfig = {
+          inputOptions: {
+            [property]: value,
+          },
+        };
+
+        validateRollupConfig(config);
+        expect(config).toEqual({
+          rollupConfig: {
+            inputOptions: {
+              [property]: value,
+            },
+            outputOptions: {},
+          },
+        });
+      });
+    }
+  });
+
+  describe('output properties validation', () => {
+    const outputTestOptions: Required<RollupOutputOptions> = {'globals': {}};
+
+    for (const property of Object.keys(outputTestOptions)) {
+      const value = outputTestOptions[property as keyof RollupOutputOptions];
+
+      it(`should pass through the valid outputOption '${property}'`, () => {
+        config.rollupConfig = {
+          outputOptions: {
+            [property]: value,
+          },
+        };
+
+        validateRollupConfig(config);
+        expect(config).toEqual({
+          rollupConfig: {
+            inputOptions: {},
+            outputOptions: {
+              [property]: value,
+            },
+          },
+        });
+      });
+    }
   });
 });

--- a/src/compiler/config/validate-rollup-config.ts
+++ b/src/compiler/config/validate-rollup-config.ts
@@ -16,7 +16,7 @@ const getCleanRollupConfig = (rollupConfig: d.RollupConfig): d.RollupConfig => {
   if (rollupConfig.inputOptions && isObject(rollupConfig.inputOptions)) {
     cleanRollupConfig = {
       ...cleanRollupConfig,
-      inputOptions: pluck(rollupConfig.inputOptions, ['context', 'moduleContext', 'treeshake']),
+      inputOptions: pluck(rollupConfig.inputOptions, ['context', 'moduleContext', 'treeshake', 'preserveSymlinks']),
     };
   }
 

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1434,6 +1434,7 @@ export interface RollupInputOptions {
   context?: string;
   moduleContext?: ((id: string) => string) | { [id: string]: string };
   treeshake?: boolean;
+  preserveSymlinks?: boolean;
 }
 
 export interface RollupOutputOptions {


### PR DESCRIPTION
## What 

Provides the option to override the default rules for `rollup` by specifying the `preserveSymlinks` configuration property.

In the case the option is not provided, this will continue to be undefined, and has no breaking changes.

## Fixes

This fixes various build tooling such as Bazel which make extensive use of symlinks for builds.

## Tests

Tests included provide runtime validation and type checking which requires all inputs possible on the `RollupInputOptions` and `RollupOutputOptions` be provided in the test cases.

Refs: #2840