### PR TITLE
chore(types): updating typings for merge-source-map

### DIFF
--- a/src/compiler/optimize/optimize-module.ts
+++ b/src/compiler/optimize/optimize-module.ts
@@ -170,7 +170,7 @@ export const prepareModule = async (
     if (tsResults.sourceMapText) {
       // need to merge sourcemaps at this point
       const mergeMap = sourceMapMerge(
-        (minifyOpts.sourceMap as SourceMapOptions).content as SourceMap,
+        (minifyOpts.sourceMap as SourceMapOptions)?.content as SourceMap,
         JSON.parse(tsResults.sourceMapText)
       ) as SourceMap;
       minifyOpts.sourceMap = { content: mergeMap };

--- a/types/merge-source-map.d.ts
+++ b/types/merge-source-map.d.ts
@@ -23,9 +23,9 @@ declare module 'merge-source-map' {
    *
    * @param oldMap the original sourcemap to merge
    * @param newMap the new sourcemap to merge with the `oldMap`
-   * @returns the merged sourcemap
+   * @returns the merged sourcemap, or undefined if both maps are falsy
    */
-  function merge(oldMap: MergeSourceMap, newMap: MergeSourceMap): MergeSourceMap;
+  function merge(oldMap: MergeSourceMap, newMap: MergeSourceMap): MergeSourceMap | undefined;
 
   /**
    * mark the `merge` function as the default export of the module, so that the JSDoc for `merge` is properly picked up

--- a/types/merge-source-map.d.ts
+++ b/types/merge-source-map.d.ts
@@ -1,6 +1,11 @@
-
+/**
+ * Ambient module declaration for the [merge-source-map library](https://github.com/keik/merge-source-map).
+ *
+ * At the time of this writing, no official nor third party type declaration files exist for v1.1.0 of library, and are
+ * recreated here for type safety purposes.
+ */
 declare module 'merge-source-map' {
-  interface SourceMap {
+  interface MergeSourceMap {
     file: string;
     mappings: string;
     names: string[];
@@ -10,8 +15,21 @@ declare module 'merge-source-map' {
     version: number;
   }
 
-  namespace merge {}
-  function merge(oldMap: SourceMap, newMap: SourceMap): SourceMap;
+  /**
+   * Merge an existing sourcemap with a new one
+   *
+   * This type declaration differs from the output of running `tsc -d` on the entrypoint of the merge-source-map
+   * module. It prefers concrete `MergeSourceMap` formal arguments over `(object | string)`.
+   *
+   * @param oldMap the original sourcemap to merge
+   * @param newMap the new sourcemap to merge with the `oldMap`
+   * @returns the merged sourcemap
+   */
+  function merge(oldMap: MergeSourceMap, newMap: MergeSourceMap): MergeSourceMap;
 
+  /**
+   * mark the `merge` function as the default export of the module, so that the JSDoc for `merge` is properly picked up
+   * by IntelliSense
+   */
   export = merge;
 }

--- a/types/merge-source-map.d.ts
+++ b/types/merge-source-map.d.ts
@@ -5,16 +5,6 @@
  * recreated here for type safety purposes.
  */
 declare module 'merge-source-map' {
-  interface MergeSourceMap {
-    file: string;
-    mappings: string;
-    names: string[];
-    sourceRoot?: string;
-    sources: string[];
-    sourcesContent?: string[];
-    version: number;
-  }
-
   /**
    * Merge an existing sourcemap with a new one
    *
@@ -25,7 +15,10 @@ declare module 'merge-source-map' {
    * @param newMap the new sourcemap to merge with the `oldMap`
    * @returns the merged sourcemap, or undefined if both maps are falsy
    */
-  function merge(oldMap: MergeSourceMap, newMap: MergeSourceMap): MergeSourceMap | undefined;
+  function merge(
+    oldMap: import('../src/declarations').SourceMap,
+    newMap: import('../src/declarations').SourceMap
+  ): import('../src/declarations').SourceMap | undefined;
 
   /**
    * mark the `merge` function as the default export of the module, so that the JSDoc for `merge` is properly picked up


### PR DESCRIPTION
this PR makes changes to the Stencil-defined type declaration file for `merge-source-map`

`merge-source-map` does not offer any `d.ts` file, nor does it have a third party offering on Definitely Typed, so the intent of this effort was to see "how correct is our type definition for our use case, while not deviating from the actual library's implicit typings".

I _did_ try to ask the compiler to generate the `d.ts` file for me with `tsc -d node_modules/merge-source-map/index.js --allowJs --outDir ./out`, which generated invalid TS:
```typescript
export = merge;
/**
 * Merge old source map and new source map and return merged.
 * If old or new source map value is falsy, return another one as it is.
 *
 * @param {object|string} [oldMap] old source map object
 * @param {object|string} [newmap] new source map object
 * @return {object|undefined} merged source map object, or undefined when both old and new source map are undefined
 */
declare function merge(oldMap?: object | string, newMap: any): object | undefined;
```
(the invalid part being you can't have a non-optional type following an optional one). I can always tweak _that_ and use that if folks prefer it.
