### PR TITLE
fix(build): add screenshot/index.js.map to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ dist/
 /testing
 
 /screenshot/index.js
+/screenshot/index.js.map
 /screenshot/package.json
 /screenshot/pixel-match.js
 /screenshot/*.d.ts


### PR DESCRIPTION
add index.js.map, which is generated on every build, to the .gitignore
file, alongside the other autogenerated files

Testing:
- on `master`, run `npm run build`, observe this file being created/noticed by git via `git status`
- on this branch, run the same command, and it's magically ignored ✨ 