### PR TITLE
feat(runtime): event emitter accepts event specific custom event

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -454,8 +454,8 @@ export interface ComponentInterface {
 }
 
 // General types important to applications using stencil built components
-export interface EventEmitter<T = any> {
-  emit: (data?: T) => CustomEvent<T>;
+export interface EventEmitter<T = any, EventCustomEvent extends CustomEvent<T> = CustomEvent<T>> {
+  emit: (data?: T) => EventCustomEvent;
 }
 
 export interface RafCallback {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The interface for event emitter that all Stencil events are typed to does not allow overriding the signature of the `CustomEvent` type.

Considering this pattern:
```ts
@Event() myEvent: EventEmitter<void>;

doThing() {
  this.myEvent.emit();
}

@Method()
async complete() {}
```

When implementing this component, the user needs to get access to the element reference, to execute the `complete()` method after the event is fired.

```ts
<my-component onMyEvent={ev => ev.target.complete()} />
```

This code results in a typing error, since the type signature of `ev` is `CustomEvent<void>` and does not include the element target. 

GitHub Issue Number: N/A

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Add a secondary generic to the `EventEmitter` interface, that allows Stencil custom events to specify a different type signature for the `CustomEvent` (must extend `CustomEvent`).

Taking the same example from above, it becomes:
```ts
interface MyEventCustomEvent extends CustomEvent {
  target: HTMLMyComponentElement;
}

@Event() myEvent: EventEmitter<void, MyEventCustomEvent>;
```

This will make the generated types include our HTML element, making this valid syntax/type safe:

```ts
<my-component onMyEvent={ev => ev.target.complete()} />
```

`ev.target` = `HTMLMyComponentElement`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
