### PR TITLE
docs(ADR): Adding ADR's, adding how to contribute.

### DIFF
--- a/.adr.json
+++ b/.adr.json
@@ -1,0 +1,1 @@
+{"language":"en","path":"docs/adr/","prefix":"","digits":4}

--- a/docs/adr/0001-telemetry-in-stencil-cli.md
+++ b/docs/adr/0001-telemetry-in-stencil-cli.md
@@ -1,0 +1,48 @@
+# 1. Telemetry in Stencil CLI
+
+Date: 2021-07-08
+
+## Status
+
+accepted
+
+## Context
+
+We do not have any data on how our customers use Stencil and all of it's features. We need a feature built into the Stencil CLI which tracks the following data:
+
+ - Machine UUID [string] The value of telemetry.token from ~/.ionic/config.json
+ - CPU Model [string]
+ - Component Count [number] Captured only during a build.
+ - Output targets [string[]]
+ - Packages [string[]] Only captures @stencil  @capacitor or @ionic scoped packages
+ - Arguments [string[]]
+ - Task [string]
+ - Stencil version [string]
+ - Yarn [boolean]
+ - Node version [string]
+ - Typescript version [string]
+ - Rollup version [string]
+ - Platform [string] 
+ - Build [number] Date of the build
+ - Duration in Seconds [number]
+
+We must allow a user to opt-in and opt-out of Telemetry, and ensure that nothing introduced here harms other Ionic CLI's. 
+
+## Options
+
+1. Follow Ionic and Capacitor's Lead on CLI implementation, and push tracking data into segment via an /events endpoint on ionic.io - check that code into Stencil core. 
+2. Create a new telemetry methodology and share as a package that other CLI's can consume. 
+
+## Decision
+
+We went with **option 1**, because the code already exists today and is a good baseline to begin with, and the code will likely show dissimilarities that would take time for other teams to integrate into something that already works well for them. 
+
+For Toggling the feature and saving state, we have created [ADR-2](./0002-shared-config-files-on-ionic-projects.md).
+
+## Consequences
+
+We will have CLI data collected as a a way to understand how our customers use Stencil, and we'll build trust with them by ensuring that the data collected is anonymous. We have a new task in the Stencil CLI which provides toggling telemetry. 
+
+## Links
+
+Capacitors Telemetry Documentation: https://capacitorjs.com/telemetry

--- a/docs/adr/0001-telemetry-in-stencil-cli.md
+++ b/docs/adr/0001-telemetry-in-stencil-cli.md
@@ -8,7 +8,7 @@ accepted
 
 ## Context
 
-We do not have any data on how our customers use Stencil and all of it's features. We need a feature built into the Stencil CLI which tracks the following data:
+We do not have any data on how our customers use Stencil and all of its features. We need a feature built into the Stencil CLI which tracks the following data:
 
  - Machine UUID [string] The value of telemetry.token from ~/.ionic/config.json
  - CPU Model [string]

--- a/docs/adr/0002-shared-config-files-on-ionic-projects.md
+++ b/docs/adr/0002-shared-config-files-on-ionic-projects.md
@@ -1,0 +1,35 @@
+# 2. Shared Config files on Ionic projects
+
+Date: 2021-08-06
+
+## Status
+
+accepted
+
+## Context
+
+There is no shared configuration for stats and analytics across Ionic CLI's, notably for telemetry with Stencil. 
+
+## Options
+
+1. Create a new `{Project DIR}/.stencil/.config` that holds the Machine UUID and other data. 
+2. Adopt Ionic CLI's `~/.ionic/config.json` file that holds the Machine UUID and other data. 
+3. Adopt Capacitor CLI's `~/Library/Preferences/capacitor/sysconfig.json` file that holds the Machine UUID and other data.
+
+## Decision
+
+We went with Option 2, because Ionic's approach is inline with the company's name, so it is something all Ionic CLI's can rally around. 
+
+## Consequences
+
+We can now try to loop in all other CLI's into using the same approach to telemetry and gathering data that Stencil and Ionic uses. Capacitor is now the odd one out, which could help motivate the Capacitor team to migrate.
+
+The original format of the file has been updated with a "stencil.telemetry" boolean. 
+
+Because we reference a file that has user names and emails, we could theoretically collect identifiable information.
+
+## Links
+
+Cap's Approach: [https://github.com/ionic-team/capacitor/blob/9a6e74e2eee1f8fd09f915fe7651b09df52e96b5/cli/src/tasks/init.ts#L55](https://github.com/ionic-team/capacitor/blob/9a6e74e2eee1f8fd09f915fe7651b09df52e96b5/cli/src/tasks/init.ts#L55)
+
+Ionic CLI's Approach: [https://github.com/ionic-team/ionic-cli/blob/5ca557bad2e04a147fc5aed9fbf0298def628a0e/packages/%40ionic/cli/src/lib/config.ts#L58](https://github.com/ionic-team/ionic-cli/blob/5ca557bad2e04a147fc5aed9fbf0298def628a0e/packages/%40ionic/cli/src/lib/config.ts#L58)

