### PR TITLE
chore(types) remove bespoke rollup types

### DIFF
--- a/src/compiler/bundle/app-data-plugin.ts
+++ b/src/compiler/bundle/app-data-plugin.ts
@@ -1,7 +1,7 @@
 import type * as d from '../../declarations';
 import MagicString from 'magic-string';
 import { createJsVarName, normalizePath, isString, loadTypeScriptDiagnostics } from '@utils';
-import type { Plugin } from 'rollup';
+import type { LoadResult, Plugin, ResolveIdResult, TransformResult } from 'rollup';
 import { removeCollectionImports } from '../transformers/remove-collection-imports';
 import {
   APP_DATA_CONDITIONAL,
@@ -31,7 +31,7 @@ export const appDataPlugin = (
   return {
     name: 'appDataPlugin',
 
-    resolveId(id, importer) {
+    resolveId(id: string, importer: string | undefined): ResolveIdResult {
       if (id === STENCIL_APP_DATA_ID || id === STENCIL_APP_GLOBALS_ID) {
         if (platform === 'worker') {
           this.error('@stencil/core packages cannot be imported from a worker.');
@@ -54,7 +54,7 @@ export const appDataPlugin = (
       return null;
     },
 
-    load(id): d.RollupLoadHook {
+    load(id: string): LoadResult {
       if (id === STENCIL_APP_GLOBALS_ID) {
         const s = new MagicString(``);
         appendGlobalScripts(globalScripts, s);
@@ -80,7 +80,7 @@ export const appDataPlugin = (
       return { code: module.staticSourceFileText, map: sourceMap };
     },
 
-    transform(code, id) {
+    transform(code: string, id: string): TransformResult {
       id = normalizePath(id);
       if (globalScripts.some((s) => s.path === id)) {
         const program = this.parse(code, {});

--- a/src/compiler/bundle/ext-format-plugin.ts
+++ b/src/compiler/bundle/ext-format-plugin.ts
@@ -1,13 +1,13 @@
 import type * as d from '../../declarations';
 import { basename } from 'path';
 import { createJsVarName, normalizeFsPathQuery } from '@utils';
-import type { Plugin, TransformPluginContext } from 'rollup';
+import type { Plugin, TransformPluginContext, TransformResult } from 'rollup';
 
 export const extFormatPlugin = (config: d.Config): Plugin => {
   return {
     name: 'extFormatPlugin',
 
-    transform(code, importPath): d.RollupTransformHook {
+    transform(code: string, importPath: string): TransformResult {
       if (/\0/.test(importPath)) {
         return null;
       }

--- a/src/compiler/bundle/typescript-plugin.ts
+++ b/src/compiler/bundle/typescript-plugin.ts
@@ -2,7 +2,7 @@ import type * as d from '../../declarations';
 import type { BundleOptions } from './bundle-interface';
 import { getModule } from '../transpile/transpiled-module';
 import { isString, normalizeFsPath } from '@utils';
-import type { Plugin } from 'rollup';
+import type { LoadResult, Plugin, TransformResult } from 'rollup';
 import { tsResolveModuleName } from '../sys/typescript/typescript-resolve-module';
 import { isAbsolute, basename } from 'path';
 import ts from 'typescript';
@@ -11,7 +11,7 @@ export const typescriptPlugin = (compilerCtx: d.CompilerCtx, bundleOpts: BundleO
   return {
     name: `${bundleOpts.id}TypescriptPlugin`,
 
-    load(id): d.RollupLoadHook {
+    load(id: string): LoadResult {
       if (isAbsolute(id)) {
         const fsFilePath = normalizeFsPath(id);
         const module = getModule(compilerCtx, fsFilePath);
@@ -28,7 +28,7 @@ export const typescriptPlugin = (compilerCtx: d.CompilerCtx, bundleOpts: BundleO
       }
       return null;
     },
-    transform(_, id): d.RollupTransformHook {
+    transform(_code: string, id: string): TransformResult {
       if (isAbsolute(id)) {
         const fsFilePath = normalizeFsPath(id);
         const mod = getModule(compilerCtx, fsFilePath);

--- a/src/compiler/output-targets/dist-lazy/generate-lazy-module.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-lazy-module.ts
@@ -3,6 +3,7 @@ import { writeLazyModule } from './write-lazy-entry-module';
 import { formatComponentRuntimeMeta, stringifyRuntimeData, hasDependency, rollupSrcMapToObj } from '@utils';
 import { optimizeModule } from '../../optimize/optimize-module';
 import { join } from 'path';
+import type { SourceMap as RollupSourceMap } from 'rollup';
 
 export const generateLazyModules = async (
   config: d.Config,
@@ -318,7 +319,7 @@ const convertChunk = async (
   isCore: boolean,
   isBrowserBuild: boolean,
   code: string,
-  rollupSrcMap: d.RollupSourceMap
+  rollupSrcMap: RollupSourceMap
 ) => {
   let sourceMap = rollupSrcMapToObj(rollupSrcMap);
   const inlineHelpers = isBrowserBuild || !hasDependency(buildCtx, 'tslib');

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -32,6 +32,8 @@ import type {
   VNodeData,
 } from './stencil-public-runtime';
 
+import type { SourceMap as RollupSourceMap } from 'rollup';
+
 export interface SourceMap {
   file: string;
   mappings: string;
@@ -41,41 +43,6 @@ export interface SourceMap {
   sourcesContent?: string[];
   version: number;
 }
-
-export interface RollupSourceMap {
-  file: string;
-  mappings: string;
-  names: string[];
-  sources: string[];
-  sourcesContent: string[];
-  version: number;
-  toString(): string;
-  toUrl(): string;
-}
-
-export type RollupTransformHook =
-  | string
-  | null
-  | {
-      code?: string;
-      map?: string | SourceMap;
-      ast?: any;
-      moduleSideEffects?: boolean | 'no-treeshake' | null;
-      syntheticNamedExports?: boolean | string | null;
-      meta?: { [plugin: string]: any } | null;
-    };
-
-export type RollupLoadHook =
-  | string
-  | null
-  | {
-      code: string;
-      map?: string | SourceMap;
-      ast?: any;
-      moduleSideEffects?: boolean | 'no-treeshake' | null;
-      syntheticNamedExports?: boolean | string | null;
-      meta?: { [plugin: string]: any } | null;
-    };
 
 export interface PrintLine {
   lineIndex: number;


### PR DESCRIPTION
this PR replaces our custom typings for rollup hooks with those
provided by rollup

since this is only a change to the typings, I did not do any functional testing, rather ensured the compiler still ran