### PR TITLE
fix(vdom): properly warn for step attr on input

### DIFF
--- a/src/runtime/vdom/h.ts
+++ b/src/runtime/vdom/h.ts
@@ -163,16 +163,22 @@ const convertToPrivate = (node: d.ChildNode): d.VNode => {
   return vnode;
 };
 
-const validateInputProperties = (vnodeData: any) => {
-  const props = Object.keys(vnodeData);
-  const typeIndex = props.indexOf('type');
-  const minIndex = props.indexOf('min');
-  const maxIndex = props.indexOf('max');
-  const stepIndex = props.indexOf('min');
+/**
+ * Validates the ordering of attributes on an input element
+ * @param inputElm the element to validate
+ */
+const validateInputProperties = (inputElm: HTMLInputElement): void => {
+  const props = Object.keys(inputElm);
+
   const value = props.indexOf('value');
   if (value === -1) {
     return;
   }
+
+  const typeIndex = props.indexOf('type');
+  const minIndex = props.indexOf('min');
+  const maxIndex = props.indexOf('max');
+  const stepIndex = props.indexOf('step');
   if (value < typeIndex || value < minIndex || value < maxIndex || value < stepIndex) {
     consoleDevWarn(`The "value" prop of <input> should be set after "min", "max", "type" and "step"`);
   }


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Stencil performs dev-time checking of the order of `input` element attributes. The check for the `step` attribute is incorrect, as it points to `min`

GitHub Issue Number: https://github.com/ionic-team/stencil/issues/2406


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

fix `indexOf` call for the step attribute to look for the correct
attribute name.

hoist the check for `value` attribute to exit early if the attribute
does not exist, avoiding unneeded lookups of other attributes
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

First, I built this branch, `npm ci && npm run clean && npm run build && npm pack`.

I spun up a new Stencil component library (`npm init stencil` -> component), ran `npm i` for the component, then installed the tarball generated from the previous call to `npm pack`

Replace the `render` fn in `src/my-component.tsx`:
```tsx
  render() {
    // note 'step' is after 'value'
    return <input value={"Hello"} step={1}></input>;
  }
```

Run `npm start` in a terminal window whose cwd is the root of the Stencil component library that was spun up.  Open dev tools in your browser of choice to see the err msg.
![Screen Shot 2021-12-29 at 9 41 11 AM](https://user-images.githubusercontent.com/1930213/147673561-f7366875-3e1a-42ce-9d23-a9a44e6c149a.png)


Similarly, removing 'step'/reordering the attributes removes the error message:
```tsx
  render() {
    // note 'value' is after 'step'
    return <input step={1} value={"Hello"}></input>;
  }
```

