### PR TITLE
fix(bundling): allow proper webpack treeshaking

### DIFF
--- a/src/compiler/output-targets/dist-custom-elements/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements/index.ts
@@ -17,6 +17,7 @@ import { addDefineCustomElementFunctions } from '../../transformers/component-na
 import { optimizeModule } from '../../optimize/optimize-module';
 import { removeCollectionImports } from '../../transformers/remove-collection-imports';
 import { STENCIL_INTERNAL_CLIENT_ID, USER_INDEX_ENTRY_ID, STENCIL_APP_GLOBALS_ID } from '../../bundle/entry-alias-ids';
+import { proxyCustomElement } from '../../transformers/component-native/proxy-custom-element-function';
 import { updateStencilCoreImports } from '../../transformers/update-stencil-core-import';
 
 export const outputCustomElements = async (
@@ -186,6 +187,7 @@ const getCustomElementBundleCustomTransformer = (
     addDefineCustomElementFunctions(compilerCtx, components, outputTarget),
     updateStencilCoreImports(transformOpts.coreImportPath),
     nativeComponentTransform(compilerCtx, transformOpts),
+    proxyCustomElement(compilerCtx, transformOpts),
     removeCollectionImports(compilerCtx),
   ];
 };

--- a/src/compiler/transformers/add-component-meta-proxy.ts
+++ b/src/compiler/transformers/add-component-meta-proxy.ts
@@ -26,3 +26,29 @@ export const createComponentMetadataProxy = (compilerMeta: d.ComponentCompilerMe
 
   return ts.createCall(ts.createIdentifier(PROXY_CUSTOM_ELEMENT), [], [literalCmpClassName, literalMeta]);
 };
+
+/**
+ * Create a call expression for wrapping a component represented as an anonymous class in a proxy. This call expression
+ * takes a form:
+ * ```ts
+ * PROXY_CUSTOM_ELEMENT(Clazz, Metadata);
+ * ```
+ * where
+ * - `PROXY_CUSTOM_ELEMENT` is a Stencil internal identifier that will be replaced with the name of the actual function
+ * name at compile name
+ * - `Clazz` is an anonymous class to be proxied
+ * - `Metadata` is the compiler metadata associated with the Stencil component
+ *
+ * @param compilerMeta compiler metadata associated with the component to be wrapped in a proxy
+ * @param clazz the anonymous class to proxy
+ * @returns the generated call expression
+ */
+export const createAnonymousClassMetadataProxy = (
+  compilerMeta: d.ComponentCompilerMeta,
+  clazz: ts.Expression
+): ts.CallExpression => {
+  const compactMeta: d.ComponentRuntimeMetaCompact = formatComponentRuntimeMeta(compilerMeta, true);
+  const literalMeta = convertValueToLiteral(compactMeta);
+
+  return ts.factory.createCallExpression(ts.factory.createIdentifier(PROXY_CUSTOM_ELEMENT), [], [clazz, literalMeta]);
+};

--- a/src/compiler/transformers/component-native/add-define-custom-element-function.ts
+++ b/src/compiler/transformers/component-native/add-define-custom-element-function.ts
@@ -2,8 +2,6 @@ import type * as d from '../../../declarations';
 import { createImportStatement, getModuleFromSourceFile } from '../transform-utils';
 import { dashToPascalCase } from '@utils';
 import ts from 'typescript';
