### PR TITLE
feat(node): add warning of future node support

### DIFF
--- a/bin/stencil
+++ b/bin/stencil
@@ -2,7 +2,7 @@
 'use strict';
 
 var minimumVersion = '12.10';
-var futureDeprecationMinVersion = '14.0'
+var futureDeprecationMinVersion = '14.0';
 var recommendedVersion = '14.5';
 var currentVersion = process.versions.node;
 

--- a/bin/stencil
+++ b/bin/stencil
@@ -27,7 +27,7 @@ if (isNodeLT(futureDeprecationMinVersion)) {
   console.warn(
     '\nIn an upcoming major release of Stencil, Node v' +
     recommendedVersion +
-    ' or higher will be required.\n'
+    '.0 or higher will be required.\n'
   );
 } else if (isNodeLT(recommendedVersion)) {
   console.warn(

--- a/bin/stencil
+++ b/bin/stencil
@@ -2,6 +2,7 @@
 'use strict';
 
 var minimumVersion = '12.10';
+var futureDeprecationMinVersion = '14.0'
 var recommendedVersion = '14.5';
 var currentVersion = process.versions.node;
 
@@ -22,7 +23,13 @@ if (isNodeLT(minimumVersion)) {
   process.exit(1);
 }
 
-if (isNodeLT(recommendedVersion)) {
+if (isNodeLT(futureDeprecationMinVersion)) {
+  console.warn(
+    '\nIn an upcoming major release of Stencil, Node v' +
+    recommendedVersion +
+    ' or higher will be required.\n'
+  );
+} else if (isNodeLT(recommendedVersion)) {
   console.warn(
     '\nYour current version of Node is v' +
       currentVersion +


### PR DESCRIPTION
**Please do not merge, see 'Other Information' below**

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature - NOTE: Calling it a 'feature' to raise awareness
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Stencil v2.X supports Node 12, which will hit end of life in April. Stencil v3 (which will release some time after said end of life of Node 12) will no longer support Node 12. We do not have a non-blocking way of disseminating this knowledge at this time.
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit adds a warning to the console stating that support for node
v14.5.0 and under will be removed in a future major version update of
stencil. this commit only adds the notice to the `bin` entrypoint of
stencil, and does not add any notice to using compiler api's directly
(we expect the latter to be handled by `package.json#engines`).

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
To start, spin up a new stencil project (`npm init stencil component test-warning-msg`), then pull this branch and build it (`npm ci && npm run build && npm pack`). Install the tarball to your stencil project.

Using Volta, I tested this against the latest versions of v12 & v13. For both of these versions, the warning is present when running `npm run build`. I also tested v14.0.0, where we should expect a different (pre-existing) warning message regarding minor version of v14:
![Screen Shot 2022-03-08 at 4 02 06 PM](https://user-images.githubusercontent.com/1930213/157326933-5983218a-91f6-4d81-973c-477df62d6693.png)

Testing with v14.5.0 and v16, we do not see the warning present:


![Screen Shot 2022-03-08 at 4 04 24 PM](https://user-images.githubusercontent.com/1930213/157326984-35fcada7-22d8-4cb2-944c-fbde5622b94d.png)

## Other Information

I consider [the upcoming support policy](https://github.com/ionic-team/stencil-site/pull/842) a precursor (or at least a sibling) PR to this one. Feel free to review/test, but I'd like to avoid merging until the Stencil Site is updated