### PR TITLE
fix(puppeteer-page): add existing head content to page

### DIFF
--- a/src/testing/puppeteer/puppeteer-page.ts
+++ b/src/testing/puppeteer/puppeteer-page.ts
@@ -213,6 +213,10 @@ async function e2eSetContent(page: E2EPageInternal, html: string, options: WaitF
 
   const output: string[] = [];
 
+  const headContent: string = await page.$eval('head', async (headElement: Element) => {
+    return headElement ? headElement.innerHTML : '';
+  });
+
   const appScriptUrl = env.__STENCIL_APP_SCRIPT_URL__;
   if (typeof appScriptUrl !== 'string') {
     throw new Error('invalid e2eSetContent() app script url');
@@ -221,6 +225,8 @@ async function e2eSetContent(page: E2EPageInternal, html: string, options: WaitF
   output.push(`<!doctype html>`);
   output.push(`<html>`);
   output.push(`<head>`);
+
+  output.push(headContent);
 
   const appStyleUrl = env.__STENCIL_APP_STYLE_URL__;
   if (typeof appStyleUrl === 'string') {


### PR DESCRIPTION
Read the existing head element content, add that content to the e2e page that is being created. This prevents a user losing script or style tags that may have been added to the page before using the setContent method. Fixes #3229

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
Fixes the issue described in #3229 

GitHub Issue Number: 3229

## What is the new behavior?
Before creating the new e2e page, pull the content from the head element and add the content to the new page.
This prevents e2ePage.setContent from removing style and script tags added to the page before calling setContent.

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I manually linked the project into a Stencil project of my own. I used Puppeteer's `addScriptTag` method to add scripts to my e2ePage, then called the `setContent` method. Afterwards, I manually verified that the script tags were still present in my e2e page.