-import { createComponentMetadataProxy } from '../add-component-meta-proxy';
-import { addCoreRuntimeApi, RUNTIME_APIS } from '../core-runtime-apis';
 
 /**
  * Import and define components along with any component dependents within the `dist-custom-elements` output.
@@ -25,24 +23,9 @@ export const addDefineCustomElementFunctions = (
       const caseStatements: ts.CaseClause[] = [];
       const tagNames: string[] = [];
 
-      addCoreRuntimeApi(moduleFile, RUNTIME_APIS.proxyCustomElement);
-
       if (moduleFile.cmps.length) {
         const principalComponent = moduleFile.cmps[0];
         tagNames.push(principalComponent.tagName);
-
-        // wraps the initial component class in a `proxyCustomElement` wrapper.
-        // This is what will be exported and called from the `defineCustomElement` call.
-        const proxyDefinition = createComponentMetadataProxy(principalComponent);
-        const metaExpression = ts.factory.createExpressionStatement(
-          ts.factory.createBinaryExpression(
-            ts.factory.createIdentifier(principalComponent.componentClassName),
-            ts.factory.createToken(ts.SyntaxKind.EqualsToken),
-            proxyDefinition
-          )
-        );
-        newStatements.push(metaExpression);
-        ts.addSyntheticLeadingComment(proxyDefinition, ts.SyntaxKind.MultiLineCommentTrivia, '@__PURE__', false);
 
         // define the current component - `customElements.define(tagName, MyProxiedComponent);`
         const customElementsDefineCallExpression = ts.factory.createCallExpression(

--- a/src/compiler/transformers/component-native/proxy-custom-element-function.ts
+++ b/src/compiler/transformers/component-native/proxy-custom-element-function.ts
@@ -1,0 +1,98 @@
+import ts from 'typescript';
+import type * as d from '../../../declarations';
+import { createAnonymousClassMetadataProxy } from '../add-component-meta-proxy';
+import { addImports } from '../add-imports';
+import { RUNTIME_APIS } from '../core-runtime-apis';
+import { getModuleFromSourceFile } from '../transform-utils';
+
+/**
+ * Proxy custom elements for the `dist-custom-elements` output target. This function searches for a Stencil component's
+ * class initializer (found on the righthand side of the '=' operator):
+ *
+ * ```ts
+ * const MyComponent = class extends HTMLElement { // Implementation omitted }
+ * ```
+ *
+ * and wraps the initializer into a `proxyCustomElement` call:
+ *
+ * ```ts
+ * const MyComponent = proxyCustomElement(class extends HTMLElement { // Implementation omitted }, componentMetadata);
+ * ```
+ *
+ * This is to work around an issue where treeshaking does not work for webpack users, whose details are captured in full
+ * in [this issue on the webpack GitHub repo](https://github.com/webpack/webpack/issues/14963).
+ *
+ * @param compilerCtx current compiler context
+ * @param transformOpts transpilation options for the current build
+ * @returns a TypeScript AST transformer factory function that performs the above described transformation
+ */
+export const proxyCustomElement = (
+  compilerCtx: d.CompilerCtx,
+  transformOpts: d.TransformOptions
+): ts.TransformerFactory<ts.SourceFile> => {
+  return () => {
+    return (tsSourceFile: ts.SourceFile): ts.SourceFile => {
+      const moduleFile = getModuleFromSourceFile(compilerCtx, tsSourceFile);
+      if (!moduleFile.cmps.length) {
+        return tsSourceFile;
+      }
+
+      const principalComponent = moduleFile.cmps[0];
+
+      for (let [stmtIndex, stmt] of tsSourceFile.statements.entries()) {
+        if (ts.isVariableStatement(stmt)) {
+          for (let [declarationIndex, declaration] of stmt.declarationList.declarations.entries()) {
+            if (declaration.name.getText() !== principalComponent.componentClassName) {
+              continue;
+            }
+
+            // wrap the Stencil component's class declaration in a component proxy
+            const proxyCreationCall = createAnonymousClassMetadataProxy(principalComponent, declaration.initializer);
+            ts.addSyntheticLeadingComment(proxyCreationCall, ts.SyntaxKind.MultiLineCommentTrivia, '@__PURE__', false);
+
+            // update the component's variable declaration to use the new initializer
+            const proxiedComponentDeclaration = ts.factory.updateVariableDeclaration(
+              declaration,
+              declaration.name,
+              declaration.exclamationToken,
+              declaration.type,
+              proxyCreationCall
+            );
+
+            // update the declaration list that contains the updated variable declaration
+            const updatedDeclarationList = ts.factory.updateVariableDeclarationList(stmt.declarationList, [
+              ...stmt.declarationList.declarations.slice(0, declarationIndex),
+              proxiedComponentDeclaration,
+              ...stmt.declarationList.declarations.slice(declarationIndex + 1),
+            ]);
+
+            // update the variable statement containing the updated declaration list
+            const updatedVariableStatement = ts.factory.updateVariableStatement(
+              stmt,
+              [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+              updatedDeclarationList
+            );
+
+            // update the source file's statements to use the new variable statement
+            tsSourceFile = ts.factory.updateSourceFile(tsSourceFile, [
+              ...tsSourceFile.statements.slice(0, stmtIndex),
+              updatedVariableStatement,
+              ...tsSourceFile.statements.slice(stmtIndex + 1),
+            ]);
+
+            // finally, ensure that the proxyCustomElement function is imported
+            tsSourceFile = addImports(
+              transformOpts,
+              tsSourceFile,
+              [RUNTIME_APIS.proxyCustomElement],
+              transformOpts.coreImportPath
+            );
+
+            return tsSourceFile;
+          }
+        }
+      }
+      return tsSourceFile;
+    };
+  };
+};

--- a/src/compiler/transformers/test/add-component-meta-proxy.spec.ts
+++ b/src/compiler/transformers/test/add-component-meta-proxy.spec.ts
@@ -1,0 +1,109 @@
+import type * as d from '../../../declarations';
+import { createAnonymousClassMetadataProxy } from '../add-component-meta-proxy';
+import * as TransformUtils from '../transform-utils';
+import * as FormatComponentRuntimeMeta from '../../../utils/format-component-runtime-meta';
+import ts from 'typescript';
+import { HTML_ELEMENT } from '../core-runtime-apis';
+
+describe('add-component-meta-proxy', () => {
+  describe('createAnonymousClassMetadataProxy()', () => {
+    let classExpr: ts.ClassExpression;
+    let htmlElementHeritageClause: ts.HeritageClause;
+    let literalMetadata: ts.StringLiteral;
+
+    let formatComponentRuntimeMetaSpy: jest.SpyInstance<
+      ReturnType<typeof FormatComponentRuntimeMeta.formatComponentRuntimeMeta>,
+      Parameters<typeof FormatComponentRuntimeMeta.formatComponentRuntimeMeta>
+    >;
+    let convertValueToLiteralSpy: jest.SpyInstance<
+      ReturnType<typeof TransformUtils.convertValueToLiteral>,
+      Parameters<typeof TransformUtils.convertValueToLiteral>
+    >;
+
+    beforeEach(() => {
+      htmlElementHeritageClause = ts.factory.createHeritageClause(ts.SyntaxKind.ExtendsKeyword, [
+        ts.factory.createExpressionWithTypeArguments(ts.factory.createIdentifier(HTML_ELEMENT), []),
+      ]);
+
+      classExpr = ts.factory.createClassExpression(
+        undefined,
+        undefined,
+        'MyComponent',
+        undefined,
+        [htmlElementHeritageClause],
+        undefined
+      );
+      literalMetadata = ts.factory.createStringLiteral('MyComponent');
+
+      formatComponentRuntimeMetaSpy = jest.spyOn(FormatComponentRuntimeMeta, 'formatComponentRuntimeMeta');
+      formatComponentRuntimeMetaSpy.mockImplementation(
+        (_compilerMeta: d.ComponentCompilerMeta, _includeMethods: boolean) => [0, 'tag-name']
+      );
+
+      convertValueToLiteralSpy = jest.spyOn(TransformUtils, 'convertValueToLiteral');
+      convertValueToLiteralSpy.mockImplementation((_compactMeta: d.ComponentRuntimeMetaCompact) => literalMetadata);
+    });
+
+    afterEach(() => {
+      formatComponentRuntimeMetaSpy.mockRestore();
+      convertValueToLiteralSpy.mockRestore();
+    });
+
+    it('returns a call expression', () => {
+      const result: ts.CallExpression = createAnonymousClassMetadataProxy(
+        // TODO(STENCIL-378): Replace with a getMockComponentCompilerMeta() call
+        [] as unknown as d.ComponentCompilerMeta,
+        classExpr
+      );
+
+      expect(ts.isCallExpression(result)).toBe(true);
+    });
+
+    it('wraps the initializer in PROXY_CUSTOM_ELEMENT', () => {
+      const result: ts.CallExpression = createAnonymousClassMetadataProxy(
+        // TODO(STENCIL-378): Replace with a getMockComponentCompilerMeta() call
+        [] as unknown as d.ComponentCompilerMeta,
+        classExpr
+      );
+
+      expect((result.expression as ts.Identifier).escapedText).toBe('___stencil_proxyCustomElement');
+    });
+
+    it("doesn't add any type arguments to the call", () => {
+      const result: ts.CallExpression = createAnonymousClassMetadataProxy(
+        // TODO(STENCIL-378): Replace with a getMockComponentCompilerMeta() call
+        [] as unknown as d.ComponentCompilerMeta,
+        classExpr
+      );
+
+      expect(result.typeArguments).toHaveLength(0);
+    });
+
+    it('adds the correct arguments to the PROXY_CUSTOM_ELEMENT call', () => {
+      const result: ts.CallExpression = createAnonymousClassMetadataProxy(
+        // TODO(STENCIL-378): Replace with a getMockComponentCompilerMeta() call
+        [] as unknown as d.ComponentCompilerMeta,
+        classExpr
+      );
+
+      expect(result.arguments).toHaveLength(2);
+      expect(result.arguments[0]).toBe(classExpr);
+      expect(result.arguments[1]).toBe(literalMetadata);
+    });
+
+    it('includes the heritage clause', () => {
+      const result: ts.CallExpression = createAnonymousClassMetadataProxy(
+        // TODO(STENCIL-378): Replace with a getMockComponentCompilerMeta() call
+        [] as unknown as d.ComponentCompilerMeta,
+        classExpr
+      );
+
+      expect(result.arguments.length).toBeGreaterThanOrEqual(1);
+      const createdClassExpression = result.arguments[0];
+
+      expect(ts.isClassExpression(createdClassExpression)).toBe(true);
+      expect((createdClassExpression as ts.ClassExpression).heritageClauses).toHaveLength(1);
+      expect((createdClassExpression as ts.ClassExpression).heritageClauses[0]).toBe(htmlElementHeritageClause);
+    });
+  });
+});

--- a/src/compiler/transformers/test/proxy-custom-element-function.spec.ts
+++ b/src/compiler/transformers/test/proxy-custom-element-function.spec.ts
@@ -1,0 +1,181 @@
+import { mockCompilerCtx } from '@stencil/core/testing';
+import * as d from '@stencil/core/declarations';
+import { transpileModule } from './transpile';
+import { proxyCustomElement } from '../component-native/proxy-custom-element-function';
+import * as AddComponentMetaProxy from '../add-component-meta-proxy';
+import * as TransformUtils from '../transform-utils';
+import { PROXY_CUSTOM_ELEMENT } from '../core-runtime-apis';
+import * as ts from 'typescript';
+
+describe('proxy-custom-element-function', () => {
+  const componentClassName = 'MyComponent';
+  let compilerCtx: d.CompilerCtx;
+  let transformOpts: d.TransformOptions;
+
+  let getModuleFromSourceFileSpy: jest.SpyInstance<
+    ReturnType<typeof TransformUtils.getModuleFromSourceFile>,
+    Parameters<typeof TransformUtils.getModuleFromSourceFile>
+  >;
+  let createAnonymousClassMetadataProxySpy: jest.SpyInstance<
+    ReturnType<typeof AddComponentMetaProxy.createAnonymousClassMetadataProxy>,
+    Parameters<typeof AddComponentMetaProxy.createAnonymousClassMetadataProxy>
+  >;
+
+  beforeEach(() => {
+    compilerCtx = mockCompilerCtx();
+
+    transformOpts = {
+      coreImportPath: '@stencil/core',
+      componentExport: null,
+      componentMetadata: null,
+      currentDirectory: '/',
+      proxy: null,
+      style: 'static',
+      styleImportData: 'queryparams',
+    };
+
+    getModuleFromSourceFileSpy = jest.spyOn(TransformUtils, 'getModuleFromSourceFile');
+    getModuleFromSourceFileSpy.mockImplementation((_compilerCtx: d.CompilerCtx, _tsSourceFile: ts.SourceFile) => {
+      // TODO(STENCIL-379): Replace with a getMockModule() call
+      return {
+        cmps: [
+          {
+            componentClassName,
+          },
+        ],
+      } as d.Module;
+    });
+
+    createAnonymousClassMetadataProxySpy = jest.spyOn(AddComponentMetaProxy, 'createAnonymousClassMetadataProxy');
+    createAnonymousClassMetadataProxySpy.mockImplementation(
+      (_compilerMeta: d.ComponentCompilerMeta, clazz: ts.Expression) =>
+        ts.factory.createCallExpression(
+          ts.factory.createIdentifier(PROXY_CUSTOM_ELEMENT),
+          [],
+          [clazz, ts.factory.createTrue()]
+        )
+    );
+  });
+
+  afterEach(() => {
+    getModuleFromSourceFileSpy.mockRestore();
+    createAnonymousClassMetadataProxySpy.mockRestore();
+  });
+
+  describe('proxyCustomElement()', () => {
+    it('imports PROXY_CUSTOM_ELEMENT', () => {
+      const code = `const ${componentClassName} = class extends HTMLElement {};`;
+
+      const transformer = proxyCustomElement(compilerCtx, transformOpts);
+      const transpiledModule = transpileModule(code, null, compilerCtx, null, [], [transformer]);
+
+      expect(transpiledModule.outputText).toContain(
+        `import { proxyCustomElement as __stencil_proxyCustomElement } from "@stencil/core";`
+      );
+    });
+
+    it('wraps a class initializer in a proxyCustomElement call', () => {
+      const code = `const ${componentClassName} = class extends HTMLElement {};`;
+
+      const transformer = proxyCustomElement(compilerCtx, transformOpts);
+      const transpiledModule = transpileModule(code, null, compilerCtx, null, [], [transformer]);
+
+      expect(transpiledModule.outputText).toContain(
+        `export const ${componentClassName} = /*@__PURE__*/ __stencil_proxyCustomElement(class extends HTMLElement {}, true);`
+      );
+    });
+
+    describe('multiple variable declarations', () => {
+      it('wraps a class initializer properly when a variable declaration precedes it', () => {
+        const code = `const foo = 'hello world!', ${componentClassName} = class extends HTMLElement {};`;
+
+        const transformer = proxyCustomElement(compilerCtx, transformOpts);
+        const transpiledModule = transpileModule(code, null, compilerCtx, null, [], [transformer]);
+
+        expect(transpiledModule.outputText).toContain(
+          `export const foo = 'hello world!', ${componentClassName} = /*@__PURE__*/ __stencil_proxyCustomElement(class extends HTMLElement {}, true);`
+        );
+      });
+
+      it('wraps a class initializer properly when it precedes another variable declaration', () => {
+        const code = `const ${componentClassName} = class extends HTMLElement {}, foo = 'hello world!';`;
+
+        const transformer = proxyCustomElement(compilerCtx, transformOpts);
+        const transpiledModule = transpileModule(code, null, compilerCtx, null, [], [transformer]);
+
+        expect(transpiledModule.outputText).toContain(
+          `export const ${componentClassName} = /*@__PURE__*/ __stencil_proxyCustomElement(class extends HTMLElement {}, true), foo = 'hello world!';`
+        );
+      });
+
+      it('wraps a class initializer properly in the middle of multiple variable declarations', () => {
+        const code = `const foo = 'hello world!', ${componentClassName} = class extends HTMLElement {}, bar = 'goodbye?'`;
+
+        const transformer = proxyCustomElement(compilerCtx, transformOpts);
+        const transpiledModule = transpileModule(code, null, compilerCtx, null, [], [transformer]);
+
+        expect(transpiledModule.outputText).toContain(
+          `export const foo = 'hello world!', ${componentClassName} = /*@__PURE__*/ __stencil_proxyCustomElement(class extends HTMLElement {}, true), bar = 'goodbye?';`
+        );
+      });
+    });
+  });
+
+  describe('source file unchanged', () => {
+    it('returns the source file when no Stencil module is found', () => {
+      getModuleFromSourceFileSpy.mockImplementation((_compilerCtx: d.CompilerCtx, _tsSourceFile: ts.SourceFile) => {
+        // TODO(STENCIL-379): Replace with a getMockModule() call
+        return {
+          cmps: [],
+        } as d.Module;
+      });
+
+      const code = `const ${componentClassName} = class extends HTMLElement {};`;
+
+      const transformer = proxyCustomElement(compilerCtx, transformOpts);
+      const transpiledModule = transpileModule(code, null, compilerCtx, null, [], [transformer]);
+
+      expect(transpiledModule.outputText).toBe(code);
+    });
+
+    it('returns the source file when no variable statements are found', () => {
+      getModuleFromSourceFileSpy.mockImplementation((_compilerCtx: d.CompilerCtx, _tsSourceFile: ts.SourceFile) => {
+        // TODO(STENCIL-379): Replace with a getMockModule() call
+        return {
+          cmps: [
+            {
+              componentClassName,
+            },
+          ],
+        } as d.Module;
+      });
+
+      const code = `helloWorld();`;
+
+      const transformer = proxyCustomElement(compilerCtx, transformOpts);
+      const transpiledModule = transpileModule(code, null, compilerCtx, null, [], [transformer]);
+
+      expect(transpiledModule.outputText).toBe(code);
+    });
+
+    it("returns the source file when variable statements don't match the component name", () => {
+      getModuleFromSourceFileSpy.mockImplementation((_compilerCtx: d.CompilerCtx, _tsSourceFile: ts.SourceFile) => {
+        // TODO(STENCIL-379): Replace with a getMockModule() call
+        return {
+          cmps: [
+            {
+              componentClassName: 'ComponentNameDoesNotExist',
+            },
+          ],
+        } as d.Module;
+      });
+
+      const code = `const ${componentClassName} = class extends HTMLElement {};`;
+
+      const transformer = proxyCustomElement(compilerCtx, transformOpts);
+      const transpiledModule = transpileModule(code, null, compilerCtx, null, [], [transformer]);
+
+      expect(transpiledModule.outputText).toBe(code);
+    });
+  });
+});

--- a/src/compiler/transformers/update-component-class.ts
+++ b/src/compiler/transformers/update-component-class.ts
@@ -62,7 +62,7 @@ const createConstClass = (
           ts.createClassExpression(classModifiers, undefined, classNode.typeParameters, heritageClauses, members)
         ),
       ],
