### PR TITLE
chore(typings): update browser-compile typings

### DIFF
--- a/test/browser-compile/src/components/app-root/app-root.tsx
+++ b/test/browser-compile/src/components/app-root/app-root.tsx
@@ -183,7 +183,8 @@ export class AppRoot {
       }
 
       this.preview();
-    } catch (e) {
+    } catch (e: any) {
+      // TODO(STENCIL-371): Update typings for `e` to be more narrow than `any`
       this.bundledInput.value = e;
       if (e.loc && e.loc.file) {
         this.bundledInput.value += '\n\n\n' + e.loc.file;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Preflight [checklists](https://github.com/ionic-team/stencil/blob/main/scripts/readme.md#manually-testing-stencils-browser-api) for releasing Stencil can't be followed, as there are typescript errors outside the core compiler - specifically as a part of a manual testing suite.


GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit is a quick fix for the browser-compile tests that currently
do not compile after setting `useUnknownInCatchVariables` in
https://github.com/ionic-team/stencil/pull/3211. This went unnoticed as
this application is not currently type checked by our CI process. In
order to get the application to compile, we type the error as `any` for
now, with the intent of properly narrowing it in STENCIL-371 (and adding
proper CI checks there as well). this commit only unblocks next monday's
release.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Checkout this branch, and build Stencil: `npm ci && npm run build`:
Start the browser-compile project - `cd test/browser-compile && npm run start` 
## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

I intend to really fix this in a future ticket, this is just to unblock next Monday's release
