### PR TITLE
chore(ionitron): remove 'awaiting reply' on comment from issues

### DIFF
--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -34,7 +34,7 @@ noReply:
   lock: false
   message: >
     Hey there! Just a friendly reminder that the Stencil team would like some additional
-    input on this issue. Thanks!
+    input on this issue. Thank you!
   dryRun: false
 
 stale:

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -34,7 +34,7 @@ noReply:
   dryRun: false
 
 stale:
-  days: 30
+  days: 180
   maxIssuesPerRun: 100
   exemptLabels:
     - good first issue

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -25,12 +25,16 @@ closeAndLock:
   dryRun: false
 
 noReply:
+  days: 30
   maxIssuesPerRun: 100
   includePullRequests: false
   label: Awaiting Reply
   responseLabel: Reply Received
   close: false
   lock: false
+  message: >
+    Hey there! Just a friendly reminder that the Stencil team would like some additional
+    input on this issue. Thanks!
   dryRun: false
 
 stale:

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -25,16 +25,12 @@ closeAndLock:
   dryRun: false
 
 noReply:
-  days: 30
   maxIssuesPerRun: 100
   includePullRequests: false
   label: Awaiting Reply
   responseLabel: Reply Received
   close: false
   lock: false
-  message: >
-    Hey there! Just a friendly reminder that the Stencil team would like some additional
-    input on this issue. Thank you!
   dryRun: false
 
 stale:

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -24,12 +24,22 @@ closeAndLock:
   lock: true
   dryRun: false
 
+noReply:
+  maxIssuesPerRun: 100
+  includePullRequests: false
+  label: Awaiting Reply
+  responseLabel: Reply Received
+  close: false
+  lock: false
+  dryRun: false
+
 stale:
   days: 30
   maxIssuesPerRun: 100
   exemptLabels:
-    - help wanted
     - good first issue
+    - help wanted
+    - Reply Received
     - triage
   exemptAssigned: true
   exemptProjects: true


### PR DESCRIPTION
this PR is the first step in trying to improve our automation in GitHub.
it removes the 'Awaiting Reply' label and replaces it with the 'Reply
Received' label when an individual replies to a GitHub issue via a
comment.

this PR also prevents issues that are tagged with 'Reply Received' from
being culled by the stale issue configuration.

this is a first step in improving our workflow. this PR does not cover
every possibility/scenario for interacting with the community.