### PR TITLE
chore(release): prompt for OTP for npm publish

### DIFF
--- a/scripts/release-tasks.ts
+++ b/scripts/release-tasks.ts
@@ -171,7 +171,7 @@ export function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<string>)
         title: 'Publish @stencil/core to npm',
         task: () => {
           const cmd = 'npm';
-          const cmdArgs = ['publish'].concat(opts.tag ? ['--tag', opts.tag] : []);
+          const cmdArgs = ['publish', '--otp', opts.otp].concat(opts.tag ? ['--tag', opts.tag] : []);
 
           if (isDryRun) {
             return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -189,12 +189,24 @@ async function publishRelease(opts: BuildOptions, args: ReadonlyArray<string>): 
         return `Will publish ${opts.vermoji}  ${color.yellow(opts.version)}${tagPart}. Continue?`;
       },
     },
+    {
+      type: 'input',
+      name: 'otp',
+      message: 'Enter OTP:',
+      validate: (input: any) => {
+        if (input.length !== 6) {
+          return 'Please enter a valid one-time password.';
+        }
+        return true;
+      },
+    },
   ];
 
   await inquirer
     .prompt(prompts)
     .then((answers) => {
       if (answers.confirm) {
+        opts.otp = answers.otp;
         runReleaseTasks(opts, args);
       }
     })

--- a/scripts/utils/options.ts
+++ b/scripts/utils/options.ts
@@ -191,6 +191,7 @@ export interface BuildOptions {
   parse5Verion?: string;
   sizzleVersion?: string;
   terserVersion?: string;
+  otp?: '';
 }
 
 export interface CmdLineArgs {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

Publishing to the npm registry fails when two-factor authentication is required.


## What is the new behavior?

The release script will now prompt for OTP.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

`npm run release.prepare && npm run release -- --dry-run`

The release script prompts for OTP which is then included as the `--otp` argument for `npm publish`.

## Other information

