### PR TITLE
fix: Solve issue where worker thread didn't have access to fetch

### DIFF
--- a/src/compiler/sys/stencil-sys.ts
+++ b/src/compiler/sys/stencil-sys.ts
@@ -505,7 +505,15 @@ export const createSystem = (c?: { logger?: Logger }) => {
     return results;
   };
 
-  const fetch = self?.fetch ?? global?.fetch ?? window?.fetch;
+  // Reference fetch from a worker thread, then a browser thread, then a node thread.
+  const fetch =
+    typeof self !== 'undefined'
+      ? self?.fetch
+      : typeof window !== 'undefined'
+      ? window?.fetch
+      : typeof global !== 'undefined'
+      ? global?.fetch
+      : undefined;
 
   const writeFile = async (p: string, data: string) => writeFileSync(p, data);
 

--- a/src/compiler/sys/stencil-sys.ts
+++ b/src/compiler/sys/stencil-sys.ts
@@ -506,13 +506,13 @@ export const createSystem = (c?: { logger?: Logger }) => {
   };
 
   /**
-  * `self` is the global namespace object used within a web worker.
-  * `window` is the browser's global namespace object (I reorganized this to check the reference on that second)
-  * `global` is Node's global namespace object. https://nodejs.org/api/globals.html#globals_global
-  *
-  * loading in this order should allow workers, which are most common, then browser, 
-  * then Node to grab the reference to fetch correctly. 
-  */
+   * `self` is the global namespace object used within a web worker.
+   * `window` is the browser's global namespace object (I reorganized this to check the reference on that second)
+   * `global` is Node's global namespace object. https://nodejs.org/api/globals.html#globals_global
+   *
+   * loading in this order should allow workers, which are most common, then browser,
+   * then Node to grab the reference to fetch correctly.
+   */
   const fetch =
     typeof self !== 'undefined'
       ? self?.fetch

--- a/src/compiler/sys/stencil-sys.ts
+++ b/src/compiler/sys/stencil-sys.ts
@@ -505,7 +505,14 @@ export const createSystem = (c?: { logger?: Logger }) => {
     return results;
   };
 
-  // Reference fetch from a worker thread, then a browser thread, then a node thread.
+  /**
+  * `self` is the global namespace object used within a web worker.
+  * `window` is the browser's global namespace object (I reorganized this to check the reference on that second)
+  * `global` is Node's global namespace object. https://nodejs.org/api/globals.html#globals_global
+  *
+  * loading in this order should allow workers, which are most common, then browser, 
+  * then Node to grab the reference to fetch correctly. 
+  */
   const fetch =
     typeof self !== 'undefined'
       ? self?.fetch

--- a/src/compiler/sys/stencil-sys.ts
+++ b/src/compiler/sys/stencil-sys.ts
@@ -505,7 +505,7 @@ export const createSystem = (c?: { logger?: Logger }) => {
     return results;
   };
 
-  const fetch = global.fetch;
+  const fetch = self?.fetch ?? global?.fetch ?? window?.fetch;
 
   const writeFile = async (p: string, data: string) => writeFileSync(p, data);
 

--- a/test/browser-compile/src/components/app-root/app-root.tsx
+++ b/test/browser-compile/src/components/app-root/app-root.tsx
@@ -57,7 +57,6 @@ export class AppRoot {
   }
 
   async compile() {
-    console.clear();
     console.log(`compile: stencil v${stencil.version}, typescript v${stencil.versions.typescript}`);
 
     const opts: StencilTypes.TranspileOptions = {

--- a/test/browser-compile/src/utils/css-template-plugin.ts
+++ b/test/browser-compile/src/utils/css-template-plugin.ts
@@ -70,7 +70,7 @@ export const cssTemplatePlugin = {
   async load(id: string) {
     let code = styleImports.get(id.split('?')[0]);
     if (code) {
-      const results = await stencil.compile(code, {
+      const results = await stencil.transpile(code, {
         file: id,
       });
       return results.code;


### PR DESCRIPTION
Closes #3011

The worker thread's in-memory system did not have the correct reference to fetch. 

How to test:
1. Check this branch out
2. Build the compiler with `npm run build`
3. Visit the `/test/browser-compile` directory. 
4. Run `npm i && npm start`
5. This app will display an app that runs the compiler in the browser. It lets you run the compiler with different settings. 

Originally, before this, the transpile results pane displayed empty and there were multiple errors in dev tools. 