### PR TITLE
fix(testing): don't run tests against non-test files

### DIFF
--- a/src/compiler/config/test/validate-testing.spec.ts
+++ b/src/compiler/config/test/validate-testing.spec.ts
@@ -125,4 +125,123 @@ describe('validateTesting', () => {
     const { config } = validateConfig(userConfig);
     expect(config.testing.testEnvironment).toBeUndefined();
   });
+
+  describe('testRegex', () => {
+    let testRegex: RegExp;
+
+    beforeEach(() => {
+      userConfig.flags.spec = true;
+
+      const { testing: testConfig } = validateConfig(userConfig).config;
+      const testRegexSetting = testConfig?.testRegex;
+
+      if (!testRegexSetting) {
+        fail('No testRegex was found in the Stencil TestingConfig. Failing test.');
+      }
+
+      testRegex = new RegExp(testRegexSetting);
+    });
+
+    describe('test.* extensions', () => {
+      it('matches files ending in .test.ts', () => {
+        expect(testRegex.test('my-component.test.ts')).toBe(true);
+      });
+
+      it('matches files ending in .test.tsx', () => {
+        expect(testRegex.test('my-component.test.tsx')).toBe(true);
+      });
+
+      it('matches files ending in .test.js', () => {
+        expect(testRegex.test('my-component.test.js')).toBe(true);
+      });
+
+      it('matches files ending in .test.jsx', () => {
+        expect(testRegex.test('my-component.test.jsx')).toBe(true);
+      });
+
+      it("doesn't match files ending in test.ts", () => {
+        expect(testRegex.test('my-component-test.ts')).toBe(false);
+      });
+
+      it("doesn't match files ending in test.tsx", () => {
+        expect(testRegex.test('my-component-test.tsx')).toBe(false);
+      });
+
+      it("doesn't match files ending in test.js", () => {
+        expect(testRegex.test('my-component-test.js')).toBe(false);
+      });
+
+      it("doesn't match files ending in test.jsx", () => {
+        expect(testRegex.test('my-component-test.jsx')).toBe(false);
+      });
+    });
+
+    describe('spec.* extensions', () => {
+      it('matches files ending in .spec.ts', () => {
+        expect(testRegex.test('my-component.spec.ts')).toBe(true);
+      });
+
+      it('matches files ending in .spec.tsx', () => {
+        expect(testRegex.test('my-component.spec.tsx')).toBe(true);
+      });
+
+      it('matches files ending in .spec.js', () => {
+        expect(testRegex.test('my-component.spec.js')).toBe(true);
+      });
+
+      it('matches files ending in .spec.jsx', () => {
+        expect(testRegex.test('my-component.spec.jsx')).toBe(true);
+      });
+
+      it("doesn't match files ending in spec.ts", () => {
+        expect(testRegex.test('my-component-spec.ts')).toBe(false);
+      });
+
+      it("doesn't match files ending in spec.tsx", () => {
+        expect(testRegex.test('my-component-spec.tsx')).toBe(false);
+      });
+
+      it("doesn't match files ending in spec.js", () => {
+        expect(testRegex.test('my-component-spec.js')).toBe(false);
+      });
+
+      it("doesn't match files ending in spec.jsx", () => {
+        expect(testRegex.test('my-component-spec.jsx')).toBe(false);
+      });
+    });
+
+    describe('e2e.* extensions', () => {
+      it('matches files ending in .e2e.ts', () => {
+        expect(testRegex.test('my-component.e2e.ts')).toBe(true);
+      });
+
+      it('matches files ending in .e2e.tsx', () => {
+        expect(testRegex.test('my-component.e2e.tsx')).toBe(true);
+      });
+
+      it('matches files ending in .e2e.js', () => {
+        expect(testRegex.test('my-component.e2e.js')).toBe(true);
+      });
+
+      it('matches files ending in .e2e.jsx', () => {
+        expect(testRegex.test('my-component.e2e.jsx')).toBe(true);
+      });
+
+      it("doesn't match files ending in e2e.ts", () => {
+        expect(testRegex.test('my-component-e2e.ts')).toBe(false);
+      });
+
+      it("doesn't match files ending in e2e.tsx", () => {
+        expect(testRegex.test('my-component-e2e.tsx')).toBe(false);
+      });
+
+      it("doesn't match files ending in e2e.js", () => {
+        expect(testRegex.test('my-component-e2e.js')).toBe(false);
+      });
+
+      it("doesn't match files ending in e2e.jsx", () => {
+        expect(testRegex.test('my-component-e2e.jsx')).toBe(false);
+      });
+    });
+  });
 });

--- a/src/compiler/config/test/validate-testing.spec.ts
+++ b/src/compiler/config/test/validate-testing.spec.ts
@@ -259,12 +259,12 @@ describe('validateTesting', () => {
         expect(testRegex.test('my-component-e2e.jsx')).toBe(false);
       });
 
-      it("doesn't match files ending in .spec.t", () => {
-        expect(testRegex.test('my-component.spec.t')).toBe(false);
+      it("doesn't match files ending in .e2e.t", () => {
+        expect(testRegex.test('my-component.e2e.t')).toBe(false);
       });
 
-      it("doesn't match files ending in .spec.j", () => {
-        expect(testRegex.test('my-component.spec.j')).toBe(false);
+      it("doesn't match files ending in .e2e.j", () => {
+        expect(testRegex.test('my-component.e2e.j')).toBe(false);
       });
     });
   });

