### PR TITLE
chore(config): coerce sourceMap config value to boolean 

### DIFF
--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -372,21 +372,21 @@ describe('validation', () => {
   });
 
   describe('sourceMap', () => {
-    it('set sourceMap true', () => {
+    it('sets the field to true when the set to true in the config', () => {
       userConfig.sourceMap = true;
       const { config } = validateConfig(userConfig);
       expect(config.sourceMap).toBe(true);
     });
 
-    it('set sourceMap false', () => {
+    it('sets the field to false when set to false in the config', () => {
       userConfig.sourceMap = false;
       const { config } = validateConfig(userConfig);
       expect(config.sourceMap).toBe(false);
     });
 
-    it('default sourceMap undefined', () => {
+    it('defaults the field to false when not set in the config', () => {
       const { config } = validateConfig(userConfig);
-      expect(config.sourceMap).toBe(undefined);
+      expect(config.sourceMap).toBe(false);
     });
   });
 });

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -45,7 +45,7 @@ export const validateConfig = (userConfig?: Config) => {
 
   setBooleanConfig(config, 'minifyCss', null, !config.devMode);
   setBooleanConfig(config, 'minifyJs', null, !config.devMode);
-  setBooleanConfig(config, 'sourceMap', null, config.sourceMap);
+  setBooleanConfig(config, 'sourceMap', null, typeof config.sourceMap === 'undefined' ? false : config.sourceMap);
   setBooleanConfig(config, 'watch', 'watch', false);
   setBooleanConfig(config, 'buildDocs', 'docs', !config.devMode);
   setBooleanConfig(config, 'buildDist', 'esm', !config.devMode || config.buildEs5);

--- a/src/compiler/optimize/optimize-module.ts
+++ b/src/compiler/optimize/optimize-module.ts
@@ -95,7 +95,7 @@ export const getTerserOptions = (config: Config, sourceTarget: SourceTarget, pre
     ie8: false,
     safari10: !!config.extras.safari10,
     format: {},
-    sourceMap: !!config.sourceMap,
+    sourceMap: config.sourceMap,
   };
 
   if (sourceTarget === 'es5') {

--- a/src/compiler/output-targets/dist-custom-elements-bundle/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements-bundle/index.ts
@@ -33,12 +33,12 @@ export const outputCustomElementsBundle = async (
   }
 
   const timespan = buildCtx.createTimeSpan(
-    `generate custom elements bundle${!!config.sourceMap ? ' + source maps' : ''} started`
+    `generate custom elements bundle${config.sourceMap ? ' + source maps' : ''} started`
   );
 
   await Promise.all(outputTargets.map((o) => bundleCustomElements(config, compilerCtx, buildCtx, o)));
 
-  timespan.finish(`generate custom elements bundle${!!config.sourceMap ? ' + source maps' : ''} finished`);
+  timespan.finish(`generate custom elements bundle${config.sourceMap ? ' + source maps' : ''} finished`);
 };
 
 const bundleCustomElements = async (

--- a/src/compiler/output-targets/dist-lazy/generate-cjs.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-cjs.ts
@@ -21,7 +21,7 @@ export const generateCjs = async (
       entryFileNames: '[name].cjs.js',
       assetFileNames: '[name]-[hash][extname]',
       preferConst: true,
-      sourcemap: !!config.sourceMap,
+      sourcemap: config.sourceMap,
     };
     const results = await generateRollupOutput(rollupBuild, esmOpts, config, buildCtx.entryModules);
     if (results != null) {

--- a/src/compiler/output-targets/dist-lazy/generate-esm-browser.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-esm-browser.ts
@@ -20,7 +20,7 @@ export const generateEsmBrowser = async (
       chunkFileNames: config.hashFileNames ? 'p-[hash].js' : '[name]-[hash].js',
       assetFileNames: config.hashFileNames ? 'p-[hash][extname]' : '[name]-[hash][extname]',
       preferConst: true,
-      sourcemap: !!config.sourceMap,
+      sourcemap: config.sourceMap,
     };
     if (config.extras.dynamicImportShim) {
       // for Edge 16-18

--- a/src/compiler/output-targets/dist-lazy/generate-esm.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-esm.ts
@@ -21,7 +21,7 @@ export const generateEsm = async (
       entryFileNames: '[name].js',
       assetFileNames: '[name]-[hash][extname]',
       preferConst: true,
-      sourcemap: !!config.sourceMap,
+      sourcemap: config.sourceMap,
     };
     const outputTargetType = esmOutputs[0].type;
     const output = await generateRollupOutput(rollupBuild, esmOpts, config, buildCtx.entryModules);

--- a/src/compiler/output-targets/dist-lazy/generate-system.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-system.ts
@@ -22,7 +22,7 @@ export const generateSystem = async (
       chunkFileNames: config.hashFileNames ? 'p-[hash].system.js' : '[name]-[hash].system.js',
       assetFileNames: config.hashFileNames ? 'p-[hash][extname]' : '[name]-[hash][extname]',
       preferConst: true,
-      sourcemap: !!config.sourceMap,
+      sourcemap: config.sourceMap,
     };
     const results = await generateRollupOutput(rollupBuild, esmOpts, config, buildCtx.entryModules);
     if (results != null) {

--- a/src/compiler/output-targets/dist-lazy/lazy-output.ts
+++ b/src/compiler/output-targets/dist-lazy/lazy-output.ts
@@ -30,7 +30,7 @@ export const outputLazy = async (config: d.Config, compilerCtx: d.CompilerCtx, b
     return;
   }
 
-  const timespan = buildCtx.createTimeSpan(`generate lazy${!!config.sourceMap ? ' + source maps' : ''} started`);
+  const timespan = buildCtx.createTimeSpan(`generate lazy${config.sourceMap ? ' + source maps' : ''} started`);
 
   try {
     // const criticalBundles = getCriticalPath(buildCtx);
@@ -75,7 +75,7 @@ export const outputLazy = async (config: d.Config, compilerCtx: d.CompilerCtx, b
     catchError(buildCtx.diagnostics, e);
   }
 
-  timespan.finish(`generate lazy${!!config.sourceMap ? ' + source maps' : ''} finished`);
+  timespan.finish(`generate lazy${config.sourceMap ? ' + source maps' : ''} finished`);
 };
 
 const getLazyCustomTransformer = (config: d.Config, compilerCtx: d.CompilerCtx) => {

--- a/src/compiler/sys/typescript/typescript-config.ts
+++ b/src/compiler/sys/typescript/typescript-config.ts
@@ -93,8 +93,8 @@ export const validateTsConfig = async (config: d.Config, sys: d.CompilerSystem, 
             warn.messageText = `To improve bundling, it is always recommended to set the tsconfig.json “module” setting to “esnext”. Note that the compiler will automatically handle bundling both modern and legacy builds.`;
           }
 
-          tsconfig.compilerOptions.sourceMap = !!config.sourceMap;
-          tsconfig.compilerOptions.inlineSources = !!config.sourceMap;
+          tsconfig.compilerOptions.sourceMap = config.sourceMap;
+          tsconfig.compilerOptions.inlineSources = config.sourceMap;
         }
       }
     }
@@ -152,8 +152,8 @@ const createDefaultTsConfig = (config: d.Config) =>
         jsx: 'react',
         jsxFactory: 'h',
         jsxFragmentFactory: 'Fragment',
-        sourceMap: !!config.sourceMap,
-        inlineSources: !!config.sourceMap,
+        sourceMap: config.sourceMap,
+        inlineSources: config.sourceMap,
       },
       include: [relative(config.rootDir, config.srcDir)],
     },

--- a/src/compiler/transpile/ts-config.ts
+++ b/src/compiler/transpile/ts-config.ts
@@ -10,8 +10,8 @@ export const getTsOptionsToExtend = (config: d.Config) => {
     moduleResolution: ts.ModuleResolutionKind.NodeJs,
     noEmitOnError: false,
     outDir: config.cacheDir || config.sys.tmpDirSync(),
-    sourceMap: !!config.sourceMap,
-    inlineSources: !!config.sourceMap,
+    sourceMap: config.sourceMap,
+    inlineSources: config.sourceMap,
   };
   return tsOptions;
 };


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/master/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm run test.karma.prod`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`config.sourcemap` can be either `undefined | true | false` when a user's configuration is validated. I'd prefer to narrow that to a boolean, even if we don't strictly do that using the type system right now. See [this comment](https://github.com/ionic-team/stencil/pull/3005#discussion_r697615319) in the parent PR that expounds upon this

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

ensure that upon validating a user's stencil config, the value of the
'sourcemap' field is never undefined.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

After checking this commit out, I:
- installed dependencies (`npm ci`)
- built the project and generated the tarball for it (`npm run build && npm pack`)
- installed it on a fresh stencil project (`npm stencil init && npm i <PATH_TO_TARBALL>`)
- started the project (`npm start`)
- once Stencil's dev server had opened chrome, I opened dev tools and verified sourcemaps were still generated

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

N/A