### PR TITLE
fix(compiler): add delegatesFocus to custom elements targets

### DIFF
--- a/src/compiler/transformers/test/native-constructor.spec.ts
+++ b/src/compiler/transformers/test/native-constructor.spec.ts
@@ -1,0 +1,70 @@
+import { mockCompilerCtx } from '@stencil/core/testing';
+import * as d from '@stencil/core/declarations';
+import { transpileModule } from './transpile';
+import { nativeComponentTransform } from '../component-native/tranform-to-native-component';
+
+describe('nativeComponentTransform', () => {
+  let compilerCtx: d.CompilerCtx;
+  let transformOpts: d.TransformOptions;
+
+  beforeEach(() => {
+    compilerCtx = mockCompilerCtx();
+    transformOpts = {
+      coreImportPath: '@stencil/core',
+      componentExport: 'customelement',
+      componentMetadata: null,
+      currentDirectory: '/',
+      proxy: null,
+      style: 'static',
+      styleImportData: undefined,
+    };
+  });
+
+  describe('updateNativeComponentClass', () => {
+    it("adds __attachShadow() calls when a component doesn't have a constructor", () => {
+      const code = `
+          @Component({
+            tag: 'cmp-a',
+            shadow: true,
+          })
+          export class CmpA {
+            @Prop() foo: number;
+          }
+        `;
+
+      const transformer = nativeComponentTransform(compilerCtx, transformOpts);
+
+      const transpiledModule = transpileModule(code, null, compilerCtx, null, [], [transformer]);
+
+      expect(transpiledModule.outputText).toContain(
+        `import { attachShadow as __stencil_attachShadow, defineCustomElement as __stencil_defineCustomElement } from "@stencil/core";`
+      );
+      expect(transpiledModule.outputText).toContain(`this.__attachShadow()`);
+    });
+
+    it('adds __attachShadow() calls when a component has a constructor', () => {
+      const code = `
+          @Component({
+            tag: 'cmp-a',
+            shadow: true,
+          })
+          export class CmpA {
+            @Prop() foo: number;
+
+            constructor() {
+              super();
+            }
+          }
+        `;
+
+      const transformer = nativeComponentTransform(compilerCtx, transformOpts);
+
+      const transpiledModule = transpileModule(code, null, compilerCtx, null, [], [transformer]);
+
+      expect(transpiledModule.outputText).toContain(
+        `import { attachShadow as __stencil_attachShadow, defineCustomElement as __stencil_defineCustomElement } from "@stencil/core";`
+      );
+      expect(transpiledModule.outputText).toContain(`this.__attachShadow()`);
+    });
+  });
+});

--- a/src/hydrate/platform/index.ts
+++ b/src/hydrate/platform/index.ts
@@ -161,7 +161,6 @@ export { hydrateApp } from './hydrate-app';
 
 export {
   addHostEventListeners,
-  attachShadow,
   defineCustomElement,
   forceModeUpdate,
   proxyCustomElement,

--- a/src/runtime/bootstrap-custom-element.ts
+++ b/src/runtime/bootstrap-custom-element.ts
@@ -52,8 +52,23 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
         originalDisconnectedCallback.call(this);
       }
     },
+    __attachShadow() {
+      if (supportsShadow) {
+        if (BUILD.shadowDelegatesFocus) {
+          this.attachShadow({
+            mode: 'open',
+            delegatesFocus: !!(cmpMeta.$flags$ & CMP_FLAGS.shadowDelegatesFocus),
+          });
+        } else {
+          this.attachShadow({ mode: 'open' });
+        }
+      } else {
+        (this as any).shadowRoot = this;
+      }
+    },
   });
   Cstr.is = cmpMeta.$tagName$;
+
   return proxyComponent(Cstr, cmpMeta, PROXY_FLAGS.isElementConstructor | PROXY_FLAGS.proxyState);
 };
 
@@ -78,13 +93,5 @@ export const forceModeUpdate = (elm: d.RenderNode) => {
         forceUpdate(elm);
       }
     }
-  }
-};
-
-export const attachShadow = (el: HTMLElement) => {
-  if (supportsShadow) {
-    el.attachShadow({ mode: 'open' });
-  } else {
-    (el as any).shadowRoot = el;
   }
 };

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,5 +1,5 @@
 export { addHostEventListeners } from './host-listener';
