### PR TITLE
Update app-es5-disabled.ts

### DIFF
--- a/src/compiler/app-core/app-es5-disabled.ts
+++ b/src/compiler/app-core/app-es5-disabled.ts
@@ -44,7 +44,7 @@ h2 {
   <ul>
     <li>ES5 builds are disabled <strong>during development</strong> to take advantage of 2x faster build times.</li>
     <li>Please see the example below or our <a href="https://stenciljs.com/docs/stencil-config" target="_blank" rel="noopener noreferrer">config docs</a> if you would like to develop on a browser that does not fully support ES2017 and custom elements.</li>
-    <li>Note that by default, ES5 builds and polyfills are enabled during production builds.</li>
+    <li>Note that by default, ES5 builds and polyfills are <strong>disabled</strong> during production builds.</li>
     <li>When testing browsers it is recommended to always test in production mode, and ES5 builds should always be enabled during production builds.</li>
     <li><em>This is only an experiment and if it slows down app development then we will revert this and enable ES5 builds during dev.</em></li>
   </ul>


### PR DESCRIPTION
According to the latest docs, and the output I see, es5 builds are now disabled by default for production, so this message should be corrected?
https://stenciljs.com/docs/config#buildes5