### PR TITLE
 fix(types): generate types for dist-custom-elements

### DIFF
--- a/src/compiler/config/outputs/validate-custom-element.ts
+++ b/src/compiler/config/outputs/validate-custom-element.ts
@@ -1,14 +1,34 @@
-import type { Config, OutputTarget, OutputTargetDistCustomElements, OutputTargetCopy } from '../../../declarations';
+import type {
+  Config,
+  OutputTarget,
+  OutputTargetDistCustomElements,
+  OutputTargetDistTypes,
+  OutputTargetCopy,
+} from '../../../declarations';
 import { getAbsolutePath } from '../config-utils';
-import { isBoolean } from '@utils';
-import { COPY, isOutputTargetDistCustomElements } from '../../output-targets/output-utils';
+import { COPY, DIST_TYPES, isOutputTargetDistCustomElements } from '../../output-targets/output-utils';
 import { validateCopy } from '../validate-copy';
+import { isBoolean } from '@utils';
+import { join } from 'path';
 
-export const validateCustomElement = (config: Config, userOutputs: OutputTarget[]) => {
-  return userOutputs.filter(isOutputTargetDistCustomElements).reduce((arr, o) => {
+/**
+ * Validate one or more `dist-custom-elements` output targets. Validation of an output target may involve back-filling
+ * fields that are omitted with sensible defaults and/or creating additional supporting output targets that were not
+ * explicitly defined by the user
+ * @param config the Stencil configuration associated with the project being compiled
+ * @param userOutputs the output target(s) specified by the user
+ * @returns the validated output target(s)
+ */
+export const validateCustomElement = (
+  config: Config,
+  userOutputs: ReadonlyArray<OutputTarget>
+): ReadonlyArray<OutputTargetDistCustomElements | OutputTargetDistTypes | OutputTargetCopy> => {
+  const defaultDir = 'dist';
+
+  return userOutputs.filter(isOutputTargetDistCustomElements).reduce((outputs, o) => {
     const outputTarget = {
       ...o,
-      dir: getAbsolutePath(config, o.dir || 'dist/components'),
+      dir: getAbsolutePath(config, o.dir || join(defaultDir, 'components')),
     };
     if (!isBoolean(outputTarget.empty)) {
       outputTarget.empty = true;
@@ -16,17 +36,28 @@ export const validateCustomElement = (config: Config, userOutputs: OutputTarget[
     if (!isBoolean(outputTarget.externalRuntime)) {
       outputTarget.externalRuntime = true;
     }
+
+    // unlike other output targets, Stencil does not allow users to define the output location of types at this time
+    if (outputTarget.generateTypeDeclarations) {
+      const typesDirectory = getAbsolutePath(config, join(defaultDir, 'types'));
+      outputs.push({
+        type: DIST_TYPES,
+        dir: outputTarget.dir,
+        typesDir: typesDirectory,
+      });
+    }
+
     outputTarget.copy = validateCopy(outputTarget.copy, []);
 
     if (outputTarget.copy.length > 0) {
-      arr.push({
+      outputs.push({
         type: COPY,
         dir: config.rootDir,
         copy: [...outputTarget.copy],
       });
     }
-    arr.push(outputTarget);
+    outputs.push(outputTarget);
 
-    return arr;
-  }, [] as (OutputTargetDistCustomElements | OutputTargetCopy)[]);
+    return outputs;
+  }, [] as (OutputTargetDistCustomElements | OutputTargetCopy | OutputTargetDistTypes)[]);
 };

--- a/src/compiler/config/test/validate-output-dist-custom-element.spec.ts
+++ b/src/compiler/config/test/validate-output-dist-custom-element.spec.ts
@@ -1,0 +1,254 @@
+import type * as d from '@stencil/core/declarations';
+import { mockConfig } from '@stencil/core/testing';
+import { COPY, DIST_CUSTOM_ELEMENTS, DIST_TYPES } from '../../output-targets/output-utils';
+import { validateConfig } from '../validate-config';
+import path from 'path';
+
+describe('validate-output-dist-custom-element', () => {
+  describe('validateCustomElement', () => {
+    const rootDir = path.resolve('/');
+    const defaultDistDir = path.join(rootDir, 'dist', 'components');
+    const distCustomElementsDir = 'my-dist-custom-elements';
+    let userConfig: d.Config;
+
+    beforeEach(() => {
+      userConfig = mockConfig();
+    });
+
+    it('generates a default dist-custom-elements output target', () => {
+      const outputTarget: d.OutputTargetDistCustomElements = {
+        type: DIST_CUSTOM_ELEMENTS,
+      };
+      userConfig.outputTargets = [outputTarget];
+
+      const { config } = validateConfig(userConfig);
+      expect(config.outputTargets).toEqual([
+        {
+          type: DIST_CUSTOM_ELEMENTS,
+          copy: [],
+          dir: defaultDistDir,
+          empty: true,
+          externalRuntime: true,
+        },
+      ]);
+    });
+
+    it('uses a provided dir field over a default directory', () => {
+      const outputTarget: d.OutputTargetDistCustomElements = {
+        type: DIST_CUSTOM_ELEMENTS,
+        dir: distCustomElementsDir,
+      };
+      userConfig.outputTargets = [outputTarget];
+
+      const { config } = validateConfig(userConfig);
+      expect(config.outputTargets).toEqual([
+        {
+          type: DIST_CUSTOM_ELEMENTS,
+          copy: [],
+          dir: path.join(rootDir, distCustomElementsDir),
+          empty: true,
+          externalRuntime: true,
+        },
+      ]);
+    });
+
+    describe('"empty" field', () => {
+      it('defaults the "empty" field to true if not provided', () => {
+        const outputTarget: d.OutputTargetDistCustomElements = {
+          type: DIST_CUSTOM_ELEMENTS,
+          externalRuntime: false,
+        };
+        userConfig.outputTargets = [outputTarget];
+
+        const { config } = validateConfig(userConfig);
+        expect(config.outputTargets).toEqual([
+          {
+            type: DIST_CUSTOM_ELEMENTS,
+            copy: [],
+            dir: defaultDistDir,
+            empty: true,
+            externalRuntime: false,
+          },
+        ]);
+      });
+
+      it('defaults the "empty" field to true it\'s not a boolean', () => {
+        const outputTarget: d.OutputTargetDistCustomElements = {
+          type: DIST_CUSTOM_ELEMENTS,
+          empty: undefined,
+          externalRuntime: false,
+        };
+        userConfig.outputTargets = [outputTarget];
+
+        const { config } = validateConfig(userConfig);
+        expect(config.outputTargets).toEqual([
+          {
+            type: DIST_CUSTOM_ELEMENTS,
+            copy: [],
+            dir: defaultDistDir,
+            empty: true,
+            externalRuntime: false,
+          },
+        ]);
+      });
+    });
+
+    describe('"externalRuntime" field', () => {
+      it('defaults the "externalRuntime" field to true if not provided', () => {
+        const outputTarget: d.OutputTargetDistCustomElements = {
+          type: DIST_CUSTOM_ELEMENTS,
+          empty: false,
+        };
+        userConfig.outputTargets = [outputTarget];
+
+        const { config } = validateConfig(userConfig);
+        expect(config.outputTargets).toEqual([
+          {
+            type: DIST_CUSTOM_ELEMENTS,
+            copy: [],
+            dir: defaultDistDir,
+            empty: false,
+            externalRuntime: true,
+          },
+        ]);
+      });
+
+      it('defaults the "externalRuntime" field to true it\'s not a boolean', () => {
+        const outputTarget: d.OutputTargetDistCustomElements = {
+          type: DIST_CUSTOM_ELEMENTS,
+          empty: false,
+          externalRuntime: undefined,
+        };
+        userConfig.outputTargets = [outputTarget];
+
+        const { config } = validateConfig(userConfig);
+        expect(config.outputTargets).toEqual([
+          {
+            type: DIST_CUSTOM_ELEMENTS,
+            copy: [],
+            dir: defaultDistDir,
+            empty: false,
+            externalRuntime: true,
+          },
+        ]);
+      });
+    });
+
+    describe('"generateTypeDeclarations" field', () => {
+      it('creates a types directory when "generateTypeDeclarations" is true', () => {
+        const outputTarget: d.OutputTargetDistCustomElements = {
+          type: DIST_CUSTOM_ELEMENTS,
+          empty: false,
+          externalRuntime: false,
+          generateTypeDeclarations: true,
+        };
+        userConfig.outputTargets = [outputTarget];
+
+        const { config } = validateConfig(userConfig);
+        expect(config.outputTargets).toEqual([
+          {
+            type: DIST_TYPES,
+            dir: defaultDistDir,
+            typesDir: path.join(rootDir, 'dist', 'types'),
+          },
+          {
+            type: DIST_CUSTOM_ELEMENTS,
+            copy: [],
+            dir: defaultDistDir,
+            empty: false,
+            externalRuntime: false,
+            generateTypeDeclarations: true,
+          },
+        ]);
+      });
+
+      it('creates a types directory for a custom directory', () => {
+        const outputTarget: d.OutputTargetDistCustomElements = {
+          type: DIST_CUSTOM_ELEMENTS,
+          dir: distCustomElementsDir,
+          empty: false,
+          externalRuntime: false,
+          generateTypeDeclarations: true,
+        };
+        userConfig.outputTargets = [outputTarget];
+
+        const { config } = validateConfig(userConfig);
+        expect(config.outputTargets).toEqual([
+          {
+            type: DIST_TYPES,
+            dir: path.join(rootDir, distCustomElementsDir),
+            typesDir: path.join(rootDir, 'dist', 'types'),
+          },
+          {
+            type: DIST_CUSTOM_ELEMENTS,
+            copy: [],
+            dir: path.join(rootDir, distCustomElementsDir),
+            empty: false,
+            externalRuntime: false,
+            generateTypeDeclarations: true,
+          },
+        ]);
+      });
+
+      it('doesn\'t create a types directory when "generateTypeDeclarations" is false', () => {
+        const outputTarget: d.OutputTargetDistCustomElements = {
+          type: DIST_CUSTOM_ELEMENTS,
+          empty: false,
+          externalRuntime: false,
+          generateTypeDeclarations: false,
+        };
+        userConfig.outputTargets = [outputTarget];
+
+        const { config } = validateConfig(userConfig);
+        expect(config.outputTargets).toEqual([
+          {
+            type: DIST_CUSTOM_ELEMENTS,
+            copy: [],
+            dir: defaultDistDir,
+            empty: false,
+            externalRuntime: false,
+            generateTypeDeclarations: false,
+          },
+        ]);
+      });
+    });
+
+    describe('copy tasks', () => {
+      it('copies existing copy tasks over to the output target', () => {
+        const copyOutputTarget: d.CopyTask = {
+          src: 'mock/src',
+          dest: 'mock/dest',
+        };
+        const copyOutputTarget2: d.CopyTask = {
+          src: 'mock/src2',
+          dest: 'mock/dest2',
+        };
+
+        const outputTarget: d.OutputTargetDistCustomElements = {
+          type: DIST_CUSTOM_ELEMENTS,
+          copy: [copyOutputTarget, copyOutputTarget2],
+          dir: distCustomElementsDir,
+          empty: false,
+          externalRuntime: false,
+        };
+        userConfig.outputTargets = [outputTarget];
+
+        const { config } = validateConfig(userConfig);
+        expect(config.outputTargets).toEqual([
+          {
+            type: COPY,
+            dir: rootDir,
+            copy: [copyOutputTarget, copyOutputTarget2],
+          },
+          {
+            type: DIST_CUSTOM_ELEMENTS,
+            copy: [copyOutputTarget, copyOutputTarget2],
+            dir: path.join(rootDir, distCustomElementsDir),
+            empty: false,
+            externalRuntime: false,
+          },
+        ]);
+      });
+    });
+  });
+});

--- a/src/compiler/output-targets/dist-custom-elements/custom-elements-types.ts
+++ b/src/compiler/output-targets/dist-custom-elements/custom-elements-types.ts
@@ -3,12 +3,21 @@ import { isOutputTargetDistCustomElements } from '../output-utils';
 import { dirname, join, relative } from 'path';
 import { normalizePath, dashToPascalCase } from '@utils';
 
+/**
+ * Entrypoint for generating types for one or more `dist-custom-elements` output targets defined in a Stencil project's
+ * configuration
+ * @param config the Stencil configuration associated with the project being compiled
+ * @param compilerCtx the current compiler context
+ * @param buildCtx the context associated with the current build
+ * @param distDtsFilePath the path to a type declaration file (.d.ts) that is being generated for the output target.
+ * This path is not necessarily the `components.d.ts` file that is found in the root of a project's `src` directory.
+ */
 export const generateCustomElementsTypes = async (
   config: d.Config,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   distDtsFilePath: string
-) => {
+): Promise<void> => {
   const outputTargets = config.outputTargets.filter(isOutputTargetDistCustomElements);
 
   await Promise.all(
@@ -18,12 +27,21 @@ export const generateCustomElementsTypes = async (
   );
 };
 
+/**
+ * Generates types for a single `dist-custom-elements` output target definition in a Stencil project's configuration
+ * @param config the Stencil configuration associated with the project being compiled
+ * @param compilerCtx the current compiler context
+ * @param buildCtx the context associated with the current build
+ * @param distDtsFilePath the path to a type declaration file (.d.ts) that is being generated for the output target.
+ * This path is not necessarily the `components.d.ts` file that is found in the root of a project's `src` directory.
+ * @param outputTarget the output target for which types are being currently generated
+ */
 export const generateCustomElementsTypesOutput = async (
   config: d.Config,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   distDtsFilePath: string,
-  outputTarget: d.OutputTargetDistCustomElementsBundle | d.OutputTargetDistCustomElements
+  outputTarget: d.OutputTargetDistCustomElements
 ) => {
   const customElementsDtsPath = join(outputTarget.dir, 'index.d.ts');
   const componentsDtsRelPath = relDts(outputTarget.dir, distDtsFilePath);
@@ -40,7 +58,7 @@ export const generateCustomElementsTypesOutput = async (
     ` * "setAssetPath(document.currentScript.src)", or using a bundler's replace plugin to`,
     ` * dynamically set the path at build time, such as "setAssetPath(process.env.ASSET_PATH)".`,
     ` * But do note that this configuration depends on how your script is bundled, or lack of`,
-    ` * bunding, and where your assets can be loaded from. Additionally custom bundling`,
+    ` * bundling, and where your assets can be loaded from. Additionally custom bundling`,
     ` * will have to ensure the static assets are copied to its build directory.`,
     ` */`,
     `export declare const setAssetPath: (path: string) => void;`,
@@ -80,7 +98,14 @@ export const generateCustomElementsTypesOutput = async (
   );
 };
 
-const generateCustomElementType = (componentsDtsRelPath: string, cmp: d.ComponentCompilerMeta) => {
+/**
+ * Generate a type declaration file for a specific Stencil component
+ * @param componentsDtsRelPath the path to a root type declaration file from which commonly used entities can be
+ * referenced from in the newly generated file
+ * @param cmp the component to generate the type declaration file for
+ * @returns the contents of the type declaration file for the provided `cmp`
+ */
+const generateCustomElementType = (componentsDtsRelPath: string, cmp: d.ComponentCompilerMeta): string => {
   const tagNameAsPascal = dashToPascalCase(cmp.tagName);
   const o: string[] = [
     `import type { Components, JSX } from "${componentsDtsRelPath}";`,
@@ -100,7 +125,14 @@ const generateCustomElementType = (componentsDtsRelPath: string, cmp: d.Componen
   return o.join('\n');
 };
 
-const relDts = (fromPath: string, dtsPath: string) => {
+/**
+ * Determines the relative path between two provided paths. If a type declaration file extension is present on
+ * `dtsPath`, it will be removed from the computed relative path.
+ * @param fromPath the path from which to start at
+ * @param dtsPath the destination path
+ * @returns the relative path from the provided `fromPath` to the `dtsPath`
+ */
+const relDts = (fromPath: string, dtsPath: string): string => {
   dtsPath = relative(fromPath, dtsPath);
   if (!dtsPath.startsWith('.')) {
     dtsPath = '.' + dtsPath;

--- a/src/compiler/output-targets/output-types.ts
+++ b/src/compiler/output-targets/output-types.ts
@@ -2,7 +2,17 @@ import type * as d from '../../declarations';
 import { generateTypes } from '../types/generate-types';
 import { isOutputTargetDistTypes } from './output-utils';
 
-export const outputTypes = async (config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
+/**
+ * Entrypoint for generating types for all output targets
+ * @param config the Stencil configuration associated with the project being compiled
+ * @param compilerCtx the current compiler context
+ * @param buildCtx the context associated with the current build
+ */
+export const outputTypes = async (
+  config: d.Config,
+  compilerCtx: d.CompilerCtx,
+  buildCtx: d.BuildCtx
+): Promise<void> => {
   const outputTargets = config.outputTargets.filter(isOutputTargetDistTypes);
   if (outputTargets.length === 0) {
     return;

--- a/src/compiler/types/generate-component-types.ts
+++ b/src/compiler/types/generate-component-types.ts
@@ -5,12 +5,12 @@ import { generateMethodTypes } from './generate-method-types';
 import { generatePropTypes } from './generate-prop-types';
 
 /**
- * Generate a string based on the types that are defined within a component.
- *
+ * Generate a string based on the types that are defined within a component
  * @param cmp the metadata for the component that a type definition string is generated for
- * @param importPath the path of the component file
+ * @param areTypesInternal `true` if types being generated are for a project's internal purposes, `false` otherwise
+ * @returns the generated types string alongside additional metadata
  */
-export const generateComponentTypes = (cmp: d.ComponentCompilerMeta, internal: boolean): d.TypesModule => {
+export const generateComponentTypes = (cmp: d.ComponentCompilerMeta, areTypesInternal: boolean): d.TypesModule => {
   const tagName = cmp.tagName.toLowerCase();
   const tagNameAsPascal = dashToPascalCase(tagName);
   const htmlElementName = `HTML${tagNameAsPascal}Element`;
@@ -19,9 +19,13 @@ export const generateComponentTypes = (cmp: d.ComponentCompilerMeta, internal: b
   const methodAttributes = generateMethodTypes(cmp.methods);
   const eventAttributes = generateEventTypes(cmp.events);
 
-  const componentAttributes = attributesToMultiLineString([...propAttributes, ...methodAttributes], false, internal);
+  const componentAttributes = attributesToMultiLineString(
+    [...propAttributes, ...methodAttributes],
+    false,
+    areTypesInternal
+  );
   const isDep = cmp.isCollectionDependency;
-  const jsxAttributes = attributesToMultiLineString([...propAttributes, ...eventAttributes], true, internal);
+  const jsxAttributes = attributesToMultiLineString([...propAttributes, ...eventAttributes], true, areTypesInternal);
 
   const element = [
     `        interface ${htmlElementName} extends Components.${tagNameAsPascal}, HTMLStencilElement {`,

--- a/src/compiler/types/generate-types.ts
+++ b/src/compiler/types/generate-types.ts
@@ -6,24 +6,39 @@ import { generateCustomElementsBundleTypes } from '../output-targets/dist-custom
 import { generateCustomElementsTypes } from '../output-targets/dist-custom-elements/custom-elements-types';
 import { isDtsFile } from '@utils';
 
+/**
+ * For a single output target, generate types, then copy the Stencil core type declaration file
+ * @param config the Stencil configuration associated with the project being compiled
+ * @param compilerCtx the current compiler context
+ * @param buildCtx the context associated with the current build
+ * @param outputTarget the output target to generate types for
+ */
 export const generateTypes = async (
   config: d.Config,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   outputTarget: d.OutputTargetDistTypes
-) => {
+): Promise<void> => {
   if (!buildCtx.hasError) {
     await generateTypesOutput(config, compilerCtx, buildCtx, outputTarget);
     await copyStencilCoreDts(config, compilerCtx);
   }
 };
 
+/**
+ * Generate type definition files and write them to a dist directory
+ * @param config the Stencil configuration associated with the project being compiled
+ * @param compilerCtx the current compiler context
+ * @param buildCtx the context associated with the current build
+ * @param outputTarget the output target to generate types for
+ */
 const generateTypesOutput = async (
   config: d.Config,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   outputTarget: d.OutputTargetDistTypes
-) => {
+): Promise<void> => {
+  // get all type declaration files in a project's src/ directory
   const srcDirItems = await compilerCtx.fs.readdir(config.srcDir, { recursive: false });
   const srcDtsFiles = srcDirItems.filter((srcItem) => srcItem.isFile && isDtsFile(srcItem.absPath));
 

--- a/src/compiler/types/stencil-types.ts
+++ b/src/compiler/types/stencil-types.ts
@@ -3,8 +3,18 @@ import { dirname, join, relative } from 'path';
 import { isOutputTargetDistTypes } from '../output-targets/output-utils';
 import { normalizePath } from '@utils';
 
-export const updateStencilTypesImports = (typesDir: string, dtsFilePath: string, dtsContent: string) => {
+/**
+ * Update a type declaration file's import declarations using the module `@stencil/core`
+ * @param typesDir the directory where type declaration files are expected to exist
+ * @param dtsFilePath the path of the type declaration file being updated, used to derive the correct import declaration
+ * module
+ * @param dtsContent the content of a type declaration file to update
+ * @returns the updated type declaration file contents
+ */
+export const updateStencilTypesImports = (typesDir: string, dtsFilePath: string, dtsContent: string): string => {
   const dir = dirname(dtsFilePath);
+  // determine the relative path between the directory of the .d.ts file and the types directory. this value may result
+  // in '.' if they are the same
   const relPath = relative(dir, typesDir);
 
   let coreDtsPath = join(relPath, CORE_FILENAME);
@@ -20,7 +30,16 @@ export const updateStencilTypesImports = (typesDir: string, dtsFilePath: string,
   return dtsContent;
 };
 
-export const copyStencilCoreDts = async (config: d.Config, compilerCtx: d.CompilerCtx) => {
+/**
+ * Writes Stencil core typings file to disk for a dist-* output target
+ * @param config the Stencil configuration associated with the project being compiled
+ * @param compilerCtx the current compiler context
+ * @returns
+ */
+export const copyStencilCoreDts = async (
+  config: d.Config,
+  compilerCtx: d.CompilerCtx
+): Promise<ReadonlyArray<d.FsWriteResults>> => {
   const typesOutputTargets = config.outputTargets.filter(isOutputTargetDistTypes).filter((o) => o.typesDir);
 
   const srcStencilDtsPath = join(config.sys.getCompilerExecutingPath(), '..', '..', 'internal', CORE_DTS);

--- a/src/compiler/types/update-import-refs.ts
+++ b/src/compiler/types/update-import-refs.ts
@@ -2,20 +2,19 @@ import type * as d from '../../declarations';
 import { dirname, resolve } from 'path';
 
 /**
- * Find all referenced types by a component and add them to the importDataObj and return the newly
- * updated importDataObj
- *
+ * Find all referenced types by a component and add them to the `importDataObj` parameter
  * @param importDataObj key/value of type import file, each value is an array of imported types
- * @param cmpMeta the metadata for the component that is referencing the types
+ * @param allTypes an output parameter containing a map of seen types and the number of times the type has been seen
+ * @param cmp the metadata associated with the component whose types are being inspected
  * @param filePath the path of the component file
- * @param config general config that all of stencil uses
+ * @returns the updated import data
  */
 export const updateReferenceTypeImports = (
   importDataObj: d.TypesImportData,
   allTypes: Map<string, number>,
   cmp: d.ComponentCompilerMeta,
   filePath: string
-) => {
+): d.TypesImportData => {
   const updateImportReferences = updateImportReferenceFactory(allTypes, filePath);
 
   return [...cmp.properties, ...cmp.events, ...cmp.methods]

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1930,6 +1930,10 @@ export interface OutputTargetDistCustomElements extends OutputTargetBaseNext {
    * children, etc. Users of this flag should be aware that enabling this functionality may increase bundle size.
    */
   autoDefineCustomElements?: boolean;
+  /**
+   * Enables the generation of type definition files for the output target.
+   */
+  generateTypeDeclarations?: boolean;
 }
 
 export interface OutputTargetDistCustomElementsBundle extends OutputTargetBaseNext {

--- a/src/utils/test/util.spec.ts
+++ b/src/utils/test/util.spec.ts
@@ -113,7 +113,7 @@ describe('util', () => {
       expect(util.isDtsFile('foo.spec.ts')).toEqual(false);
     });
 
-    it('should be case insenitive', () => {
+    it('should be case insensitive', () => {
       expect(util.isDtsFile('foo/bar.D.tS')).toEqual(true);
     });
   });

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -53,7 +53,13 @@ export const isTsFile = (filePath: string) => {
   return false;
 };
 
-export const isDtsFile = (filePath: string) => {
+/**
+ * Determines if a given file path points to a type declaration file (ending in .d.ts) or not. This function is
+ * case-insensitive in its heuristics.
+ * @param filePath the path to check
+ * @returns `true` if the given `filePath` points to a type declaration file, `false` otherwise
+ */
+export const isDtsFile = (filePath: string): boolean => {
   const parts = filePath.toLowerCase().split('.');
   if (parts.length > 2) {
     return parts[parts.length - 2] === 'd' && parts[parts.length - 1] === 'ts';


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Type declarations are not created for users of the `dist-custom-elements` output target,
unless they also provide the `dist` output target as well

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

### Commit 1

this commit introduces a new experimental flag,
`generateTypeDeclarations` on the `dist-custom-elements` output target.
when enabled, it allows a user to generate type declaration files for
their stencil project (that uses `dist-custom-elements`) without also
specifying the `dist` output target.

this experimental flag generates types in the `dist/types` directory.
this destination is not configurable at this time to better understand
the needs of users for generating these types

### Commit 2

this commit adds jsdoc, clarifying comments, and minor type updates to
the codebase. this work was completed while working through adding
`generateTypeDeclarations` to the `dist-custom-elements` output target,
but was split into a separate commit as to not detract from the work
being completed.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Unit tests have been added to ensure that validating a `dist-custom-elements` output target returns the expected result. For these tests, I followed patterns existing in similar tests. While it may not be how I'd personally write them, i think maintaining consistency is more important in this matter, especially as we try to add new tests like these

Next, I generated a stencil project to serve as the foundation for a few manual tests (tested with Stencil v2.14.1):
`npm init stencil component test-types`.

By default, the Stencil CLI generates a Stencil config with the following:
```ts
{
  outputTargets: [
      {
        type: 'dist',
        esmLoaderPath: '../loader',
      },
      {
        type: 'dist-custom-elements',
      }
  ]
}
```
I ran `npm run build` - then took this branch and installed it on said project and ran `npm run build` again (without modifying my stencil config).  I diffed the `dist` directory from both builds, and saw minimal differences (stencil versions and one typo fix):
![Screen Shot 2022-03-08 at 2 17 22 PM](https://user-images.githubusercontent.com/1930213/157312871-5872b913-91fb-4646-aa88-c290c635ad90.png).

Then, I modified my Stencil config for `dist-custom-elements` and removed `dist`:
```diff
{
  outputTargets: [
-     {
-       type: 'dist',
-       esmLoaderPath: '../loader',
-     },
      {
        type: 'dist-custom-elements',
+       generateTypeDeclarations: true,
      }
  ]
}
```

I then diff'ed this against the previous `dist` generated, and verified that the custom-elements contents were found in both `dist` directories, and unnecessary files were not in my newly generated `dist`:

![Screen Shot 2022-03-08 at 2 18 51 PM](https://user-images.githubusercontent.com/1930213/157313266-df38f2c0-e319-461a-9b0c-f0f395c0b642.png)


Finally, I modified my stencil config one last time to specify a custom output directory for `dist-custom-elements`. One more diff shows that the paths are set correctly for this build:
```diff
{
  outputTargets: [
      {
        type: 'dist-custom-elements',
        generateTypeDeclarations: true,
+       dir: 'custom-elements-specified-dir'
      }
  ]
}
```
![Screen Shot 2022-03-08 at 2 22 59 PM](https://user-images.githubusercontent.com/1930213/157313394-f9c87505-7ba4-41da-a483-906c3a58b558.png)



## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Documentation PR: https://github.com/ionic-team/stencil-site/pull/845
