### PR TITLE
feat(typescript): typescript 4.5 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "sizzle": "^2.3.6",
         "terser": "5.6.1",
         "tslib": "^2.1.0",
-        "typescript": "4.3.5",
+        "typescript": "^4.4.4",
         "webpack": "^4.46.0",
         "ws": "7.4.6"
       },
@@ -11239,9 +11239,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -21162,9 +21162,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "sizzle": "^2.3.6",
         "terser": "5.6.1",
         "tslib": "^2.1.0",
-        "typescript": "^4.4.4",
+        "typescript": "4.5.4",
         "webpack": "^4.46.0",
         "ws": "7.4.6"
       },
@@ -11239,9 +11239,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -21162,9 +21162,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "sizzle": "^2.3.6",
     "terser": "5.6.1",
     "tslib": "^2.1.0",
-    "typescript": "4.3.5",
+    "typescript": "^4.4.4",
     "webpack": "^4.46.0",
     "ws": "7.4.6"
   },

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "sizzle": "^2.3.6",
     "terser": "5.6.1",
     "tslib": "^2.1.0",
-    "typescript": "^4.4.4",
+    "typescript": "4.5.4",
     "webpack": "^4.46.0",
     "ws": "7.4.6"
   },

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -15,6 +15,7 @@
     "pretty": true,
     "target": "es2017",
     "incremental": false,
