### PR TITLE
chore(github): update old ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,27 +9,15 @@ Before submitting an issue, please consult our docs -> https://stenciljs.com/
  @stencil/core@<version>
 ```
 
-**I'm submitting a:**
-<!-- (check one with "x") -->
-[ ] bug report
-[ ] feature request
-[ ] support request => Please do not submit support requests here, use one of these channels: https://stencil-worldwide.herokuapp.com/ or https://forum.ionicframework.com/
-
 **Current behavior:**
 <!-- Describe how the bug manifests. -->
 
 **Expected behavior:**
 <!-- Describe what the behavior would be without the bug. -->
 
-**Steps to reproduce:**
-<!-- If you are able to illustrate the bug or feature request with an example, please provide steps to reproduce and if possible a demo
--->
-
-**Related code:**
-
-```tsx
-// insert any relevant code here
-```
+**GitHub Reproduction Link:**
+<!-- Please reproduce this issue in a blank Stencil starter application and provide a link to the repo. Run `npm init stencil` to quickly spin up a Stencil project.
+This is the best way to ensure this issue is triaged quickly. Issues without a code reproduction may be closed if the Stencil Team cannot reproduce the issue you are reporting. -->
 
 **Other information:**
 <!-- List any other information that is relevant to your issue. Stack traces, related issues, suggestions on how to fix, Stack Overflow links, forum links, etc. -->


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

the 'old style' issue template has fallen out of sync with the newer one. Folks are using the existing `ISSUE_TEMPLATE.md` file in `.github/` to create issues, which doesn't have all the information the team wants/needs to effectively triage issues. 

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

update the 'old' ISSUE_TEMPLATE.md file to ensure we get similar
information to the one that uses GitHub's V2 Issues templates (currently
in beta).

this file was updated rather than removed because users can still reach
it in the GitHub UI under the 'Issues' tab, where GitHub currently
provides a "Don't see your issue here? Open a Blank Issue" link that
opens this file.  this file will be deprecated/removed once GitHub
removes that call to action.


![Screen Shot 2021-10-20 at 8 39 01 AM](https://user-images.githubusercontent.com/1930213/138095649-c2553886-b6f1-4832-803c-3c9cbcbbcf0b.png)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. -->
Previewed in Markdown renderer
## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
