### PR TITLE
fix(preamble): restore preamble functionality

### DIFF
--- a/src/compiler/app-core/app-es5-disabled.ts
+++ b/src/compiler/app-core/app-es5-disabled.ts
@@ -1,5 +1,5 @@
 import type * as d from '../../declarations';
-import { escapeHtml } from '@utils';
+import { escapeHtml, generatePreamble } from '@utils';
 import { join } from 'path';
 
 export const generateEs5DisabledMessage = async (
@@ -112,7 +112,7 @@ h2 {
   )}</code>
     </pre>
   `;
-  return `
+  return `${generatePreamble(config)}
 (function() {
   function checkSupport() {
     if (!document.body) {

--- a/src/compiler/bundle/dev-module.ts
+++ b/src/compiler/bundle/dev-module.ts
@@ -3,6 +3,7 @@ import { basename, dirname, join, relative } from 'path';
 import { BuildContext } from '../build/build-ctx';
 import { getRollupOptions } from './bundle-output';
 import { OutputOptions, PartialResolvedId, rollup } from 'rollup';
+import { generatePreamble } from '@utils';
 
 export const devNodeModuleResolveId = async (
   config: d.Config,
@@ -143,6 +144,7 @@ const bundleDevModule = async (
     const rollupBuild = await rollup(inputOpts);
 
     const outputOpts: OutputOptions = {
+      banner: generatePreamble(config),
       format: 'es',
     };
 

--- a/src/compiler/bundle/worker-plugin.ts
+++ b/src/compiler/bundle/worker-plugin.ts
@@ -1,7 +1,7 @@
 import type * as d from '../../declarations';
 import type { Plugin, TransformResult, PluginContext } from 'rollup';
 import { bundleOutput } from './bundle-output';
-import { normalizeFsPath, hasError } from '@utils';
+import { normalizeFsPath, hasError, generatePreamble } from '@utils';
 import { optimizeModule } from '../optimize/optimize-module';
 import { STENCIL_INTERNAL_ID } from './entry-alias-ids';
 
@@ -178,10 +178,10 @@ const buildWorker = async (
   });
 
   if (build) {
-    // Generate commonjs output so we can intercept exports at runtme
+    // Generate commonjs output so we can intercept exports at runtime
     const output = await build.generate({
       format: 'commonjs',
-      banner: '(()=>{\n',
+      banner: `${generatePreamble(config)}\n(()=>{\n`,
       footer: '})();',
       intro: getWorkerIntro(workerMsgId, config.devMode),
       esModule: false,

--- a/src/compiler/output-targets/dist-collection/index.ts
+++ b/src/compiler/output-targets/dist-collection/index.ts
@@ -1,5 +1,5 @@
 import type * as d from '../../../declarations';
-import { catchError } from '@utils';
+import { catchError, generatePreamble } from '@utils';
 import { isOutputTargetDistCollection } from '../output-utils';
 import { join, relative } from 'path';
 import { writeCollectionManifests } from '../output-collection';
@@ -19,7 +19,10 @@ export const outputCollection = async (
   try {
     await Promise.all(
       changedModuleFiles.map(async (mod) => {
-        const code = mod.staticSourceFileText;
+        let code = mod.staticSourceFileText;
+        if (config.preamble) {
+          code = `${generatePreamble(config)}\n${code}`;
+        }
 
         await Promise.all(
           outputTargets.map(async (o) => {

--- a/src/compiler/output-targets/dist-custom-elements-bundle/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements-bundle/index.ts
@@ -1,7 +1,14 @@
 import type * as d from '../../../declarations';
 import type { BundleOptions } from '../../bundle/bundle-interface';
 import { bundleOutput } from '../../bundle/bundle-output';
-import { catchError, dashToPascalCase, formatComponentRuntimeMeta, hasError, stringifyRuntimeData } from '@utils';
+import {
+  catchError,
+  dashToPascalCase,
+  formatComponentRuntimeMeta,
+  generatePreamble,
+  hasError,
+  stringifyRuntimeData,
+} from '@utils';
 import { getCustomElementsBuildConditionals } from './custom-elements-build-conditionals';
 import { isOutputTargetDistCustomElementsBundle } from '../output-utils';
 import { join } from 'path';
@@ -59,6 +66,7 @@ const bundleCustomElements = async (
     const build = await bundleOutput(config, compilerCtx, buildCtx, bundleOpts);
     if (build) {
       const rollupOutput = await build.generate({
+        banner: generatePreamble(config),
         format: 'esm',
         sourcemap: config.sourceMap,
         chunkFileNames: outputTarget.externalRuntime || !config.hashFileNames ? '[name].js' : 'p-[hash].js',

--- a/src/compiler/output-targets/dist-custom-elements/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements/index.ts
@@ -1,7 +1,7 @@
 import type * as d from '../../../declarations';
 import type { BundleOptions } from '../../bundle/bundle-interface';
 import { bundleOutput } from '../../bundle/bundle-output';
-import { catchError, dashToPascalCase, hasError } from '@utils';
+import { catchError, dashToPascalCase, generatePreamble, hasError } from '@utils';
 import { getCustomElementsBuildConditionals } from '../dist-custom-elements-bundle/custom-elements-build-conditionals';
 import { isOutputTargetDistCustomElements } from '../output-utils';
 import { join } from 'path';
@@ -63,6 +63,7 @@ const bundleCustomElements = async (
     const build = await bundleOutput(config, compilerCtx, buildCtx, bundleOpts);
     if (build) {
       const rollupOutput = await build.generate({
+        banner: generatePreamble(config),
         format: 'esm',
         sourcemap: config.sourceMap,
         chunkFileNames: outputTarget.externalRuntime || !config.hashFileNames ? '[name].js' : 'p-[hash].js',

--- a/src/compiler/output-targets/dist-hydrate-script/generate-hydrate-app.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/generate-hydrate-app.ts
@@ -1,6 +1,6 @@
 import type * as d from '../../../declarations';
 import { bundleHydrateFactory } from './bundle-hydrate-factory';
-import { catchError, createOnWarnFn, loadRollupDiagnostics } from '@utils';
+import { catchError, createOnWarnFn, generatePreamble, loadRollupDiagnostics } from '@utils';
 import { getBuildFeatures, updateBuildConditionals } from '../../app-core/app-data';
 import { HYDRATE_FACTORY_INTRO, HYDRATE_FACTORY_OUTRO } from './hydrate-factory-closure';
 import { updateToHydrateComponents } from './update-to-hydrate-components';
@@ -57,6 +57,7 @@ export const generateHydrateApp = async (
 
     const rollupAppBuild = await rollup(rollupOptions);
     const rollupOutput = await rollupAppBuild.generate({
+      banner: generatePreamble(config),
       format: 'cjs',
       file: 'index.js',
     });

--- a/src/compiler/output-targets/dist-lazy/generate-cjs.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-cjs.ts
@@ -4,6 +4,7 @@ import { generateLazyModules } from './generate-lazy-module';
 import { join } from 'path';
 import type { OutputOptions, RollupBuild } from 'rollup';
 import { relativeImport } from '../output-utils';
+import { generatePreamble } from '@utils';
 
 export const generateCjs = async (
   config: d.Config,
@@ -17,6 +18,7 @@ export const generateCjs = async (
   if (cjsOutputs.length > 0) {
     const outputTargetType = cjsOutputs[0].type;
     const esmOpts: OutputOptions = {
+      banner: generatePreamble(config),
       format: 'cjs',
       entryFileNames: '[name].cjs.js',
       assetFileNames: '[name]-[hash][extname]',

--- a/src/compiler/output-targets/dist-lazy/generate-esm-browser.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-esm-browser.ts
@@ -2,7 +2,7 @@ import type * as d from '../../../declarations';
 import { generateRollupOutput } from '../../app-core/bundle-app-core';
 import { generateLazyModules } from './generate-lazy-module';
 import type { OutputOptions, RollupBuild } from 'rollup';
-import { getDynamicImportFunction } from '@utils';
+import { generatePreamble, getDynamicImportFunction } from '@utils';
 
 export const generateEsmBrowser = async (
   config: d.Config,
@@ -15,6 +15,7 @@ export const generateEsmBrowser = async (
   if (esmOutputs.length) {
     const outputTargetType = esmOutputs[0].type;
     const esmOpts: OutputOptions = {
+      banner: generatePreamble(config),
       format: 'es',
       entryFileNames: '[name].esm.js',
       chunkFileNames: config.hashFileNames ? 'p-[hash].js' : '[name]-[hash].js',

--- a/src/compiler/output-targets/dist-lazy/generate-esm.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-esm.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import type { OutputOptions, RollupBuild } from 'rollup';
 import { relativeImport } from '../output-utils';
 import type { RollupResult } from '../../../declarations';
+import { generatePreamble } from '@utils';
 
 export const generateEsm = async (
   config: d.Config,
@@ -17,6 +18,7 @@ export const generateEsm = async (
   const esmOutputs = outputTargets.filter((o) => !!o.esmDir && !o.isBrowserBuild);
   if (esmOutputs.length + esmEs5Outputs.length > 0) {
     const esmOpts: OutputOptions = {
+      banner: generatePreamble(config),
       format: 'es',
       entryFileNames: '[name].js',
       assetFileNames: '[name]-[hash][extname]',

--- a/src/compiler/output-targets/dist-lazy/generate-system.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-system.ts
@@ -5,6 +5,7 @@ import { getAppBrowserCorePolyfills } from '../../app-core/app-polyfills';
 import { join } from 'path';
 import type { OutputOptions, RollupBuild } from 'rollup';
 import { relativeImport } from '../output-utils';
+import { generatePreamble } from '@utils';
 
 export const generateSystem = async (
   config: d.Config,
@@ -17,6 +18,7 @@ export const generateSystem = async (
 
   if (systemOutputs.length > 0) {
     const esmOpts: OutputOptions = {
+      banner: generatePreamble(config),
       format: 'system',
       entryFileNames: config.hashFileNames ? 'p-[hash].system.js' : '[name].system.js',
       chunkFileNames: config.hashFileNames ? 'p-[hash].system.js' : '[name]-[hash].system.js',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -87,5 +87,5 @@ export const XML_NS = 'http://www.w3.org/XML/1998/namespace';
 /**
  * File names and value
  */
-export const BANNER = `Built with http://stenciljs.com`;
+export const BANNER = `Built with https://stenciljs.com`;
 export const COLLECTION_MANIFEST_FILE_NAME = 'collection-manifest.json';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -87,5 +87,4 @@ export const XML_NS = 'http://www.w3.org/XML/1998/namespace';
 /**
  * File names and value
  */
-export const BANNER = `Built with https://stenciljs.com`;
 export const COLLECTION_MANIFEST_FILE_NAME = 'collection-manifest.json';

--- a/src/utils/test/util.spec.ts
+++ b/src/utils/test/util.spec.ts
@@ -1,6 +1,108 @@
+import { mockConfig } from '@stencil/core/testing';
 import * as util from '../util';
 
 describe('util', () => {
+  describe('generatePreamble', () => {
+    it('generates a comment with a single line preamble when no options are provided', () => {
+      const testConfig = mockConfig();
+      testConfig.preamble = 'I am Stencil';
+
+      const result = util.generatePreamble(testConfig);
+
+      expect(result).toBe(`/*!
+ * I am Stencil
+ */`);
+    });
+
+    it('generates a comment with a multi-line preamble when no options are provided', () => {
+      const testConfig = mockConfig();
+      testConfig.preamble = 'I am Stencil\nHear me roar';
+
+      const result = util.generatePreamble(testConfig);
+
+      expect(result).toBe(`/*!
+ * I am Stencil
+ * Hear me roar
+ */`);
+    });
+
+    it('generates a preamble with a prefix', () => {
+      const testConfig = mockConfig();
+      testConfig.preamble = 'I am Stencil\nHear me roar';
+
+      const result = util.generatePreamble(testConfig, { prefix: 'this is the prefix to the preamble' });
+
+      expect(result).toBe(`/*!
+ * I am Stencil
+ * Hear me roar
+ * this is the prefix to the preamble
+ */`);
+    });
+
+    it('generates a preamble with the default banner', () => {
+      const testConfig = mockConfig();
+      testConfig.preamble = 'I am Stencil\nHear me roar';
+
+      const result = util.generatePreamble(testConfig, { defaultBanner: true });
+
+      expect(result).toBe(`/*!
+ * I am Stencil
+ * Hear me roar
+ * Built with https://stenciljs.com
+ */`);
+    });
+
+    it('generates a preamble with a suffix', () => {
+      const testConfig = mockConfig();
+      testConfig.preamble = 'I am Stencil\nHear me roar';
+
+      const result = util.generatePreamble(testConfig, { suffix: 'this is the suffix to the preamble' });
+
+      expect(result).toBe(`/*!
+ * I am Stencil
+ * Hear me roar
+ * this is the suffix to the preamble
+ */`);
+    });
+
+    it('generates a preamble with multiple options provided', () => {
+      const testConfig = mockConfig();
+      testConfig.preamble = 'I am Stencil\nHear me roar';
+
+      const result = util.generatePreamble(testConfig, {
+        prefix: 'this is the prefix to the preamble',
+        defaultBanner: true,
+        suffix: 'this is the suffix to the preamble',
+      });
+
+      expect(result).toBe(`/*!
+ * I am Stencil
+ * Hear me roar
+ * this is the prefix to the preamble
+ * Built with https://stenciljs.com
+ * this is the suffix to the preamble
+ */`);
+    });
+
+    it('returns an empty string if no preamble, or options are provided', () => {
+      const testConfig = mockConfig();
+
+      const result = util.generatePreamble(testConfig);
+
+      expect(result).toBe('');
+    });
+
+    it('returns the default banner if the option is provided, and there is no preamble', () => {
+      const testConfig = mockConfig();
+
+      const result = util.generatePreamble(testConfig, { defaultBanner: true });
+
+      expect(result).toBe(`/*!
+ * Built with https://stenciljs.com
+ */`);
+    });
+  });
+
   describe('isTsFile', () => {
     it('should return true for regular .ts and .tsx files', () => {
       expect(util.isTsFile('.ts')).toEqual(true);

--- a/src/utils/test/util.spec.ts
+++ b/src/utils/test/util.spec.ts
@@ -34,6 +34,15 @@ describe('util', () => {
       expect(result).toBe('');
     });
 
+    it('returns an empty string a null preamble is provided', () => {
+      const testConfig = mockConfig();
+      testConfig.preamble = null;
+
+      const result = util.generatePreamble(testConfig);
+
+      expect(result).toBe('');
+    });
+
     it('returns an empty string if an empty preamble is provided', () => {
       const testConfig = mockConfig();
       testConfig.preamble = '';

--- a/src/utils/test/util.spec.ts
+++ b/src/utils/test/util.spec.ts
@@ -3,7 +3,7 @@ import * as util from '../util';
 
 describe('util', () => {
   describe('generatePreamble', () => {
-    it('generates a comment with a single line preamble when no options are provided', () => {
+    it('generates a comment with a single line preamble', () => {
       const testConfig = mockConfig();
       testConfig.preamble = 'I am Stencil';
 
@@ -14,7 +14,7 @@ describe('util', () => {
  */`);
     });
 
-    it('generates a comment with a multi-line preamble when no options are provided', () => {
+    it('generates a comment with a multi-line preamble', () => {
       const testConfig = mockConfig();
       testConfig.preamble = 'I am Stencil\nHear me roar';
 
@@ -26,65 +26,7 @@ describe('util', () => {
  */`);
     });
 
-    it('generates a preamble with a prefix', () => {
-      const testConfig = mockConfig();
-      testConfig.preamble = 'I am Stencil\nHear me roar';
-
-      const result = util.generatePreamble(testConfig, { prefix: 'this is the prefix to the preamble' });
-
-      expect(result).toBe(`/*!
- * I am Stencil
- * Hear me roar
- * this is the prefix to the preamble
- */`);
-    });
-
-    it('generates a preamble with the default banner', () => {
-      const testConfig = mockConfig();
-      testConfig.preamble = 'I am Stencil\nHear me roar';
-
-      const result = util.generatePreamble(testConfig, { defaultBanner: true });
-
-      expect(result).toBe(`/*!
- * I am Stencil
- * Hear me roar
- * Built with https://stenciljs.com
- */`);
-    });
-
-    it('generates a preamble with a suffix', () => {
-      const testConfig = mockConfig();
-      testConfig.preamble = 'I am Stencil\nHear me roar';
-
-      const result = util.generatePreamble(testConfig, { suffix: 'this is the suffix to the preamble' });
-
-      expect(result).toBe(`/*!
- * I am Stencil
- * Hear me roar
- * this is the suffix to the preamble
- */`);
-    });
-
-    it('generates a preamble with multiple options provided', () => {
-      const testConfig = mockConfig();
-      testConfig.preamble = 'I am Stencil\nHear me roar';
-
-      const result = util.generatePreamble(testConfig, {
-        prefix: 'this is the prefix to the preamble',
-        defaultBanner: true,
-        suffix: 'this is the suffix to the preamble',
-      });
-
-      expect(result).toBe(`/*!
- * I am Stencil
- * Hear me roar
- * this is the prefix to the preamble
- * Built with https://stenciljs.com
- * this is the suffix to the preamble
- */`);
-    });
-
-    it('returns an empty string if no preamble, or options are provided', () => {
+    it('returns an empty string if no preamble is provided', () => {
       const testConfig = mockConfig();
 
       const result = util.generatePreamble(testConfig);
@@ -92,14 +34,13 @@ describe('util', () => {
       expect(result).toBe('');
     });
 
-    it('returns the default banner if the option is provided, and there is no preamble', () => {
+    it('returns an empty string if an empty preamble is provided', () => {
       const testConfig = mockConfig();
+      testConfig.preamble = '';
 
-      const result = util.generatePreamble(testConfig, { defaultBanner: true });
+      const result = util.generatePreamble(testConfig);
 
-      expect(result).toBe(`/*!
- * Built with https://stenciljs.com
- */`);
+      expect(result).toBe('');
     });
   });
 

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -95,7 +95,7 @@ export const isHtmlFile = (filePath: string) => {
 export const generatePreamble = (config: d.Config): string => {
   const { preamble } = config;
 
-  if (preamble === undefined || preamble.length === 0) {
+  if (!preamble) {
     return '';
   }
 

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -88,10 +88,26 @@ export const isHtmlFile = (filePath: string) => {
   return hasFileExtension(filePath, ['html', 'htm']);
 };
 
-export const generatePreamble = (
-  config: d.Config,
-  opts: { prefix?: string; suffix?: string; defaultBanner?: boolean } = {}
-) => {
+// TODO(NOW): Fix these comments, make it clearer what we're doing once I'm sure I want to keep this stuff
+/**
+ * Internal Stencil options for configuring the preamble
+ */
+type PreambleOptions = Partial<{
+  // a line of text that will appear _after_ the user's provided preamble
+  prefix: string;
+  // a line of text that will appear at the end of the entire preamble
+  suffix: string;
+  /** whether or not the default {@link BANNER} should be displayed in the preamble */
+  defaultBanner: boolean;
+}>;
+
+/**
+ * Generate the preamble to be placed atop the main file of the build
+ * @param config the Stencil configuration file
+ * @param opts a series of configuration options to customize the preamble
+ * @return the generated preamble
+ */
+export const generatePreamble = (config: d.Config, opts: PreambleOptions = {}): string => {
   let preamble: string[] = [];
 
   if (config.preamble) {
@@ -114,7 +130,7 @@ export const generatePreamble = (
     });
   }
 
-  if (preamble.length > 1) {
+  if (preamble.length >= 1) {
     preamble = preamble.map((l) => ` * ${l}`);
 
     preamble.unshift(`/*!`);
@@ -123,9 +139,6 @@ export const generatePreamble = (
     return preamble.join('\n');
   }
 
-  if (opts.defaultBanner === true) {
-    return `/*! ${BANNER} */`;
-  }
   return '';
 };
 

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -1,5 +1,4 @@
 import type * as d from '../declarations';
-import { BANNER } from './constants';
 import { buildError } from './message-utils';
 import { dashToPascalCase, isString, toDashCase } from './helpers';
 
@@ -88,58 +87,25 @@ export const isHtmlFile = (filePath: string) => {
   return hasFileExtension(filePath, ['html', 'htm']);
 };
 
-// TODO(NOW): Fix these comments, make it clearer what we're doing once I'm sure I want to keep this stuff
-/**
- * Internal Stencil options for configuring the preamble
- */
-type PreambleOptions = Partial<{
-  // a line of text that will appear _after_ the user's provided preamble
-  prefix: string;
-  // a line of text that will appear at the end of the entire preamble
-  suffix: string;
-  /** whether or not the default {@link BANNER} should be displayed in the preamble */
-  defaultBanner: boolean;
-}>;
-
 /**
  * Generate the preamble to be placed atop the main file of the build
  * @param config the Stencil configuration file
- * @param opts a series of configuration options to customize the preamble
  * @return the generated preamble
  */
-export const generatePreamble = (config: d.Config, opts: PreambleOptions = {}): string => {
-  let preamble: string[] = [];
+export const generatePreamble = (config: d.Config): string => {
+  const { preamble } = config;
 
-  if (config.preamble) {
-    preamble = config.preamble.split('\n');
+  if (preamble === undefined || preamble.length === 0) {
+    return '';
   }
 
-  if (typeof opts.prefix === 'string') {
-    opts.prefix.split('\n').forEach((c) => {
-      preamble.push(c);
-    });
-  }
+  // generate the body of the JSDoc-style comment
+  const preambleComment: string[] = preamble.split('\n').map((l) => ` * ${l}`);
 
-  if (opts.defaultBanner === true) {
-    preamble.push(BANNER);
-  }
+  preambleComment.unshift(`/*!`);
+  preambleComment.push(` */`);
 
-  if (typeof opts.suffix === 'string') {
-    opts.suffix.split('\n').forEach((c) => {
-      preamble.push(c);
-    });
-  }
-
-  if (preamble.length >= 1) {
-    preamble = preamble.map((l) => ` * ${l}`);
-
-    preamble.unshift(`/*!`);
-    preamble.push(` */`);
-
-    return preamble.join('\n');
-  }
-
-  return '';
+  return preambleComment.join('\n');
 };
 
 const lineBreakRegex = /\r?\n|\r/g;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/master/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Stencil's [preamble](https://stenciljs.com/docs/config#preamble) functionality has been broken for some time. This PR seeks to restore that functionality.

GitHub Issue Number: https://github.com/ionic-team/stencil/issues/2169

Doc Link: https://github.com/ionic-team/stencil-site/pull/776


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Restore the addition of a preamble, specified in `stencil.config.ts` to all emitted JS files
  - I.E. the preamble is not added to polyfills, nor is it added to files that are `.d.ts`, `.json`, etc. 
  - Generate preamble for the following targets:
    - `dist-custom-elements-bundle`
    - `dist-custom-elements`
    - `dist-hydrate-script`
    - `www` (with service worker, although the worker file generated by Workbox will not have the preamble) 
- Removes legacy (internal) configuration for adding a suffix/prefix/banner to the preamble
  - The `BANNER` global constant is no longer used and was not exported for consumers, remove it

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

* Checkout this branch, build it with `npm ci && npm run build.prod && npm pack`
* Checkout a small reproduction repro, https://github.com/rwaskiewicz/stencil-preamble-example
  * `git clone git@github.com:rwaskiewicz/stencil-preamble-example.git`
  * The important thing here is the [`stencil.config.ts` file](https://github.com/rwaskiewicz/stencil-preamble-example/blob/main/stencil.config.ts) which has the output targets defined
* Install the generated tarball of this Stencil branch into the reproduction:  `npm i <PATH-TO-TARBALL>`
* Run `npm run build`, which has been [modified to rimraf the output dirs](https://github.com/rwaskiewicz/stencil-preamble-example/blob/dff768bf9294a3e6394d60f1289094bde4952394/package.json#L16-L17)
* Inspect the output of the `dist`, `hydrate` and `www` dirs for the preamble, defined [here](https://github.com/rwaskiewicz/stencil-preamble-example/blob/main/stencil.config.ts#L22)

### Testing Pre-render
* In the example reproduction, check out https://github.com/rwaskiewicz/stencil-preamble-example/tree/pre-render
* Run `npm run buld-prerender`
* Inspect the output of the `www` dir for the preamble, defined [here](https://github.com/rwaskiewicz/stencil-preamble-example/blob/main/stencil.config.ts#L22)
## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
