### PR TITLE
chore(fixups): minor sourcemap fixups

### DIFF
--- a/src/compiler/app-core/bundle-app-core.ts
+++ b/src/compiler/app-core/bundle-app-core.ts
@@ -1,5 +1,5 @@
 import type * as d from '../../declarations';
-import { OutputOptions, RollupBuild } from 'rollup';
+import type { OutputAsset, OutputChunk, OutputOptions, RollupBuild } from 'rollup';
 import { STENCIL_CORE_ID } from '../bundle/entry-alias-ids';
 
 export const generateRollupOutput = async (
@@ -12,8 +12,8 @@ export const generateRollupOutput = async (
     return null;
   }
 
-  const { output } = await build.generate(options);
-  return output.map((chunk) => {
+  const { output }: { output: [OutputChunk, ...(OutputChunk | OutputAsset)[]] } = await build.generate(options);
+  return output.map((chunk: OutputChunk | OutputAsset) => {
     if (chunk.type === 'chunk') {
       const isCore = Object.keys(chunk.modules).some((m) => m.includes('@stencil/core'));
       return {

--- a/src/compiler/output-targets/dist-collection/index.ts
+++ b/src/compiler/output-targets/dist-collection/index.ts
@@ -9,13 +9,14 @@ export const outputCollection = async (
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   changedModuleFiles: d.Module[]
-) => {
+): Promise<void> => {
   const outputTargets = config.outputTargets.filter(isOutputTargetDistCollection);
   if (outputTargets.length === 0) {
     return;
   }
 
-  const timespan = buildCtx.createTimeSpan(`generate collections started`, true);
+  const bundlingEventMessage = `generate collections${config.sourceMap ? ' + source maps' : ''}`;
+  const timespan = buildCtx.createTimeSpan(`${bundlingEventMessage} started`, true);
   try {
     await Promise.all(
       changedModuleFiles.map(async (mod) => {
@@ -42,5 +43,5 @@ export const outputCollection = async (
     catchError(buildCtx.diagnostics, e);
   }
 
-  timespan.finish(`generate collections finished`);
+  timespan.finish(`${bundlingEventMessage} finished`);
 };

--- a/src/compiler/output-targets/dist-collection/index.ts
+++ b/src/compiler/output-targets/dist-collection/index.ts
@@ -29,10 +29,11 @@ export const outputCollection = async (
             const filePath = join(o.collectionDir, relPath);
             await compilerCtx.fs.writeFile(filePath, code, { outputTargetType: o.type });
 
-            if (!mod.sourceMapPath) return;
-            const relMapPath = relative(config.srcDir, mod.sourceMapPath);
-            const mapFilePath = join(o.collectionDir, relMapPath);
-            await compilerCtx.fs.writeFile(mapFilePath, mapCode, { outputTargetType: o.type });
+            if (mod.sourceMapPath) {
+              const relativeSourceMapPath = relative(config.srcDir, mod.sourceMapPath);
+              const sourceMapOutputFilePath = join(o.collectionDir, relativeSourceMapPath);
+              await compilerCtx.fs.writeFile(sourceMapOutputFilePath, mapCode, { outputTargetType: o.type });
+            }
           })
         );
       })

--- a/src/compiler/output-targets/dist-custom-elements-bundle/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements-bundle/index.ts
@@ -22,7 +22,7 @@ export const outputCustomElementsBundle = async (
   config: d.Config,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx
-) => {
+): Promise<void> => {
   if (!config.buildDist) {
     return;
   }
@@ -32,13 +32,12 @@ export const outputCustomElementsBundle = async (
     return;
   }
 
-  const timespan = buildCtx.createTimeSpan(
-    `generate custom elements bundle${config.sourceMap ? ' + source maps' : ''} started`
-  );
+  const bundlingEventMessage = `generate custom elements bundle${config.sourceMap ? ' + source maps' : ''}`;
+  const timespan = buildCtx.createTimeSpan(`${bundlingEventMessage} started`);
 
   await Promise.all(outputTargets.map((o) => bundleCustomElements(config, compilerCtx, buildCtx, o)));
 
-  timespan.finish(`generate custom elements bundle${config.sourceMap ? ' + source maps' : ''} finished`);
+  timespan.finish(`${bundlingEventMessage} finished`);
 };
 
 const bundleCustomElements = async (

--- a/src/compiler/output-targets/dist-custom-elements/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements/index.ts
@@ -32,12 +32,12 @@ export const outputCustomElements = async (
     return;
   }
 
-  const bundlingEventMessage = 'generate custom elements started';
-  const timespan = buildCtx.createTimeSpan(bundlingEventMessage);
+  const bundlingEventMessage = 'generate custom elements';
+  const timespan = buildCtx.createTimeSpan(${bundlingEventMessage} started);
 
   await Promise.all(outputTargets.map((o) => bundleCustomElements(config, compilerCtx, buildCtx, o)));
 
-  timespan.finish(bundlingEventMessage);
+  timespan.finish(${bundlingEventMessage} finished);
 };
 
 const bundleCustomElements = async (

--- a/src/compiler/output-targets/dist-custom-elements/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements/index.ts
@@ -33,11 +33,11 @@ export const outputCustomElements = async (
   }
 
   const bundlingEventMessage = 'generate custom elements';
-  const timespan = buildCtx.createTimeSpan(${bundlingEventMessage} started);
+  const timespan = buildCtx.createTimeSpan(`${bundlingEventMessage} started`);
 
   await Promise.all(outputTargets.map((o) => bundleCustomElements(config, compilerCtx, buildCtx, o)));
 
-  timespan.finish(${bundlingEventMessage} finished);
+  timespan.finish(`${bundlingEventMessage} finished`);
 };
 
 const bundleCustomElements = async (

--- a/src/compiler/output-targets/dist-custom-elements/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements/index.ts
@@ -18,7 +18,11 @@ import { removeCollectionImports } from '../../transformers/remove-collection-im
 import { STENCIL_INTERNAL_CLIENT_ID, USER_INDEX_ENTRY_ID, STENCIL_APP_GLOBALS_ID } from '../../bundle/entry-alias-ids';
 import { updateStencilCoreImports } from '../../transformers/update-stencil-core-import';
 
-export const outputCustomElements = async (config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
+export const outputCustomElements = async (
+  config: d.Config,
+  compilerCtx: d.CompilerCtx,
+  buildCtx: d.BuildCtx
+): Promise<void> => {
   if (!config.buildDist) {
     return;
   }
@@ -28,11 +32,12 @@ export const outputCustomElements = async (config: d.Config, compilerCtx: d.Comp
     return;
   }
 
-  const timespan = buildCtx.createTimeSpan(`generate custom elements started`);
+  const bundlingEventMessage = 'generate custom elements started';
+  const timespan = buildCtx.createTimeSpan(bundlingEventMessage);
 
   await Promise.all(outputTargets.map((o) => bundleCustomElements(config, compilerCtx, buildCtx, o)));
 
-  timespan.finish(`generate custom elements finished`);
+  timespan.finish(bundlingEventMessage);
 };
 
 const bundleCustomElements = async (

--- a/src/compiler/output-targets/dist-lazy/lazy-output.ts
+++ b/src/compiler/output-targets/dist-lazy/lazy-output.ts
@@ -24,13 +24,14 @@ import { removeCollectionImports } from '../../transformers/remove-collection-im
 import { updateStencilCoreImports } from '../../transformers/update-stencil-core-import';
 import MagicString from 'magic-string';
 
-export const outputLazy = async (config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
+export const outputLazy = async (config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx): Promise<void> => {
   const outputTargets = config.outputTargets.filter(isOutputTargetDistLazy);
   if (outputTargets.length === 0) {
     return;
   }
 
-  const timespan = buildCtx.createTimeSpan(`generate lazy${config.sourceMap ? ' + source maps' : ''} started`);
+  const bundleEventMessage = `generate lazy${config.sourceMap ? ' + source maps' : ''}`;
+  const timespan = buildCtx.createTimeSpan(`${bundleEventMessage} started`);
 
   try {
     const bundleOpts: BundleOptions = {
@@ -74,7 +75,7 @@ export const outputLazy = async (config: d.Config, compilerCtx: d.CompilerCtx, b
     catchError(buildCtx.diagnostics, e);
   }
 
-  timespan.finish(`generate lazy${config.sourceMap ? ' + source maps' : ''} finished`);
+  timespan.finish(`${bundleEventMessage} finished`);
 };
 
 const getLazyCustomTransformer = (config: d.Config, compilerCtx: d.CompilerCtx) => {

--- a/src/compiler/output-targets/output-collection.ts
+++ b/src/compiler/output-targets/output-collection.ts
@@ -43,15 +43,17 @@ const writeModuleFile = async (
       return compilerCtx.fs.writeFile(outputFilePath, jsContent);
     })
   );
-  if (!moduleFile.sourceMapPath) return;
-  const mapRelPath = relative(config.srcDir, moduleFile.sourceMapPath);
-  const mapContent = await compilerCtx.fs.readFile(moduleFile.sourceMapPath);
-  await Promise.all(
-    outputTargets.map((o) => {
-      const outputFilePath = join(o.collectionDir, mapRelPath);
-      return compilerCtx.fs.writeFile(outputFilePath, mapContent);
-    })
-  );
+
+  if (moduleFile.sourceMapPath) {
+    const sourceMapRelativePath = relative(config.srcDir, moduleFile.sourceMapPath);
+    const sourceMapContent = await compilerCtx.fs.readFile(moduleFile.sourceMapPath);
+    await Promise.all(
+      outputTargets.map((o) => {
+        const sourceMapOutputFilePath = join(o.collectionDir, sourceMapRelativePath);
+        return compilerCtx.fs.writeFile(sourceMapOutputFilePath, sourceMapContent);
+      })
+    );
+  }
 };
 
 export const writeCollectionManifests = async (

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -378,7 +378,7 @@ export interface RollupChunkResult {
   isBrowserLoader: boolean;
   imports: string[];
   moduleFormat: ModuleFormat;
-  map: RollupSourceMap;
+  map?: RollupSourceMap;
 }
 
 export interface BundleModule {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/master/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

This PR performs 4 minor refactorings, each confined to their own commit. Each seemed too small to put in their own PR, hence one with the separate commits




GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- https://github.com/ionic-team/stencil/commit/05320d291e9f4dd76d82e4cdcffd358d452f1534 - this commit adds additional tyings to `generateRollupOutput` to help make it easier to understand the map() function call that is invoked on the results of calling `build.generate()`
- https://github.com/ionic-team/stencil/commit/d5afae2b02664a5b87c7862f275a442a34d6e90f - sets the `map` property on our sourcemap representation to optional, match sourcemaps
- https://github.com/ionic-team/stencil/commit/c4140dda3aa58bdec0f4f0e70bbfc5c912fd786e - extract the labels used in timespans to variables, to make it less likely we'll mess up their content in two different callsites
- https://github.com/ionic-team/stencil/commit/3b956ef4b0bc038f4b91cadb024447c1c347eb07 - updates the control flow for a few files, updates variable names

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Smoke tested locally

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
