### PR TITLE
test(prop-parsing): add numeric prop parsing tests

### DIFF
--- a/src/runtime/test/parse-property-value.spec.ts
+++ b/src/runtime/test/parse-property-value.spec.ts
@@ -1,0 +1,69 @@
+import { parsePropertyValue } from '../parse-property-value';
+import { MEMBER_FLAGS } from '../../utils';
+
+describe('parse-property-value', () => {
+  describe('parsePropertyValue', () => {
+    describe('number coercion', () => {
+      it('coerces a number value to a number', () => {
+        const result = parsePropertyValue(42, MEMBER_FLAGS.Number);
+        expect(result).toBe(42);
+      });
+
+      it('coerces a stringified value to a number', () => {
+        const result = parsePropertyValue('42', MEMBER_FLAGS.Number);
+        expect(result).toBe(42);
+      });
+
+      it('coerces a float value to a number', () => {
+        const result = parsePropertyValue('4.2', MEMBER_FLAGS.Number);
+        expect(result).toBe(4.2);
+      });
+
+      it('coerces a positive value to a number', () => {
+        const result = parsePropertyValue('+4.2', MEMBER_FLAGS.Number);
+        expect(result).toBe(4.2);
+      });
+
+      it('coerces a negative value to a number', () => {
+        const result = parsePropertyValue('-4.2', MEMBER_FLAGS.Number);
+        expect(result).toBe(-4.2);
+      });
+
+      it('coerces a stringified scientific value to a number', () => {
+        const result = parsePropertyValue('42e1', MEMBER_FLAGS.Number);
+        expect(result).toBe(420);
+      });
+
+      it('returns NaN when parsing a boolean', () => {
+        const result = parsePropertyValue(true, MEMBER_FLAGS.Number);
+        expect(result).toBe(NaN);
+      });
+
+      it('returns NaN when parsing a string', () => {
+        const result = parsePropertyValue('hello world', MEMBER_FLAGS.Number);
+        expect(result).toBe(NaN);
+      });
+
+      it('returns an object prop unchanged', () => {
+        const originalProp = { hello: 'world' };
+        const result = parsePropertyValue(originalProp, MEMBER_FLAGS.Number);
+        expect(result).toBe(originalProp);
+      });
+
+      it('returns an undefined prop unchanged', () => {
+        const result = parsePropertyValue(undefined, MEMBER_FLAGS.Number);
+        expect(result).toBe(undefined);
+      });
+
+      it('returns a null prop unchanged', () => {
+        const result = parsePropertyValue(null, MEMBER_FLAGS.Number);
+        expect(result).toBe(null);
+      });
+
+      it('returns NaN when NaN is received', () => {
+        const result = parsePropertyValue(NaN, MEMBER_FLAGS.Number);
+        expect(result).toBe(NaN);
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There are no unit tests for `src/runtime/parse-property-value.ts#parsePropertyValue`

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit adds tests to `src/runtime/parse-property-value.ts`.
specifically it adds tests to the case where we parse numbers using the
`parsePropertyValue` function.

these tests were originally a part of
https://github.com/ionic-team/stencil/pull/3254, but were removed from
the pull request. the reason for which is the fix implementation in 3254
ultimately went on a different layer of abstraction then
`parse-property-value`. these tests were originally written with a
different fix in mind; rather than scraping them, they've been updated
to fit the current implementation of the function under test

the intent with this pull request is not to cover every corner case of
`parseFloat`, which is the underlying implementation for this section of
the code. rather it is to document how the function under test will
respond to inputs across different types and of different numeric values

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

unit tests run/pass

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

the intent with this pull request is not to cover every corner case of
`parseFloat`, if you feel we're getting a little too ridiculous with the cases,
please LMK and we'll see if we can find a happy medium 🙂 