### PR TITLE
chore(docs): document the release process 

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -14,8 +14,14 @@ import { sysNode, sysNodeExternalBundles } from './bundles/sys-node';
 import { testing } from './bundles/testing';
 import { validateBuild } from './test/validate-build';
 import { rollup } from 'rollup';
+import type { RollupOptions } from 'rollup';
 
-export async function run(rootDir: string, args: string[]) {
+/**
+ * Runner for releasing a new version of Stencil
+ * @param rootDir the root directory of the Stencil repository
+ * @param args stringifed arguments that influence the release process
+ */
+export async function run(rootDir: string, args: ReadonlyArray<string>): Promise<void> {
   try {
     if (args.includes('--release')) {
       await release(rootDir, args);
@@ -34,7 +40,12 @@ export async function run(rootDir: string, args: string[]) {
   }
 }
 
-export async function createBuild(opts: BuildOptions) {
+/**
+ * Build the rollup configuration for each submodule of the project
+ * @param opts build options to be used as a part of the configuration generation
+ * @returns the rollup configurations used to build each of the project's major submodules
+ */
+export async function createBuild(opts: BuildOptions): Promise<readonly RollupOptions[]> {
   await Promise.all([
     emptyDir(opts.output.cliDir),
     emptyDir(opts.output.compilerDir),
@@ -64,7 +75,11 @@ export async function createBuild(opts: BuildOptions) {
   return bundles.flat();
 }
 
-export async function bundleBuild(opts: BuildOptions) {
+/**
+ * Initiates writing bundled Stencil submodules to disk
+ * @param opts build options to be used to generate the underlying rollup configuration
+ */
+export async function bundleBuild(opts: BuildOptions): Promise<void> {
   const bundles = await createBuild(opts);
 
   await Promise.all(

--- a/scripts/license.ts
+++ b/scripts/license.ts
@@ -3,6 +3,9 @@ import { join } from 'path';
 import { BuildOptions, getOptions } from './utils/options';
 import { PackageData } from './utils/write-pkg-json';
 
+/**
+ * Dependencies that will be included in the Stencil output
+ */
 const entryDeps = [
   '@rollup/plugin-commonjs',
   '@rollup/plugin-json',
@@ -51,7 +54,11 @@ const manuallyNotBundled = new Set([
   'urix',
 ]);
 
-export function createLicense(rootDir: string) {
+/**
+ * Generate LICENSE.md for Stencil
+ * @param rootDir the root directory of the Stencil repo
+ */
+export function createLicense(rootDir: string): void {
   const opts = getOptions(rootDir);
   const thirdPartyLicensesRootPath = join(opts.rootDir, 'NOTICE.md');
 
@@ -105,19 +112,29 @@ ${bundledDeps.map((l) => l.content).join('\n')}
   fs.writeFileSync(join(opts.buildDir, 'license-source.txt'), licenseSource.join('\n'));
 }
 
-function createBundledDeps(opts: BuildOptions, bundledDeps: BundledDep[], deps: string[]) {
-  if (Array.isArray(deps)) {
-    deps.forEach((moduleId) => {
-      if (includeDepLicense(bundledDeps, moduleId)) {
-        const bundledDep = createBundledDepLicense(opts, moduleId);
-        bundledDeps.push(bundledDep);
+/**
+ * Generate license metadata for a series of dependencies
+ * @param bundledDeps the current list of dependencies to bundle
+ * @param deps the dependencies to generate metadata for
+ */
+function createBundledDeps(opts: BuildOptions, bundledDeps: BundledDep[], deps: ReadonlyArray<string>): void {
+  deps.forEach((moduleId) => {
+    if (includeDepLicense(bundledDeps, moduleId)) {
+      const bundledDep = createBundledDepLicense(opts, moduleId);
+      bundledDeps.push(bundledDep);
 
-        createBundledDeps(opts, bundledDeps, bundledDep.dependencies);
-      }
-    });
-  }
+      // evaluate the dependencies of the dependency for inclusion
+      createBundledDeps(opts, bundledDeps, bundledDep.dependencies);
+    }
+  });
 }
 
+/**
+ * Generate license metadata for a single dependency
+ * @param opts build options to be used to determine where to inspect dependencies
+ * @param moduleId the name of the dependency to generate a license for
+ * @returns all metadata for a dependency that was able to be retrieved for the given dependency
+ */
 function createBundledDepLicense(opts: BuildOptions, moduleId: string): BundledDep {
   const pkgJsonFile = join(opts.nodeModulesDir, moduleId, 'package.json');
   const pkgJson: PackageData = fs.readJsonSync(pkgJsonFile);
@@ -181,6 +198,9 @@ function createBundledDepLicense(opts: BuildOptions, moduleId: string): BundledD
   };
 }
 
+/**
+ * Representation of a dependency that is bundled with Stencil which has a license to be written to disk
+ */
 interface BundledDep {
   moduleId: string;
   content: string;
@@ -188,40 +208,58 @@ interface BundledDep {
   dependencies: string[];
 }
 
-function getContributors(prop: any) {
-  if (typeof prop === 'string') {
-    return prop;
+/**
+ * Format the list of contributors for a dependency
+ * @param contributors the contributors, as read from a `package.json` file
+ * @returns the contributors list, formatted
+ */
+function getContributors(contributors: unknown): typeof contributors {
+  if (typeof contributors === 'string') {
+    return contributors;
   }
 
-  if (Array.isArray(prop)) {
-    return prop
+  if (Array.isArray(contributors)) {
+    return contributors
       .map(getAuthor)
       .filter((c) => !!c)
       .join(', ');
   }
 
-  if (prop) {
-    return getAuthor(prop);
+  if (contributors) {
+    return getAuthor(contributors);
   }
 }
 
-function getAuthor(c: any) {
-  if (typeof c === 'string') {
-    return c;
+/**
+ * Formats an individual contributor's information
+ * @param contributor the contributor information
+ * @returns the formatted contributor information
+ */
+function getAuthor(contributor: any): string {
+  if (typeof contributor === 'string') {
+    return contributor;
   }
-  if (typeof c.name === 'string') {
-    if (typeof c.url === 'string') {
-      return `[${c.name}](${c.url})`;
+  if (typeof contributor.name === 'string') {
+    if (typeof contributor.url === 'string') {
+      return `[${contributor.name}](${contributor.url})`;
     } else {
-      return c.name;
+      return contributor.name;
     }
   }
-  if (typeof c.url === 'string') {
-    return c.url;
+  if (typeof contributor.url === 'string') {
+    return contributor.url;
   }
 }
 
-function getBundledDepLicenseContent(opts: BuildOptions, moduleId: string) {
+/**
+ * Retrieve the license file for a dependency. This function assumes that the license will be provided in an external
+ * file by the dependency. It is therefore possible that the addition/removal of a license file in a dependency will
+ * alter Stencil's generated LICENSE.md file between releases.
+ * @param opts build options to be used to determine where to look for a license
+ * @param moduleId the name of the dependency to check
+ * @returns the license for a dependency, undefined if none was found
+ */
+function getBundledDepLicenseContent(opts: BuildOptions, moduleId: string): string | undefined {
   const licenseFiles = ['LICENSE', 'LICENSE.md', 'LICENSE-MIT', 'LICENSE.txt'];
   for (const licenseFile of licenseFiles) {
     try {
@@ -231,7 +269,13 @@ function getBundledDepLicenseContent(opts: BuildOptions, moduleId: string) {
   }
 }
 
-function includeDepLicense(bundledDeps: BundledDep[], moduleId: string) {
+/**
+ * Determines if a dependency's license should be included in the generated license file or not
+ * @param bundledDeps the current list of dependencies to bundle
+ * @param moduleId the name of the dependency to check for inclusion
+ * @returns true of the dependency's license should be included, false otherwise
+ */
+function includeDepLicense(bundledDeps: BundledDep[], moduleId: string): boolean {
   if (manuallyNotBundled.has(moduleId)) {
     return false;
   }

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -1,15 +1,9 @@
-# Local Build and Testing
-
-1. `npm run build`
-2. From the root of this local @stencil/core repo, run `npm link`
-3. From the root of a local stencil app, run `npm link @stencil/core`
-4. Every time you run `npm run build` your linked projects will have to restart the dev server.
-5. Test test test. Add unit tests for any updates and always run `npm run test`.
-
-
 # Release
 
 1. `npm run release.prepare`
-2. Check the changelog and make sure it is good, then commit the changes.
-3. `npm run release`
-4. :tada:
+2. Check the [CHANGELOG.md](../CHANGELOG.md) and make sure it includes all the changes that have landed since the last 
+release.
+3. Commit the changes - use the commit message :emoji: v<VERSION>. e.g. :star2: v2.7.0 
+4. `npm run release`
+5. Publish the release notes in GitHub
+6. :tada:

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -13,7 +13,12 @@ import {
   isPrereleaseVersion,
 } from './utils/release-utils';
 
-export async function release(rootDir: string, args: string[]) {
+/**
+ * Runner for creating a release of Stencil
+ * @param rootDir the root directory of the Stencil repository
+ * @param args stringified arguments used to influence the release steps that are taken
+ */
+export async function release(rootDir: string, args: ReadonlyArray<string>): Promise<void> {
   const buildDir = join(rootDir, 'build');
   const releaseDataPath = join(buildDir, 'release-data.json');
 
@@ -40,34 +45,41 @@ export async function release(rootDir: string, args: string[]) {
   }
 }
 
-async function prepareRelease(opts: BuildOptions, args: string[], releaseDataPath: string) {
+/**
+ * Prepares a release of Stencil
+ * @param opts build options containing the metadata needed to release a new version of Stencil
+ * @param args stringified arguments used to influence the release steps that are taken
+ * @param releaseDataPath the fully qualified path of `release-data.json` to write to disk during this step
+ */
+async function prepareRelease(opts: BuildOptions, args: ReadonlyArray<string>, releaseDataPath: string): Promise<void> {
   const pkg = opts.packageJson;
   const oldVersion = opts.packageJson.version;
   console.log(
     `\nPrepare to publish ${opts.vermoji}  ${color.bold.magenta(pkg.name)} ${color.dim(`(currently ${oldVersion})`)}\n`
   );
 
+  const NON_SERVER_INCREMENTS: ReadonlyArray<{ name: string; value: string }> = [
+    {
+      name: 'Dry Run',
+      value: getNewVersion(oldVersion, 'patch') + '-dryrun',
+    },
+    {
+      name: 'Other (specify)',
+      value: null,
+    },
+  ];
+
   const prompts = [
     {
       type: 'list',
       name: 'version',
       message: 'Select semver increment or specify new version',
-      pageSize: SEMVER_INCREMENTS.length + 2,
+      pageSize: SEMVER_INCREMENTS.length + NON_SERVER_INCREMENTS.length,
       choices: SEMVER_INCREMENTS.map((inc) => ({
         name: `${inc}   ${prettyVersionDiff(oldVersion, inc)}`,
         value: inc,
-      })).concat([
-        new inquirer.Separator() as any,
-        {
-          name: 'Dry Run',
-          value: getNewVersion(oldVersion, 'patch') + '-dryrun',
-        },
-        {
-          name: 'Other (specify)',
-          value: null,
-        },
-      ]),
-      filter: (input: any) => (isValidVersionInput(input) ? getNewVersion(oldVersion, input) : input),
+      })).concat([new inquirer.Separator() as any, ...NON_SERVER_INCREMENTS]),
+      filter: (input: string) => (isValidVersionInput(input) ? getNewVersion(oldVersion, input) : input),
     },
     {
       type: 'input',
@@ -96,6 +108,7 @@ async function prepareRelease(opts: BuildOptions, args: string[], releaseDataPat
     .then((answers) => {
       if (answers.confirm) {
         opts.version = answers.version;
+        // write `release-data.json`
         fs.writeJsonSync(releaseDataPath, opts, { spaces: 2 });
         runReleaseTasks(opts, args);
       }
@@ -106,7 +119,12 @@ async function prepareRelease(opts: BuildOptions, args: string[], releaseDataPat
     });
 }
 
-async function publishRelease(opts: BuildOptions, args: string[]) {
+/**
+ * Initiates the publish of a Stencil release.
+ * @param opts build options containing the metadata needed to publish a new version of Stencil
+ * @param args stringified arguments used to influence the publish steps that are taken
+ */
+async function publishRelease(opts: BuildOptions, args: ReadonlyArray<string>): Promise<void> {
   const pkg = opts.packageJson;
 
   if (opts.version !== pkg.version) {

--- a/scripts/utils/options.ts
+++ b/scripts/utils/options.ts
@@ -3,7 +3,17 @@ import { getVermoji } from './vermoji';
 import { PackageData } from './write-pkg-json';
 import { readFileSync } from 'fs-extra';
 
-export function getOptions(rootDir: string, inputOpts: BuildOptions = {}) {
+/**
+ * Retrieves information used during a 'process' that requires knowledge of various project file paths, Stencil version
+ * information, and GitHub repo metadata. A 'process' may include, but is not limited to:
+ * - generating a new release
+ * - regenerating a license file
+ * - validating a build
+ * @param rootDir the root directory of the project
+ * @param inputOpts any build options to override manually
+ * @returns an entity containing various fields to be used by some process
+ */
+export function getOptions(rootDir: string, inputOpts: BuildOptions = {}): BuildOptions {
   const srcDir = join(rootDir, 'src');
   const packageJsonPath = join(rootDir, 'package.json');
   const packageLockJsonPath = join(rootDir, 'package-lock.json');


### PR DESCRIPTION
While going through the release process more thoroughly this morning, I did a fair amount of documentation of the code/fixed up some typings where I could. Rather than creating a Notion doc that would sit and rot, I decided to put this in the form of code comments that hopefully won't rot as quickly 😄 

Changes:
document the build process via JSDocs on all functions that are involved
with generating a release for Stencil. the intent here is that moving
forward, context for different aspects of the release process can be
quickly acquired rather than running through a mountain of code

Testing:
- Ran `npm run tsc.scripts` to verify the typings I edited are semantically correct
- Ran `npm run release.prepare` with the 'dry-run' option to best estimate going through the release process