### PR TITLE
fix(testing): update test regex for 'e2e.ts'

### DIFF
--- a/src/compiler/config/test/validate-testing.spec.ts
+++ b/src/compiler/config/test/validate-testing.spec.ts
@@ -159,6 +159,22 @@ describe('validateTesting', () => {
         expect(testRegex.test('my-component.test.jsx')).toBe(true);
       });
 
+      it('matches the file "test.ts"', () => {
+        expect(testRegex.test('some/path/test.ts')).toBe(true);
+      });
+
+      it('matches the file "test.tsx"', () => {
+        expect(testRegex.test('some/path/test.tsx')).toBe(true);
+      });
+
+      it('matches the file "test.js"', () => {
+        expect(testRegex.test('some/path/test.js')).toBe(true);
+      });
+
+      it('matches the file "test.jsx"', () => {
+        expect(testRegex.test('some/path/test.jsx')).toBe(true);
+      });
+
       it("doesn't match files ending in test.ts", () => {
         expect(testRegex.test('my-component-test.ts')).toBe(false);
       });
@@ -201,6 +217,22 @@ describe('validateTesting', () => {
         expect(testRegex.test('my-component.spec.jsx')).toBe(true);
       });
 
+      it('matches the file "spec.ts"', () => {
+        expect(testRegex.test('some/path/spec.ts')).toBe(true);
+      });
+
+      it('matches the file "spec.tsx"', () => {
+        expect(testRegex.test('some/path/spec.tsx')).toBe(true);
+      });
+
+      it('matches the file "spec.js"', () => {
+        expect(testRegex.test('some/path/spec.js')).toBe(true);
+      });
+
+      it('matches the file "spec.jsx"', () => {
+        expect(testRegex.test('some/path/spec.jsx')).toBe(true);
+      });
+
       it("doesn't match files ending in spec.ts", () => {
         expect(testRegex.test('my-component-spec.ts')).toBe(false);
       });
@@ -241,6 +273,22 @@ describe('validateTesting', () => {
 
       it('matches files ending in .e2e.jsx', () => {
         expect(testRegex.test('my-component.e2e.jsx')).toBe(true);
+      });
+
+      it('matches the file "e2e.ts"', () => {
+        expect(testRegex.test('some/path/e2e.ts')).toBe(true);
+      });
+
+      it('matches the file "e2e.tsx"', () => {
+        expect(testRegex.test('some/path/e2e.tsx')).toBe(true);
+      });
+
+      it('matches the file "e2e.js"', () => {
+        expect(testRegex.test('some/path/e2e.js')).toBe(true);
+      });
+
+      it('matches the file "e2e.jsx"', () => {
+        expect(testRegex.test('some/path/e2e.jsx')).toBe(true);
       });
 
       it("doesn't match files ending in e2e.ts", () => {

--- a/src/compiler/config/validate-testing.ts
+++ b/src/compiler/config/validate-testing.ts
@@ -125,7 +125,18 @@ export const validateTesting = (config: d.Config, diagnostics: d.Diagnostic[]) =
   }
 
   if (testing.testRegex === undefined) {
-    testing.testRegex = '(/__tests__/.*|\\.(test|spec|e2e))\\.(tsx|ts|jsx|js)$';
+    /**
+     * The test regex covers cases of:
+     * - files under a `__tests__` directory
+     * - the case where a test file has a name such as `test.ts`, `spec.ts` or `e2e.ts`.
+     *   - these files can use any of the following file extensions: .ts, .tsx, .js, .jsx.
+     *   - this regex only handles the entire path of a file, e.g. `/some/path/e2e.ts`
+     * - the case where a test file ends with `.test.ts`, `.spec.ts`, or `.e2e.ts`.
+     *   - these files can use any of the following file extensions: .ts, .tsx, .js, .jsx.
+     *   - this regex case shall match file names such as `my-cmp.spec.ts`, `test.spec.ts`
+     *   - this regex case shall not match file names such as `attest.ts`, `bespec.ts`
+     */
+    testing.testRegex = '(/__tests__/.*|(\\.|/)(test|spec|e2e))\\.[jt]sx?';
   }
 
   if (Array.isArray(testing.testMatch)) {


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

c6fda394f256eb3be68a1a6ff2f0c2ef0193958f created a regression where files named `e2e.ts` would not be picked up correctly by the test runner

GitHub Issue Number: https://github.com/ionic-team/stencil/issues/3275

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
this commit fixes an edge case where unit tests were not being properly
detected following https://github.com/ionic-team/stencil/commit/c6fda394f256eb3be68a1a6ff2f0c2ef0193958f

the ionic framework has tests named `e2e.ts` that we must account for in
this regex. because jest doesn't error when no tests are found, we
missed this in the original implementation.

tests of name 'spec.ts' and 'test.ts' (or any other acceptable
extension) are considered unit tests, and tests of the name 'e2e.ts' are
considered end-to-end tests

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

I pulled this branch, built this branch, and generated a tarball: `npm ci && npm run build && npm pack`

Within Ionic Core, I installed my tarball in `ionic-framework/core` and ran two tests:

1. Tested the original reproduction command: `npm run test src/components/modal/test/basic` to verify tests are run 
2. Ran the entire test suite, taking note of the number of tests that are run with `npm t -- --no-cache`:
![Screen Shot 2022-03-10 at 4 05 55 PM](https://user-images.githubusercontent.com/1930213/157754608-34c6b454-0f77-4f76-bf06-10c8c906e1b6.png)

I then installed Stencil v2.14.0 (prior to the regression) and ran the entire test suite to verify the counts aligned:
![Screen Shot 2022-03-10 at 4 00 47 PM](https://user-images.githubusercontent.com/1930213/157754726-a3d217f0-01ee-4d8e-9fa4-7ec401b66382.png)

(this doesn't to a test-for-test comparison, but it does give us a high degree of confidence that the fix works when the first test case is taken into account).

I finally installed Stencil v2.14.1 (which has the regression) to observe some tests are omitted:
![Screen Shot 2022-03-10 at 4 08 55 PM](https://user-images.githubusercontent.com/1930213/157755006-bf7367d3-c8f4-4055-b807-334f38211462.png)
## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


Related to https://github.com/ionic-team/stencil/issues/3276, but at the time of this writing am not 100% sure
this solves the that issue