-export { attachShadow, defineCustomElement, forceModeUpdate, proxyCustomElement } from './bootstrap-custom-element';
+export { defineCustomElement, forceModeUpdate, proxyCustomElement } from './bootstrap-custom-element';
 export { bootstrapLazy } from './bootstrap-lazy';
 export { connectedCallback } from './connected-callback';
 export { createEvent } from './event-emitter';

--- a/test/karma/package.json
+++ b/test/karma/package.json
@@ -19,7 +19,7 @@
     "karma.prod": "npm run build.sibling && npm run build.invisible-prehydration && npm run build.app && npm run karma.webpack && npm run build.prerender && npm run karma",
     "karma.ie": "karma start karma.config.js --browsers=IE --single-run=false",
     "karma.edge": "karma start karma.config.js --browsers=Edge --single-run=false",
-    "karma.webpack": "webpack-cli --config test-app/esm-webpack/webpack.config.js && webpack-cli --config test-app/custom-elements-output-webpack/webpack.config.js && webpack-cli --config test-app/custom-elements-output-tag-class-different/webpack.config.js",
+    "karma.webpack": "webpack-cli --config test-app/esm-webpack/webpack.config.js && webpack-cli --config test-app/custom-elements-output-webpack/webpack.config.js && webpack-cli --config test-app/custom-elements-output-tag-class-different/webpack.config.js && webpack-cli --config test-app/custom-elements-delegates-focus/webpack.config.js",
     "start": "node ../../bin/stencil build --dev --watch --serve --es5"
   },
   "devDependencies": {

--- a/test/karma/test-app/components.d.ts
+++ b/test/karma/test-app/components.d.ts
@@ -76,6 +76,10 @@ export namespace Components {
     }
     interface CustomElementRootDifferentNameThanClass {
     }
+    interface CustomElementsDelegatesFocus {
+    }
+    interface CustomElementsNoDelegatesFocus {
+    }
     interface CustomEventRoot {
     }
     interface DelegatesFocus {
@@ -457,6 +461,18 @@ declare global {
     var HTMLCustomElementRootDifferentNameThanClassElement: {
         prototype: HTMLCustomElementRootDifferentNameThanClassElement;
         new (): HTMLCustomElementRootDifferentNameThanClassElement;
+    };
+    interface HTMLCustomElementsDelegatesFocusElement extends Components.CustomElementsDelegatesFocus, HTMLStencilElement {
+    }
+    var HTMLCustomElementsDelegatesFocusElement: {
+        prototype: HTMLCustomElementsDelegatesFocusElement;
+        new (): HTMLCustomElementsDelegatesFocusElement;
+    };
+    interface HTMLCustomElementsNoDelegatesFocusElement extends Components.CustomElementsNoDelegatesFocus, HTMLStencilElement {
+    }
+    var HTMLCustomElementsNoDelegatesFocusElement: {
+        prototype: HTMLCustomElementsNoDelegatesFocusElement;
+        new (): HTMLCustomElementsNoDelegatesFocusElement;
     };
     interface HTMLCustomEventRootElement extends Components.CustomEventRoot, HTMLStencilElement {
     }
@@ -1077,6 +1093,8 @@ declare global {
         "custom-element-nested-child": HTMLCustomElementNestedChildElement;
         "custom-element-root": HTMLCustomElementRootElement;
         "custom-element-root-different-name-than-class": HTMLCustomElementRootDifferentNameThanClassElement;
+        "custom-elements-delegates-focus": HTMLCustomElementsDelegatesFocusElement;
+        "custom-elements-no-delegates-focus": HTMLCustomElementsNoDelegatesFocusElement;
         "custom-event-root": HTMLCustomEventRootElement;
         "delegates-focus": HTMLDelegatesFocusElement;
         "dom-reattach": HTMLDomReattachElement;
@@ -1245,6 +1263,10 @@ declare namespace LocalJSX {
     interface CustomElementRoot {
     }
     interface CustomElementRootDifferentNameThanClass {
+    }
+    interface CustomElementsDelegatesFocus {
+    }
+    interface CustomElementsNoDelegatesFocus {
     }
     interface CustomEventRoot {
     }
@@ -1514,6 +1536,8 @@ declare namespace LocalJSX {
         "custom-element-nested-child": CustomElementNestedChild;
         "custom-element-root": CustomElementRoot;
         "custom-element-root-different-name-than-class": CustomElementRootDifferentNameThanClass;
+        "custom-elements-delegates-focus": CustomElementsDelegatesFocus;
+        "custom-elements-no-delegates-focus": CustomElementsNoDelegatesFocus;
         "custom-event-root": CustomEventRoot;
         "delegates-focus": DelegatesFocus;
         "dom-reattach": DomReattach;
@@ -1643,6 +1667,8 @@ declare module "@stencil/core" {
             "custom-element-nested-child": LocalJSX.CustomElementNestedChild & JSXBase.HTMLAttributes<HTMLCustomElementNestedChildElement>;
             "custom-element-root": LocalJSX.CustomElementRoot & JSXBase.HTMLAttributes<HTMLCustomElementRootElement>;
             "custom-element-root-different-name-than-class": LocalJSX.CustomElementRootDifferentNameThanClass & JSXBase.HTMLAttributes<HTMLCustomElementRootDifferentNameThanClassElement>;
+            "custom-elements-delegates-focus": LocalJSX.CustomElementsDelegatesFocus & JSXBase.HTMLAttributes<HTMLCustomElementsDelegatesFocusElement>;
+            "custom-elements-no-delegates-focus": LocalJSX.CustomElementsNoDelegatesFocus & JSXBase.HTMLAttributes<HTMLCustomElementsNoDelegatesFocusElement>;
             "custom-event-root": LocalJSX.CustomEventRoot & JSXBase.HTMLAttributes<HTMLCustomEventRootElement>;
             "delegates-focus": LocalJSX.DelegatesFocus & JSXBase.HTMLAttributes<HTMLDelegatesFocusElement>;
             "dom-reattach": LocalJSX.DomReattach & JSXBase.HTMLAttributes<HTMLDomReattachElement>;

--- a/test/karma/test-app/custom-elements-delegates-focus/custom-elements-delegates-focus.tsx
+++ b/test/karma/test-app/custom-elements-delegates-focus/custom-elements-delegates-focus.tsx
@@ -1,0 +1,18 @@
+import { Component, Host, h } from '@stencil/core';
+
+@Component({
+  tag: 'custom-elements-delegates-focus',
+  styleUrl: 'shared-delegates-focus.css',
+  shadow: {
+    delegatesFocus: true,
+  },
+})
+export class CustomElementsDelegatesFocus {
+  render() {
+    return (
+      <Host>
+        <input />
+      </Host>
+    );
+  }
+}

--- a/test/karma/test-app/custom-elements-delegates-focus/custom-elements-no-delegates-focus.tsx
+++ b/test/karma/test-app/custom-elements-delegates-focus/custom-elements-no-delegates-focus.tsx
@@ -1,0 +1,16 @@
+import { Component, Host, h } from '@stencil/core';
+
+@Component({
+  tag: 'custom-elements-no-delegates-focus',
+  styleUrl: 'shared-delegates-focus.css',
+  shadow: true,
+})
+export class CustomElementsNoDelegatesFocus {
+  render() {
+    return (
+      <Host>
+        <input />
+      </Host>
+    );
+  }
+}

--- a/test/karma/test-app/custom-elements-delegates-focus/index.esm.js
+++ b/test/karma/test-app/custom-elements-delegates-focus/index.esm.js
@@ -1,0 +1,3 @@
+import { defineCustomElement } from '../../test-components/custom-elements-delegates-focus';
+
+defineCustomElement();

--- a/test/karma/test-app/custom-elements-delegates-focus/index.html
+++ b/test/karma/test-app/custom-elements-delegates-focus/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf8">
+<script src="/custom-elements-delegates-focus/main.js"></script>
+
+<custom-elements-delegates-focus></custom-elements-delegates-focus>
+<custom-elements-no-delegates-focus></custom-elements-no-delegates-focus>

--- a/test/karma/test-app/custom-elements-delegates-focus/karma.spec.ts
+++ b/test/karma/test-app/custom-elements-delegates-focus/karma.spec.ts
@@ -1,0 +1,31 @@
+import { setupDomTests } from '../util';
+
+describe('custom-elements-delegates-focus', () => {
+  const { setupDom, tearDownDom } = setupDomTests(document);
+  let app: HTMLElement;
+
+  beforeEach(async () => {
+    app = await setupDom('/custom-elements-delegates-focus/index.html');
+  });
+  afterEach(tearDownDom);
+
+  it('sets delegatesFocus correctly', async () => {
+    expect(customElements.get('custom-elements-delegates-focus')).toBeDefined();
+
+    const elm: Element = app.querySelector('custom-elements-delegates-focus');
+
+    expect(elm.shadowRoot).toBeDefined();
+    // as of TypeScript 4.3, `delegatesFocus` does not exist on the `shadowRoot` object
+    expect((elm.shadowRoot as any).delegatesFocus).toBe(true);
+  });
+
+  it('does not set delegatesFocus when shadow is set to "true"', async () => {
+    expect(customElements.get('custom-elements-no-delegates-focus')).toBeDefined();
+
+    const elm: Element = app.querySelector('custom-elements-no-delegates-focus');
+
+    expect(elm.shadowRoot).toBeDefined();
+    // as of TypeScript 4.3, `delegatesFocus` does not exist on the `shadowRoot` object
+    expect((elm.shadowRoot as any).delegatesFocus).toBe(false);
+  });
+});

--- a/test/karma/test-app/custom-elements-delegates-focus/shared-delegates-focus.css
+++ b/test/karma/test-app/custom-elements-delegates-focus/shared-delegates-focus.css
@@ -1,0 +1,15 @@
+:host {
+  display: block;
+  border: 5px solid red;
+  padding: 10px;
+  margin: 10px;
+}
+
+:host(:focus) {
+  border: 5px solid green;
+}
+
+input {
+  display: block;
+  width: 100%;
+}

--- a/test/karma/test-app/custom-elements-delegates-focus/webpack.config.js
+++ b/test/karma/test-app/custom-elements-delegates-focus/webpack.config.js
@@ -1,0 +1,19 @@
+const path = require('path');
+
+module.exports = {
+  entry: path.resolve(__dirname, 'index.esm.js'),
+  output: {
+    path: path.resolve(__dirname, '..', '..', 'www', 'custom-elements-delegates-focus'),
+    publicPath: '/custom-elements-delegates-focus/',
+  },
+  mode: 'production',
+  optimization: {
+    minimize: false,
+  },
+  resolve: {
+    alias: {
+      '@stencil/core/internal/client': '../../../internal/client',
+      '@stencil/core/internal/app-data': '../app-data',
+    },
+  },
+};


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x]  Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`delegatesFocus` is not honored/applied in the `dist-custom-elements` nor in the `dist-custom-elements-bundle` output targets (it is simply ignored)

GitHub Issue Number: https://github.com/ionic-team/stencil/issues/3002


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit allows `delegatesFocus` to be properly applied to components
generated using the following output targets:
- dist-custom-elements
- dist-custom-elements-bundle

the generation of the `attachShadow` call is moved from a standalone
function to being attached to the prototype of the custom element when
we proxy it. the reason for this is that we need the component metadata
to to determine whether or not each individual component should have
delegateFocus enabled or not.

this change also led to the transition from using ts.create*() calls to
ts.factory.create*() calls for nativeAttachShadowStatement, which is the
general direction I'd like to take such calls, since the former is now
deprecated

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

this led to the removal of the original standalone attachShadow
function. I do not consider this to be a breaking change, as we don't
publicly state our runtime APIs are available for general consumption.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. -->

I've added unit tests and karma tests for this change. The unit tests validate that we output a custom element component correctly (it calls `attachShadow` in the constructor), while the karma tests ensure that we set the `delegatesFocus` field properly whenever we use the shadow DOM.

I manually tested this by building and packing this branch (`npm ci && npm run build && npm pack`) and installed it in https://github.com/Amiiiirali/delegates-focus-test (the repro for the linked GH Issue). Running `npm ci && npm run build && npm start` in Chrome, Edge, FF (Beta, see other information section below) and Safari confirms the fix

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

`delegatesFocus` is implemented in FireFox 94. At the time of this writing, v94 is only available on the FireFox beta channel. Testing in FF requires a beta build in order to verify this all works.

Docs update: https://github.com/ionic-team/stencil-site/pull/781
