### PR TITLE
docs(declarations): typos in public compiler

### DIFF
--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -47,7 +47,7 @@ export interface StencilConfig {
    * However, it's still common to have styles which should be "global" across all components and the website.
    * A global CSS file is often useful to set CSS Variables.
    *
-   * Additonally, the globalStyle config can be used to precompile styles with Sass, PostCss, etc.
+   * Additionally, the globalStyle config can be used to precompile styles with Sass, PostCss, etc.
    * Below is an example folder structure containing a webapp's global sass file, named app.css.
    */
   globalStyle?: string;
@@ -116,7 +116,7 @@ export interface StencilConfig {
   nodeResolve?: NodeResolveConfig;
 
   /**
-   * Passes custom configuration down to rollup itself, not all rollup options can be overriden.
+   * Passes custom configuration down to rollup itself, not all rollup options can be overridden.
    */
   rollupConfig?: RollupConfig;
 
@@ -166,7 +166,7 @@ export interface StencilConfig {
    * The hydrated flag identifies if a component and all of its child components
    * have finished hydrating. This helps prevent any flash of unstyled content (FOUC)
    * as various components are asynchronously downloaded and rendered. By default it
-   * will add the `hydrated` CSS class to the element. The `hydratedFlag` confg can be used
+   * will add the `hydrated` CSS class to the element. The `hydratedFlag` config can be used
    * to change the name of the CSS class, change it to an attribute, or change which
    * type of CSS properties and values are assigned before and after hydrating. This config
    * can also be used to not include the hydrated flag at all by setting it to `null`.
@@ -174,7 +174,7 @@ export interface StencilConfig {
   hydratedFlag?: HydratedFlag;
 
   /**
-   * Ionic perfers to hide all components prior to hydration with a style tag appended
+   * Ionic prefers to hide all components prior to hydration with a style tag appended
    * to the head of the document containing some `visibility: hidden;` css rules.
    *
    * Disabling this will remove the style tag that sets `visibility: hidden;` on all
@@ -201,11 +201,11 @@ export interface StencilConfig {
    * - `congestionAsync`: DOM reads and writes are scheduled in the next frame to prevent layout
    *   thrashing. When the app is heavily tasked and the queue becomes congested it will then
    *   split the work across multiple frames to prevent blocking the main thread. However, it can
-   *   also introduce unnecesary reflows in some cases, especially during startup. `congestionAsync`
-   *   is ideal for apps running animations while also simultaniously executing intesive tasks
+   *   also introduce unnecessary reflows in some cases, especially during startup. `congestionAsync`
+   *   is ideal for apps running animations while also simultaneously executing intensive tasks
    *   which may lock-up the main thread.
    *
-   * - `immediate`: Makes writeTask() and readTask() callbacks to be executed syncronously. Tasks
+   * - `immediate`: Makes writeTask() and readTask() callbacks to be executed synchronously. Tasks
    *   are not scheduled to run in the next frame, but do note there is at least one microtask.
    *   The `immediate` setting is ideal for apps that do not provide long running and smooth
    *   animations. Like the async setting, if the app has intensive tasks causing the main thread
@@ -251,7 +251,7 @@ export interface ConfigExtras {
    * By default, the slot polyfill does not update `appendChild()` so that it appends
    * new child nodes into the correct child slot like how shadow dom works. This is an opt-in
    * polyfill for those who need it when using `element.appendChild(node)` and expecting the
-   * child to be appended in the same location shadom dom would. This is not required for
+   * child to be appended in the same location shadow dom would. This is not required for
    * IE11 or Edge 18, but can be enabled if the app is using `appendChild()`. Defaults to `false`.
    */
   appendChildSlotFix?: boolean;
@@ -468,7 +468,7 @@ export interface StencilDevServerConfig {
    */
   ssr?: boolean;
   /**
-   * If the dev server fails to start up within the given timout (in milliseconds), the startup will
+   * If the dev server fails to start up within the given timeout (in milliseconds), the startup will
    * be canceled. Set to zero to disable the timeout. Defaults to `15000`.
    */
   startupTimeout?: number;
@@ -776,7 +776,7 @@ export interface SerializeDocumentOptions extends HydrateDocumentOptions {
    * Sets an approximate line width the HTML should attempt to stay within.
    * Note that this is "approximate", in that HTML may often not be able
    * to be split at an exact line width. Additionally, new lines created
-   * is where HTML naturally already has whitespce, such as before an
+   * is where HTML naturally already has whitespace, such as before an
    * attribute or spaces between words. Defaults to `100`.
    */
   approximateLineWidth?: number;
@@ -884,7 +884,7 @@ export interface SitemapXmpResults {
  * build all actions the in-memory fs performed will be written to disk using this system.
  * A NodeJS based system will use APIs such as `fs` and `crypto`, and a web-based system
  * will use in-memory Maps and browser APIs. Either way, the compiler itself is unaware
- * of the actual platform it's being ran ontop of.
+ * of the actual platform it's being ran on top of.
  */
 export interface CompilerSystem {
   name: 'node' | 'in-memory';
@@ -930,7 +930,7 @@ export interface CompilerSystem {
    */
   isTTY(): boolean;
   /**
-   * Each plaform as a different way to dynamically import modules.
+   * Each platform as a different way to dynamically import modules.
    */
   dynamicImport?(p: string): Promise<any>;
   /**
@@ -1676,7 +1676,7 @@ export interface TestingConfig extends JestConfig {
 
   /**
    * By default, all E2E pages wait until the "load" event, this global setting can be used
-   * to change the default `waitUntil` behaviour.
+   * to change the default `waitUntil` behavior.
    */
   browserWaitUntil?: 'load' | 'domcontentloaded' | 'networkidle0' | 'networkidle2';
 
@@ -2026,7 +2026,7 @@ export interface OutputTargetWww extends OutputTargetBase {
 
   /**
    * By default, stencil will include all the polyfills required by legacy browsers in the ES5 build.
-   * If it's `false`, stencil will not emit this polyfills anymore and it's your responsability to provide them before
+   * If it's `false`, stencil will not emit this polyfills anymore and it's your responsibility to provide them before
    * stencil initializes.
    */
   polyfills?: boolean;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixes several typo/documentation issues in the Stencil public compiler interfaces.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
