### PR TITLE
refactor(dist-custom-elements-bundle): add deprecation warning

### DIFF
--- a/src/compiler/config/outputs/index.ts
+++ b/src/compiler/config/outputs/index.ts
@@ -1,6 +1,6 @@
 import type * as d from '../../../declarations';
-import { buildError } from '@utils';
-import { VALID_TYPES } from '../../output-targets/output-utils';
+import { buildError, buildWarn } from '@utils';
+import { DIST_CUSTOM_ELEMENTS_BUNDLE, VALID_TYPES } from '../../output-targets/output-utils';
 import { validateCollection } from './validate-collection';
 import { validateCustomElement } from './validate-custom-element';
 import { validateCustomOutput } from './validate-custom-output';
@@ -22,6 +22,9 @@ export const validateOutputTargets = (config: d.Config, diagnostics: d.Diagnosti
       err.messageText = `Invalid outputTarget type "${
         outputTarget.type
       }". Valid outputTarget types include: ${VALID_TYPES.map((t) => `"${t}"`).join(', ')}`;
+    } else if (outputTarget.type === DIST_CUSTOM_ELEMENTS_BUNDLE) {
+      const warning = buildWarn(diagnostics);
+      warning.messageText = `dist-custom-elements-bundle is deprecated and will be removed in a future version. Use "dist-custom-elements" instead. If "dist-custom-elements" does not meet your needs, please add a comment to https://github.com/ionic-team/stencil/issues/3136.`;
     }
   });
 

--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -312,6 +312,16 @@ describe('validation', () => {
     expect(validated.diagnostics).toHaveLength(1);
   });
 
+  it('should warn when dist-custom-elements-bundle is found', () => {
+    userConfig.outputTargets = [
+      {
+        type: 'dist-custom-elements-bundle',
+      } as any,
+    ];
+    const validated = validateConfig(userConfig);
+    expect(validated.diagnostics).toHaveLength(1);
+  });
+
   it('should default outputTargets with www', () => {
     const { config } = validateConfig(userConfig);
     expect(config.outputTargets.some((o) => o.type === 'www')).toBe(true);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`dist-custom-elements-bundle` is being deprecated in an upcoming major release of Stencil. See discussion in the following GitHub issue. Currently, no warning is shown to the user communicating this.

GitHub Issue Number: #3136


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

If `dist-custom-elements-bundle` is found in a Stencil config, a warning is fired when the build process begins that states: `dist-custom-elements-bundle is deprecated and will be removed in a future version. Use "dist-custom-elements" instead. If "dist-custom-elements" does not meet your needs, please add a comment to https://github.com/ionic-team/stencil/issues/3136.`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

A npm package tarball was generated from this branch (npm ci && npm run build && npm pack). It was then installed in a fresh Stencil project (`npx init stencil`). Said project was built both with and without `dist-custom-elements-bundle` being present in the output targets config to verify that the warning only appeared when the output target is present.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
