### PR TITLE
chore(sourcemaps): minification with sourcemaps

### DIFF
--- a/src/compiler/optimize/minify-js.ts
+++ b/src/compiler/optimize/minify-js.ts
@@ -23,6 +23,15 @@ export const minifyJs = async (input: string, opts?: MinifyOptions): Promise<d.O
         mangleProperties.regex = new RegExp(mangleProperties.regex);
       }
     }
+    if (opts.sourceMap) {
+      /**
+       * sourceMap, when used in conjunction with compress, can lead to sourcemaps that don't in every browser. despite
+       * there being a sourcemap spec, each browser has it's own tricks for trying to get sourcemaps to properly map
+       * minified JS back to its original form. for the most consistent results across all browsers, explicitly disable
+       * compress.
+       */
+      opts.compress = undefined;
+    }
   }
 
   try {
@@ -30,9 +39,9 @@ export const minifyJs = async (input: string, opts?: MinifyOptions): Promise<d.O
 
     results.output = minifyResults.code;
     results.sourceMap = typeof minifyResults.map === 'string' ? JSON.parse(minifyResults.map) : minifyResults.map;
-
     const compress = opts.compress as CompressOptions;
     if (compress && compress.module && results.output.endsWith('};')) {
+      // stripping the semicolon here _shouldn't_ be of significant consequence for the already generated sourcemap
       results.output = results.output.substring(0, results.output.length - 1);
     }
   } catch (e) {

--- a/src/compiler/optimize/minify-js.ts
+++ b/src/compiler/optimize/minify-js.ts
@@ -2,11 +2,11 @@ import type * as d from '../../declarations';
 import { splitLineBreaks } from '@utils';
 import { CompressOptions, MangleOptions, ManglePropertiesOptions, MinifyOptions, minify } from 'terser';
 
-export const minifyJs = async (input: string, opts?: MinifyOptions) => {
-  const results = {
+export const minifyJs = async (input: string, opts?: MinifyOptions): Promise<d.OptimizeJsResult> => {
+  const results: d.OptimizeJsResult = {
     output: input,
-    sourceMap: null as d.SourceMap,
-    diagnostics: [] as d.Diagnostic[],
+    sourceMap: null,
+    diagnostics: [],
   };
 
   if (opts) {

--- a/src/compiler/optimize/minify-js.ts
+++ b/src/compiler/optimize/minify-js.ts
@@ -2,6 +2,12 @@ import type * as d from '../../declarations';
 import { splitLineBreaks } from '@utils';
 import { CompressOptions, MangleOptions, ManglePropertiesOptions, MinifyOptions, minify } from 'terser';
 
+/**
+ * Performs the minification of JavaScript source
+ * @param input the JavaScript source to minify
+ * @param opts the options used by the minifier
+ * @returns the resulting minified JavaScript
+ */
 export const minifyJs = async (input: string, opts?: MinifyOptions): Promise<d.OptimizeJsResult> => {
   const results: d.OptimizeJsResult = {
     output: input,

--- a/src/compiler/optimize/optimize-module.ts
+++ b/src/compiler/optimize/optimize-module.ts
@@ -15,6 +15,13 @@ interface OptimizeModuleOptions {
   modeName?: string;
 }
 
+/**
+ * Begins the process of minifying a user's JavaScript
+ * @param config the Stencil configuration file that was provided as a part of the build step
+ * @param compilerCtx the current compiler context
+ * @param opts minification options that specify how the JavaScript ought to be minified
+ * @returns the minified JavaScript result
+ */
 export const optimizeModule = async (
   config: Config,
   compilerCtx: CompilerCtx,
@@ -95,6 +102,13 @@ export const optimizeModule = async (
   return results;
 };
 
+/**
+ * Builds a configuration object to be used by Terser for the purposes of minifying a user's JavaScript
+ * @param config the Stencil configuration file that was provided as a part of the build step
+ * @param sourceTarget the version of JavaScript being targeted (e.g. ES2017)
+ * @param prettyOutput if true, set the necessary flags to beautify the output of terser
+ * @returns the minification options
+ */
 export const getTerserOptions = (config: Config, sourceTarget: SourceTarget, prettyOutput: boolean): MinifyOptions => {
   const opts: MinifyOptions = {
     ie8: false,
@@ -142,6 +156,15 @@ export const getTerserOptions = (config: Config, sourceTarget: SourceTarget, pre
   return opts;
 };
 
+/**
+ * This method is likely to be called by a worker on the compiler context, rather than directly.
+ * @param input the source code to minify
+ * @param minifyOpts options to be used by the minifier
+ * @param transpileToEs5 if true, use the TypeScript compiler to transpile the input to ES5 prior to minification
+ * @param inlineHelpers when true, emits less terse JavaScript by allowing global helpers created by the TypeScript
+ * compiler to be added directly to the transpiled source. Used only if `transpileToEs5` is true.
+ * @returns minified input, as JavaScript
+ */
 export const prepareModule = async (
   input: string,
   minifyOpts: MinifyOptions,

--- a/src/compiler/optimize/optimize-module.ts
+++ b/src/compiler/optimize/optimize-module.ts
@@ -57,7 +57,9 @@ export const optimizeModule = async (
 
   if (opts.sourceTarget === 'es5' || opts.minify) {
     minifyOpts = getTerserOptions(config, opts.sourceTarget, isDebug);
-    if (config.sourceMap) minifyOpts.sourceMap = { content: opts.sourceMap };
+    if (config.sourceMap) {
+      minifyOpts.sourceMap = { content: opts.sourceMap };
+    }
 
     const compressOpts = minifyOpts.compress as CompressOptions;
     const mangleOptions = minifyOpts.mangle as MangleOptions;
@@ -96,7 +98,9 @@ export const optimizeModule = async (
       results.output = results.output.replace(/disconnectedCallback\(\)\{\},/g, '');
     }
     await compilerCtx.cache.put(cacheKey, results.output);
-    if (results.sourceMap) await compilerCtx.cache.put(cacheKey + 'Map', JSON.stringify(results.sourceMap));
+    if (results.sourceMap) {
+      await compilerCtx.cache.put(cacheKey + 'Map', JSON.stringify(results.sourceMap));
+    }
   }
 
   return results;

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -397,6 +397,15 @@ export interface RollupSourceMap {
   toUrl(): string;
 }
 
+/**
+ * Result of Stencil compressing, mangling, and otherwise 'minifying' JavaScript
+ */
+export type OptimizeJsResult = {
+  output: string;
+  diagnostics: Diagnostic[];
+  sourceMap?: SourceMap;
+};
+
 export interface BundleModule {
   entryKey: string;
   rollupResult: RollupChunkResult;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/master/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Sourcemaps with minification produce inconsistent results across browsers. In particular, I was looking at Firefox
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->


this commit introduces a new type, OptimizeJsResult, to be used to name
the shape of the object that is returned by various methods that are
used to minify a user's JavaScript. using this type in the return
signature of methods + in the declaration of objects allows us to
eliminate unnessary type assertions on the individual fields of said
objects.

- add JSDoc to minification to the functions that were investigated as a
part of this effort. 

account for minification with sourcemaps

- sourcemaps in some regard are at odds with attempting to minize and
compress our JavaScript files. Ideally there's no fidelity lost when
compressing JS, but in some cases, we get inconsistent behaviors across
browsers when we have both 'sourcemap' and 'compress' enabled in our
terser configuration.

- after diffing through the terser source/docs, I think our best route
forward for now is to simply disable the compress step. I took a sample
Stencil app and did a `diff` of the output where in one scenario we
didn't set compress to undefined, and one where we did set it to
undefined. other than the sourcemaps themselves, the differences were
rather minimal, and I believe this shouldn't have a large impact on the
output



## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. -->
I spun up a basic Stencil component library with `npm init stencil`. Run `npm i` in the created project.

Navigate to `src/utils/utils.ts` and update the file as such:
```typescript
export function format(first: string, middle: string, last: string): string {
  const str =  `the one and only` + 
      (first || '') + 
      (middle ? ` ${middle}` : '') + 
      (last ? ` ${last}` : '');
  return 'why it is ' + str; 
}
```

Update your `stencil.config.ts`, setting:
```ts
  minifyJs: true,
  sourceMap: true,
```
Checkout the `rwaskiewicz-rebase-again-sourcemaps` branch, which allows for sourcemaps to be used. Build stencil with `npm ci && npm run build && npm pack` and install the tarball in your component library

Finally start the dev server with `npm start`.

Observe the following breakpoint behaviors in Firefox, Safari, Edge and Chrom (clockwise starting in the left hand corner).


![Screen Shot 2021-10-05 at 3 06 25 PM](https://user-images.githubusercontent.com/1930213/136087001-cf017b56-bbc5-416f-92a4-235aec9675e1.png)

Note that above we:
- cannot put breakpoints on lines 2 or 6, the start of statements in any browser
- safari's mappings look a little funky
- we don't have `scopes` properly supplied, `str` is not consistently reported in the debugger

Pull down this branch, `npm run build && npm pack` it, then install the tarball in your component library.
`npm start` again, and observe nicer breakpoint behavior remediating the issues above


![Screen Shot 2021-10-05 at 3 00 45 PM](https://user-images.githubusercontent.com/1930213/136086314-cd91ad47-1511-479a-b1a5-10daedb72602.png)

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
