### PR TITLE
fix(cli): wait for help task to finish before exiting

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -134,7 +134,7 @@ export const runTask = async (
       break;
 
     case 'help':
-      taskHelp(config, config.logger, sys);
+      await taskHelp(config, config.logger, sys);
       break;
 
     case 'prerender':
@@ -162,7 +162,7 @@ export const runTask = async (
 
     default:
       config.logger.error(`${config.logger.emoji('❌ ')}Invalid stencil command, please see the options below:`);
-      taskHelp(config, config.logger, sys);
+      await taskHelp(config, config.logger, sys);
       return config.sys.exit(1);
   }
 };


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Running `npx stencil` and `npx stencil --help`, should print the same options to the user, but `npx stencil` is exiting before the telemetry and example sections are printed. 

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Running `npx stencil` and `npx stencil --help` now print the same information.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. -->
N/A

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
