### PR TITLE
docs(license): add adr for license attribution

### DIFF
--- a/docs/adr/0008-license-attribution.md
+++ b/docs/adr/0008-license-attribution.md
@@ -1,0 +1,35 @@
+# 8. License Attribution
+
+Date: 2021-08-23
+
+## Status
+
+historical
+
+## Context
+
+Stencil is a distributable that contains third party packages that helps it compile projects. Examples include the 
+TypeScript compiler, rollup, etc. Those projects need to be properly attributed per their respective licenses.
+
+## Options
+
+N/A - the decision described this ADR predates the current Stencil team.
+
+## Decision
+
+Third party scripts that are included in the Stencil output shall be placed in the `entryDeps` field in a 
+[license generation script](../../scripts/license.ts). This script shall be responsible for generating `NOTICE.md` when
+a release of Stencil is generated, and any changes must be checked into source code.
+
+The license generation script shall recursively search the dependencies of the listed dependencies to ensure that all
+bundled source code is properly attributed.
+
+## Consequences
+
+When a third party package is bundled with Stencil, the onus is on the developers/reviewers to ensure that the package
+is added to the `entryDeps` field in the [license generation script](../../scripts/license.ts).
+
+## Links
+
+Source: [https://adr.github.io/](https://adr.github.io/)
+Template Source: [https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/templates/decision-record-template-by-michael-nygard/index.md](https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/templates/decision-record-template-by-michael-nygard/index.md)

--- a/docs/adr/0008-license-attribution.md
+++ b/docs/adr/0008-license-attribution.md
@@ -28,8 +28,3 @@ bundled source code is properly attributed.
 
 When a third party package is bundled with Stencil, the onus is on the developers/reviewers to ensure that the package
 is added to the `entryDeps` field in the [license generation script](../../scripts/license.ts).
-
-## Links
-
-Source: [https://adr.github.io/](https://adr.github.io/)
-Template Source: [https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/templates/decision-record-template-by-michael-nygard/index.md](https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/templates/decision-record-template-by-michael-nygard/index.md)

--- a/docs/adr/CONTRIBUTING.md
+++ b/docs/adr/CONTRIBUTING.md
@@ -18,6 +18,6 @@ We use the [Node version of ADR tools](https://github.com/phodal/adr), installab
 npm install -g adr
 ```
 
-And usable per their documentation. 
+And usable per their documentation. Note that the `adr` tool should be run from the root of this repository.
 
 You can search for ADR's by running `adr s "phrase"` e.g. `adr s "proposed"` to get all the proposed documents.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,3 +7,4 @@
 * [5. repo-structure](0005-repo-structure.md)
 * [6. organizing-utility-functions](0006-organizing-utility-functions.md)
 * [7. unit-testing-expectations](0007-unit-testing-expectations.md)
+* [8. license-attribution](0008-license-attribution.md)


### PR DESCRIPTION
add an ADR describing how third party projects that are bundled in the
Stencil distributable should be attributed. I confirmed this practice
with Adam as a part of #3016.