### PR TITLE
chore(github): fix typos in issue labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,7 +4,7 @@ title: 'bug: '
 body:
   - type: checkboxes
     attributes:
-      label: Prequisites
+      label: Prerequisites
       description: Please ensure you have completed all of the following.
       options:
         - label: I have read the [Contributing Guidelines](https://github.com/ionic-team/stencil/blob/master/.github/CONTRIBUTING.md).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,7 +4,7 @@ title: 'feat: '
 body:
   - type: checkboxes
     attributes:
-      label: Prequisites
+      label: Prerequisites
       description: Please ensure you have completed all of the following.
       options:
         - label: I have read the [Contributing Guidelines](https://github.com/ionic-team/stencil/blob/master/.github/CONTRIBUTING.md).


### PR DESCRIPTION
fix typos in 'prerequisites' in issue templates

🤦 