### PR TITLE
chore(jsdoc): document @Prop() parsing

### DIFF
--- a/src/compiler/transformers/decorators-to-static/decorator-utils.ts
+++ b/src/compiler/transformers/decorators-to-static/decorator-utils.ts
@@ -18,6 +18,15 @@ const getDeclarationParameter = (arg: ts.Expression): any => {
   throw new Error(`invalid decorator argument: ${arg.getText()}`);
 };
 
+/**
+ * Returns a function that checks if a decorator:
+ * - is a call expression. these are decorators that are immediately followed by open/close parenthesis with optional
+ *   arg(s), e.g. `@Prop()`
+ * - the name of the decorator matches the provided `propName`
+ *
+ * @param propName the name of the decorator to match against
+ * @returns true if the conditions above are both true, false otherwise
+ */
 export const isDecoratorNamed = (propName: string) => {
   return (dec: ts.Decorator): boolean => {
     return ts.isCallExpression(dec.expression) && dec.expression.expression.getText() === propName;

--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -14,13 +14,24 @@ import { isDecoratorNamed, getDeclarationParameters } from './decorator-utils';
 import { validatePublicName } from '../reserved-public-members';
 import ts from 'typescript';
 
+/**
+ * Parse a collection of class members decorated with `@Prop()`
+ * @param diagnostics a collection of compiler diagnostics. During the parsing process, any errors detected must be
+ * added to this collection
+ * @param decoratedProps a collection of class elements that may or may not my class members decorated with `@Prop`.
+ * Only those decorated with `@Prop()` will be parsed.
+ * @param typeChecker a reference to the TypeScript type checker
+ * @param watchable a collection of class members that can be watched for changes using Stencil's `@Watch` decorator
+ * @param newMembers a collection that parsed `@Prop` annotated class members should be pushed to as a side effect of
+ * calling this function
+ */
 export const propDecoratorsToStatic = (
   diagnostics: d.Diagnostic[],
   decoratedProps: ts.ClassElement[],
   typeChecker: ts.TypeChecker,
   watchable: Set<string>,
   newMembers: ts.ClassElement[]
-) => {
+): void => {
   const properties = decoratedProps
     .filter(ts.isPropertyDeclaration)
     .map((prop) => parsePropDecorator(diagnostics, typeChecker, prop, watchable))
@@ -31,12 +42,21 @@ export const propDecoratorsToStatic = (
   }
 };
 
+/**
+ * Parse a single `@Prop` decorator annotated class member
+ * @param diagnostics a collection of compiler diagnostics. During the parsing process, any errors detected must be
+ * added to this collection
+ * @param typeChecker a reference to the TypeScript type checker
+ * @param prop the TypeScript `PropertyDeclaration` to parse
+ * @param watchable a collection of class members that can be watched for changes using Stencil's `@Watch` decorator
+ * @returns a property assignment expression to be added to the Stencil component's class
+ */
 const parsePropDecorator = (
   diagnostics: d.Diagnostic[],
   typeChecker: ts.TypeChecker,
   prop: ts.PropertyDeclaration,
   watchable: Set<string>
-) => {
+): ts.PropertyAssignment => {
   const propDecorator = prop.decorators.find(isDecoratorNamed('Prop'));
   if (propDecorator == null) {
     return null;
@@ -93,7 +113,13 @@ const parsePropDecorator = (
   return staticProp;
 };
 
-const getAttributeName = (propName: string, propOptions: d.PropOptions) => {
+/**
+ * Format the attribute name provided as an argument to `@Prop({attribute: ''}`
+ * @param propName the prop's name, used as a fallback value
+ * @param propOptions the options passed in to the `@Prop` call expression
+ * @returns the formatted attribute name
+ */
+const getAttributeName = (propName: string, propOptions: d.PropOptions): string | undefined => {
   if (propOptions.attribute === null) {
     return undefined;
   }
@@ -105,7 +131,15 @@ const getAttributeName = (propName: string, propOptions: d.PropOptions) => {
   return toDashCase(propName);
 };
 
-const getReflect = (diagnostics: d.Diagnostic[], propDecorator: ts.Decorator, propOptions: d.PropOptions) => {
+/**
+ * Determines if the 'reflect' property should be applied to the class member decorated with `@Prop`
+ * @param diagnostics a collection of compiler diagnostics. Any errors detected with setting 'reflect' must be added to
+ * this collection
+ * @param propDecorator the AST containing the Prop decorator
+ * @param propOptions the options passed in to the `@Prop` call expression
+ * @returns `true` if the prop should be reflected in the DOM, `false` otherwise
+ */
+const getReflect = (diagnostics: d.Diagnostic[], propDecorator: ts.Decorator, propOptions: d.PropOptions): boolean => {
   if (typeof propOptions.reflect === 'boolean') {
     return propOptions.reflect;
   }
@@ -132,7 +166,14 @@ const getComplexType = (
   };
 };
 
-export const propTypeFromTSType = (type: ts.Type) => {
+/**
+ * Derives a Stencil-permitted prop type from the TypeScript compiler's output. This function may narrow the type of a
+ * prop, as the types that can be returned from the TypeScript compiler may be more complex than what Stencil can/should
+ * handle for props.
+ * @param type the prop type to narrow
+ * @returns a valid Stencil prop type
+ */
+export const propTypeFromTSType = (type: ts.Type): 'any' | 'boolean' | 'number' | 'string' | 'unknown' => {
   const isAnyType = checkType(type, isAny);
 
   if (isAnyType) {
@@ -161,8 +202,18 @@ export const propTypeFromTSType = (type: ts.Type) => {
   return 'unknown';
 };
 
-const checkType = (type: ts.Type, check: (type: ts.Type) => boolean) => {
+/**
+ * Determines if a TypeScript compiler given `Type` is of a particular type according to the provided `check` parameter.
+ * Union types (e.g. `boolean | number | string`) will be evaluated one type at a time.
+ * @param type the TypeScript `Type` entity to evaluate
+ * @param check a function that takes a TypeScript `Type` as its only argument and returns `true` if the `Type` conforms
+ * to a particular type
+ * @returns the result of the `check` argument. The result of `check` is `true` for one or more types in a union type,
+ * return `true`.
+ */
+const checkType = (type: ts.Type, check: (type: ts.Type) => boolean): boolean => {
   if (type.flags & ts.TypeFlags.Union) {
+    // if the type is a union, check each type in the union
     const union = type as ts.UnionType;
     if (union.types.some((type) => checkType(type, check))) {
       return true;
@@ -171,28 +222,48 @@ const checkType = (type: ts.Type, check: (type: ts.Type) => boolean) => {
   return check(type);
 };
 
-const isBoolean = (t: ts.Type) => {
+/**
+ * Determine if a TypeScript compiler `Type` is a boolean
+ * @param t the `Type` to evaluate
+ * @returns `true` if the `Type` has any boolean-similar flags, `false` otherwise
+ */
+const isBoolean = (t: ts.Type): boolean => {
   if (t) {
-    return !!(t.flags & (ts.TypeFlags.Boolean | ts.TypeFlags.BooleanLike | ts.TypeFlags.BooleanLike));
+    return !!(t.flags & (ts.TypeFlags.Boolean | ts.TypeFlags.BooleanLike));
   }
   return false;
 };
 
-const isNumber = (t: ts.Type) => {
+/**
+ * Determine if a TypeScript compiler `Type` is a number
+ * @param t the `Type` to evaluate
+ * @returns `true` if the `Type` has any number-similar flags, `false` otherwise
+ */
+const isNumber = (t: ts.Type): boolean => {
   if (t) {
     return !!(t.flags & (ts.TypeFlags.Number | ts.TypeFlags.NumberLike | ts.TypeFlags.NumberLiteral));
   }
   return false;
 };
 
-const isString = (t: ts.Type) => {
+/**
+ * Determine if a TypeScript compiler `Type` is a string
+ * @param t the `Type` to evaluate
+ * @returns `true` if the `Type` has any string-similar flags, `false` otherwise
+ */
+const isString = (t: ts.Type): boolean => {
   if (t) {
     return !!(t.flags & (ts.TypeFlags.String | ts.TypeFlags.StringLike | ts.TypeFlags.StringLiteral));
   }
   return false;
 };
 
-const isAny = (t: ts.Type) => {
+/**
+ * Determine if a TypeScript compiler `Type` is of type any
+ * @param t the `Type` to evaluate
+ * @returns `true` if the `Type` has the `Any` flag set on it, `false` otherwise
+ */
+const isAny = (t: ts.Type): boolean => {
   if (t) {
     return !!(t.flags & ts.TypeFlags.Any);
   }

--- a/src/compiler/transformers/reserved-public-members.ts
+++ b/src/compiler/transformers/reserved-public-members.ts
@@ -2,13 +2,23 @@ import type * as d from '../../declarations';
 import { augmentDiagnosticWithNode, buildWarn } from '@utils';
 import ts from 'typescript';
 
+/**
+ * Determine if a public class member collides with a reserved name for HTML elements, nodes, or JSX
+ * @param diagnostics a collection of compiler diagnostics. If a naming collision is found, a diagnostic detected must
+ * be added to this collection
+ * @param memberName the name of the class member to check for collision
+ * @param decorator the decorator associated with the class member, used in providing richer error diagnostics
+ * @param memberType a string representing the class member's type. e.g. 'prop'. Used in providing richer error
+ * diagnostics
+ * @param node the TypeScript AST node at which the class member is defined
+ */
 export const validatePublicName = (
   diagnostics: d.Diagnostic[],
   memberName: string,
   decorator: string,
   memberType: string,
   node: ts.Node
-) => {
+): void => {
   if (RESERVED_PUBLIC_MEMBERS.has(memberName.toLowerCase())) {
     const warn = buildWarn(diagnostics);
     warn.messageText = [

--- a/src/runtime/parse-property-value.ts
+++ b/src/runtime/parse-property-value.ts
@@ -1,7 +1,30 @@
 import { MEMBER_FLAGS, isComplexType } from '@utils';
 import { BUILD } from '@app-data';
 
-export const parsePropertyValue = (propValue: any, propType: number) => {
+/**
+ * Parse a new property value for a given property type.
+ *
+ * While the prop value can reasonably be expected to be of `any` type as far as TypeScript's type checker is concerned,
+ * it is not safe to assume that the string returned by evaluating `typeof propValue` matches:
+ *   1. `any`, the type given to `propValue` in the function signature
+ *   2. the type stored from `propType`.
+ *
+ * This function provides the capability to parse/coerce a property's value to potentially any other JavaScript type.
+ *
+ * Property values represented in TSX preserve their type information. In the example below, the number 0 is passed to
+ * a component. This `propValue` will preserve its type information (`typeof propValue === 'number'`). Note that is
+ * based on the type of the value being passed in, not the type declared of the class member decorated with `@Prop`.
+ * ```tsx
+ * <my-cmp prop-val={0}></my-cmp>
+ * ```
+ *
+ * HTML prop values on the other hand, will always a string
+ *
+ * @param propValue the new value to coerce to some type
+ * @param propType the type of the prop, expressed as a binary number
+ * @returns the parsed/coerced value
+ */
+export const parsePropertyValue = (propValue: any, propType: number): any => {
   // ensure this value is of the correct prop type
 
   if (propValue != null && !isComplexType(propValue)) {


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] (JS)Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

While doing an investigation surrounding prop behavior for union types (STENCIL-349), I took a little extra time to JSDoc some of the functions associated with prop parsing (although not all of them).  The idea here was to "leave the forest a little nicer than you found it"

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit adds jsdoc + explicit return types to a portion of the
codebase that parses Stencil members that are decorated with @Prop()

it also includes a minor code change where a duplicated enum is removed
from a bitwise calculation when determining whether or not a prop's type
is of the type 'boolean' or not


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

N/A (I consider the JSDoc non-testable). I don't think there's any testing that can be done for the duplicated enum I removed from the bitwise calc, but LMK if you have any ideas.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Some items out of scope of the investigatory work I was doing have been TODO'ed in the codebase