### PR TITLE
test(message-utils): add message-utils testing

### DIFF
--- a/src/utils/message-utils.ts
+++ b/src/utils/message-utils.ts
@@ -137,13 +137,13 @@ export const catchError = (diagnostics: d.Diagnostic[], err: Error | null | unde
   };
 
   if (isString(msg)) {
-    diagnostic.messageText = msg;
+    diagnostic.messageText = msg.length ? msg : 'UNKNOWN ERROR';
   } else if (err != null) {
     if (err.stack != null) {
       diagnostic.messageText = err.stack.toString();
     } else {
       if (err.message != null) {
-        diagnostic.messageText = err.message.toString();
+        diagnostic.messageText = err.message.length ? err.message : 'UNKNOWN ERROR';
       } else {
         diagnostic.messageText = err.toString();
       }

--- a/src/utils/test/message-utils.spec.ts
+++ b/src/utils/test/message-utils.spec.ts
@@ -1,0 +1,275 @@
+import type * as d from '../../declarations';
+import { catchError } from '../message-utils';
+
+describe('message-utils', () => {
+  describe('catchError()', () => {
+    describe('called with no error, no message', () => {
+      it('returns a template diagnostic', () => {
+        const diagnostic = catchError([], null);
+
+        expect(diagnostic).toEqual<d.Diagnostic>({
+          level: 'error',
+          type: 'build',
+          header: 'Build Error',
+          messageText: 'build error',
+          relFilePath: null,
+          absFilePath: null,
+          lines: [],
+        });
+      });
+
+      it('pushes a template diagnostic onto a collection of diagnostics', () => {
+        const diagnostics: d.Diagnostic[] = [];
+
+        const diagnostic = catchError(diagnostics, null);
+
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0]).toBe(diagnostic);
+      });
+    });
+
+    describe('called with an Error', () => {
+      describe('with a valid stacktrace', () => {
+        const stackTrace = 'test stack';
+        let err: Error;
+
+        beforeEach(() => {
+          err = new Error();
+          err.stack = stackTrace;
+        });
+
+        it('returns a diagnostic', () => {
+          const diagnostic = catchError([], err);
+
+          expect(diagnostic).toEqual<d.Diagnostic>({
+            level: 'error',
+            type: 'build',
+            header: 'Build Error',
+            messageText: stackTrace,
+            relFilePath: null,
+            absFilePath: null,
+            lines: [],
+          });
+        });
+
+        it('pushes a template diagnostic onto a collection of diagnostics', () => {
+          const diagnostics: d.Diagnostic[] = [];
+
+          const diagnostic = catchError(diagnostics, err);
+
+          expect(diagnostics).toHaveLength(1);
+          expect(diagnostics[0]).toBe(diagnostic);
+        });
+
+        describe('"task canceled"', () => {
+          const taskCanceledMessage = 'task canceled';
+
+          beforeEach(() => {
+            err.stack = taskCanceledMessage;
+          });
+
+          it('returns a diagnostic', () => {
+            const diagnostic = catchError([], err);
+
+            expect(diagnostic).toEqual<d.Diagnostic>({
+              level: 'error',
+              type: 'build',
+              header: 'Build Error',
+              messageText: taskCanceledMessage,
+              relFilePath: null,
+              absFilePath: null,
+              lines: [],
+            });
+          });
+
+          it("doesn't push a template diagnostic", () => {
+            const diagnostics: d.Diagnostic[] = [];
+
+            catchError(diagnostics, err);
+
+            expect(diagnostics).toHaveLength(0);
+          });
+        });
+      });
+
+      describe('with a valid message', () => {
+        const message = 'test message';
+        let err: Error;
+
+        beforeEach(() => {
+          err = new Error();
+          err.stack = undefined;
+          err.message = message;
+        });
+
+        it('returns a diagnostic', () => {
+          const diagnostic = catchError([], err);
+
+          expect(diagnostic).toEqual<d.Diagnostic>({
+            level: 'error',
+            type: 'build',
+            header: 'Build Error',
+            messageText: message,
+            relFilePath: null,
+            absFilePath: null,
+            lines: [],
+          });
+        });
+
+        it('pushes a template diagnostic onto a collection of diagnostics', () => {
+          const diagnostics: d.Diagnostic[] = [];
+
+          const diagnostic = catchError(diagnostics, err);
+
+          expect(diagnostics).toHaveLength(1);
+          expect(diagnostics[0]).toBe(diagnostic);
+        });
+
+        it('prints "UNKNOWN ERROR" for an empty message', () => {
+          err.message = '';
+          const diagnostic = catchError([], err);
+
+          expect(diagnostic).toEqual<d.Diagnostic>({
+            level: 'error',
+            type: 'build',
+            header: 'Build Error',
+            messageText: 'UNKNOWN ERROR',
+            relFilePath: null,
+            absFilePath: null,
+            lines: [],
+          });
+        });
+
+        describe('"task canceled"', () => {
+          const taskCanceledMessage = 'task canceled';
+
+          beforeEach(() => {
+            err.message = taskCanceledMessage;
+          });
+
+          it('returns a diagnostic', () => {
+            const diagnostic = catchError([], err);
+
+            expect(diagnostic).toEqual<d.Diagnostic>({
+              level: 'error',
+              type: 'build',
+              header: 'Build Error',
+              messageText: taskCanceledMessage,
+              relFilePath: null,
+              absFilePath: null,
+              lines: [],
+            });
+          });
+
+          it("doesn't push a template diagnostic", () => {
+            const diagnostics: d.Diagnostic[] = [];
+
+            catchError(diagnostics, err);
+
+            expect(diagnostics).toHaveLength(0);
+          });
+        });
+      });
+
+      describe('with an invalid message', () => {
+        let err: Error;
+
+        beforeEach(() => {
+          err = new Error();
+          err.message = undefined;
+          err.stack = undefined;
+        });
+
+        it('returns a diagnostic', () => {
+          const diagnostic = catchError([], err);
+
+          expect(diagnostic).toEqual<d.Diagnostic>({
+            level: 'error',
+            type: 'build',
+            header: 'Build Error',
+            messageText: 'Error',
+            relFilePath: null,
+            absFilePath: null,
+            lines: [],
+          });
+        });
+
+        it('pushes a template diagnostic onto a collection of diagnostics', () => {
+          const diagnostics: d.Diagnostic[] = [];
+
+          const diagnostic = catchError(diagnostics, err);
+
+          expect(diagnostics).toHaveLength(1);
+          expect(diagnostics[0]).toBe(diagnostic);
+        });
+      });
+    });
+
+    describe('called with a message, but no error', () => {
+      const message = 'this is a test message';
+
+      it('returns a diagnostic with the message', () => {
+        const diagnostic = catchError([], null, message);
+
+        expect(diagnostic).toEqual<d.Diagnostic>({
+          level: 'error',
+          type: 'build',
+          header: 'Build Error',
+          messageText: message,
+          relFilePath: null,
+          absFilePath: null,
+          lines: [],
+        });
+      });
+
+      it('pushes the diagnostic onto a collection of diagnostics', () => {
+        const diagnostics: d.Diagnostic[] = [];
+
+        const diagnostic = catchError(diagnostics, null, message);
+
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0]).toBe(diagnostic);
+      });
+
+      it('prints "UNKNOWN ERROR" when the message text is empty', () => {
+        const diagnostic = catchError([], null, '');
+
+        expect(diagnostic).toEqual<d.Diagnostic>({
+          level: 'error',
+          type: 'build',
+          header: 'Build Error',
+          messageText: 'UNKNOWN ERROR',
+          relFilePath: null,
+          absFilePath: null,
+          lines: [],
+        });
+      });
+
+      describe('"task canceled"', () => {
+        const taskCanceledMessage = 'task canceled';
+
+        it('returns a diagnostic', () => {
+          const diagnostic = catchError([], null, taskCanceledMessage);
+
+          expect(diagnostic).toEqual<d.Diagnostic>({
+            level: 'error',
+            type: 'build',
+            header: 'Build Error',
+            messageText: taskCanceledMessage,
+            relFilePath: null,
+            absFilePath: null,
+            lines: [],
+          });
+        });
+
+        it("doesn't push a template diagnostic", () => {
+          const diagnostics: d.Diagnostic[] = [];
+
+          catchError([], null, taskCanceledMessage);
+
+          expect(diagnostics).toHaveLength(0);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There's no unit testing around the message utils we have, which came up in #3211. #3211 did a lot of explicit type annotation around passing `any` into our `message-utils#catchError` method, so I figured I'd start there in introducing some tests.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- add tests to `catchError`
- fix cases where we could print a zero-len string 
  - it's still not great, but I'd argue "UNKNOWN ERROR" is better than literally nothing 

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Unit tests were run with coverage to validate we handle the entirety of this method

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

**Please do not merge, relies on** #3211 