-      ts.NodeFlags.Let
+      ts.NodeFlags.Const
     )
   );
 };


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See the GitHub Issue below. In short, applications using Stencil + Webpack are susceptible to tree shaking issues with the `dist-custom-elements` output target

GitHub Issue Number: [3191](https://github.com/ionic-team/stencil/issues/3191)


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit solves an issue where stencil projects using webpack were
unable to treeshake properly. specifically, this is a workaround to a
webpack issue (https://github.com/webpack/webpack/issues/14963) where
webpack fails to treeshake when a variable is reassigned.

with this commit, we introduce a new transformer to be run during the
typescript transpilation process, `proxyCustomElement` that takes a
stencil component's class initializer and hoists it as the first
argument of `proxyCustomElement`. this eliminates the need to reassign
the variable in the final output, which was causing code generated using
the `dist-custom-elements` output target to fail to treeshake when used
in a webpack project.

with the introduction of this separate transformer, the creation of the
`proxyCustomElement` call is removed from the
`addDefineCustomElementFunctions` transformer. this was done for two
reasons:
1. separation of concerns - proxying the component is not strictly
   necessary when creating `define` calls
2. proxying must occur after the initializer has been generated.
   currently, this occurs in `nativeComponentTransform`. therefore, this
   step must occur after `nativeComponentTransform`.

as a part of creating this new transformer, a new function,
`createAnonymousClassMetadataProxy` was created. we intentionally choose
not to use the existing proxy creation funcitons in the same file where
the new file is defiend in order to pass the class initializer directly
to our new helper function.

update-component-class has a variable statement creation call that was
modified from `const` to `let` in
6987e4321b9dfd10710aa27a55e53e983e867729. With this commit, we can
safely revert this change as we no longer redefine the variable holding
the stencil component


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

### Unit Tests
Unit tests were added, and traced with the debugger locally to verify they worked as expected.

### Karma Tests
Existing karma tests surrounding defining custom elements still work
- https://github.com/ionic-team/stencil/tree/main/test/karma/test-app/custom-elements-output-webpack
- https://github.com/ionic-team/stencil/tree/main/test/karma/test-app/custom-elements-output-tag-class-different

### Manual Tests

#### autoDefineCustomElements
Manually verified `autoDefineCustomElements` still works as intended

#### Reproduction Case
Using Liam's reproduction application (see the linked GH Issue, [3191](https://github.com/ionic-team/stencil/issues/3191)), we can reproduce the original issue like so:

```
git clone git@github.com:liamdebeasi/webpack-reassignment-demo.git
cd webpack-reassignment-demo
git checkout stencil
cd component-library && npm i && npm run build && npm pack
cd ../
npm i 
npm i ./component-library/component-library-0.0.1.tgz --force
npx webpack
grep -o -i -E 'Avatar Component|Badge Component' dist/main.js
```
The above will install the dependencies on the component library and build it, install the component library in the parent project, then run webpack. The `grep` command looks for components in the output of webpack. Here we see 
```
Badge Component
Avatar Component
```
which is _not_ what we want. We should only see `Badge Component` as its the only component used.

To test the fix, pull down this branch, `npm run clean && npm ci && npm run build && npm pack` to generate the tarball. Here, I'm using a fresh copy of Liam's repro:
```
git clone git@github.com:liamdebeasi/webpack-reassignment-demo.git
cd webpack-reassignment-demo
git checkout stencil
cd component-library
npm i
npm i PATH_TO_TARBALL --force
npm run build && npm pack
cd ../
npm i
npm i ./component-library/component-library-0.0.1.tgz --force
npx webpack
grep -o -i -E 'Avatar Component|Badge Component' dist/main.js
```

Again, the above will install the dependencies on the component library and build it (this time using our tarball), install the component library in the parent project, then run webpack. The only other real difference/thing worth noting is the separate npm install commands that forcefully install our special packages to make sure we have the latest & greatest. This time when we run the `grep` command we see "Badge Component", as intended.

#### Ionic Framework
Finally, as one last testing step, I installed my local tarball into Ionic Framework's core package, then `npm run build && npm run test.e2e && npm run test.spec`

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other Information

If it's helpful to visualize, for a simple component:
```tsx
import { Component, h } from "@stencil/core";

@Component({
    tag: 'my-cmp',
})
export class MyCmp {
    render() {
        return <div>Hello</div>;
    }
}
```

Before this PR, the output of running the `dist-custom-elements` output target with stock options would be:

```tsx
import { HTMLElement, h, proxyCustomElement } from '@stencil/core/internal/client';

let MyCmp$1 = class extends HTMLElement {
  constructor() {
    super();
    this.__registerHost();
  }
  render() {
    return h("div", null, "Hello");
  }
};
MyCmp$1 = /*@__PURE__*/ proxyCustomElement(MyCmp$1, [0, "my-cmp"]);
function defineCustomElement$1() {
  if (typeof customElements === "undefined") {
    return;
  }
  const components = ["my-cmp"];
  components.forEach(tagName => { switch (tagName) {
    case "my-cmp":
      if (!customElements.get(tagName)) {
        customElements.define(tagName, MyCmp$1);
      }
      break;
  } });
}

const MyCmp = MyCmp$1;
const defineCustomElement = defineCustomElement$1;

export { MyCmp, defineCustomElement };

```

With this PR, we now generate:

```tsx
import { proxyCustomElement, HTMLElement, h } from '@stencil/core/internal/client';

const MyCmp$1 = /*@__PURE__*/ proxyCustomElement(class extends HTMLElement {
  constructor() {
    super();
    this.__registerHost();
  }
  render() {
    return h("div", null, "Hello");
  }
}, [0, "my-cmp"]);
function defineCustomElement$1() {
  if (typeof customElements === "undefined") {
    return;
  }
  const components = ["my-cmp"];
  components.forEach(tagName => { switch (tagName) {
    case "my-cmp":
      if (!customElements.get(tagName)) {
        customElements.define(tagName, MyCmp$1);
      }
      break;
  } });
}

const MyCmp = MyCmp$1;
const defineCustomElement = defineCustomElement$1;

export { MyCmp, defineCustomElement };

```
