### PR TITLE
chore(ionitron): don't mark feature requests as stale

### DIFF
--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -37,6 +37,7 @@ stale:
   days: 180
   maxIssuesPerRun: 100
   exemptLabels:
+    - "Feature: Want this? Upvote it!"
     - good first issue
     - help wanted
     - Reply Received


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): GitHub Integration changes


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

ionitron can mark issues with the "Feature: Want this? Upvote it!" label as stale

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

make issues with the label "Feature: Want this? Upvote it!" exempt from
ionitron marking such issues as stale. it's an acceptable situation
where we get a totally valid issue/feature request, we mark it as such,
but it's not the top of the backlog. we should be performing manual
checks of these for now (although making this smarter in the future to
look at the number of votes/comments and taking those into account would
be ideal)


## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

I didn't test this, although I'm "pretty sure" (famous last words) that I'm using the double quotes properly in this YAML file (since the label contains a colon). The tricky part here is Ionitron marks such issues after 180 days of inactivity, and I don't want to move that value down at the risk of marking more issues accidentally.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The impetus for this PR is https://github.com/ionic-team/stencil/issues/2648 being marked as stale incorrectly over the weekend.
