### PR TITLE
fix(sourcemaps): do not encode inline sourcemaps

### DIFF
--- a/src/compiler/transpile.ts
+++ b/src/compiler/transpile.ts
@@ -1,5 +1,5 @@
 import { TranspileOptions, TranspileResults, Config, TransformOptions, TransformCssToEsmInput } from '../declarations';
-import { catchError, getSourceMappingUrlLinker, isString } from '@utils';
+import { catchError, isString, JS_SOURCE_MAPPING_URL_LINKER } from '@utils';
 import { getPublicCompilerMeta } from './transformers/add-component-meta-static';
 import { getTranspileCssConfig, getTranspileConfig, getTranspileResults } from './config/transpile-options';
 import { patchTypescript } from './sys/typescript/typescript-sys';
@@ -74,10 +74,12 @@ const transpileCode = (
         mapObject.sources = [transpileOpts.file];
         delete mapObject.sourceRoot;
 
+        // generate a data URI for the inlined sourcemap. because we do the base-64 encoding ourselves and we do not
+        // want to encode the prefix & MIME type, build the sourcemap URI by hand
         const mapBase64 = Buffer.from(JSON.stringify(mapObject), 'utf8').toString('base64');
         const sourceMapInlined = `data:application/json;charset=utf-8;base64,` + mapBase64;
         const sourceMapComment = results.code.lastIndexOf('//#');
-        results.code = results.code.slice(0, sourceMapComment) + getSourceMappingUrlLinker(sourceMapInlined);
+        results.code = results.code.slice(0, sourceMapComment) + JS_SOURCE_MAPPING_URL_LINKER + sourceMapInlined;
       } catch (e) {
         console.error(e);
       }

--- a/src/compiler/transpile.ts
+++ b/src/compiler/transpile.ts
@@ -1,5 +1,5 @@
 import { TranspileOptions, TranspileResults, Config, TransformOptions, TransformCssToEsmInput } from '../declarations';
-import { catchError, isString, JS_SOURCE_MAPPING_URL_LINKER } from '@utils';
+import { catchError, getInlineSourceMappingUrlLinker, isString } from '@utils';
 import { getPublicCompilerMeta } from './transformers/add-component-meta-static';
 import { getTranspileCssConfig, getTranspileConfig, getTranspileResults } from './config/transpile-options';
 import { patchTypescript } from './sys/typescript/typescript-sys';
@@ -74,12 +74,9 @@ const transpileCode = (
         mapObject.sources = [transpileOpts.file];
         delete mapObject.sourceRoot;
 
-        // generate a data URI for the inlined sourcemap. because we do the base-64 encoding ourselves and we do not
-        // want to encode the prefix & MIME type, build the sourcemap URI by hand
-        const mapBase64 = Buffer.from(JSON.stringify(mapObject), 'utf8').toString('base64');
-        const sourceMapInlined = `data:application/json;charset=utf-8;base64,` + mapBase64;
         const sourceMapComment = results.code.lastIndexOf('//#');
-        results.code = results.code.slice(0, sourceMapComment) + JS_SOURCE_MAPPING_URL_LINKER + sourceMapInlined;
+        results.code =
+          results.code.slice(0, sourceMapComment) + getInlineSourceMappingUrlLinker(JSON.stringify(mapObject));
       } catch (e) {
         console.error(e);
       }

