### PR TITLE
fix(typings): fix external typings for rollup

### DIFF
--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -32,8 +32,6 @@ import type {
   VNodeData,
 } from './stencil-public-runtime';
 
-import type { SourceMap as RollupSourceMap } from 'rollup';
-
 export interface SourceMap {
   file: string;
   mappings: string;
@@ -358,6 +356,12 @@ export interface BundleEntryInputs {
   [entryKey: string]: string;
 }
 
+/**
+ * A note regarding Rollup types:
+ * As of this writing, there is no great way to import external types for packages that are directly embedded in the
+ * Stencil source. As a result, some types are duplicated here for Rollup that will be used within the codebase.
+ */
+
 export type RollupResult = RollupChunkResult | RollupAssetResult;
 
 export interface RollupAssetResult {
@@ -379,6 +383,17 @@ export interface RollupChunkResult {
   imports: string[];
   moduleFormat: ModuleFormat;
   map?: RollupSourceMap;
+}
+
+export interface RollupSourceMap {
+  file: string;
+  mappings: string;
+  names: string[];
+  sources: string[];
+  sourcesContent: string[];
+  version: number;
+  toString(): string;
+  toUrl(): string;
 }
 
 export interface BundleModule {


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/master/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Stencil won't run on the sourcemaps branch after busting caches

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

duplicate the typings for rollup (again).

Why? Well, turns out stencil cannot resolve the rollup typings in the private compiler api
typings at run time for consuming projects. As a result, we duplicate
the sourcemap typings from rollup

partial revert of https://github.com/ionic-team/stencil/pull/3009/

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. -->

I built the project in full and ran the dev-server in a newly spun up project

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