--- a/docs/adr/0003-supported-node-versions.md
+++ b/docs/adr/0003-supported-node-versions.md
@@ -1,0 +1,22 @@
+# 3. Supported Node versions
+
+Date: 2021-07-22
+
+## Status
+
+historical
+
+## Context
+
+Node maintains four supported release tracks: Maintenance LTS, Active LTS, Current, and Unstable. It has been unclear which versions of Node the Stencil CLI officially supports.
+
+## Decision
+
+The Stencil CLI should be able to run on Maintenance LTS, Active LTS, and Current releases of Node. The Stencil CLI can drop support for a Node release once it has reached End-of-life.
+
+## Consequences
+
+Since production applications are expected to use a Maintenance LTS or Active LTS release of Node the Stencil CLI should work with these releases. This does mean we have to test the Stencil CLI with three or four different Node releases at any given time.
+
+## Links
+Node releases: https://nodejs.org/en/about/releases/

--- a/docs/adr/0004-jest-27-support.md
+++ b/docs/adr/0004-jest-27-support.md
@@ -1,0 +1,55 @@
+# 4. Jest 27 Support
+
+Date: 2021-07-30
+
+## Status
+
+accepted
+
+## Context
+
+The community has been asking for the ability to use a newer version on the Jest library (v27.0.0). Stencil does runtime checks on the version of the Jest library that the user is currently using, and fails up front if the user does not have what it deems to be an acceptable version installed.
+
+Jest 27 introduces [multiple breaking changes](https://jestjs.io/blog/2021/05/25/jest-27), including:
+
+- Moving away from [core Jasmine testing infrastructure](https://jestjs.io/blog/2021/05/25/jest-27#flipping-defaults) to `jest-circus`)
+- Changing the default runtime environment from JSDom to Node
+- Changing the signature of `getCacheKey` for file transformations
+- Inclusion of it's own type declarations, deprecating the community supported `@types/jest` package
+
+The Stencil code base needs to take these items into consideration for two similar, but distinct items to be completed:
+
+- Stencil being able to support Jest 27 for projects that consume `@stencil`
+- Stencil running its own tests in Jest 27
+
+## Options
+
+1. Hack in support for Jest 27, which has been prototyped and [pushed to GitHub](https://github.com/ionic-team/stencil/pull/2980/commits/19dcb631f7eceb49c20a3788957254d66424b8c0) as a work in progress branch.
+    1. Pros:
+        1. Gets Jest 27 support out the door for the community
+        2. Allows the team to receive quick feedback around Jest 27 usage from users
+    2. Cons:
+        1. The prototype hacks around `@types/jest` checking
+        2. Comprehensive testing is still required
+        3. Any hacks that are released need to be fixed at a future date
+2. Perform a more comprehensive evaluation of the upgrade & split the effort into multiple user stories to be done in Q3
+    1. Pros:
+        1. Allows the team to produce more maintainable hack code
+        2. Time to evaluate Jest 27 support with other libraries (like Puppeteer, which Stencil uses today for snapshot testing) is available
+        3. Additional time to test support for Jest 27
+    2. Cons:
+        1. Jest 27 support is delayed
+
+## Decision
+
+We went with **option 2** - Perform a more comprehensive evaluation of the upgrade & split the effort into multiple user stories to be done in Q3
+
+## Consequences
+
+The number of breaking changes in Jest 27, coupled with changes to the Stencil code base to support both users using the library and using the library in the compiler's tests is a large enough effort that requires more thorough work. This effort has already received initial sign off to be included in 2021Q3.
+
+## Links
+
+Source: [https://adr.github.io/](https://adr.github.io/)
+
+Template Source: [https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/templates/decision-record-template-by-michael-nygard/index.md](https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/templates/decision-record-template-by-michael-nygard/index.md)

--- a/docs/adr/0004-jest-27-support.md
+++ b/docs/adr/0004-jest-27-support.md
@@ -15,7 +15,7 @@ Jest 27 introduces [multiple breaking changes](https://jestjs.io/blog/2021/05/25
 - Moving away from [core Jasmine testing infrastructure](https://jestjs.io/blog/2021/05/25/jest-27#flipping-defaults) to `jest-circus`)
 - Changing the default runtime environment from JSDom to Node
 - Changing the signature of `getCacheKey` for file transformations
-- Inclusion of it's own type declarations, deprecating the community supported `@types/jest` package
+- Inclusion of its own type declarations, deprecating the community supported `@types/jest` package
 
 The Stencil code base needs to take these items into consideration for two similar, but distinct items to be completed:
 

--- a/docs/adr/0005-repo-structure.md
+++ b/docs/adr/0005-repo-structure.md
@@ -1,0 +1,29 @@
+# 5. Repo Structure
+
+Date: 2021-08-06
+
+## Status
+
+historical
+
+## Context
+
+Building out the wide array of products, features, and functionality that Stencil offers can create a hard to explore repo of source code. Reusing well tested code is encouraged, and understanding where to place that code and it's responsibilities
+
+## Options
+
+1. Continue to develop a non-organized repo
+2. Use Lerna as a monorepo dependency, where we can use and organize our code in a maintainable way that the software's opinion provides. 
+3. Use Nx as a monorepo dependency, where we can use and organize our code in a maintainable way that the software's opinion provides. 
+4. Use a sub-module organization, without a separate dependency, using TypeScript and Jest to map module names to sub-paths.
+
+## Decision
+
+We decided on #4, because mapping module names, though manually maintained, could help us organize our code and build without worrying about publishing and consuming separate packages. It also allows us to manually maintain the mapped modules. We can bundle all the built code as the code that's published on NPM as @stencil/core. 
+
+## Consequences
+
+We can now provide a module mapped as the `@utils` string to the code, as opposed to something that would need to be published, such as with Lerna. See [ADR-6 • Organizing Helper Methods](./0006-organizing-utility-functions.md).
+
+## Links
+Based off the information we learned from Adam in our first meeting. 

--- a/docs/adr/0006-organizing-utility-functions.md
+++ b/docs/adr/0006-organizing-utility-functions.md
@@ -8,7 +8,7 @@ historical
 
 ## Context
 
-Helper/utility methods are a common artifact of a large application, and we need a wy to organize them to be reusable across the sub-modules we develop per [ADR-5](./0005-repo-structure.md)
+Helper/utility methods are a common artifact of a large application, and we need a way to organize them to be reusable across the sub-modules we develop per [ADR-5](./0005-repo-structure.md)
 
 ## Options
 1. Place helper methods within the directory that they will be commonly consumed.

--- a/docs/adr/0006-organizing-utility-functions.md
+++ b/docs/adr/0006-organizing-utility-functions.md
@@ -1,0 +1,23 @@
+# 6. Organizing Utility Functions
+
+Date: 2021-08-06
+
+## Status
+
+historical
+
+## Context
+
+Helper/utility methods are a common artifact of a large application, and we need a wy to organize them to be reusable across the sub-modules we develop per [ADR-5](./0005-repo-structure.md)
+
+## Options
+1. Place helper methods within the directory that they will be commonly consumed.
+2. Place helper methods within a utils sub-module, where they will be commonly consumed.
+
+## Decision
+
+Based on [ADR-5 • Repo Structure](./0005-repo-structure.md), we will map helper methods to a `@utils` string. All helper functions should be exported and testing from within that directory. 
+
+## Consequences
+
+Discoverability of helper methods should become easier by providing these at the utils directory. 

--- a/docs/adr/0007-unit-testing-expectations.md
+++ b/docs/adr/0007-unit-testing-expectations.md
@@ -1,0 +1,27 @@
+# 7. Unit Testing Expectations
+
+Date: 2021-08-06
+
+## Status
+
+proposed
+
+## Context
+
+Our test coverage should help us to identify bugs before those bugs are presented to our customers. 
+
+## Options
+
+1. No tests.
+2. Test all code to 100% coverage. 
+3. Set an expectation of high coverage or above for code located within the @utils sub-module, covering all exported members. Set an expectation of moderate coverage for code located within other sub-modules, covering as many exported members as possible and to never allow the untested coverage threshold to fall when introducing new code.
+
+## Decision
+
+Decision here...
+
+## Consequences
+
+[What becomes easier or more difficult to do because of this change?]
+
+## Links

--- a/docs/adr/CONTRIBUTING.md
+++ b/docs/adr/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# What is this?
+Architecture Decision Records (ADR's) are a way to capture abstract choices that engineers make throughout a repo. Whenever the Stencil team discovers a concept that's hard to share with other people in plain language, that's often when we'll find an opportunity to write an ADR. 
+
+These ADR's serve a few different people:
+1. It helps the Stencil team to communicate together about a decision that could make an impact, at any point during our process. 
+2. It helps Community members understand where we're at on decisions. 
+3. It helps the Stencil team begin to have open discussion about the changes we're making to Stencil. 
+4. It helps new developers, whether they're on the Stencil team or they're in the community, learn about the decisions we've made within the code.
+5. It helps eveyone to have a running, historical list of changes that have been incorporated into the codebase. 
+
+# Who can propose an ADR? 
+Anybody can propose an ADR and request for comment on them. 
+
+
+# How do I contribute? 
+We use the [Node version of ADR tools](https://github.com/phodal/adr), installable via npm as:
+```
+npm install -g adr
+```
+
+And usable per their documentation. 
+
+You can search for ADR's by running `adr s "phrase"` e.g. `adr s "proposed"` to get all the proposed documents.

--- a/docs/adr/CONTRIBUTING.md
+++ b/docs/adr/CONTRIBUTING.md
@@ -6,7 +6,7 @@ These ADR's serve a few different people:
 2. It helps Community members understand where we're at on decisions. 
 3. It helps the Stencil team begin to have open discussion about the changes we're making to Stencil. 
 4. It helps new developers, whether they're on the Stencil team or they're in the community, learn about the decisions we've made within the code.
-5. It helps eveyone to have a running, historical list of changes that have been incorporated into the codebase. 
+5. It helps everyone to have a running, historical list of changes that have been incorporated into the codebase. 
 
 # Who can propose an ADR? 
 Anybody can propose an ADR and request for comment on them. 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,9 @@
+# Architecture Decision Records
+
+* [1. telemetry-in-stencil-cli](0001-telemetry-in-stencil-cli.md)
+* [2. shared-config-files-on-ionic-projects](0002-shared-config-files-on-ionic-projects.md)
+* [3. supported-node-versions](0003-supported-node-versions.md)
+* [4. jest-27-support](0004-jest-27-support.md)
+* [5. repo-structure](0005-repo-structure.md)
+* [6. organizing-utility-functions](0006-organizing-utility-functions.md)
+* [7. unit-testing-expectations](0007-unit-testing-expectations.md)

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,28 @@
+# {number}. {title}
+
+Date: {date}
+
+## Status
+
+[proposed | accepted | rejected | deprecated | superseded | historical]
+
+## Context
+
+[What is the issue that we're seeing that is motivating this decision or change?]
+
+## Options
+
+1. [Describe the many options, their pros/cons, side effects, and any perspective a given team member has]
+
+## Decision
+
+[What is the change that we're proposing and/or doing?]
+
+## Consequences
+
+[What becomes easier or more difficult to do because of this change?]
+
+## Links
+
+Source: [https://adr.github.io/](https://adr.github.io/)
+Template Source: [https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/templates/decision-record-template-by-michael-nygard/index.md](https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/templates/decision-record-template-by-michael-nygard/index.md)


### PR DESCRIPTION
This PR allows the Stencil team to begin using public ADR's within Git instead of our other tooling. 

See the [CONTRIBUTING.md file](https://github.com/ionic-team/stencil/pull/2992/files#diff-536896b1dab96faa3d75dc8aaefbf8b5308c69c87a0e3ac1aa263710b1d4c04b) for details about the purpose of ADR's. 

With the `adr` tool, README.md is wiped on update, so I couldn't place the content of CONTRIBUTING.md within it. 