### PR TITLE
chore(build): fixup release scripts 

### DIFF
--- a/scripts/license.ts
+++ b/scripts/license.ts
@@ -114,6 +114,7 @@ ${bundledDeps.map((l) => l.content).join('\n')}
 
 /**
  * Generate license metadata for a series of dependencies
+ * @param opts metadata used during the generation of a license
  * @param bundledDeps the current list of dependencies to bundle
  * @param deps the dependencies to generate metadata for
  */

--- a/scripts/release-tasks.ts
+++ b/scripts/release-tasks.ts
@@ -200,7 +200,7 @@ export function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<string>)
           if (isDryRun) {
             return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
           }
-          return execa('git', cmdArgs, { cwd: rootDir });
+          return execa(cmd, cmdArgs, { cwd: rootDir });
         },
       },
       {
@@ -212,7 +212,7 @@ export function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<string>)
           if (isDryRun) {
             return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
           }
-          return execa('git', cmdArgs, { cwd: rootDir });
+          return execa(cmd, cmdArgs, { cwd: rootDir });
         },
       }
     );
@@ -221,13 +221,13 @@ export function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<string>)
       tasks.push({
         title: 'Also set "next" npm tag on @stencil/core',
         task: () => {
-          const cmd = 'git';
+          const cmd = 'npm';
           const cmdArgs = ['dist-tag', 'add', '@stencil/core@' + opts.version, 'next'];
 
           if (isDryRun) {
             return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
           }
-          return execa('npm', cmdArgs, { cwd: rootDir });
+          return execa(cmd, cmdArgs, { cwd: rootDir });
         },
       });
     }

--- a/scripts/release-tasks.ts
+++ b/scripts/release-tasks.ts
@@ -151,14 +151,9 @@ export function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<string>)
       },
       {
         title: `Set package.json version to ${color.bold.yellow(opts.version)}`,
-        task: () => {
-          const packageJson = JSON.parse(fs.readFileSync(opts.packageJsonPath, 'utf8'));
-          packageJson.version = opts.version;
-          fs.writeFileSync(opts.packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
-
-          const packageLockJson = JSON.parse(fs.readFileSync(opts.packageLockJsonPath, 'utf8'));
-          packageLockJson.version = opts.version;
-          fs.writeFileSync(opts.packageLockJsonPath, JSON.stringify(packageLockJson, null, 2) + '\n');
+        task: async () => {
+          // use `--no-git-tag-version` to ensure that the tag for the release is not prematurely created
+          await execa('npm', ['version', '--no-git-tag-version', opts.version], { cwd: rootDir });
         },
       },
       {

--- a/scripts/release-tasks.ts
+++ b/scripts/release-tasks.ts
@@ -15,7 +15,7 @@ import { createLicense } from './license';
 import { bundleBuild } from './build';
 
 /**
- * Runs a littany of tasks used to ensure a safe release of a new version of Stencil
+ * Runs a litany of tasks used to ensure a safe release of a new version of Stencil
  * @param opts build options containing the metadata needed to release a new version of Stencil
  * @param args stringified arguments used to influence the release steps that are taken
  */

--- a/scripts/utils/release-utils.ts
+++ b/scripts/utils/release-utils.ts
@@ -125,7 +125,14 @@ export async function postGithubRelease(opts: BuildOptions): Promise<void> {
   // https://docs.github.com/en/github/administering-a-repository/automation-for-release-forms-with-query-parameters
   const url = new URL(`https://github.com/${opts.ghRepoOrg}/${opts.ghRepoName}/releases/new`);
   url.searchParams.set('tag', versionTag);
-  url.searchParams.set('title', title);
+
+  const now = new Date();
+  let timestamp = now.getUTCFullYear() + '-';
+  timestamp += ('0' + (now.getUTCMonth() + 1)).slice(-2) + '-';
+  timestamp += ('0' + now.getUTCDate()).slice(-2);
+
+  url.searchParams.set('title', encodeURIComponent(`${title} (${timestamp})`));
+
   url.searchParams.set('body', body.trim());
   if (opts.tag === 'next' || opts.tag === 'test') {
     url.searchParams.set('prerelease', '1');

--- a/scripts/utils/release-utils.ts
+++ b/scripts/utils/release-utils.ts
@@ -91,7 +91,7 @@ export function prettyVersionDiff(oldVersion: string, inc: any): string {
 }
 
 /**
- * Write CHANGELOG.md to disk. Stencil uses the Angular-variant of convential commits; commits must be formatted
+ * Write CHANGELOG.md to disk. Stencil uses the Angular-variant of conventional commits; commits must be formatted
  * accordingly in order to be added to the changelog properly.
  * @param opts build options to be used to update the changelog
  */

--- a/scripts/utils/release-utils.ts
+++ b/scripts/utils/release-utils.ts
@@ -126,10 +126,7 @@ export async function postGithubRelease(opts: BuildOptions): Promise<void> {
   const url = new URL(`https://github.com/${opts.ghRepoOrg}/${opts.ghRepoName}/releases/new`);
   url.searchParams.set('tag', versionTag);
 
-  const now = new Date();
-  let timestamp = now.getUTCFullYear() + '-';
-  timestamp += ('0' + (now.getUTCMonth() + 1)).slice(-2) + '-';
-  timestamp += ('0' + now.getUTCDate()).slice(-2);
+  const timestamp = new Date().toISOString().substring(0, 10);
 
   url.searchParams.set('title', encodeURIComponent(`${title} (${timestamp})`));
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/master/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 



Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

This PR fixes minor issues with the existing release scripts. There are additional things the team would like to do in this domain, but I held off from bloating scope of this PR _too_ much. 

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

 Each commit consists of one type of change:
- https://github.com/ionic-team/stencil/commit/8d44ca0c5a9e81f829bac0dfd1c67996e1e34cce is just typo fixes
- https://github.com/ionic-team/stencil/commit/76d19f8990d60fbfbb08b66aa07b5557d7253378 ends writing `package-lock.json` and `package.json` in full, and fixes the issue where in the V2 of a lockfile, we had to manually update one of the package versions
- https://github.com/ionic-team/stencil/commit/3766d92c8ee188aafb02826af90941d460f0d170 programmatically adds the date in ISO-8601 to the GitHub release title
  - There is some copy paste of the date generation logic here, but it didn't feel significant enough to refactor into a common util, plus changing a common util could make it harder to detect potential breakages when used in the release (because we cut a release only every few weeks)
- https://github.com/ionic-team/stencil/commit/5d7c090bf32d0ef2a4b39d159f23af8fa6bfb294 uniformly uses `cmd` variables for debugging/running a command

## Does this introduce a breaking change?

- [ ] Yes
- [x] No - if someone is parsing our GH releases page, _maybe_, but we don't make any guarantees here

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. -->

- Described inline for each testable change (see my comments)
## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
