### PR TITLE
chore(github): clean up labels/automation

### DIFF
--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -80,7 +80,6 @@ stale:
     - help wanted
     - Reply Received
     - "Request For Comments"
-    - "Resolution: Needs Documentation"
     - "Resolution: Needs Investigation"
     - "Resolution: Refine"
     - triage

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -32,9 +32,9 @@ comment:
         need a code reproduction.
 
 
-        Please reproduce this issue in an Ionic starter application and provide a way for us to access it (GitHub repo,
-        StackBlitz, etc). Without a reliable code reproduction, it is unlikely we will be able to resolve the issue,
-        leading to it being closed.
+        Please reproduce this issue in an Stencil starter component library and provide a way for us to access it
+        (GitHub repo, StackBlitz, etc). Without a reliable code reproduction, it is unlikely we will be able to resolve
+        the issue, leading to it being closed.
 
 
         If you have already provided a code snippet and are seeing this message, it is likely that the code snippet was

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -79,7 +79,7 @@ stale:
     - good first issue
     - help wanted
     - Reply Received
-    - "Request For Comments"
+    - Request For Comments
     - "Resolution: Needs Investigation"
     - "Resolution: Refine"
     - triage

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -75,7 +75,6 @@ stale:
   days: 180
   maxIssuesPerRun: 100
   exemptLabels:
-    - "Bug: Needs Validation"
     - "Bug: Validated"
     - "Feature: Want this? Upvote it!"
     - good first issue

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -44,8 +44,6 @@ stale:
     - help wanted
     - Reply Received
     - "Request For Comments"
-    - "Resolution: Backlog"
-    - "Resolution: Blocked"
     - "Resolution: Needs Documentation"
     - "Resolution: Needs Investigation"
     - "Resolution: Refine"

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -24,6 +24,27 @@ closeAndLock:
   lock: true
   dryRun: false
 
+comment:
+  labels:
+    - label: "ionitron: needs reproduction"
+      message: >
+        Thanks for the issue! This issue has been labeled as `needs reproduction`. This label is added to issues that
+        need a code reproduction.
+
+
+        Please reproduce this issue in an Ionic starter application and provide a way for us to access it (GitHub repo,
+        StackBlitz, etc). Without a reliable code reproduction, it is unlikely we will be able to resolve the issue,
+        leading to it being closed.
+
+
+        If you have already provided a code snippet and are seeing this message, it is likely that the code snippet was
+        not enough for our team to reproduce the issue.
+
+
+        For a guide on how to create a good reproduction, see our
+        [Contributing Guide](https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md).
+  dryRun: false
+
 noReply:
   maxIssuesPerRun: 100
   includePullRequests: false

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -54,6 +54,23 @@ noReply:
   lock: false
   dryRun: false
 
+noReproduction:
+  days: 14
+  maxIssuesPerRun: 100
+  label: "ionitron: needs reproduction"
+  responseLabel: triage
+  exemptProjects: true
+  exemptMilestones: true
+  message: >
+    Thanks for the issue! This issue is being closed due to the lack of a code reproduction. If this is still
+    an issue with the latest version of Stencil, please create a new issue and ensure the template is fully filled out.
+
+
+    Thank you for using Stencil!
+  close: true
+  lock: true
+  dryRun: false
+
 stale:
   days: 180
   maxIssuesPerRun: 100

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -49,7 +49,6 @@ noReply:
   maxIssuesPerRun: 100
   includePullRequests: false
   label: Awaiting Reply
-  responseLabel: Reply Received
   close: false
   lock: false
   dryRun: false

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -26,6 +26,5 @@ release.
    1. Mark this version of Stencil as 'released' in JIRA
    2. Move the task card in this current sprint to the 'Done' swimlane
    3. Stub out the next release and task for the release in JIRA
-9. Ensure all GitHub Issues associated with stories/tasks that shipped in this version of Stencil are closed and
-   labeled as 'Resolution: Shipped'
+9. Ensure all GitHub Issues associated with stories/tasks that shipped in this version of Stencil are closed
 10. :tada:


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Update our GitHub automations


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Last week, the repo had 64 or so labels that could be applied to issues
and pull requests. Although this was expressive, it was difficult in practice
to determine what label should be applied and when. This had a downstream
effect on the automations, as issues that would be closed + locked due to
either:
1. inappropriate labels being applied
2. appropriate labels being applied, but those issues not being marked as exempt
from issue closure.

The maintenance of the whole thing was getting unstable, which led me to work
on revamping this as a part of my hack days time.

GitHub Issue Number: https://github.com/ionic-team/stencil/issues/3297


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Over 40 labels have been removed, and issues with those labels have been re-triaged.
For a full list of labels removed, please see #3297. As a result of these removals, I've
removed any labels that were removed from the repo from our exemption list


This PR also adds Ionitron enforcement of missing reproduction cases to the repo.
We will look to use this to notify folks about needing a repro and closing issues that
do not have a repro (after 14 days have passed).

STENCIL-374: Clean Up Labels/Automation in Stencil Core Repo  

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
There's no _great_ way to test this without landing it first, which I intend to make a dummy issue for after we land this