### PR TITLE
fix(telemetry): handle malformed telemetry tokens 

### DIFF
--- a/src/cli/ionic-config.ts
+++ b/src/cli/ionic-config.ts
@@ -15,6 +15,11 @@ export interface TelemetryConfig {
   'tokens.telemetry'?: string;
 }
 
+/**
+ * Reads an Ionic configuration file from disk, parses it, and performs any necessary corrections to it if ceratin
+ * values are deemed to be malformed
+ * @returns the config read from disk that has been potentially been updated
+ */
 export async function readConfig(): Promise<TelemetryConfig> {
   let config: TelemetryConfig = await readJson(defaultConfig());
 
@@ -25,7 +30,10 @@ export async function readConfig(): Promise<TelemetryConfig> {
     };
 
     await writeConfig(config);
-  } else if (!!config && !config['tokens.telemetry'].match(UUID_REGEX)) {
+  } else if (
+    !!config &&
+    (typeof config['tokens.telemetry'] !== 'string' || !config['tokens.telemetry'].match(UUID_REGEX))
+  ) {
     const newUuid = uuidv4();
     await writeConfig({ ...config, 'tokens.telemetry': newUuid });
     config['tokens.telemetry'] = newUuid;

--- a/src/cli/ionic-config.ts
+++ b/src/cli/ionic-config.ts
@@ -30,10 +30,7 @@ export async function readConfig(): Promise<TelemetryConfig> {
     };
 
     await writeConfig(config);
-  } else if (
-    !!config &&
-    (typeof config['tokens.telemetry'] !== 'string' || !config['tokens.telemetry'].match(UUID_REGEX))
-  ) {
+  } else if (!UUID_REGEX.test(config['tokens.telemetry'])) {
     const newUuid = uuidv4();
     await writeConfig({ ...config, 'tokens.telemetry': newUuid });
     config['tokens.telemetry'] = newUuid;

--- a/src/cli/telemetry/helpers.ts
+++ b/src/cli/telemetry/helpers.ts
@@ -49,7 +49,12 @@ export function uuidv4(): string {
   });
 }
 
-export async function readJson(path: string) {
+/**
+ * Reads and parses a JSON file from the given `path`
+ * @param path the path on the file system to read and parse
+ * @returns the parsed JSON
+ */
+export async function readJson(path: string): Promise<any> {
   const file = await getCompilerSystem().readFile(path);
   return !!file && JSON.parse(file);
 }

--- a/src/cli/test/ionic-config.spec.ts
+++ b/src/cli/test/ionic-config.spec.ts
@@ -44,6 +44,29 @@ describe('readConfig', () => {
     expect(!!config['tokens.telemetry'].match(UUID_REGEX)).toBe(true);
   });
 
+  it('handles a non-string telemetry token', async () => {
+    // our typings state that `tokens.telemetry` is of type `string | undefined`, but technically this value could be
+    // anything. use `undefined` to make the typings happy (this should cover all non-string telemetry tokens). the
+    // important thing here is that the value is _not_ a string for this test!
+    await writeConfig({ 'telemetry.stencil': true, 'tokens.telemetry': undefined });
+
+    const config = await readConfig();
+
+    expect(Object.keys(config).join()).toBe('telemetry.stencil,tokens.telemetry');
+    expect(config['telemetry.stencil']).toBe(true);
+    expect(config['tokens.telemetry']).toMatch(UUID_REGEX);
+  });
+
+  it('handles a non-existent telemetry token', async () => {
+    await writeConfig({ 'telemetry.stencil': true });
+
+    const config = await readConfig();
+
+    expect(Object.keys(config).join()).toBe('telemetry.stencil,tokens.telemetry');
+    expect(config['telemetry.stencil']).toBe(true);
+    expect(config['tokens.telemetry']).toMatch(UUID_REGEX);
+  });
+
   it('should read a file if it exists', async () => {
     await writeConfig({ 'telemetry.stencil': true, 'tokens.telemetry': UUID1 });
 

--- a/src/cli/test/ionic-config.spec.ts
+++ b/src/cli/test/ionic-config.spec.ts
@@ -14,15 +14,14 @@ describe('readConfig', () => {
     args: [],
   });
 
+  beforeEach(async () => {
+    await getCompilerSystem().removeFile(defaultConfig());
+  });
+
   it('should create a file if it does not exist', async () => {
-    let result = await getCompilerSystem().stat(defaultConfig());
+    const result = await getCompilerSystem().stat(defaultConfig());
 
-    if (result.isFile) {
-      await getCompilerSystem().removeFile(defaultConfig());
-    }
-
-    result = await getCompilerSystem().stat(defaultConfig());
-
+    // expect the file to have been deleted by the test setup
     expect(result.isFile).toBe(false);
 
     const config = await readConfig();
@@ -30,10 +29,10 @@ describe('readConfig', () => {
     expect(Object.keys(config).join()).toBe('tokens.telemetry,telemetry.stencil');
   });
 
-  it('should fix the telemetry token if necessary', async () => {
+  it("should fix the telemetry token if it's a string, but an invalid UUID", async () => {
     await writeConfig({ 'telemetry.stencil': true, 'tokens.telemetry': 'aaaa' });
 
-    let result = await getCompilerSystem().stat(defaultConfig());
+    const result = await getCompilerSystem().stat(defaultConfig());
 
     expect(result.isFile).toBe(true);
 
@@ -41,7 +40,7 @@ describe('readConfig', () => {
 
     expect(Object.keys(config).join()).toBe('telemetry.stencil,tokens.telemetry');
     expect(config['telemetry.stencil']).toBe(true);
-    expect(!!config['tokens.telemetry'].match(UUID_REGEX)).toBe(true);
+    expect(config['tokens.telemetry']).toMatch(UUID_REGEX);
   });
 
   it('handles a non-string telemetry token', async () => {


### PR DESCRIPTION
Fixes: #3013 

**Summary:**

this fix handles the event that a user has an Ionic configuration file,
but does not have a 'tokens.telemetry' field in said file.

**Replication:**
With `master@HEAD`, modify your local `~/.ionic/config.json` in one of two ways
1. remove `'tokens.telemetry'` completely
2. set `'tokens.telemetry'` to undefined (or any other valid JSON)

Then, spin up a small Stencil project, and attempt to turn telemetry off/on:
 ```shell
$ cd <your_sandbox_dir>
$ npm init stencil
<create an ionic pwa app>
$ cd <your_app_name>
$ npx stencil telemetry on
[25:32.7]  @stencil/core
[25:32.8]  v2.7.0 🌟

[ ERROR ]  uncaught cli error: TypeError: Cannot read property 'match' of undefined
```

**Testing:**
With the HEAD of this branch, build it and install it in the PWA app you build
```shell
$ cd stencil
$ npm run build && npm pack
$ cd <your_sandbox_dir>/<your_app_name>
$ npm i <location_of_stencil_tarball>
$  ionic-pwa npx stencil telemetry on
[28:20.0]  @stencil/core
[28:20.1]  [LOCAL DEV] 🏆

Telemetry is now Enabled. Thank you for helping to make Stencil better! 💖
```