### PR TITLE
fix(testing): handle snapshot filepaths for jest

### DIFF
--- a/src/compiler/config/test/validate-testing.spec.ts
+++ b/src/compiler/config/test/validate-testing.spec.ts
@@ -175,6 +175,22 @@ describe('validateTesting', () => {
         expect(testRegex.test('some/path/test.jsx')).toBe(true);
       });
 
+      it("doesn't match snap files ending in test.ts.snap", () => {
+        expect(testRegex.test('my-component.test.ts.snap')).toBe(false);
+      });
+
+      it("doesn't match snap files ending in test.tsx.snap", () => {
+        expect(testRegex.test('my-component.test.tsx.snap')).toBe(false);
+      });
+
+      it("doesn't match snap files ending in test.js.snap", () => {
+        expect(testRegex.test('my-component.test.js.snap')).toBe(false);
+      });
+
+      it("doesn't match snap files ending in test.jsx.snap", () => {
+        expect(testRegex.test('my-component.test.jsx.snap')).toBe(false);
+      });
+
       it("doesn't match files ending in test.ts", () => {
         expect(testRegex.test('my-component-test.ts')).toBe(false);
       });
@@ -233,6 +249,22 @@ describe('validateTesting', () => {
         expect(testRegex.test('some/path/spec.jsx')).toBe(true);
       });
 
+      it("doesn't match snap files ending in spec.ts.snap", () => {
+        expect(testRegex.test('my-component.spec.ts.snap')).toBe(false);
+      });
+
+      it("doesn't match snap files ending in spec.tsx.snap", () => {
+        expect(testRegex.test('my-component.spec.tsx.snap')).toBe(false);
+      });
+
+      it("doesn't match snap files ending in spec.js.snap", () => {
+        expect(testRegex.test('my-component.spec.js.snap')).toBe(false);
+      });
+
+      it("doesn't match snap files ending in spec.jsx.snap", () => {
+        expect(testRegex.test('my-component.spec.jsx.snap')).toBe(false);
+      });
+
       it("doesn't match files ending in spec.ts", () => {
         expect(testRegex.test('my-component-spec.ts')).toBe(false);
       });
@@ -289,6 +321,22 @@ describe('validateTesting', () => {
 
       it('matches the file "e2e.jsx"', () => {
         expect(testRegex.test('some/path/e2e.jsx')).toBe(true);
+      });
+
+      it("doesn't match snap files ending in e2e.ts.snap", () => {
+        expect(testRegex.test('my-component.e2e.ts.snap')).toBe(false);
+      });
+
+      it("doesn't match snap files ending in e2e.tsx.snap", () => {
+        expect(testRegex.test('my-component.e2e.tsx.snap')).toBe(false);
+      });
+
+      it("doesn't match snap files ending in e2e.js.snap", () => {
+        expect(testRegex.test('my-component.e2e.js.snap')).toBe(false);
+      });
+
+      it("doesn't match snap files ending in e2e.jsx.snap", () => {
+        expect(testRegex.test('my-component.e2e.jsx.snap')).toBe(false);
       });
 
       it("doesn't match files ending in e2e.ts", () => {

--- a/src/compiler/config/validate-testing.ts
+++ b/src/compiler/config/validate-testing.ts
@@ -136,7 +136,7 @@ export const validateTesting = (config: d.Config, diagnostics: d.Diagnostic[]) =
      *   - this regex case shall match file names such as `my-cmp.spec.ts`, `test.spec.ts`
      *   - this regex case shall not match file names such as `attest.ts`, `bespec.ts`
      */
-    testing.testRegex = '(/__tests__/.*|(\\.|/)(test|spec|e2e))\\.[jt]sx?';
+    testing.testRegex = '(/__tests__/.*|(\\.|/)(test|spec|e2e))\\.[jt]sx?$';
   }
 
   if (Array.isArray(testing.testMatch)) {


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

cf42114edf04520c11421c60673e4f03be22df49 created a regression where files named `e2e.ts.snap` would not be picked up correctly by the test runner


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the testing regex in our jest base configuration to
handle files such as testing snapshots - those that contain 'spec.ts'
(or a similarly acceptable file extension for tests), but do not end
with that extension. For example, `my-component.test.ts.snap`

this fixes a regression introduced in cf42114edf04520c11421c60673e4f03be22df49

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I pulled this branch, built this branch, and generated a tarball: `npm ci && npm run build && npm pack`

Within Ionic Core, I installed my tarball in `ionic-framework/core` from the build command above, and verified the correct number of tests were run (verifying against https://github.com/ionic-team/stencil/pull/3277's results from late last week)
![Screen Shot 2022-03-14 at 12 43 27 PM](https://user-images.githubusercontent.com/1930213/158219875-5008376e-9cd2-4333-a530-008eb84e1d3c.png)

I also tested this in a local (small) stencil project.

First, let's create a project and verify we can run tests:
```
npm init stencil@latest component snap
cd snap
npm i && npm t
```
Those tests pass, let's add a `.snap` file to verify the issue:
```
touch src/components/my-component/my-component.spec.ts.snap
npm t
```
Returns a warning that we found a test file without any tests in it. Let's install our tarball to verify it fixes it:
```
npm i <TARBALL>
npm t
```
🎉 