--- a/src/compiler/config/test/validate-testing.spec.ts
+++ b/src/compiler/config/test/validate-testing.spec.ts
@@ -174,6 +174,14 @@ describe('validateTesting', () => {
       it("doesn't match files ending in test.jsx", () => {
         expect(testRegex.test('my-component-test.jsx')).toBe(false);
       });
+
+      it("doesn't match files ending in .test.t", () => {
+        expect(testRegex.test('my-component.test.t')).toBe(false);
+      });
+
+      it("doesn't match files ending in .test.j", () => {
+        expect(testRegex.test('my-component.test.j')).toBe(false);
+      });
     });
 
     describe('spec.* extensions', () => {
@@ -208,6 +216,14 @@ describe('validateTesting', () => {
       it("doesn't match files ending in spec.jsx", () => {
         expect(testRegex.test('my-component-spec.jsx')).toBe(false);
       });
+
+      it("doesn't match files ending in .spec.t", () => {
+        expect(testRegex.test('my-component.spec.t')).toBe(false);
+      });
+
+      it("doesn't match files ending in .spec.j", () => {
+        expect(testRegex.test('my-component.spec.j')).toBe(false);
+      });
     });
 
     describe('e2e.* extensions', () => {
@@ -241,6 +257,14 @@ describe('validateTesting', () => {
 
       it("doesn't match files ending in e2e.jsx", () => {
         expect(testRegex.test('my-component-e2e.jsx')).toBe(false);
+      });
+
+      it("doesn't match files ending in .spec.t", () => {
+        expect(testRegex.test('my-component.spec.t')).toBe(false);
+      });
+
+      it("doesn't match files ending in .spec.j", () => {
+        expect(testRegex.test('my-component.spec.j')).toBe(false);
       });
     });
   });

--- a/src/compiler/config/validate-testing.ts
+++ b/src/compiler/config/validate-testing.ts
@@ -125,7 +125,7 @@ export const validateTesting = (config: d.Config, diagnostics: d.Diagnostic[]) =
   }
 
   if (testing.testRegex === undefined) {
-    testing.testRegex = '(/__tests__/.*|\\.?(test|spec|e2e))\\.(tsx?|ts?|jsx?|js?)$';
+    testing.testRegex = '(/__tests__/.*|\\.(test|spec|e2e))\\.(tsx?|ts?|jsx?|js?)$';
   }
 
   if (Array.isArray(testing.testMatch)) {

--- a/src/compiler/config/validate-testing.ts
+++ b/src/compiler/config/validate-testing.ts
@@ -125,7 +125,7 @@ export const validateTesting = (config: d.Config, diagnostics: d.Diagnostic[]) =
   }
 
   if (testing.testRegex === undefined) {
-    testing.testRegex = '(/__tests__/.*|\\.(test|spec|e2e))\\.(tsx?|ts?|jsx?|js?)$';
+    testing.testRegex = '(/__tests__/.*|\\.(test|spec|e2e))\\.(tsx|ts|jsx|js)$';
   }
 
   if (Array.isArray(testing.testMatch)) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There are two issues that this PR solves (in 2 commits):
1. files that end with `(test|spec|e2e).(js|ts|jsx|tsx)` (without a period preceding any combination of that string) are picked up by the test runner - e.g. `my-test.tsx` will be picked up by the test runn
2. files that end in `.j` or `.t` will be picked up by the test runner

GitHub Issue Number: https://github.com/ionic-team/stencil/issues/3221


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

I  split the two issues solved here into two commits, and will likely 'rebase and merge' them. Each commit has a fix:

Commit 1: this commit adds test infrastructure for files picked up by jest for
testing purposes. because there is no efficient way to get the
interaction with stencil+jest (or any libary+jest for that matter) under test, we
instead extract the testRegex field out of the stencil `TestConfig` and
perform `RegExp.test()`-based assertions.

remove a single '?' from the `testRegex` field used that was making the
period preceding (test|spec|e2e) optional

Commit 2: update stencil's default `testRegex` to not capture `.j` and `.t` files

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

First and foremost, unit tests were added and passed.

Next, I built Stencil on this branch (`npm ci && npm run clean && npm run build`). I then ran each of our test suites to verify we didn't regress in the number of tests we run on this branch vs `main`
- `npm t`
- `npm run test.karma.prod`
- `npm run test.end-to-end`

Finally, I `npm pack`ed the built artifact to test this on a Stencil project:
1. `npm init stencil component my-cmp` to generate a new Stencil project
2. `cd my-cmp && npm i` to get dependencies installed
3. `npm t` to get a baseline & verify that everything passed
4. `npm run generate` to generate a new component, `my-test`, accept default test files when prompted
5. `npm run generate` to generate a new component, `my-e2e`, accept default test files when prompted
6. `npm run generate` to generate a new component, `my-spec`, accept default test files when prompted
7. `npm t` to see that there are now failing tests for each of the new file
![Screen Shot 2022-02-10 at 11 39 50 AM](https://user-images.githubusercontent.com/1930213/153453995-d875ac28-4459-48fa-8072-f922be25ad9a.png)
s
8. `npm i PATH_TO_TARBALL`
9. `npm t` to see all tests pass and the created component files aren't pick up anymore