--- a/src/utils/sourcemaps.ts
+++ b/src/utils/sourcemaps.ts
@@ -26,7 +26,7 @@ export const rollupToStencilSourceMap = (rollupSourceMap: RollupSourceMap | unde
  * found in the [Linking generated code to source maps](https://sourcemaps.info/spec.html#h.lmz475t4mvbx) section of
  * the Sourcemaps V3 specification proposal.
  */
-const JS_SOURCE_MAPPING_URL_LINKER = '//# sourceMappingURL=';
+export const JS_SOURCE_MAPPING_URL_LINKER = '//# sourceMappingURL=';
 
 /**
  * Generates an RFC-3986 compliant string for the given input.

--- a/src/utils/sourcemaps.ts
+++ b/src/utils/sourcemaps.ts
@@ -26,7 +26,7 @@ export const rollupToStencilSourceMap = (rollupSourceMap: RollupSourceMap | unde
  * found in the [Linking generated code to source maps](https://sourcemaps.info/spec.html#h.lmz475t4mvbx) section of
  * the Sourcemaps V3 specification proposal.
  */
-export const JS_SOURCE_MAPPING_URL_LINKER = '//# sourceMappingURL=';
+const JS_SOURCE_MAPPING_URL_LINKER = '//# sourceMappingURL=';
 
 /**
  * Generates an RFC-3986 compliant string for the given input.
@@ -36,7 +36,7 @@ export const JS_SOURCE_MAPPING_URL_LINKER = '//# sourceMappingURL=';
  * @param filename the filename to encode
  * @returns the encoded URI
  */
-const encodeFilenameToRfc3986 = (filename: string): string => {
+const encodeToRfc3986 = (filename: string): string => {
   const encodedUri = encodeURIComponent(filename);
   // replace all '!', single quotes, '(', ')', and '*' with their hexadecimal values (UTF-16)
   return encodedUri.replace(/[!'()*]/g, (matchedCharacter) => {
@@ -51,7 +51,21 @@ const encodeFilenameToRfc3986 = (filename: string): string => {
  * @returns a linker string, of the format {@link JS_SOURCE_MAPPING_URL_LINKER}=<url>
  */
 export const getSourceMappingUrlLinker = (url: string): string => {
-  return `${JS_SOURCE_MAPPING_URL_LINKER}${encodeFilenameToRfc3986(url)}`;
+  return `${JS_SOURCE_MAPPING_URL_LINKER}${encodeToRfc3986(url)}`;
+};
+
+/**
+ * Generates a string used to link generated code with the original source, to be placed at the end of the generated
+ * code as an inline source map.
+ * @param sourceMapContents the sourceMapContents of the source map
+ * @returns a linker string, of the format {@link JS_SOURCE_MAPPING_URL_LINKER}<dataUriPrefixAndMime><sourceMapContents>
+ */
+export const getInlineSourceMappingUrlLinker = (sourceMapContents: string): string => {
+  const mapBase64 = Buffer.from(sourceMapContents, 'utf8').toString('base64');
+
+  // do not RFC-3986 encode an already valid base64 string. the sourcemaps will not resolve correctly when there is an
+  // allowed base64 character is encoded (because it is a disallowed RFC-3986 character)
+  return `${JS_SOURCE_MAPPING_URL_LINKER}data:application/json;charset=utf-8;base64,${mapBase64}`;
 };
 
 /**

--- a/src/utils/test/sourcemaps.spec.ts
+++ b/src/utils/test/sourcemaps.spec.ts
@@ -1,4 +1,9 @@
-import { getSourceMappingUrlLinker, getSourceMappingUrlForEndOfFile, rollupToStencilSourceMap } from '@utils';
+import {
+  getSourceMappingUrlLinker,
+  getSourceMappingUrlForEndOfFile,
+  rollupToStencilSourceMap,
+  getInlineSourceMappingUrlLinker,
+} from '@utils';
 import { SourceMap as RollupSourceMap } from 'rollup';
 import type * as d from '../../declarations';
 
@@ -81,6 +86,129 @@ describe('sourcemaps', () => {
 
     it('encodes multiple disallowed characters at once', () => {
       expect(getSourceMappingUrlLinker('!some-(pkg)*')).toBe('//# sourceMappingURL=%21some-%28pkg%29%2a');
+    });
+  });
+
+  describe('getInlineSourceMappingUrlLinker', () => {
+    it('returns a correctly formatted sourcemap', () => {
+      expect(
+        getInlineSourceMappingUrlLinker(
+          '{"version":3,"file":"sourcemaps.js","sourceRoot":"","sources":["sourcemaps.ts"],"names":[],"mappings":";;AAAA,mCAKgB;"}'
+        )
+      ).toBe(
+        '//# sourceMappingURL=data:application/json;charset=utf-8;base64,' +
+          'eyJ2ZXJzaW9uIjozLCJmaWxlIjoic291cmNlbWFwcy5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbInNvdXJjZW1hcHMudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7QUFBQSxtQ0FLZ0I7In0='
+      );
+    });
+
+    it('handles question marks in sourcemaps', () => {
+      expect(
+        getInlineSourceMappingUrlLinker(
+          '{"version":3,"file":"source?maps.js","sourceRoot":"","sources":["source?maps.ts"],"names":[],"mappings":";;AAAA,mCAKgB;"}'
+        )
+      ).toBe(
+        '//# sourceMappingURL=data:application/json;charset=utf-8;base64,' +
+          'eyJ2ZXJzaW9uIjozLCJmaWxlIjoic291cmNlP21hcHMuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJzb3VyY2U/bWFwcy50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOztBQUFBLG1DQUtnQjsifQ=='
+      );
+    });
+
+    it('handles plus signs in sourcemaps', () => {
+      expect(
+        getInlineSourceMappingUrlLinker(
+          '{"version":3,"file":"source+maps.js","sourceRoot":"","sources":["source+maps.ts"],"names":[],"mappings":";;AAAA,mCAKgB;"}'
+        )
+      ).toBe(
+        '//# sourceMappingURL=data:application/json;charset=utf-8;base64,' +
+          'eyJ2ZXJzaW9uIjozLCJmaWxlIjoic291cmNlK21hcHMuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJzb3VyY2UrbWFwcy50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOztBQUFBLG1DQUtnQjsifQ=='
+      );
+    });
+
+    it('handles equal signs in sourcemaps', () => {
+      expect(
+        getInlineSourceMappingUrlLinker(
+          '{"version":3,"file":"source=maps.js","sourceRoot":"","sources":["source=maps.ts"],"names":[],"mappings":";;AAAA,mCAKgB;"}'
+        )
+      ).toBe(
+        '//# sourceMappingURL=data:application/json;charset=utf-8;base64,' +
+          'eyJ2ZXJzaW9uIjozLCJmaWxlIjoic291cmNlPW1hcHMuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJzb3VyY2U9bWFwcy50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOztBQUFBLG1DQUtnQjsifQ=='
+      );
+    });
+
+    it('handles ampersands in sourcemaps', () => {
+      expect(
+        getInlineSourceMappingUrlLinker(
+          '{"version":3,"file":"source&maps.js","sourceRoot":"","sources":["source&maps.ts"],"names":[],"mappings":";;AAAA,mCAKgB;"}'
+        )
+      ).toBe(
+        '//# sourceMappingURL=data:application/json;charset=utf-8;base64,' +
+          'eyJ2ZXJzaW9uIjozLCJmaWxlIjoic291cmNlJm1hcHMuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJzb3VyY2UmbWFwcy50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOztBQUFBLG1DQUtnQjsifQ=='
+      );
+    });
+
+    it('handles slashes in sourcemaps', () => {
+      expect(
+        getInlineSourceMappingUrlLinker(
+          '{"version":3,"file":"source/maps.js","sourceRoot":"","sources":["source/maps.js.ts"],"names":[],"mappings":";;AAAA,mCAKgB;"}'
+        )
+      ).toBe(
+        '//# sourceMappingURL=data:application/json;charset=utf-8;base64,' +
+          'eyJ2ZXJzaW9uIjozLCJmaWxlIjoic291cmNlL21hcHMuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJzb3VyY2UvbWFwcy5qcy50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOztBQUFBLG1DQUtnQjsifQ=='
+      );
+    });
+
+    it('handles exclamation points in sourcemaps', () => {
+      expect(
+        getInlineSourceMappingUrlLinker(
+          '{"version":3,"file":"sourcemaps!.js","sourceRoot":"","sources":["sourcemaps!.ts"],"names":[],"mappings":";;AAAA,mCAKgB;"}'
+        )
+      ).toBe(
+        '//# sourceMappingURL=data:application/json;charset=utf-8;base64,' +
+          'eyJ2ZXJzaW9uIjozLCJmaWxlIjoic291cmNlbWFwcyEuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJzb3VyY2VtYXBzIS50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOztBQUFBLG1DQUtnQjsifQ=='
+      );
+    });
+
+    it('handles single quotes in sourcemaps', () => {
+      expect(
+        getInlineSourceMappingUrlLinker(
+          '{"version":3,"file":"source\'maps.js","sourceRoot":"","sources":["source\'maps.ts"],"names":[],"mappings":";;AAAA,mCAKgB;"}'
+        )
+      ).toBe(
+        '//# sourceMappingURL=data:application/json;charset=utf-8;base64,' +
+          'eyJ2ZXJzaW9uIjozLCJmaWxlIjoic291cmNlJ21hcHMuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJzb3VyY2UnbWFwcy50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOztBQUFBLG1DQUtnQjsifQ=='
+      );
+    });
+
+    it('handles parenthesis in sourcemaps', () => {
+      expect(
+        getInlineSourceMappingUrlLinker(
+          '{"version":3,"file":"source()maps.js","sourceRoot":"","sources":["source()maps.ts"],"names":[],"mappings":";;AAAA,mCAKgB;"}'
+        )
+      ).toBe(
+        '//# sourceMappingURL=data:application/json;charset=utf-8;base64,' +
+          'eyJ2ZXJzaW9uIjozLCJmaWxlIjoic291cmNlKCltYXBzLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsic291cmNlKCltYXBzLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7O0FBQUEsbUNBS2dCOyJ9'
+      );
+    });
+
+    it('handles asterisks in sourcemaps', () => {
+      expect(
+        getInlineSourceMappingUrlLinker(
+          '{"version":3,"file":"source*maps.js","sourceRoot":"","sources":["source*maps.ts"],"names":[],"mappings":";;AAAA,mCAKgB;"}'
+        )
+      ).toBe(
+        '//# sourceMappingURL=data:application/json;charset=utf-8;base64,' +
+          'eyJ2ZXJzaW9uIjozLCJmaWxlIjoic291cmNlKm1hcHMuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJzb3VyY2UqbWFwcy50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOztBQUFBLG1DQUtnQjsifQ=='
+      );
+    });
+
+    it('encodes multiple disallowed characters at once', () => {
+      expect(
+        getInlineSourceMappingUrlLinker(
+          '{"version":3,"file":"!source(maps)*.js","sourceRoot":"","sources":["!source(maps)*.ts"],"names":[],"mappings":";;AAAA,mCAKgB;"}'
+        )
+      ).toBe(
+        '//# sourceMappingURL=data:application/json;charset=utf-8;base64,' +
+          'eyJ2ZXJzaW9uIjozLCJmaWxlIjoiIXNvdXJjZShtYXBzKSouanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyIhc291cmNlKG1hcHMpKi50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOztBQUFBLG1DQUtnQjsifQ=='
+      );
     });
   });
 


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

this commit fixes a regression originally introduced in #3100, where
inline sourcemaps that are data URI's are erroneously encoded using
RFC-3986. this causes the sourcemaps for tests to not correctly map the
transpiled output back to the original source code.

GitHub Issue Number: https://github.com/ionic-team/stencil/issues/3147


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

do not URI encode the data prefix+mime type

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. -->
To test, I spun up 2 component libraries using `npm init stencil`:
1. `with-sourcemap-issue`, which is the standard output one would see from the Stencil CLI (with v2.11.0 installed)
2. `with-local-stencil-build`, which differs from the above only in name and has a Stencil build with this branch installed on it (`npm ci && npm run build && npm pack` to generated the tarball, then installed with `npm i <PATH_TO_TAR>`)

From there, I ran through the two test cases described in the issue summary of #3147, described below

### 'For Call Stacks'

Reproduction setup (in both projects):
1. Open `utils.ts` and add a throwing code to line 2. Example: '1'.d();
```diff
export function format(first: string, middle: string, last: string): string {
+ '1'.d();
  return (first || '') + (middle ? ` ${middle}` : '') + (last ? ` ${last}` : '');
}

```
2. `npm test -- --coverage --verbose --no-cache`

Outcomes:
In `with-sourcemap-issue`, the sourcemap does not map back to the correct line, which should be "(src/utils/utils.ts:2:7)" (where I added the line). In `with-local-stencil-build`, the sourcemap maps back to the correct line. The results are shown below, where `with-sourcemap-issue` is on the left, and `with-local-stencil-build` is on the right

![Screen Shot 2021-12-01 at 8 57 37 AM](https://user-images.githubusercontent.com/1930213/144247245-e0d591c2-bd01-4dab-bdbd-c607e59c33a1.png)

### 'For Coverage'

Reproduction setup (in both projects):
1. Open `utils.ts` and add a branching expression that will never be hit
```diff
export function format(first: string, middle: string, last: string): string {
+  if (1==2) {
+    first = middle;
+  }
  return (first || '') + (middle ? ` ${middle}` : '') + (last ? ` ${last}` : '');
}

```
2. `npm test -- --coverage --verbose --no-cache`

Outcomes:
In `with-sourcemap-issue`, the sourcemap does not map back to the correct line when opening the coverage report. (the coverage reports can be found in the `coverage/` dir in the root of each project). In `with-local-stencil-build`, the sourcemap maps back to the correct line in the coverage report. The results are shown below, where `with-sourcemap-issue` is on the left, and `with-local-stencil-build` is on the right.


![Screen Shot 2021-12-01 at 9 02 54 AM](https://user-images.githubusercontent.com/1930213/144248096-90f664ee-2c7a-4f69-b395-940976d9854e.png)

Note how the uncovered line number column is incorrect for the following code (which is the same piece of code in each project) on the left, and correct on the right
![Screen Shot 2021-12-01 at 9 01 04 AM](https://user-images.githubusercontent.com/1930213/144247802-305306b7-c005-4dcd-846b-70bb62dbabfd.png)
![Screen Shot 2021-12-01 at 9 01 24 AM](https://user-images.githubusercontent.com/1930213/144247857-f620e175-5c85-4144-bf6f-88843bbe2ff2.png)

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Shoutout to @johnjenkins for their work in debugging this! https://github.com/ionic-team/stencil/issues/3147#issuecomment-983147710
