### PR TITLE
docs(rollup): Add an ADR + JSDoc to the bundle-output.ts

### DIFF
--- a/docs/adr/0010-rollup-plugins-build-order.md
+++ b/docs/adr/0010-rollup-plugins-build-order.md
@@ -1,0 +1,31 @@
+# 10. Rollup plugins build order
+
+Date: 2021-08-25
+
+## Status
+
+historical
+
+## Context
+
+The order of rollup plugin execution during a build is not well documented as of 2021-08-25, nor why. The goal with this document is to clarify the order of the rollup plugins that get executed. It is also to provide further, though not perfect, clarity behind the purpose of each plugin and what it does, as well as where consumers can inject their rollup plugins. 
+
+Rollup Plugins with only load functions can be called in parallel, however the plugins with transforms are called in sequence. 
+
+## Options
+
+N/A
+
+## Decision
+
+This ADR covers the order of the [bundle-output.ts file](../../src/compiler/bundle/bundle-output.ts), which is called after each component has been transpiled by TypeScript. Within this ADR's PR, Stencil now has documentation that covers the rollup plugin order during a build's bundling process.  
+
+
+## Consequences
+
+1. We transform .json, .svg, and other files types to become ES Modules for bundling. 
+2. We provide a way for consumers to write web workers by processing the worker file imported with a `?worker` string. 
+3. 
+
+## Links
+

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -8,3 +8,4 @@
 * [6. organizing-utility-functions](0006-organizing-utility-functions.md)
 * [7. unit-testing-expectations](0007-unit-testing-expectations.md)
 * [8. license-attribution](0008-license-attribution.md)
+* [9. rollup-plugins-build-order](0009-rollup-plugins-build-order.md)

--- a/src/compiler/bundle/app-data-plugin.ts
+++ b/src/compiler/bundle/app-data-plugin.ts
@@ -12,6 +12,17 @@ import {
 } from './entry-alias-ids';
 import ts from 'typescript';
 
