### PR TITLE
chore(scripts): always compile scripts/ directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "start": "npm run watch",
-    "build": "node scripts && npm run tsc.scripts && npm run tsc.prod && npm run rollup.prod.ci",
+    "build": "node scripts --prepare && npm run tsc.prod && npm run rollup.prod.ci",
     "watch": "node scripts && npm run tsc && concurrently \"npm run rollup.watch\" \"npm run tsc.watch\"",
     "release": "node scripts --release --publish",
     "release.prepare": "node scripts --release --prepare",

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,23 +1,44 @@
-const fs = require('fs-extra');
 const path = require('path');
 
+const scriptsDir = __dirname;
+const rootDir = path.join(scriptsDir, '..');
+
+/**
+ * Transpiles build scripts used to create the Stencil compiler artifact
+ */
+function transpileBuildScripts() {
+  console.log('🧩  transpiling build scripts');
+  const tscPath = path.join(rootDir, 'node_modules', '.bin', 'tsc');
+  const tsconfig = path.join(scriptsDir, 'tsconfig.json');
+  const execa = require('execa');
+  execa.sync(tscPath, ['-p', tsconfig]);
+}
+
 function main() {
-  const scriptsDir = __dirname;
-  const rootDir = path.join(scriptsDir, '..');
   const scriptsBuildDir = path.join(scriptsDir, 'build');
   const scriptsBuildJs = path.join(scriptsBuildDir, 'build.js');
   const args = process.argv.slice(2);
 
-  if (args.includes('--prepare') || !fs.existsSync(scriptsBuildJs)) {
-    // ensure we've transpiled the build scripts first
-    console.log('🧩  transpiling build scripts');
-    const tscPath = path.join(rootDir, 'node_modules', '.bin', 'tsc');
-    const tsconfig = path.join(scriptsDir, 'tsconfig.json');
-    const execa = require('execa');
-    execa.sync(tscPath, ['-p', tsconfig]);
+  if (args.includes('--prepare')) {
+    // with --prepare always compile the scripts
+    transpileBuildScripts();
   }
 
-  const build = require(scriptsBuildJs);
+  let build;
+  try {
+    build = require(scriptsBuildJs);
+  } catch (requireError) {
+    console.warn(`Unable to load build scripts: ${requireError}. Attempting to recompile them.`);
+    try {
+      // it's possible that this script was run without --prepare and the JS output is in a broken state. let's see if
+      // a recompilation will fix that
+      transpileBuildScripts();
+      build = require(scriptsBuildJs);
+    } catch (rebuildError) {
+      console.error(`Unable to recompile scripts. Exiting. ${rebuildError}`);
+      process.exit(1);
+    }
+  }
   build.run(rootDir, args);
 }
 

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -14,7 +14,7 @@
     "outDir": "build/",
     "pretty": true,
     "target": "es2017",
-    "incremental": true
+    "incremental": false,
   },
   "include": [
     "**/*.ts"


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When trying to build Stencil, if the `scripts/` directory, whose contents are used to build the Stencil compiler, are in a broken state, there's not much we can do to recover without running scripts like `tsc -b --force` in the scripts directory to try to recover. This PR tries to make this part of the build a little more resilient.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

switch the value of the `incremental` flag in `scripts/tsconfig.json` to
false. when using incremental builds, typescript does not check the
output directory to see whether or not a file that would be emitted
exists or not. this can lead to cases where deleting a file may cause it
to be re-emitted when running compile again. this incurs a ~3 second 
increase in build time, but will always ensure that the output is up to date.

refactor scripts/index.js to attempt to recompile scripts in case
require() fails as a last ditch effort to recompile/require the module
should the `--prepare` flag not be passed in during invocation

update the package.json build script to always recompile scripts/ using
the `--prepare` flag. this allows us to remove the tsc.scripts
invocation, since they effectively do the same thing
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. -->

Using this branch, there are a few scenarios to test:

### simple recompilation when we're in a broken state
- Delete `scripts/bundles/build/cli.js`
- Run `npm run tsc.scripts` - since we are no longer using `incremental: true` in `scripts/tsconfig.json`, `scripts/bundles/build/cli.js` will be generated 
- Running the above steps on `main` will cause `scripts/bundles/build/cli.js` to _not_ be regenerated

### `build.js` cannot be loaded
- Delete `scripts/bundles/build/cli.js`, this will call the [`require()` call for `build.js`](https://github.com/ionic-team/stencil/pull/3126/files#diff-7a094af86da034414240a174bdfb685fe3cf7c50ececa1b23d4b3e91523554edR29) to fail when calling `node scripts` from the root of Stencil, but will be saved by the kinda gross try/catch and run
```➜  stencil git:(force-scripts-compilation) node scripts
Unable to load build scripts: Error: Cannot find module './bundles/cli'
Require stack:
- stencil/scripts/build/build.js
- stencil/scripts/index.js. Attempting to recompile them.
🧩  transpiling build scripts
```

### `build.js` transpilation always fails/cannot be loaded
- I cheated on this one a bit and modified [this line](https://github.com/ionic-team/stencil/pull/3126/files#diff-7a094af86da034414240a174bdfb685fe3cf7c50ececa1b23d4b3e91523554edR13) to always break:
```diff
-    const execa = require('execa');
+    const execa = require('execa-nope');
```
- Delete `scripts/bundles/build/cli.js`
- Run `node scripts` from the root of the Stencil repo to get:
```
➜  stencil git:(force-scripts-compilation) ✗ node scripts
Unable to load build scripts: Error: Cannot find module './bundles/cli'
Require stack:
- stencil/scripts/build/build.js
- stencil/scripts/index.js. Attempting to recompile them.
🧩  transpiling build scripts
Unable to recompile scripts. Exiting. Error: Cannot find module 'execa-nope'
Require stack:
- stencil/scripts/index.js
```
