### PR TITLE
Allow file change events to pass through to let the Copy task succeed

### DIFF
--- a/src/sys/node/node-sys.ts
+++ b/src/sys/node/node-sys.ts
@@ -430,7 +430,7 @@ export function createNodeSys(c: { process?: any } = {}) {
         const tsFileWatcher = tsSysWatchDirectory(
           p,
           (fileName) => {
-            callback(normalizePath(fileName), null);
+            callback(normalizePath(fileName), 'fileUpdate');
           },
           recursive
         );


### PR DESCRIPTION
Allows the dev server to pick up changes during the www copy tasks, so consumers don't have to restart their dev server when developing. 

I've tested this experience on each starter repo, a monorepo, and framework. 

### Before this change: 

Set up a www output target that with a copy rule, e.g.

```
{
      type: 'www', 
      copy: [
        { src: 'images' }
      ]
}
```

Within that images directory, try to make file modifications - change the content, duplicate the file, delete the file. The contents should not be carried over during the process of the dev server's lifecycle. Commonly, you have to restart the dev server in order to make the copy task run.

### After this change: 

All file change events now get passed down to the tasks. Copy now works as expected - files get copied when needed. 

Internal ticket: STENCIL-29