### PR TITLE
feat(mock-doc): add pathname to mock anchors

### DIFF
--- a/src/mock-doc/element.ts
+++ b/src/mock-doc/element.ts
@@ -82,6 +82,9 @@ export class MockAnchorElement extends MockHTMLElement {
   set href(value: string) {
     this.setAttribute('href', value);
   }
+  get pathname() {
+    return new URL(this.href).pathname;
+  }
 }
 
 export class MockButtonElement extends MockHTMLElement {

--- a/src/mock-doc/test/element.spec.ts
+++ b/src/mock-doc/test/element.spec.ts
@@ -432,4 +432,18 @@ describe('element', () => {
       expect(input.list).toEqual(null);
     });
   });
+
+  describe('link', () => {
+    it('href', () => {
+      const elm = doc.createElement('a') as HTMLAnchorElement;
+      elm.href = 'http://stenciljs.com/path/to/page';
+      expect(elm.href).toBe('http://stenciljs.com/path/to/page');
+    });
+
+    it('pathname', () => {
+      const elm = doc.createElement('a') as HTMLAnchorElement;
+      elm.href = 'http://stenciljs.com/path/to/page';
+      expect(elm.pathname).toBe('/path/to/page');
+    });
+  });
 });


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
`MockAnchorElement`s don't have a `pathname` property.

GitHub Issue Number: #2969 


## What is the new behavior?
The pathname is generated based on the `href` and returned.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. -->
I wasn't able to run the E2E tests because it couldn't connect to Edge.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
