### PR TITLE
test(delegates-focus): show non-delegate focus case in local web server

### DIFF
--- a/test/karma/test-app/custom-elements-delegates-focus/index.esm.js
+++ b/test/karma/test-app/custom-elements-delegates-focus/index.esm.js
@@ -1,3 +1,5 @@
-import { defineCustomElement } from '../../test-components/custom-elements-delegates-focus';
+import { defineCustomElement as defineDelegatesFocus } from '../../test-components/custom-elements-delegates-focus';
+import { defineCustomElement as defineDelegatesNoFocus } from '../../test-components/custom-elements-no-delegates-focus';
 
-defineCustomElement();
+defineDelegatesFocus();
+defineDelegatesNoFocus();


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix (for local tests only)
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When serving this test locally using `npm start`, the whole test case was not properly shown



<img width="704" alt="Screen Shot 2021-11-05 at 10 56 26 AM" src="https://user-images.githubusercontent.com/1930213/140531069-97fcc1df-6646-4a99-b23c-598a8b107a70.png">

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
this commit fixes the cases where the non-delegates focus case for the
custom-elements-delegates-focus test case would not show up properly
when serving the test using `npm start` from the root of the karma
directory.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. -->

After pulling down this branch and building Stencil (`npm ci && npm run build`), navigate to the `test/karma` dir, build the tests (`npm run karma.prod`), and `npm start` - you should see _two_ input boxes now.

<img width="704" alt="Screen Shot 2021-11-05 at 10 53 41 AM" src="https://user-images.githubusercontent.com/1930213/140530748-39138f3f-d5bd-484c-af9f-321c869302f8.png">
 