+/**
+ * This plugin will load up the app data and make some information available to the resultant build.
+ *
+ * It also does work on the Stencil consumer's globalScript file by loading and transpiling that file.
+ * @param config A Config object used to refer to the consumers settings. This config should have already been validated.
+ * @param compilerCtx The current Compiler's contextual settings.
+ * @param buildCtx The context of the current build.
+ * @param build Conditionals for the current build.
+ * @param platform The platform that this plugin was called from.
+ * @returns Plugin
+ */
 export const appDataPlugin = (
   config: d.Config,
   compilerCtx: d.CompilerCtx,

--- a/src/compiler/bundle/bundle-output.ts
+++ b/src/compiler/bundle/bundle-output.ts
@@ -84,36 +84,76 @@ export const getRollupOptions = (
   const beforePlugins = config.rollupPlugins.before || [];
   const afterPlugins = config.rollupPlugins.after || [];
   const rollupOptions: RollupOptions = {
+    // Includes all the changed files as a key/value library of module id's => paths.
     input: bundleOpts.inputs,
 
     plugins: [
+      // First, we run this to resolve the compiler code to the correct path depending on a few conditions.
       coreResolvePlugin(config, compilerCtx, bundleOpts.platform, bundleOpts.externalRuntime),
+
+      // We run this next because <reason>
       appDataPlugin(config, compilerCtx, buildCtx, bundleOpts.conditionals, bundleOpts.platform),
+
+      // We run this next because <reason>
       lazyComponentPlugin(buildCtx),
+
+      // We run this next because <reason>
       loaderPlugin(bundleOpts.loader),
+
+      // We run this next because <reason>
       userIndexPlugin(config, compilerCtx),
+
+      // We run this next because <reason>
       typescriptPlugin(compilerCtx, bundleOpts),
+
+      // We run this next because <reason>
       extFormatPlugin(config),
+
+      // We run this next because <reason>
       extTransformsPlugin(config, compilerCtx, buildCtx, bundleOpts),
+
+      // We run this next because <reason>
       workerPlugin(config, compilerCtx, buildCtx, bundleOpts.platform, !!bundleOpts.inlineWorkers),
+
+      // We run this next because <reason>
       serverPlugin(config, bundleOpts.platform),
+
+      // We run this next to give space for consumers to "prepend" their own rollup plugins. This happens here so that <reason>
       ...beforePlugins,
+
+      // We run this next to help rollup locate any other modules with node's algorithm to resolve third party plugins.
       nodeResolvePlugin,
+
+      // We run this next because <reason>
       resolveIdWithTypeScript(config, compilerCtx),
+
+      // We run this next Convert CommonJS modules to ES6 (why so late though?)
       rollupCommonjsPlugin({
         include: /node_modules/,
         sourceMap: config.sourceMap,
         transformMixedEsModules: false,
         ...config.commonjs,
       }),
+
+      // We run this next to give space for consumers to "append" their own rollup plugins. This happens here so that <reason>
       ...afterPlugins,
+
+      // We run this next because <reason>
       pluginHelper(config, buildCtx, bundleOpts.platform),
+
+      // We run this next to allow consumer's json files to be processed. It's run at this point because <reason>
       rollupJsonPlugin({
         preferConst: true,
       }),
+
+      /* Automatically replace all instances of "process.env.NODE_ENV" in components. Note that there are no delimeters.
+       * It's run at this point because this is near the final step in the compilation process.
+       */
       rollupReplacePlugin({
         'process.env.NODE_ENV': config.devMode ? '"development"' : '"production"',
       }),
+
+      // We run this next because <reason>
       fileLoadPlugin(compilerCtx.fs),
     ],
 

--- a/src/compiler/bundle/core-resolve-plugin.ts
+++ b/src/compiler/bundle/core-resolve-plugin.ts
@@ -15,6 +15,14 @@ import {
 } from './entry-alias-ids';
 import type { Plugin } from 'rollup';
 
+/**
+ * The Core Resolve plugin is used to get the correct core compiler code that should be used throughout the build process.
+ * @param config A Config object used to refer to the consumers settings. This config should have already been validated.
+ * @param compilerCtx The current Compiler's contextual settings.
+ * @param platform The platform that this plugin was called from.
+ * @param externalRuntime ???
+ * @returns Plugin
+ */
 export const coreResolvePlugin = (
   config: d.Config,
   compilerCtx: d.CompilerCtx,

--- a/src/compiler/bundle/ext-format-plugin.ts
+++ b/src/compiler/bundle/ext-format-plugin.ts
@@ -3,6 +3,13 @@ import { basename } from 'path';
 import { createJsVarName, normalizeFsPathQuery } from '@utils';
 import type { Plugin, TransformPluginContext } from 'rollup';
 
+/**
+ * Sanitizes and prepares external formats, like text files or SVG's, to be able to be processed in JS as an ES Module.
+ * Also runs some file size checking on those imported files to give consumer developers feedback.
+ *
+ * @param config A Config object used to refer to the consumers settings. This config should have already been validated.
+ * @returns Plugin
+ */
 export const extFormatPlugin = (config: d.Config): Plugin => {
   return {
     name: 'extFormatPlugin',

--- a/src/compiler/bundle/ext-transforms-plugin.ts
+++ b/src/compiler/bundle/ext-transforms-plugin.ts
@@ -7,6 +7,16 @@ import { parseImportPath } from '../transformers/stencil-import-path';
 import type { Plugin } from 'rollup';
 import { runPluginTransformsEsmImports } from '../plugin/plugin';
 
+/**
+ * Sanitizes and prepares external formats, like text files or SVG's to process in JS.
+ * Also runs some file size checking on those imported files to give consumer devs feedback.
+ *
+ * @param config A Config object used to refer to the consumers settings. This config should have already been validated.
+ * @param compilerCtx The current Compiler's contextual settings.
+ * @param buildCtx The context of the current build.
+ * @param bundleOpts The options used to inform how to produce the bundle.
+ * @returns
+ */
 export const extTransformsPlugin = (
   config: d.Config,
   compilerCtx: d.CompilerCtx,

--- a/src/compiler/bundle/file-load-plugin.ts
+++ b/src/compiler/bundle/file-load-plugin.ts
@@ -2,6 +2,11 @@ import type * as d from '../../declarations';
 import { normalizeFsPath } from '@utils';
 import type { Plugin } from 'rollup';
 
+/**
+ * Used to filter out .d.ts files from being loaded, but load everything else that matches. Seems to be a feature of incremental load.
+ * @param fs An in-memory file system shim must be passed to this.
+ * @returns
+ */
 export const fileLoadPlugin = (fs: d.InMemoryFileSystem): Plugin => {
   return {
     name: 'fileLoadPlugin',

--- a/src/compiler/bundle/loader-plugin.ts
+++ b/src/compiler/bundle/loader-plugin.ts
@@ -1,5 +1,11 @@
 import type { Plugin } from 'rollup';
 
+/**
+ * Prepares the loader, which helps with Webpack compilation when a consumer library is imported with webpack.
+ *
+ * @param entries A key/value library with an id of the name in the cache mapping to the filepath for each of the components that will be loaded.
+ * @returns
+ */
 export const loaderPlugin = (entries: { [id: string]: string } = {}): Plugin => {
   return {
     name: 'stencilLoaderPlugin',

--- a/src/compiler/bundle/plugin-helper.ts
+++ b/src/compiler/bundle/plugin-helper.ts
@@ -2,7 +2,21 @@ import type * as d from '../../declarations';
 import { buildError } from '@utils';
 import { relative } from 'path';
 
-export const pluginHelper = (config: d.Config, builtCtx: d.BuildCtx, platform: string) => {
+/**
+ * Check to confirm that no builtin modules are being processed.
+ * If so, prompt the user to install a module.
+ * See the bottom of the file where this plugin definition is
+ * located for the list that toggles the prompt.
+ *
+ * This plugin also has a side effect of cleaning up the import file
+ * name if it ends with a "/" character.
+ *
+ * @param config A Config object used to refer to the consumers settings. This config should have already been validated.
+ * @param buildCtx
+ * @param platform The platform that this plugin was called from.
+ * @returns
+ */
+export const pluginHelper = (config: d.Config, buildCtx: d.BuildCtx, platform: string) => {
   return {
     name: 'pluginHelper',
     resolveId(importee: string, importer: string): null {
@@ -20,7 +34,7 @@ export const pluginHelper = (config: d.Config, builtCtx: d.BuildCtx, platform: s
         if (importer) {
           fromMsg = ` from ${relative(config.rootDir, importer)}`;
         }
-        const diagnostic = buildError(builtCtx.diagnostics);
+        const diagnostic = buildError(buildCtx.diagnostics);
         diagnostic.header = `Node Polyfills Required`;
         diagnostic.messageText = `For the import "${importee}" to be bundled${fromMsg}, ensure the "rollup-plugin-node-polyfills" plugin is installed and added to the stencil config plugins (${platform}). Please see the bundling docs for more information.
         Further information: https://stenciljs.com/docs/module-bundling`;

--- a/src/compiler/bundle/server-plugin.ts
+++ b/src/compiler/bundle/server-plugin.ts
@@ -4,6 +4,15 @@ import type { Plugin } from 'rollup';
 import { isOutputTargetHydrate } from '../output-targets/output-utils';
 import { isAbsolute } from 'path';
 
+/**
+ * Used to filter out any imported paths that include ".server",
+ * colloquially referred to in this file as server only modules,
+ * so that the code in question is not included within a web build.
+ *
+ * @param config A Config object used to refer to the consumers settings. This config should have already been validated.
+ * @param platform The platform that this plugin was called from.
+ * @returns
+ */
 export const serverPlugin = (config: d.Config, platform: string): Plugin => {
   const isHydrateBundle = platform === 'hydrate';
   const serverVarid = `@removed-server-code`;

--- a/src/compiler/bundle/typescript-plugin.ts
+++ b/src/compiler/bundle/typescript-plugin.ts
@@ -7,6 +7,12 @@ import { tsResolveModuleName } from '../sys/typescript/typescript-resolve-module
 import { isAbsolute } from 'path';
 import ts from 'typescript';
 
+/**
+ * Handles all typescript compilation. After this, the compiled javascript code is available to be worked with.
+ * @param compilerCtx The current Compiler's contextual settings.
+ * @param bundleOpts The options used to inform how to produce the bundle.
+ * @returns Plugin
+ */
 export const typescriptPlugin = (compilerCtx: d.CompilerCtx, bundleOpts: BundleOptions): Plugin => {
   const tsPrinter = ts.createPrinter();
 
@@ -37,6 +43,12 @@ export const typescriptPlugin = (compilerCtx: d.CompilerCtx, bundleOpts: BundleO
   };
 };
 
+/**
+ * Resolve (what I can only infer from this function's internals) TypeScript definition files for rollup.
+ * @param config A Config object used to refer to the consumers settings. This config should have already been validated.
+ * @param compilerCtx The current Compiler's contextual settings.
+ * @returns
+ */
 export const resolveIdWithTypeScript = (config: d.Config, compilerCtx: d.CompilerCtx): Plugin => {
   return {
     name: `resolveIdWithTypeScript`,

--- a/src/compiler/bundle/user-index-plugin.ts
+++ b/src/compiler/bundle/user-index-plugin.ts
@@ -3,6 +3,14 @@ import type { Plugin } from 'rollup';
 import { USER_INDEX_ENTRY_ID } from './entry-alias-ids';
 import { join } from 'path';
 
+/**
+ * This is called to improve incremental builds... how? Unsure.
+ *
+ * This has something to do with the USER_INDEX_ENTRY_ID and it's resolved value of the index.ts file in a consumers app.
+ * @param config A Config object used to refer to the consumers settings. This config should have already been validated.
+ * @param compilerCtx The current Compiler's contextual settings.
+ * @returns
+ */
 export const userIndexPlugin = (config: d.Config, compilerCtx: d.CompilerCtx): Plugin => {
   return {
     name: 'userIndexPlugin',

--- a/src/compiler/bundle/worker-plugin.ts
+++ b/src/compiler/bundle/worker-plugin.ts
@@ -5,6 +5,16 @@ import { normalizeFsPath, hasError } from '@utils';
 import { optimizeModule } from '../optimize/optimize-module';
 import { STENCIL_INTERNAL_ID } from './entry-alias-ids';
 
+/**
+ * Runs transforms to help support web workers in consumer components.
+ *
+ * @param config A Config object used to refer to the consumers settings. This config should have already been validated.
+ * @param compilerCtx The current Compiler's contextual settings.
+ * @param buildCtx The context of the current build.
+ * @param platform The platform that this plugin was called from.
+ * @param inlineWorkers ???
+ * @returns
+ */
 export const workerPlugin = (
   config: d.Config,
   compilerCtx: d.CompilerCtx,

--- a/src/compiler/output-targets/dist-lazy/lazy-component-plugin.ts
+++ b/src/compiler/output-targets/dist-lazy/lazy-component-plugin.ts
@@ -2,6 +2,11 @@ import type * as d from '../../../declarations';
 import { normalizePath } from '@utils';
 import type { Plugin } from 'rollup';
 
+/**
+ * Includes consumer components and resolves them as a part of TypeScript's incremental builds feature.
+ * @param buildCtx The context of the current build
+ * @returns Plugin
+ */
 export const lazyComponentPlugin = (buildCtx: d.BuildCtx) => {
   const entrys = new Map<string, d.EntryModule>();
 


### PR DESCRIPTION
The goal of this ADR is to provide clarity around why the order of rollup plugins are executed during a build.  

This ADR will be a work in progress for a while, I imagine. The end goal of this is to have each rollup plugin documented, and the order of which communicated to the team. 

If you would like to contribute, please either comment your perspective of leave a PR pointing to the `adr-rollup-plugins-ordering` branch - that's highly encouraged. 