### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/scripts/bundles/plugins/typescript-source-plugin.ts
+++ b/scripts/bundles/plugins/typescript-source-plugin.ts
@@ -75,7 +75,7 @@ async function bundleTypeScriptSource(tsPath: string, opts: BuildOptions): Promi
     throw new Error(`"${tsEnding}" not found`);
   }
   const lastEnding = code.lastIndexOf(tsEnding);
-  code = code.substr(0, lastEnding + tsEnding.length);
+  code = code.slice(0, lastEnding + tsEnding.length);
 
   // there's a billion unnecessary "var ts;" for namespaces
   // but we'll be using the top level "const ts" instead

--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -157,7 +157,7 @@ const parseArgs = (flags: any, args: string[], knownArgs: string[]) => {
 
 const configCase = (prop: string) => {
   prop = dashToPascalCase(prop);
-  return prop.charAt(0).toLowerCase() + prop.substr(1);
+  return prop.charAt(0).toLowerCase() + prop.slice(1);
 };
 
 const ARG_OPTS = {

--- a/src/cli/task-generate.ts
+++ b/src/cli/task-generate.ts
@@ -216,7 +216,7 @@ describe('${name}', () => {
  * Convert a dash case string to pascal case.
  */
 const toPascalCase = (str: string) =>
-  str.split('-').reduce((res, part) => res + part[0].toUpperCase() + part.substr(1), '');
+  str.split('-').reduce((res, part) => res + part[0].toUpperCase() + part.slice(1), '');
 
 /**
  * Extensions available to generate.

--- a/src/client/polyfills/css-shim/selectors.ts
+++ b/src/client/polyfills/css-shim/selectors.ts
@@ -83,7 +83,7 @@ export function normalizeValue(value: string) {
   value = value.replace(regex, ' ').trim();
   const important = value.endsWith(IMPORTANT);
   if (important) {
-    value = value.substr(0, value.length - IMPORTANT.length).trim();
+    value = value.slice(0, value.length - IMPORTANT.length).trim();
   }
   return {
     value,

--- a/src/compiler/html/validate-manifest-json.ts
+++ b/src/compiler/html/validate-manifest-json.ts
@@ -60,7 +60,7 @@ const validateManifestJsonIcon = async (
   }
 
   if (iconSrc.startsWith('/')) {
-    iconSrc = iconSrc.substr(1);
+    iconSrc = iconSrc.slice(1);
   }
 
   const manifestDir = dirname(manifestFilePath);

--- a/src/compiler/optimize/minify-js.ts
+++ b/src/compiler/optimize/minify-js.ts
@@ -91,7 +91,7 @@ const loadMinifyJsDiagnostics = (sourceText: string, diagnostics: d.Diagnostic[]
     d.lineNumber = errorLine.lineNumber;
     d.columnNumber = errorLine.errorCharStart;
 
-    const highlightLine = errorLine.text.substr(d.columnNumber);
+    const highlightLine = errorLine.text.slice(d.columnNumber);
     for (let i = 0; i < highlightLine.length; i++) {
       if (MINIFY_CHAR_BREAK.has(highlightLine.charAt(i))) {
         break;

--- a/src/compiler/prerender/crawl-urls.ts
+++ b/src/compiler/prerender/crawl-urls.ts
@@ -208,7 +208,7 @@ export const standardNormalizeHref = (prerenderConfig: d.PrerenderConfig, diagno
         // url should NOT have a trailing slash
         if (href.endsWith('/') && url.pathname !== '/') {
           // this has a trailing slash and it's not the root path
-          href = href.substr(0, href.length - 1);
+          href = href.slice(0, -1);
         }
       }
 

--- a/src/compiler/style/css-parser/get-css-selectors.ts
+++ b/src/compiler/style/css-parser/get-css-selectors.ts
@@ -25,11 +25,11 @@ export const getCssSelectors = (sel: string) => {
     if (items[i].length === 0) continue;
 
     if (items[i].charAt(0) === '.') {
-      SELECTORS.classNames.push(items[i].substr(1));
+      SELECTORS.classNames.push(items[i].slice(1));
     } else if (items[i].charAt(0) === '#') {
-      SELECTORS.ids.push(items[i].substr(1));
+      SELECTORS.ids.push(items[i].slice(1));
     } else if (items[i].charAt(0) === '[') {
-      items[i] = items[i].substr(1).split('=')[0].split(']')[0].trim();
+      items[i] = items[i].slice(1).split('=')[0].split(']')[0].trim();
       SELECTORS.attrs.push(items[i].toLowerCase());
     } else if (/[a-z]/g.test(items[i].charAt(0))) {
       SELECTORS.tags.push(items[i].toLowerCase());

--- a/src/compiler/sys/logger/terminal-logger.ts
+++ b/src/compiler/sys/logger/terminal-logger.ts
@@ -37,7 +37,7 @@ export const createTerminalLogger = (loggerSys: TerminalLoggerSys): Logger => {
         Math.floor((d.getMilliseconds() / 1000) * 10) +
         ']';
 
-      lines[0] = dim(prefix) + lines[0].substr(prefix.length);
+      lines[0] = dim(prefix) + lines[0].slice(prefix.length);
     }
   };
 
@@ -53,7 +53,7 @@ export const createTerminalLogger = (loggerSys: TerminalLoggerSys): Logger => {
   const warnPrefix = (lines: string[]) => {
     if (lines.length) {
       const prefix = '[ WARN  ]';
-      lines[0] = bold(yellow(prefix)) + lines[0].substr(prefix.length);
+      lines[0] = bold(yellow(prefix)) + lines[0].slice(prefix.length);
     }
   };
 
@@ -79,7 +79,7 @@ export const createTerminalLogger = (loggerSys: TerminalLoggerSys): Logger => {
   const errorPrefix = (lines: string[]) => {
     if (lines.length) {
       const prefix = '[ ERROR ]';
-      lines[0] = bold(red(prefix)) + lines[0].substr(prefix.length);
+      lines[0] = bold(red(prefix)) + lines[0].slice(prefix.length);
     }
   };
 
@@ -109,7 +109,7 @@ export const createTerminalLogger = (loggerSys: TerminalLoggerSys): Logger => {
         Math.floor((d.getMilliseconds() / 1000) * 10) +
         ']';
 
-      lines[0] = cyan(prefix) + lines[0].substr(prefix.length);
+      lines[0] = cyan(prefix) + lines[0].slice(prefix.length);
     }
   };
 
@@ -409,11 +409,11 @@ export const createTerminalLogger = (loggerSys: TerminalLoggerSys): Logger => {
     while (errorLine.length + INDENT.length > loggerSys.getColumns()) {
       if (errorCharStart > errorLine.length - errorCharStart + errorLength && errorCharStart > 5) {
         // larger on left side
-        errorLine = errorLine.substr(1);
+        errorLine = errorLine.slice(1);
         errorCharStart--;
       } else if (rightSideChars > 1) {
         // larger on right side
-        errorLine = errorLine.substr(0, errorLine.length - 1);
+        errorLine = errorLine.slice(0, -1);
         rightSideChars--;
       } else {
         break;
@@ -618,7 +618,7 @@ const removeLeadingWhitespace = (orgLines: PrintLine[]): ReadonlyArray<PrintLine
     }
     // each line has at least one line of whitespace. remove the leading character from each
     for (let i = 0; i < lines.length; i++) {
-      lines[i].text = lines[i].text.substr(1);
+      lines[i].text = lines[i].text.slice(1);
       lines[i].errorCharStart--;
       if (!lines[i].text.length) {
         return lines;

--- a/src/compiler/sys/stencil-sys.ts
+++ b/src/compiler/sys/stencil-sys.ts
@@ -535,7 +535,7 @@ export const createSystem = (c?: { logger?: Logger }) => {
     const hashArray = Array.from(new Uint8Array(arrayBuffer)); // convert buffer to byte array
     let hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join(''); // convert bytes to hex string
     if (typeof hashLength === 'number') {
-      hashHex = hashHex.substr(0, hashLength);
+      hashHex = hashHex.slice(0, hashLength);
     }
     return hashHex;
   };

--- a/src/dev-server/client/app-error.ts
+++ b/src/dev-server/client/app-error.ts
@@ -224,7 +224,7 @@ const escapeHtml = (unsafe: string) => {
   return '';
 };
 
-const titleCase = (str: string) => str.charAt(0).toUpperCase() + str.substr(1);
+const titleCase = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
 
 const highlightError = (text: string, errorCharStart: number, errorLength: number) => {
   if (typeof text !== 'string') {
@@ -269,7 +269,7 @@ const prepareLines = (orgLines: PrintLine[]) => {
       return lines;
     }
     for (let i = 0; i < lines.length; i++) {
-      lines[i].text = lines[i].text.substr(1);
+      lines[i].text = lines[i].text.slice(1);
       lines[i].errorCharStart--;
       if (!lines[i].text.length) {
         return lines;

--- a/src/mock-doc/css-style-declaration.ts
+++ b/src/mock-doc/css-style-declaration.ts
@@ -88,7 +88,7 @@ function cssCaseToJsCase(str: string) {
       .split('-')
       .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
       .join('');
-    str = str.substr(0, 1).toLowerCase() + str.substr(1);
+    str = str.slice(0, 1).toLowerCase() + str.slice(1);
   }
   return str;
 }

--- a/src/mock-doc/dataset.ts
+++ b/src/mock-doc/dataset.ts
@@ -37,7 +37,7 @@ function toDataAttribute(str: string) {
 }
 
 function dashToPascalCase(str: string) {
-  str = String(str).substr(5);
+  str = String(str).slice(5);
   return str
     .split('-')
     .map((segment, index) => {

--- a/src/screenshot/screenshot-compare.ts
+++ b/src/screenshot/screenshot-compare.ts
@@ -167,7 +167,7 @@ async function getMismatchedPixels(pixelmatchModulePath: string, pixelMatchInput
 function getCacheKey(imageA: string, imageB: string, pixelmatchThreshold: number) {
   const hash = createHash('md5');
   hash.update(`${imageA}:${imageB}:${pixelmatchThreshold}`);
-  return hash.digest('hex').substr(0, 10);
+  return hash.digest('hex').slice(0, 10);
 }
 
 function getScreenshotId(emulateConfig: d.EmulateConfig, uniqueDescription: string) {
@@ -185,5 +185,5 @@ function getScreenshotId(emulateConfig: d.EmulateConfig, uniqueDescription: stri
   hash.update(emulateConfig.viewport.hasTouch + ':');
   hash.update(emulateConfig.viewport.isMobile + ':');
 
-  return hash.digest('hex').substr(0, 8).toLowerCase();
+  return hash.digest('hex').slice(0, 8).toLowerCase();
 }

--- a/src/sys/node/node-logger.ts
+++ b/src/sys/node/node-logger.ts
@@ -65,7 +65,7 @@ export const createNodeLogger = (context: { process: NodeJS.Process }): Logger =
     const readline = await import('readline');
     let promise = Promise.resolve();
     const update = (text: string) => {
-      text = text.substr(0, prcs.stdout.columns - 5) + '\x1b[0m';
+      text = text.substring(0, prcs.stdout.columns - 5) + '\x1b[0m';
       return (promise = promise.then(() => {
         return new Promise<any>((resolve) => {
           readline.clearLine(prcs.stdout, 0);

--- a/src/sys/node/node-sys.ts
+++ b/src/sys/node/node-sys.ts
@@ -553,7 +553,7 @@ export function createNodeSys(c: { process?: any } = {}) {
     generateContentHash(content, length) {
       let hash = createHash('sha1').update(content).digest('hex').toLowerCase();
       if (typeof length === 'number') {
-        hash = hash.substr(0, length);
+        hash = hash.slice(0, length);
       }
       return Promise.resolve(hash);
     },
@@ -566,7 +566,7 @@ export function createNodeSys(c: { process?: any } = {}) {
           .on('end', () => {
             let hash = h.digest('hex').toLowerCase();
             if (typeof length === 'number') {
-              hash = hash.substr(0, length);
+              hash = hash.slice(0, length);
             }
             resolve(hash);
           });

--- a/src/testing/testing-sys.ts
+++ b/src/testing/testing-sys.ts
@@ -23,7 +23,7 @@ export const createTestingSystem = (): TestingSystem => {
     let hash = createHash('sha1').update(content).digest('hex').toLowerCase();
 
     if (typeof length === 'number') {
-      hash = hash.substr(0, length);
+      hash = hash.slice(0, length);
     }
     return Promise.resolve(hash);
   };

--- a/src/utils/logger/logger-minify-js.ts
+++ b/src/utils/logger/logger-minify-js.ts
@@ -32,7 +32,7 @@ export function loadMinifyJsDiagnostics(sourceText: string, result: d.MinifyJsRe
     d.lineNumber = errorLine.lineNumber;
     d.columnNumber = errorLine.errorCharStart;
 
-    const highlightLine = errorLine.text.substr(d.columnNumber);
+    const highlightLine = errorLine.text.slice(d.columnNumber);
     for (let i = 0; i < highlightLine.length; i++) {
       if (CHAR_BREAK.includes(highlightLine.charAt(i))) {
         break;

--- a/src/utils/logger/logger-rollup.ts
+++ b/src/utils/logger/logger-rollup.ts
@@ -57,7 +57,7 @@ export const loadRollupDiagnostics = (
             diagnostic.lineNumber = errorLine.lineNumber;
             diagnostic.columnNumber = errorLine.errorCharStart;
 
-            const highlightLine = errorLine.text.substr(loc.column);
+            const highlightLine = errorLine.text.slice(loc.column);
             for (let i = 0; i < highlightLine.length; i++) {
               if (charBreak.has(highlightLine.charAt(i))) {
                 break;

--- a/src/utils/logger/logger-utils.ts
+++ b/src/utils/logger/logger-utils.ts
@@ -43,7 +43,7 @@ const normalizeDiagnostic = (compilerCtx: d.CompilerCtx, diagnostic: d.Diagnosti
     if (typeof (<any>diagnostic.messageText).message === 'string') {
       diagnostic.messageText = (<any>diagnostic.messageText).message;
     } else if (typeof diagnostic.messageText === 'string' && diagnostic.messageText.indexOf('Error: ') === 0) {
-      diagnostic.messageText = diagnostic.messageText.substr(7);
+      diagnostic.messageText = diagnostic.messageText.slice(7);
     }
   }
 

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -13,7 +13,7 @@ export const createJsVarName = (fileName: string) => {
     fileName = dashToPascalCase(fileName);
 
     if (fileName.length > 1) {
-      fileName = fileName[0].toLowerCase() + fileName.substr(1);
+      fileName = fileName[0].toLowerCase() + fileName.slice(1);
     } else {
       fileName = fileName.toLowerCase();
     }

--- a/test/ionic-app/src/components/app-profile/app-profile.tsx
+++ b/test/ionic-app/src/components/app-profile/app-profile.tsx
@@ -10,7 +10,7 @@ export class AppProfile {
 
   formattedName(): string {
     if (this.name) {
-      return this.name.substr(0, 1).toUpperCase() + this.name.substr(1).toLowerCase();
+      return this.name.slice(0, 1).toUpperCase() + this.name.slice(1).toLowerCase();
     }
     return '';
   }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?


## What is the new behavior?

There is no user facing change

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I tested the return of each changed function to make sure it's still the same

## Other information

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.
