### PR TITLE
chore(karma): remove async and done usage

### DIFF
--- a/test/karma/test-app/conditional-rerender/karma.spec.ts
+++ b/test/karma/test-app/conditional-rerender/karma.spec.ts
@@ -9,7 +9,9 @@ describe('conditional-rerender', function () {
   });
   afterEach(tearDownDom);
 
-  it('contains a button as a child', async (done) => {
+  it('contains a button as a child', (done) => {
+    // the component has its own `setTimeout` call, therefore we must wait for that to finish using
+    // our own `setTimeout` call with a larger timeout value
     setTimeout(() => {
       const main = app.querySelector('main');
 

--- a/test/karma/test-app/shadow-dom-array/karma.spec.ts
+++ b/test/karma/test-app/shadow-dom-array/karma.spec.ts
@@ -9,7 +9,7 @@ describe('shadow-dom-array', () => {
   });
   afterEach(tearDownDom);
 
-  it('renders children', async (done) => {
+  it('renders children', (done) => {
     let r = app.querySelector('shadow-dom-array');
     expect(r.shadowRoot.children.length).toBe(1);
     expect(r.shadowRoot.children[0].textContent.trim()).toBe('0');

--- a/test/karma/test-app/slot-replace-wrapper/karma.spec.ts
+++ b/test/karma/test-app/slot-replace-wrapper/karma.spec.ts
@@ -4,9 +4,8 @@ describe('slot replace wrapper', () => {
   const { setupDom, tearDownDom } = setupDomTests(document);
   let app: HTMLElement;
 
-  beforeEach(async (done) => {
+  beforeEach(async () => {
     app = await setupDom('/slot-replace-wrapper/index.html');
-    setTimeout(done, 150);
   });
   afterEach(tearDownDom);
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When we upgraded Stencil to internally use Jest 27 (https://github.com/ionic-team/stencil/pull/3171), we began
to see warnings in the console that look something like:

> ERROR: 'DEPRECATION: An asynchronous before/it/after function took a done callback but also returned a promise. This is not supported and will stop working in the future. Either remove the done callback (recommended) or change the function to not return a promise. (in spec: shadow-dom-array renders children)'

This will be a blocker for an upgrade to Jest 28.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

I removed either the usage of the `done` parameter or `async` keyword from tests,
depending on what was required/based on the structure of the test itself

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

I've run our Karma tests on Browserstack 50 times to try to see if this introduces any additional flakiness to the e2e tests.  We saw 13 failures, most of which around disconnects from Browserstack/inability to connect to the browser in the first  place. While this number is too high, I don't think it's related to these tests themselves. 😢 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