+    "useUnknownInCatchVariables": true
   },
   "include": [
     "**/*.ts"

--- a/src/client/client-patch-browser.ts
+++ b/src/client/client-patch-browser.ts
@@ -21,6 +21,10 @@ export const patchBrowser = (): Promise<d.CustomElementsDefineOptions> => {
 
   if (BUILD.profile && !performance.mark) {
     // not all browsers support performance.mark/measure (Safari 10)
+    // because the mark/measure APIs are designed to write entries to a buffer in the browser that does not exist,
+    // simply stub the implementations out.
+    // TODO(STENCIL-323): Remove this patch when support for older browsers is removed (breaking)
+    // @ts-ignore
     performance.mark = performance.measure = () => {
       /*noop*/
     };

--- a/src/compiler/sys/dependencies.json
+++ b/src/compiler/sys/dependencies.json
@@ -52,6 +52,7 @@
         "compiler/lib.es2020.symbol.wellknown.d.ts",
         "compiler/lib.es2021.d.ts",
         "compiler/lib.es2021.full.d.ts",
+        "compiler/lib.es2021.intl.d.ts",
         "compiler/lib.es2021.promise.d.ts",
         "compiler/lib.es2021.string.d.ts",
         "compiler/lib.es2021.weakref.d.ts",

--- a/src/compiler/sys/typescript/typescript-sys.ts
+++ b/src/compiler/sys/typescript/typescript-sys.ts
@@ -83,6 +83,8 @@ export const patchTsSystemFileSystem = (
 
   tsSys.readDirectory = (path, extensions, exclude, include, depth) => {
     const cwd = stencilSys.getCurrentDirectory();
+    // TODO(STENCIL-XXXX): Remove the final argument passed to `matchFiles` when Stencil is upgraded to TS v4.5
+    // TODO(STENCIL-344): Replace `matchFiles` with a function that is publicly exposed
     return (ts as any).matchFiles(
       path,
       extensions,
@@ -92,7 +94,10 @@ export const patchTsSystemFileSystem = (
       cwd,
       depth,
       getAccessibleFileSystemEntries,
-      realpath
+      realpath,
+      // TODO: Is this the right thing to do with all the patching we do?
+      // https://github.com/parcel-bundler/parcel/pull/6784
+      ts.sys.directoryExists
     );
   };
 

--- a/src/compiler/sys/typescript/typescript-sys.ts
+++ b/src/compiler/sys/typescript/typescript-sys.ts
@@ -83,7 +83,6 @@ export const patchTsSystemFileSystem = (
 
   tsSys.readDirectory = (path, extensions, exclude, include, depth) => {
     const cwd = stencilSys.getCurrentDirectory();
-    // TODO(STENCIL-XXXX): Remove the final argument passed to `matchFiles` when Stencil is upgraded to TS v4.5
     // TODO(STENCIL-344): Replace `matchFiles` with a function that is publicly exposed
     return (ts as any).matchFiles(
       path,
@@ -94,10 +93,7 @@ export const patchTsSystemFileSystem = (
       cwd,
       depth,
       getAccessibleFileSystemEntries,
-      realpath,
-      // TODO: Is this the right thing to do with all the patching we do?
-      // https://github.com/parcel-bundler/parcel/pull/6784
-      ts.sys.directoryExists
+      realpath
     );
   };
 

--- a/src/compiler/transformers/style-imports.ts
+++ b/src/compiler/transformers/style-imports.ts
@@ -70,12 +70,13 @@ const updateEsmStyleImportPath = (
         const orgImportPath = n.moduleSpecifier.text;
         const importPath = getStyleImportPath(transformOpts, tsSourceFile, cmp, style, orgImportPath);
 
-        statements[i] = ts.updateImportDeclaration(
+        statements[i] = ts.factory.updateImportDeclaration(
           n,
           n.decorators,
           n.modifiers,
           n.importClause,
-          ts.createStringLiteral(importPath)
+          ts.factory.createStringLiteral(importPath),
+          undefined
         );
         break;
       }

--- a/src/compiler/transformers/test/parse-props.spec.ts
+++ b/src/compiler/transformers/test/parse-props.spec.ts
@@ -168,7 +168,7 @@ describe('parse props', () => {
               location: 'global',
             },
           },
-          resolved: 'any',
+          resolved: 'Object',
           original: 'Object',
         },
         docs: {

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -595,9 +595,12 @@ export const createImportStatement = (importFnNames: string[], importPath: strin
       importFnName = splt[0];
     }
 
-    return ts.createImportSpecifier(
-      typeof importFnName === 'string' && importFnName !== importAs ? ts.createIdentifier(importFnName) : undefined,
-      ts.createIdentifier(importAs)
+    return ts.factory.createImportSpecifier(
+      false,
+      typeof importFnName === 'string' && importFnName !== importAs
+        ? ts.factory.createIdentifier(importFnName)
+        : undefined,
+      ts.factory.createIdentifier(importAs)
     );
   });
 

--- a/src/compiler/transformers/update-stencil-core-import.ts
+++ b/src/compiler/transformers/update-stencil-core-import.ts
@@ -25,17 +25,21 @@ export const updateStencilCoreImports = (updatedCoreImportPath: string): ts.Tran
                 const keepImports = origImports.map((e) => e.getText()).filter((name) => KEEP_IMPORTS.has(name));
 
                 if (keepImports.length > 0) {
-                  const newImport = ts.updateImportDeclaration(
+                  const newImport = ts.factory.updateImportDeclaration(
                     s,
                     undefined,
                     undefined,
-                    ts.createImportClause(
+                    ts.factory.createImportClause(
+                      false,
                       undefined,
-                      ts.createNamedImports(
-                        keepImports.map((name) => ts.createImportSpecifier(undefined, ts.createIdentifier(name)))
+                      ts.factory.createNamedImports(
+                        keepImports.map((name) =>
+                          ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier(name))
+                        )
                       )
                     ),
-                    ts.createStringLiteral(updatedCoreImportPath)
+                    ts.factory.createStringLiteral(updatedCoreImportPath),
+                    undefined
                   );
                   newStatements.push(newImport);
                 }

--- a/src/dev-server/dev-server-client/app-update.ts
+++ b/src/dev-server/dev-server-client/app-update.ts
@@ -65,7 +65,7 @@ const appUpdate = (win: d.DevClientWindow, config: d.DevClientConfig, buildResul
       // then let's refresh the page from the root of the server
       appReset(win, config, () => {
         logReload(`Initial load`);
-        win.location.reload(true);
+        win.location.reload();
       });
       return;
     }
@@ -111,7 +111,7 @@ const appHmr = (win: Window, hmr: d.HotModuleReplacement) => {
   }
 
   if (shouldWindowReload) {
-    win.location.reload(true);
+    win.location.reload();
     return;
   }
 

--- a/src/dev-server/dev-server-client/client-web-socket.ts
+++ b/src/dev-server/dev-server-client/client-web-socket.ts
@@ -76,7 +76,7 @@ export const initClientWebSocket = (win: d.DevClientWindow, config: d.DevClientC
         clearInterval(requestBuildResultsTmrId);
 
         if (win['s-build-id'] !== msg.buildResults.buildId) {
-          win.location.reload(true);
+          win.location.reload();
         }
         win['s-build-id'] = msg.buildResults.buildId;
         return;

--- a/src/hydrate/runner/window-initialize.ts
+++ b/src/hydrate/runner/window-initialize.ts
@@ -47,6 +47,8 @@ export function initializeWindow(
   }
 
   try {
+    // TODO(STENCIL-345) - Evaluate reconciling MockWindow, Window differences
+    // @ts-ignore
     win.customElements = null;
   } catch (e) {}
 

--- a/src/mock-doc/custom-element-registry.ts
+++ b/src/mock-doc/custom-element-registry.ts
@@ -81,14 +81,14 @@ export class MockCustomElementRegistry implements CustomElementRegistry {
     }
   }
 
-  whenDefined(tagName: string) {
+  whenDefined(tagName: string): Promise<CustomElementConstructor> {
     tagName = tagName.toLowerCase();
 
     if (this.__registry != null && this.__registry.has(tagName) === true) {
-      return Promise.resolve();
+      return this.__registry.get(tagName).cstr;
     }
 
-    return new Promise<void>((resolve) => {
+    return new Promise<CustomElementConstructor>((resolve) => {
       if (this.__whenDefined == null) {
         this.__whenDefined = new Map();
       }

--- a/src/mock-doc/custom-element-registry.ts
+++ b/src/mock-doc/custom-element-registry.ts
@@ -85,7 +85,7 @@ export class MockCustomElementRegistry implements CustomElementRegistry {
     tagName = tagName.toLowerCase();
 
     if (this.__registry != null && this.__registry.has(tagName) === true) {
-      return this.__registry.get(tagName).cstr;
+      return Promise.resolve<CustomElementConstructor>(this.__registry.get(tagName).cstr);
     }
 
     return new Promise<CustomElementConstructor>((resolve) => {

--- a/src/mock-doc/performance.ts
+++ b/src/mock-doc/performance.ts
@@ -40,11 +40,21 @@ export class MockPerformance implements Performance {
     return [] as any;
   }
 
-  mark() {
+  // Stencil's implementation of `mark` is non-compliant with the `Performance` interface. Because Stencil will
+  // instantiate an instance of this class and may attempt to assign it to a variable of type `Performance`, the return
+  // type must match the `Performance` interface (rather than typing this function as returning `void` and ignoring the
+  // associated errors returned by the type checker)
+  // @ts-ignore
+  mark(): PerformanceMark {
     //
   }
 
-  measure() {
+  // Stencil's implementation of `measure` is non-compliant with the `Performance` interface. Because Stencil will
+  // instantiate an instance of this class and may attempt to assign it to a variable of type `Performance`, the return
+  // type must match the `Performance` interface (rather than typing this function as returning `void` and ignoring the
+  // associated errors returned by the type checker)
+  // @ts-ignore
+  measure(): PerformanceMeasure {
     //
   }
 

--- a/src/mock-doc/window.ts
+++ b/src/mock-doc/window.ts
@@ -802,6 +802,8 @@ export function cloneWindow(srcWin: Window, opts: { customElementProxy?: boolean
 
   const clonedWin = new MockWindow(false);
   if (!opts.customElementProxy) {
+    // TODO(STENCIL-345) - Evaluate reconciling MockWindow, Window differences
+    // @ts-ignore
     srcWin.customElements = null;
   }
 

--- a/src/runtime/test/tsconfig.json
+++ b/src/runtime/test/tsconfig.json
@@ -18,6 +18,7 @@
     "noUnusedParameters": true,
     "pretty": true,
     "target": "es2017",
+    "useUnknownInCatchVariables": true,
     "baseUrl": ".",
     "paths": {
       "@stencil/core": ["../../index.ts"],

--- a/src/runtime/vdom/test/tsconfig.json
+++ b/src/runtime/vdom/test/tsconfig.json
@@ -17,6 +17,7 @@
     "noUnusedParameters": true,
     "pretty": true,
     "target": "es2017",
+    "useUnknownInCatchVariables": true,
     "baseUrl": ".",
     "paths": {
       "@stencil/core": ["../../../index.ts"],

--- a/src/testing/tsconfig.internal.json
+++ b/src/testing/tsconfig.internal.json
@@ -21,6 +21,7 @@
     "noUnusedParameters": true,
     "pretty": true,
     "target": "es2017",
+    "useUnknownInCatchVariables": true,
     "baseUrl": ".",
     "paths": {
       "@stencil/core/cli": [

--- a/test/browser-compile/tsconfig.json
+++ b/test/browser-compile/tsconfig.json
@@ -20,6 +20,7 @@
     "noUnusedParameters": true,
     "pretty": true,
     "target": "es2017",
+    "useUnknownInCatchVariables": true,
     "baseUrl": ".",
     "paths": {
       "@stencil/core/testing": [

--- a/test/end-to-end/tsconfig.json
+++ b/test/end-to-end/tsconfig.json
@@ -21,6 +21,7 @@
     "noUnusedParameters": true,
     "pretty": true,
     "target": "es2017",
+    "useUnknownInCatchVariables": true,
     "baseUrl": ".",
     "paths": {
       "@stencil/core": [

--- a/test/hello-vdom/tsconfig.json
+++ b/test/hello-vdom/tsconfig.json
@@ -19,6 +19,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "target": "es2017",
+    "useUnknownInCatchVariables": true,
     "baseUrl": ".",
     "paths": {
       "@stencil/core": ["../../internal"],

--- a/test/hello-world/tsconfig.parent.json
+++ b/test/hello-world/tsconfig.parent.json
@@ -19,6 +19,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "target": "es2017",
+    "useUnknownInCatchVariables": true,
     "baseUrl": ".",
     "paths": {
       "@stencil/core": ["../../internal"],

--- a/test/ionic-app/tsconfig.json
+++ b/test/ionic-app/tsconfig.json
@@ -12,6 +12,7 @@
     "noUnusedParameters": true,
     "jsx": "react",
     "jsxFactory": "h",
+    "useUnknownInCatchVariables": true,
     "baseUrl": ".",
     "paths": {
       "@stencil/core": ["../../internal"],

--- a/test/jest-spec-runner/tsconfig.json
+++ b/test/jest-spec-runner/tsconfig.json
@@ -19,6 +19,7 @@
     "noUnusedParameters": true,
     "pretty": true,
     "target": "es2017",
+    "useUnknownInCatchVariables": true,
     "baseUrl": ".",
     "paths": {
       "@stencil/core": ["../../internal"],

--- a/test/karma/package-lock.json
+++ b/test/karma/package-lock.json
@@ -3,35 +3,35 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.16.0"
+        "@babel/highlight": "^7.16.7"
       }
     },
     "@babel/compat-data": {
-      "version": "7.16.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.4.tgz",
-      "integrity": "sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==",
+      "version": "7.16.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.8.tgz",
+      "integrity": "sha512-m7OkX0IdKLKPpBlJtF561YJal5y/jyI5fNfWbPxh2D/nbzzGI4qRyrD8xO2jB24u7l+5I2a43scCG2IrfjC50Q==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.0.tgz",
-      "integrity": "sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.7.tgz",
+      "integrity": "sha512-aeLaqcqThRNZYmbMqtulsetOQZ/5gbR/dWruUCJcpas4Qoyy+QeagfDsPdMrqwsPRDNxJvBlRiZxxX7THO7qtA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/generator": "^7.16.0",
-        "@babel/helper-compilation-targets": "^7.16.0",
-        "@babel/helper-module-transforms": "^7.16.0",
-        "@babel/helpers": "^7.16.0",
-        "@babel/parser": "^7.16.0",
-        "@babel/template": "^7.16.0",
-        "@babel/traverse": "^7.16.0",
-        "@babel/types": "^7.16.0",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.16.7",
+        "@babel/helper-compilation-targets": "^7.16.7",
+        "@babel/helper-module-transforms": "^7.16.7",
+        "@babel/helpers": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.16.7",
+        "@babel/types": "^7.16.7",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -70,12 +70,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
-      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
+      "version": "7.16.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
+      "integrity": "sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0",
+        "@babel/types": "^7.16.8",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -89,13 +89,13 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.3.tgz",
-      "integrity": "sha512-vKsoSQAyBmxS35JUOOt+07cLc6Nk/2ljLIHwmq2/NM6hdioUaqEXq/S+nXvbvXbZkNDlWOymPanJGOc4CBjSJA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
+      "integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.16.0",
-        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/compat-data": "^7.16.4",
+        "@babel/helper-validator-option": "^7.16.7",
         "browserslist": "^4.17.5",
         "semver": "^6.3.0"
       },
@@ -108,146 +108,125 @@
         }
       }
     },
-    "@babel/helper-function-name": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
-      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+    "@babel/helper-environment-visitor": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
+      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.16.0",
-        "@babel/template": "^7.16.0",
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
+      "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
-      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
+      "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
-      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
+      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
-      }
-    },
-    "@babel/helper-member-expression-to-functions": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.0.tgz",
-      "integrity": "sha512-bsjlBFPuWT6IWhl28EdrQ+gTvSvj5tqVP5Xeftp07SEuz5pLnsXZuDkDD3Rfcxy0IsHmbZ+7B2/9SHzxO0T+sQ==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
-      "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+      "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.0.tgz",
-      "integrity": "sha512-My4cr9ATcaBbmaEa8M0dZNA74cfI6gitvUAskgDtAFmAqyFKDSHQo5YstxPbN+lzHl2D9l/YOEFqb2mtUh4gfA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
+      "integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.16.0",
-        "@babel/helper-replace-supers": "^7.16.0",
-        "@babel/helper-simple-access": "^7.16.0",
-        "@babel/helper-split-export-declaration": "^7.16.0",
-        "@babel/helper-validator-identifier": "^7.15.7",
-        "@babel/template": "^7.16.0",
-        "@babel/traverse": "^7.16.0",
-        "@babel/types": "^7.16.0"
-      }
-    },
-    "@babel/helper-optimise-call-expression": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz",
-      "integrity": "sha512-SuI467Gi2V8fkofm2JPnZzB/SUuXoJA5zXe/xzyPP2M04686RzFKFHPK6HDVN6JvWBIEW8tt9hPR7fXdn2Lgpw==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.0"
-      }
-    },
-    "@babel/helper-replace-supers": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.0.tgz",
-      "integrity": "sha512-TQxuQfSCdoha7cpRNJvfaYxxxzmbxXw/+6cS7V02eeDYyhxderSoMVALvwupA54/pZcOTtVeJ0xccp1nGWladA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.16.0",
-        "@babel/helper-optimise-call-expression": "^7.16.0",
-        "@babel/traverse": "^7.16.0",
-        "@babel/types": "^7.16.0"
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-simple-access": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.0.tgz",
-      "integrity": "sha512-o1rjBT/gppAqKsYfUdfHq5Rk03lMQrkPHG1OWzHWpLgVXRH4HnMM9Et9CVdIqwkCQlobnGHEJMsgWP/jE1zUiw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
+      "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
-      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
+      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
       "dev": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
+      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.3.tgz",
-      "integrity": "sha512-Xn8IhDlBPhvYTvgewPKawhADichOsbkZuzN7qz2BusOM0brChsyXMDJvldWaYMMUNiCQdQzNEioXTp3sC8Nt8w==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.7.tgz",
+      "integrity": "sha512-9ZDoqtfY7AuEOt3cxchfii6C7GDyyMBffktR5B2jvWv8u2+efwvpnVKXMWzNehqy68tKgAfSwfdw/lWpthS2bw==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.16.0",
-        "@babel/traverse": "^7.16.3",
-        "@babel/types": "^7.16.0"
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/highlight": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.7.tgz",
+      "integrity": "sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.16.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
-      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
+      "version": "7.16.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.8.tgz",
+      "integrity": "sha512-i7jDUfrVBWc+7OKcBzEe5n7fbv3i2fWtxKzzCvOjnzSxMfWMigAhtfJ7qzZNGFNMsCCd67+uz553dYKWXPvCKw==",
       "dev": true
     },
     "@babel/runtime": {
@@ -260,29 +239,30 @@
       }
     },
     "@babel/template": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
-      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
+      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/parser": "^7.16.0",
-        "@babel/types": "^7.16.0"
+        "@babel/code-frame": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/traverse": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
-      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
+      "version": "7.16.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.8.tgz",
+      "integrity": "sha512-xe+H7JlvKsDQwXRsBhSnq1/+9c+LlQcCK3Tn/l5sbx02HYns/cn7ibp9+RV1sIUqu7hKg91NWsgHurO9dowITQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/generator": "^7.16.0",
-        "@babel/helper-function-name": "^7.16.0",
-        "@babel/helper-hoist-variables": "^7.16.0",
-        "@babel/helper-split-export-declaration": "^7.16.0",
-        "@babel/parser": "^7.16.3",
-        "@babel/types": "^7.16.0",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.16.8",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-hoist-variables": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/parser": "^7.16.8",
+        "@babel/types": "^7.16.8",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -305,12 +285,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
-      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+      "version": "7.16.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
+      "integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -436,9 +416,9 @@
       }
     },
     "acorn": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
-      "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
       "dev": true
     },
     "acorn-walk": {
@@ -526,9 +506,9 @@
       }
     },
     "async": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
-      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
       "dev": true
     },
     "atob": {
@@ -783,13 +763,13 @@
       }
     },
     "browserslist": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.18.1.tgz",
-      "integrity": "sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
+      "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001280",
-        "electron-to-chromium": "^1.3.896",
+        "caniuse-lite": "^1.0.30001286",
+        "electron-to-chromium": "^1.4.17",
         "escalade": "^3.1.1",
         "node-releases": "^2.0.1",
         "picocolors": "^1.0.0"
@@ -902,9 +882,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001286",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001286.tgz",
-      "integrity": "sha512-zaEMRH6xg8ESMi2eQ3R4eZ5qw/hJiVsO/HlLwniIwErij0JDr9P+8V4dtx1l+kLq6j3yy8l8W4fst1lBnat5wQ==",
+      "version": "1.0.30001299",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz",
+      "integrity": "sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==",
       "dev": true
     },
     "chalk": {
@@ -1373,9 +1353,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.14.tgz",
-      "integrity": "sha512-RsGkAN9JEAYMObS72kzUsPPcPGMqX1rBqGuXi9aa4TBKLzICoLf+DAAtd0fVFzrniJqYzpby47gthCUoObfs0Q==",
+      "version": "1.4.44",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.44.tgz",
+      "integrity": "sha512-tHGWiUUmY7GABK8+DNcr474cnZDTzD8x1736SlDosVH8+/vRJeqfaIBAEHFtMjddz/0T4rKKYsxEc8BwQRdBpw==",
       "dev": true
     },
     "elliptic": {
@@ -2169,9 +2149,9 @@
       }
     },
     "is-negative-zero": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
       "dev": true
     },
     "is-number": {
@@ -2270,12 +2250,12 @@
       }
     },
     "is-weakref": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
-      "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0"
+        "call-bind": "^1.0.2"
       }
     },
     "isarray": {
@@ -2400,9 +2380,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.1.tgz",
-      "integrity": "sha512-q1kvhAXWSsXfMjCdNHNPKZZv94OlspKnoGv+R9RGbnqOOQ0VbNfLFgQDVgi7hHenKsndGq3/o0OBdzDXthWcNw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.3.tgz",
+      "integrity": "sha512-x9LtDVtfm/t1GFiLl3NffC7hz+I1ragvgX1P/Lg1NlIagifZDKUkuuaAxH/qpwj2IuEfD8G2Bs/UKp+sZ/pKkg==",
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0",
@@ -2545,9 +2525,9 @@
       "dev": true
     },
     "karma-typescript": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/karma-typescript/-/karma-typescript-5.5.2.tgz",
-      "integrity": "sha512-2rNhiCMrIF+VR8jMuovOLSRjNkjdoE/kQ4XYZU94lMkHNQtnqCaToAnztMj4fuOPRErL7VIkwvJEO7jBd47Q6A==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/karma-typescript/-/karma-typescript-5.5.3.tgz",
+      "integrity": "sha512-l1FHurolXEBIzRa9ExpNtjzysAhsi/vLpTazpwLHWWK86mknvVpqor6pRZ5Nid7jvOPrTBqAq0JRuLgiCdRkFw==",
       "dev": true,
       "requires": {
         "acorn": "^8.1.0",
@@ -2867,9 +2847,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.1.tgz",
-      "integrity": "sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
       "dev": true
     },
     "object-is": {
@@ -3282,13 +3262,14 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
+      "integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "is-core-module": "^2.8.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
       }
     },
     "resolve-cwd": {
@@ -3807,6 +3788,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
     },
     "temp-fs": {
       "version": "0.9.9",

--- a/test/karma/package.json
+++ b/test/karma/package.json
@@ -37,7 +37,7 @@
     "karma-ie-launcher": "^1.0.0",
     "karma-jasmine": "^4.0.1",
     "karma-polyfill": "^1.1.0",
-    "karma-typescript": "^5.5.2",
+    "karma-typescript": "^5.5.3",
     "normalize.css": "^8.0.1",
     "rollup-plugin-node-polyfills": "^0.1.2",
     "webpack-cli": "^4.9.1",

--- a/test/karma/test-invisible-prehydration/tsconfig.json
+++ b/test/karma/test-invisible-prehydration/tsconfig.json
@@ -21,6 +21,7 @@
     "noUnusedParameters": false,
     "pretty": true,
     "target": "es2017",
+    "useUnknownInCatchVariables": true,
     "baseUrl": ".",
     "paths": {
       "@stencil/core": ["../../../internal"],

--- a/test/karma/test-prerender/tsconfig-prerender.json
+++ b/test/karma/test-prerender/tsconfig-prerender.json
@@ -22,6 +22,7 @@
     "noUnusedParameters": true,
     "pretty": true,
     "target": "es2017",
+    "useUnknownInCatchVariables": true,
     "baseUrl": ".",
     "paths": {
       "@stencil/core": ["../../../internal"],

--- a/test/karma/test-sibling/tsconfig.json
+++ b/test/karma/test-sibling/tsconfig.json
@@ -21,6 +21,7 @@
     "noUnusedParameters": false,
     "pretty": true,
     "target": "es2017",
+    "useUnknownInCatchVariables": true,
     "baseUrl": ".",
     "paths": {
       "@stencil/core": ["../../../internal"],

--- a/test/karma/tsconfig-stencil.json
+++ b/test/karma/tsconfig-stencil.json
@@ -22,6 +22,7 @@
     "noUnusedParameters": true,
     "pretty": true,
     "target": "es2017",
+    "useUnknownInCatchVariables": true,
     "baseUrl": ".",
     "paths": {
       "@stencil/core": ["../../internal"],

--- a/test/karma/tsconfig.json
+++ b/test/karma/tsconfig.json
@@ -21,12 +21,13 @@
     "noUnusedParameters": false,
     "pretty": true,
     "target": "es5",
+    "useUnknownInCatchVariables": true,
     "outDir": "tmp-compiled-tests",
     "baseUrl": ".",
     "paths": {
       "@stencil/core": ["../../internal"],
       "@stencil/core/internal": ["../../internal"],
-      "@stencil/core/testing": ["../../testing"],
+      "@stencil/core/testing": ["../../testing"]
     }
   },
   "include": [

--- a/test/performance/tsconfig.json
+++ b/test/performance/tsconfig.json
@@ -19,6 +19,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "target": "es2017",
+    "useUnknownInCatchVariables": true,
     "baseUrl": ".",
     "paths": {
       "@stencil/core": ["../../internal"],

--- a/test/prerender-shadow/tsconfig.json
+++ b/test/prerender-shadow/tsconfig.json
@@ -19,6 +19,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "target": "es2017",
+    "useUnknownInCatchVariables": true,
     "baseUrl": ".",
     "paths": {
       "@stencil/core": [

--- a/test/style-modes/tsconfig.json
+++ b/test/style-modes/tsconfig.json
@@ -19,6 +19,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "target": "es2017",
+    "useUnknownInCatchVariables": true,
     "baseUrl": ".",
     "paths": {
       "@stencil/core": [

--- a/test/todo-app/tsconfig.json
+++ b/test/todo-app/tsconfig.json
@@ -18,6 +18,7 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "useUnknownInCatchVariables": true,
     "target": "es2017",
     "baseUrl": ".",
     "paths": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,8 @@
     "resolveJsonModule": true,
     "sourceMap": true,
     "target": "es2018",
+    // TODO(STENCIL-346): Enable useUnknownInCatchVariables flag for main project
+    "useUnknownInCatchVariables": false,
     "baseUrl": ".",
     "paths": {
       "@app-data": ["src/app-data/index.ts"],


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We currently support v4.3 of TypeScript

GitHub Issue Numbers:
- Relates to https://github.com/ionic-team/stencil/issues/3170


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR adds support for TypeScript 4.5. I originally intended to only bump Stencil to v4.4, but there were some changes to a private TypeScript API Stencil uses (and shouldn't, more on that later) in TS v4.4 that were reverted in v4.5 (again, more on that later).  Below is a summary of each commit by name (should I rebase this and mess up the SHA links)

<details><summary>chore(dependencies): upgrade typescript to v4.4.4</summary>

Version bump us to v4.4.4 - this was before I realized we'd have a problem with 4.4. This commit will later be superseded by the upgrade to 4.5.
</details>
<details><summary>update client browser patching</summary>

update client-patch-browser.ts patching of `performance.mark()` &
`performance.measure()` to be ignored by the type checker. this patch
allows stencil to support Safari 10; since we don't have access to a
non-existent performance buffer and changing the return value for either
of these functions could be considered a breaking change, defer altering
the (non-compliant) functions until stencil drops support for Safari 10

</details>
<details><summary>remove non-compliant window.location.reload() arguments </summary>

`reload` has no parameter, although Firefox supports a non-standard
'forceGet' boolean parameter for bypassing its cache. for all other
browsers, this is otherwise ignored. these arguments are used in the
context of stencil's dev-server (IE are only used at dev time). given
these two statements, the risk of a truly breaking change is deemed
minimal here

</details>
<details><summary>update fn signature of mock-doc's customElementRegistry#whenDefined </summary>

set the return type of `whenDefined` to be
`Promise<CustomElementConstructor>` over `Promise<void>` to meet new
type checking expectations with TS v4.4. this leads to a small
functional change in that the return value for this function when the
internal registry contains an entry for a given `tagName`, the function
now returns the constructor associated with the tag name, rather than
void.

</details>
<details><summary>update mock-doc performance function signatures</summary>

update the function signatures of mock-doc's performance implementation
by declaring the return type on `mark()` and `measure()` to align with
the `Performance` interface, but _continue to return undefined_,
ignorning the type checker errors.

stencil's stubs for these functions assume access to underlying browser
api's (namely a performance buffer). given that older browsers may not
support this functionality and implementating a mock version of these
functions falls well outside the scope of a typescript update, simply
ignore the errors.

we take this approach, rather than:
```typescript
// @ts-ignore
mark(): void { /* no-op */ }
```
as stencil can (and does) instantiate an instance of `MockPerformance`
and attempts to assign it to variable(s) that are of type
`Performance`. this circumvents the type checker (although stencil was
lying to it already) to prevent additional `// @ts-ignore` pragmas

this may result in typing errors for consumers, however the actual
values shall remain the same.

</details>
<details><summary>window - add ts-ignore to handle mock-window & window type diffs</summary>

In various parts of the codebase, Window is used as a typing when the actual concrete type is a MockWindow - this leads to some tricky spots where when the TS compiler sees these as two distinct, unrelated types, calling a MockWindow method on an object typed as Window leads to compiler errors/adding @ts-ignore pragmas to the code.  Created a ticket for us to revisit this

</details>
<details><summary>useUnknownInCatchVariables </summary>

enable `useUnknownInCatchVariables` in all TSConfig files, with the
exception of the main `tsconfig.json`. Although flipping that bit was
originally going to be a part of the TS 4.4 upgrade, our decision to
upgrade from 4.3 -> 4.5 directly increased scope a bit. That and the
fact there are ~90 places where we want to rework the code, I feel more
comfortable splitting that off into a separate effort

</details>
<details><summary>[PAUSE] Stop current line of work, look into TS 4.5 level of effort</summary>

i'm concerned about the `matchFile` call and how the [method changes](https://github.com/microsoft/TypeScript/pull/44710/files#diff-1516c8349f7a625a2e4a2aa60f6bbe84e4b1a499128e8705d3087d893e01d367) for
v4.4, then is [reverted in v4.5](https://github.com/microsoft/TypeScript/pull/46787). based on the conversations/issues in GH
surrounding these changes, I'm strongly considering moving directly to
v4.5. pause here to investigate those changes

**TO BE CLEAR** - Stencil needs to move off this API. I have a story in the backlog for us to do this

</details>
<details><summary>TS 4.5</summary>

update karma-typescript with monounity/karma-typescript@f4cdc43 - this is necessary due to internal changes made in TypeScript 4.5.

update TypeScript to v4.5.4

remove the temporary hack during the TS v4.4 upgrade for `matchFile`
call to succeed.

update single unit test that was failing following the upgrade.

update typescript import statements that were broken as a result of the
upgrade to handle `AssertClause`s. move typescript calls to use factory
methods

</details>

## Does this introduce a breaking change?

- [ ] Yes
- [x] No - I'm following the same guidance we have for previous upgrades here. We treat TS upgrades as 'minor'/'non-breaking', just as the TS team does.

- [TypeScript 4.4 breaking changes](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#breaking-changes)
- [TypeScript 4.5 breaking changes](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#breaking-changes)

Because there's a little bit of a chance there could be a less than smooth upgrade here, I wanna hold off on adding this to the Stencil v2.13 release, and slate this for v2.14

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

In addition to unit/karma tests helping us out here, I also installed this branch's generated tarball (`npm run build && npm pack`) in Ionic Framework's core module, then built Framework/ran its tests.  For better or worse, the source of most breaking changes would come from the TS upgrade itself (rather than changes we made to accommodate the upgrade, since there are a few `ts-ignore` pragmas in here)


