### PR TITLE
chore(sourcemaps): update global script handling

### DIFF
--- a/src/compiler/bundle/app-data-plugin.ts
+++ b/src/compiler/bundle/app-data-plugin.ts
@@ -12,7 +12,6 @@ import {
 } from './entry-alias-ids';
 import ts from 'typescript';
 import { basename } from 'path';
-import sourceMapMerge from 'merge-source-map';
 
 export const appDataPlugin = (
   config: d.Config,
@@ -114,15 +113,11 @@ export const appDataPlugin = (
             source: id,
             // this is the name of the sourcemap, not to be confused with the `file` field in a generated sourcemap
             file: id + '.map',
+            includeContent: true,
             hires: true,
           });
 
-          const sourceMap: d.SourceMap = results.sourceMapText ? JSON.parse(results.sourceMapText) : null;
-          if (!sourceMap) {
-            return { code: results.outputText };
-          }
-
-          return { code: results.outputText, map: sourceMapMerge(sourceMap, codeMap) };
+          return { code: results.outputText, map: codeMap };
         }
 
         return { code: results.outputText };


### PR DESCRIPTION
**Please do not merge, this is targeting a parent branch for ease of review**

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/master/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

For global script sourcemap generation, there are a few minor cleanups the team wanted to perform

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

add a check to verify that a global script exists in the moduleMap on
the compiler context before accessing fields on it to prevent compiler
time errors. this is one of the items we discussed as a team in the GH
comments of #3005, and is being implemented here

reworked how sourcemaps are generated. this commit restores the original
code generation where the platform, source code, and default export are
concatenated, which allows us to reserve generating a magic string
until/if we're using source maps


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. -->
I spun up a basic Stencil component library with `npm init stencil`. Run `npm i` in the created project.

I added two files to `src/`:
```typescript
// mr-worldwide.ts
import { childGlobal } from "./child-worldwide";
/**
 * prints a name with a greeting
 * @param name the name
 */
const helloGlobal = (name?: string): void => {
    const hello: string = 'hello';
    const globe: string = 'globe';
    const result = `${hello}, ${globe} ${name ? 'and ' + name : ''}!`;
    console.log(result);
}
helloGlobal(childGlobal());
}
```
```typescript
// child-worldwide.ts
export const childGlobal = (): string => {
    return 'ryan';
}
```

Update your `stencil.config.ts`, setting:
```ts
  sourceMap: true,
```
Checkout the this  branch, which allows for sourcemaps to be used. Build stencil with `npm ci && npm run build && npm pack` and install the tarball in your component library

Finally start the dev server with `npm start`.

Observe breakpoints in the global script there.

~Note that there is a known issue where breakpoints are 'off by one', where the first eligible line my not be able to receive/stop on a breakpoint. I've added something to the Stencil team backlog to investigate further~ Fixed in https://github.com/ionic-team/stencil/pull/3094/commits/4ca0542fbcd119cde5c4130bd66c38c9cb4e658d


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
