### PR TITLE
Extend the System abstraction to support framework wrappers

### DIFF
--- a/src/compiler/sys/stencil-sys.ts
+++ b/src/compiler/sys/stencil-sys.ts
@@ -15,7 +15,7 @@ import type {
   Logger,
 } from '../../declarations';
 import platformPath from 'path-browserify';
-import { basename, dirname, join } from 'path';
+import path, { basename, dirname, join, relative } from 'path';
 import * as process from 'process';
 import * as os from 'os';
 import { buildEvents } from '../events';
@@ -565,6 +565,11 @@ export const createSystem = (c?: { logger?: Logger }) => {
 
   const fileWatchTimeout = 32;
 
+  const EOL = () => os.EOL;
+
+  const isAbsolutePath = (p: string) => path.isAbsolute(p);
+  const joinPaths = (...p: string[]) => path.join(...p);
+
   createDirSync('/');
 
   const sys: CompilerSystem = {
@@ -574,12 +579,17 @@ export const createSystem = (c?: { logger?: Logger }) => {
     access,
     accessSync,
     addDestory,
+    basename,
     copyFile,
     createDir,
     createDirSync,
+    dirname,
+    EOL,
+    getEnvironmentVar,
     homeDir,
     isTTY,
-    getEnvironmentVar,
+    isAbsolutePath,
+    joinPaths,
     destroy,
     encodeToBase64,
     exit: async (exitCode) => logger.warn(`exit ${exitCode}`),
@@ -598,6 +608,7 @@ export const createSystem = (c?: { logger?: Logger }) => {
     readFileSync,
     realpath,
     realpathSync,
+    relative,
     removeDestory,
     rename,
     fetch,

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -925,12 +925,18 @@ export interface CompilerSystem {
    */
   createDirSync(p: string, opts?: CompilerSystemCreateDirectoryOptions): CompilerSystemCreateDirectoryResults;
   homeDir(): string;
+  joinPaths(...p: string[]): string;
+  isAbsolutePath(p: string): boolean;
+  EOL(): string;
+  dirname(path: string): string;
+  basename(path: string, ext?: string): string;
+  relative(from: string, to: string): string;
   /**
    * Used to determine if the current context of the terminal is TTY.
    */
   isTTY(): boolean;
   /**
-   * Each plaform as a different way to dynamically import modules.
+   * Each platform as a different way to dynamically import modules.
    */
   dynamicImport?(p: string): Promise<any>;
   /**

--- a/src/sys/node/node-sys.ts
+++ b/src/sys/node/node-sys.ts
@@ -337,6 +337,24 @@ export function createNodeSys(c: { process?: any } = {}) {
         });
       });
     },
+    dirname(p) {
+      return path.dirname(p);
+    },
+    basename(p, ext?) {
+      return path.basename(p, ext);
+    },
+    joinPaths(...paths: string[]) {
+      return path.join(...paths);
+    },
+    relative(from, to) {
+      return path.relative(from, to);
+    },
+    EOL() {
+      return os.EOL;
+    },
+    isAbsolutePath(p) {
+      return path.isAbsolute(p);
+    },
     resolvePath(p) {
       return normalizePath(p);
     },


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

While working on the Angular bindings and applying the binding to a couple starter projects, as well as long-lived projects, I discovered that the bindings weren't relying on the abstracted system layer. This would cause me to need to install nodePolyfills/rollup-plugin-node-polyfills during compilation. This causes some pretty huge confusion points as the onboarding of a binding then causes folks to poke around at docs in order to understand the issue. 

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
This PR adds 6 new items to the Compiler system. 

- `EOL` - the end of line character for the platform the system is running on.
- `joinPaths` - the path.join option 
- `isAbsolutePath` - a function to determine if a string represents an absolute path
- `basename` - returns the last part of a path ([link](https://nodejs.org/api/path.html#pathbasenamepath-ext))
- `dirname` - returns the directory name of a path ([link](https://nodejs.org/api/path.html#pathdirnamepath)) 
- `relative` - returns the relative path from one directory to another ([link](https://nodejs.org/api/path.html#pathrelativefrom-to))

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing
<!-- Please describe the steps you took to test the changes in this PR. -->
I NPM linked this in the output target's repo, and in the starter libraries & my long-lived repo. I then rewrote parts of the Angular output target code to leverage to updated system, instead of importing from `path`, `os`, and more. I will have a corresponding PR for the output targets repo shortly.  

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
