### PR TITLE
add merge-source-map to license file list

### DIFF
--- a/scripts/license.ts
+++ b/scripts/license.ts
@@ -18,6 +18,7 @@ const entryDeps = [
   'graceful-fs',
   'fast-deep-equal',
   'is-extglob',
+  'merge-source-map',
   'minimatch',
   'node-fetch',
   'open',


### PR DESCRIPTION
add merge-source-map to license file list, as it will be included in the
Stencil distribution

Note: This PR targets our ongoing effort to merge changes into the sourcemap PR