### PR TITLE
feat(markdown): improved export to markdown

### DIFF
--- a/src/compiler/docs/readme/docs-util.ts
+++ b/src/compiler/docs/readme/docs-util.ts
@@ -31,7 +31,7 @@ export class MarkdownTable {
 
 const escapeMarkdownTableColumn = (text: string) => {
   text = text.replace(/\r?\n/g, ' ');
-  text = text.replace(/\|/g, '\\|');
+  text = text.replace(/\|/g, '&#124;');
   return text;
 };
 

--- a/src/compiler/docs/readme/markdown-css-props.ts
+++ b/src/compiler/docs/readme/markdown-css-props.ts
@@ -14,7 +14,7 @@ export const stylesToMarkdown = (styles: d.JsonDocsStyle[]) => {
   table.addHeader(['Name', 'Description']);
 
   styles.forEach((style) => {
-    table.addRow([`\`${style.name}\``, style.docs]);
+    table.addRow([`<code>${style.name}</code>`, style.docs]);
   });
 
   content.push(...table.toMarkdown());

--- a/src/compiler/docs/readme/markdown-events.ts
+++ b/src/compiler/docs/readme/markdown-events.ts
@@ -15,7 +15,7 @@ export const eventsToMarkdown = (events: d.JsonDocsEvent[]) => {
   table.addHeader(['Event', 'Description', 'Type']);
 
   events.forEach((ev) => {
-    table.addRow([`\`${ev.event}\``, getDocsField(ev), `\`CustomEvent<${ev.detail}>\``]);
+    table.addRow([`<code>${ev.event}</code>`, getDocsField(ev), `<code>CustomEvent<${ev.detail}></code>`]);
   });
 
   content.push(...table.toMarkdown());

--- a/src/compiler/docs/readme/markdown-methods.ts
+++ b/src/compiler/docs/readme/markdown-methods.ts
@@ -11,7 +11,7 @@ export const methodsToMarkdown = (methods: d.JsonDocsMethod[]) => {
   content.push(``);
 
   methods.forEach((method) => {
-    content.push(`### \`${method.signature}\``);
+    content.push(`### <code>${method.signature}</code>`);
     content.push(``);
     content.push(getDocsField(method));
     content.push(``);
@@ -34,7 +34,7 @@ export const methodsToMarkdown = (methods: d.JsonDocsMethod[]) => {
     if (method.returns) {
       content.push(`#### Returns`);
       content.push(``);
-      content.push(`Type: \`${method.returns.type}\``);
+      content.push(`Type: <code>${method.returns.type}</code>`);
       content.push(``);
       content.push(method.returns.docs);
       content.push(``);

--- a/src/compiler/docs/readme/markdown-parts.ts
+++ b/src/compiler/docs/readme/markdown-parts.ts
@@ -14,7 +14,7 @@ export const partsToMarkdown = (parts: d.JsonDocsSlot[]) => {
   table.addHeader(['Part', 'Description']);
 
   parts.forEach((style) => {
-    table.addRow([style.name === '' ? '' : `\`"${style.name}"\``, style.docs]);
+    table.addRow([style.name === '' ? '' : `<code>"${style.name}"</code>`, style.docs]);
   });
 
   content.push(...table.toMarkdown());

--- a/src/compiler/docs/readme/markdown-props.ts
+++ b/src/compiler/docs/readme/markdown-props.ts
@@ -19,8 +19,8 @@ export const propsToMarkdown = (props: d.JsonDocsProp[]) => {
       getPropertyField(prop),
       getAttributeField(prop),
       getDocsField(prop),
-      `\`${prop.type}\``,
-      `\`${prop.default}\``,
+      `<code>${prop.type}</code>`,
+      `<code>${prop.default}</code>`,
     ]);
   });
 
@@ -32,11 +32,11 @@ export const propsToMarkdown = (props: d.JsonDocsProp[]) => {
 };
 
 const getPropertyField = (prop: d.JsonDocsProp) => {
-  return `\`${prop.name}\`${prop.required ? ' _(required)_' : ''}`;
+  return `<code>${prop.name}</code>${prop.required ? ' _(required)_' : ''}`;
 };
 
 const getAttributeField = (prop: d.JsonDocsProp) => {
-  return prop.attr ? `\`${prop.attr}\`` : '--';
+  return prop.attr ? `<code>${prop.attr}</code>` : '--';
 };
 
 const getDocsField = (prop: d.JsonDocsProp) => {

--- a/src/compiler/docs/readme/markdown-slots.ts
+++ b/src/compiler/docs/readme/markdown-slots.ts
@@ -14,7 +14,7 @@ export const slotsToMarkdown = (slots: d.JsonDocsSlot[]) => {
   table.addHeader(['Slot', 'Description']);
 
   slots.forEach((style) => {
-    table.addRow([style.name === '' ? '' : `\`"${style.name}"\``, style.docs]);
+    table.addRow([style.name === '' ? '' : `<code>"${style.name}"</code>`, style.docs]);
   });
 
   content.push(...table.toMarkdown());

--- a/src/compiler/docs/test/markdown-props.spec.ts
+++ b/src/compiler/docs/test/markdown-props.spec.ts
@@ -32,10 +32,10 @@ describe('markdown props', () => {
     ]).join('\n');
     expect(markdown).toEqual(`## Properties
 
-| Property | Attribute | Description    | Type                | Default |
-| -------- | --------- | -------------- | ------------------- | ------- |
-| \`hello\`  | \`hello\`   | This is a prop | \`boolean \\| string\` | \`false\` |
-| \`hello\`  | --        | This is a prop | \`boolean \\| string\` | \`false\` |
+| Property           | Attribute          | Description    | Type                               | Default            |
+| ------------------ | ------------------ | -------------- | ---------------------------------- | ------------------ |
+| <code>hello</code> | <code>hello</code> | This is a prop | <code>boolean &#124; string</code> | <code>false</code> |
+| <code>hello</code> | --                 | This is a prop | <code>boolean &#124; string</code> | <code>false</code> |
 
 `);
   });


### PR DESCRIPTION
This PR will improve the generation of `readme.md` and make the MD tables more universal.
Some MD editors do not respect  `\|` (e.g. JetBrains WebStorm)

```md
| Property | Attribute | Description    | Type                | Default |
| -------- | --------- | -------------- | ------------------- | ------- |
| `hello`  | `hello`   | This is a prop | `boolean \| string` | `false` |
| `hello`  | --        | This is a prop | `boolean \| string` | `false` |


| Property           | Attribute          | Description    | Type                               | Default            |
| ------------------ | ------------------ | -------------- | ---------------------------------- | ------------------ |
| <code>hello</code> | <code>hello</code> | This is a prop | <code>boolean &#124; string</code> | <code>false</code> |
| <code>hello</code> | --                 | This is a prop | <code>boolean &#124; string</code> | <code>false</code> |
```