### PR TITLE
chore(sourcemaps): simplify transformation of sourcemaps

### DIFF
--- a/src/compiler/output-targets/dist-custom-elements-bundle/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements-bundle/index.ts
@@ -6,7 +6,7 @@ import {
   dashToPascalCase,
   formatComponentRuntimeMeta,
   hasError,
-  rollupSrcMapToObj,
+  rollupToStencilSourceMap,
   stringifyRuntimeData,
 } from '@utils';
 import { getCustomElementsBuildConditionals } from './custom-elements-build-conditionals';
@@ -80,7 +80,7 @@ const bundleCustomElements = async (
       const files = rollupOutput.output.map(async (bundle) => {
         if (bundle.type === 'chunk') {
           let code = bundle.code;
-          let sourceMap = rollupSrcMapToObj(bundle.map);
+          let sourceMap = rollupToStencilSourceMap(bundle.map);
           const optimizeResults = await optimizeModule(config, compilerCtx, {
             input: code,
             isCore: bundle.isEntry,

--- a/src/compiler/output-targets/dist-custom-elements/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements/index.ts
@@ -6,7 +6,7 @@ import {
   dashToPascalCase,
   formatComponentRuntimeMeta,
   hasError,
-  rollupSrcMapToObj,
+  rollupToStencilSourceMap,
   stringifyRuntimeData,
 } from '@utils';
 import { getCustomElementsBuildConditionals } from '../dist-custom-elements-bundle/custom-elements-build-conditionals';
@@ -76,7 +76,7 @@ const bundleCustomElements = async (
       const files = rollupOutput.output.map(async (bundle) => {
         if (bundle.type === 'chunk') {
           let code = bundle.code;
-          let sourceMap = rollupSrcMapToObj(bundle.map);
+          let sourceMap = rollupToStencilSourceMap(bundle.map);
           const optimizeResults = await optimizeModule(config, compilerCtx, {
             input: code,
             isCore: bundle.isEntry,

--- a/src/compiler/output-targets/dist-lazy/generate-lazy-module.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-lazy-module.ts
@@ -1,6 +1,6 @@
 import type * as d from '../../../declarations';
 import { writeLazyModule } from './write-lazy-entry-module';
-import { formatComponentRuntimeMeta, stringifyRuntimeData, hasDependency, rollupSrcMapToObj } from '@utils';
+import { formatComponentRuntimeMeta, stringifyRuntimeData, hasDependency, rollupToStencilSourceMap } from '@utils';
 import { optimizeModule } from '../../optimize/optimize-module';
 import { join } from 'path';
 import type { SourceMap as RollupSourceMap } from 'rollup';
@@ -321,7 +321,7 @@ const convertChunk = async (
   code: string,
   rollupSrcMap: RollupSourceMap
 ) => {
-  let sourceMap = rollupSrcMapToObj(rollupSrcMap);
+  let sourceMap = rollupToStencilSourceMap(rollupSrcMap);
   const inlineHelpers = isBrowserBuild || !hasDependency(buildCtx, 'tslib');
   const optimizeResults = await optimizeModule(config, compilerCtx, {
     input: code,

--- a/src/utils/sourcemaps.ts
+++ b/src/utils/sourcemaps.ts
@@ -1,9 +1,22 @@
 import type * as d from '../declarations';
 import type { SourceMap as RollupSourceMap } from 'rollup';
 
-export const rollupSrcMapToObj = (rollupSrcMap: RollupSourceMap): d.SourceMap => {
-  if (!rollupSrcMap) return null;
-  if (typeof rollupSrcMap.toUrl === 'function') return JSON.parse(rollupSrcMap.toString());
-  if (typeof rollupSrcMap === 'string') return JSON.parse(rollupSrcMap);
-  return rollupSrcMap;
+/**
+ * Converts a rollup provided source map to one that Stencil can easily understand
+ * @param rollupSourceMap the sourcemap to transform
+ * @returns the transformed sourcemap
+ */
+export const rollupToStencilSourceMap = (rollupSourceMap: RollupSourceMap | undefined): d.SourceMap => {
+  if (!rollupSourceMap) {
+    return null;
+  }
+
+  return {
+    file: rollupSourceMap.file,
+    mappings: rollupSourceMap.mappings,
+    names: rollupSourceMap.names,
+    sources: rollupSourceMap.sources,
+    sourcesContent: rollupSourceMap.sourcesContent,
+    version: rollupSourceMap.version,
+  };
 };

--- a/src/utils/test/sourcemaps.spec.ts
+++ b/src/utils/test/sourcemaps.spec.ts
@@ -1,0 +1,44 @@
+import { rollupToStencilSourceMap } from '@utils';
+import { SourceMap as RollupSourceMap } from 'rollup';
+import type * as d from '../../declarations';
+
+describe('sourcemaps', () => {
+  describe('rollupToStencilSourceMap', () => {
+    it('returns null if the given sourcemap is null', () => {
+      expect(rollupToStencilSourceMap(null)).toBeNull();
+    });
+
+    it('returns null if the given sourcemap is undefined', () => {
+      expect(rollupToStencilSourceMap(undefined)).toBeNull();
+    });
+
+    it('transforms a rollup sourcemap to a stencil sourcemap', () => {
+      const rollupSourceMap: RollupSourceMap = {
+        file: 'index.js',
+        mappings: ';;AAAA;AAC9D,GAAG,CAAC,CAAC;AACL;;;;',
+        names: ['bootstrapLazy'],
+        sources: ['"@lazy-external-entrypoint?app-data=conditional"'],
+        sourcesContent: [
+          '/*\\n Stencil Client Patch Esm v0.0.0-dev.20210825190806 | MIT Licensed | https://stenciljs.com\\n */',
+        ],
+        version: 3,
+        toString: () => 'stub',
+        toUrl: () => 'stub',
+      };
+
+      const stencilSourceMap: d.SourceMap = rollupToStencilSourceMap(rollupSourceMap);
+
+      const expectedSourceMap: d.SourceMap = {
+        file: 'index.js',
+        mappings: ';;AAAA;AAC9D,GAAG,CAAC,CAAC;AACL;;;;',
+        names: ['bootstrapLazy'],
+        sources: ['"@lazy-external-entrypoint?app-data=conditional"'],
+        sourcesContent: [
+          '/*\\n Stencil Client Patch Esm v0.0.0-dev.20210825190806 | MIT Licensed | https://stenciljs.com\\n */',
+        ],
+        version: 3,
+      };
+      expect(stencilSourceMap).toEqual(expectedSourceMap);
+    });
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/master/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm run test.karma.prod`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

simplify the transformation of sourcemaps by removing code paths that I
don't believe will be followed.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

do a 1:1 mapping of the rollup representation of a sourcemap to a Stencil one. I did briefly consider removing this altogether, but I think that there's value in having our own representation/abstraction to mitigate any damage that could be caused by the typings of a sourcemap in rollup occurring

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

After checking this commit out, I:
- installed dependencies (`npm ci`)
- built the project and generated the tarball for it (`npm run build && npm pack`)
- installed it on a fresh stencil project (`npm stencil init && npm i <PATH_TO_TARBALL>`)
- started the project (`npm start`)
- once Stencil's dev server had opened chrome, I opened dev tools and verified sourcemaps were still generated

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

N/A