### PR TITLE
test(prop): add unit tests to prop type generation 

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
   },
   coverageDirectory: './coverage/',
   coverageReporters: ['json', 'lcov', 'text', 'clover'],
+  coveragePathIgnorePatterns: ['^.*\\.stub\\.tsx?$'],
   collectCoverageFrom: [
     '<rootDir>/scripts/**/*.{js,jsx,ts,tsx}',
     '!<rootDir>/scripts/build/**/*.{js,jsx,ts,tsx}',

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "files": [
     "!**/*.map",
+    "!**/*.stub.ts",
+    "!**/*.stub.tsx",
     "bin/",
     "cli/",
     "compiler/",

--- a/scripts/test/validate-build.ts
+++ b/scripts/test/validate-build.ts
@@ -162,8 +162,8 @@ function validatePackage(opts: BuildOptions, testPkg: TestPackage, dtsEntries: s
         throw new Error(testPkg.packageJson + ' missing "files" property');
       }
       pkgJson.files.forEach((f) => {
-        if (f === '!**/*.map') {
-          // skip sourcemaps
+        if (f === '!**/*.map' || f === '!**/*.stub.ts' || f === '!**/*.stub.tsx') {
+          // skip sourcemaps, stub files
           return;
         }
         const pkgFile = join(pkgDir, f);

--- a/src/compiler/types/generate-prop-types.ts
+++ b/src/compiler/types/generate-prop-types.ts
@@ -1,6 +1,11 @@
 import type * as d from '../../declarations';
 import { getTextDocs } from '@utils';
 
+/**
+ * Generates the individual event types for all @Prop() decorated events in a component
+ * @param cmpMeta component runtime metadata for a single component
+ * @returns the generated type metadata
+ */
 export const generatePropTypes = (cmpMeta: d.ComponentCompilerMeta): d.TypeInfo => {
   return [
     ...cmpMeta.properties.map((cmpProp) => ({

--- a/src/compiler/types/tests/ComponentCompilerMeta.stub.ts
+++ b/src/compiler/types/tests/ComponentCompilerMeta.stub.ts
@@ -1,0 +1,23 @@
+import * as d from '@stencil/core/declarations';
+
+/**
+ * Generates a stub {@link ComponentCompilerMeta}. This function uses sensible defaults for the initial stub. However,
+ * any field in the object may be overridden via the `overrides` argument.
+ * @param overrides a partial implementation of `ComponentCompilerMeta`. Any provided fields will override the
+ * defaults provided by this function.
+ * @returns the stubbed `ComponentCompilerMeta`
+ */
+export const stubComponentCompilerMeta = (
+  overrides: Partial<d.ComponentCompilerMeta> = {}
+): d.ComponentCompilerMeta => {
+  // TODO(STENCIL-378): Continue to build out default stub, remove the type assertion on `default`
+  const defaults: d.ComponentCompilerMeta = {
+    events: [],
+    methods: [],
+    properties: [],
+    sourceFilePath: '/some/stubbed/path/my-component.tsx',
+    virtualProperties: [],
+  } as d.ComponentCompilerMeta;
+
+  return { ...defaults, ...overrides };
+};

--- a/src/compiler/types/tests/ComponentCompilerProperty.stub.ts
+++ b/src/compiler/types/tests/ComponentCompilerProperty.stub.ts
@@ -1,0 +1,36 @@
+import * as d from '@stencil/core/declarations';
+
+/**
+ * Generates a stub {@link ComponentCompilerProperty}. This function uses sensible defaults for the initial stub.
+ * However, any field in the object may be overridden via the `overrides` argument.
+ * @param overrides a partial implementation of `ComponentCompilerProperty`. Any provided fields will override the
+ * defaults provided by this function.
+ * @returns the stubbed `ComponentCompilerProperty`
+ */
+export const stubComponentCompilerProperty = (
+  overrides: Partial<d.ComponentCompilerProperty> = {}
+): d.ComponentCompilerProperty => {
+  const defaults: d.ComponentCompilerProperty = {
+    attribute: 'my-cmp',
+    complexType: {
+      original: 'UserCustomPropType',
+      resolved: '123 | 456',
+      references: {
+        UserImplementedEventType: {
+          location: 'import',
+          path: './resources',
+        },
+      },
+    },
+    docs: undefined,
+    internal: false,
+    mutable: false,
+    name: 'propName',
+    optional: false,
+    reflect: false,
+    required: false,
+    type: 'number',
+  };
+
+  return { ...defaults, ...overrides };
+};

--- a/src/compiler/types/tests/ComponentCompilerVirtualProperty.stub.ts
+++ b/src/compiler/types/tests/ComponentCompilerVirtualProperty.stub.ts
@@ -1,0 +1,20 @@
+import * as d from '@stencil/core/declarations';
+
+/**
+ * Generates a stub {@link ComponentCompilerVirtualProperty}. This function uses sensible defaults for the initial
+ * stub. However, any field in the object may be overridden via the `overrides` argument.
+ * @param overrides a partial implementation of `ComponentCompilerVirtualProperty`. Any provided fields will override the
+ * defaults provided by this function.
+ * @returns the stubbed `ComponentCompilerVirtualProperty`
+ */
+export const stubComponentCompilerVirtualProperty = (
+  overrides: Partial<d.ComponentCompilerVirtualProperty> = {}
+): d.ComponentCompilerVirtualProperty => {
+  const defaults: d.ComponentCompilerVirtualProperty = {
+    docs: 'this is a doc string',
+    name: 'virtualPropName',
+    type: 'number',
+  };
+
+  return { ...defaults, ...overrides };
+};

--- a/src/compiler/types/tests/generate-prop-types.spec.ts
+++ b/src/compiler/types/tests/generate-prop-types.spec.ts
@@ -1,0 +1,99 @@
+import type * as d from '../../../declarations';
+import { generatePropTypes } from '../generate-prop-types';
+import * as Util from '../../../utils/util';
+import { stubComponentCompilerMeta } from './ComponentCompilerMeta.stub';
+import { stubComponentCompilerProperty } from './ComponentCompilerProperty.stub';
+import { stubComponentCompilerVirtualProperty } from './ComponentCompilerVirtualProperty.stub';
+
+describe('generate-prop-types', () => {
+  describe('generatePropTypes', () => {
+    let getTextDocsSpy: jest.SpyInstance<ReturnType<typeof Util.getTextDocs>, Parameters<typeof Util.getTextDocs>>;
+
+    beforeEach(() => {
+      getTextDocsSpy = jest.spyOn(Util, 'getTextDocs');
+      getTextDocsSpy.mockReturnValue('');
+    });
+
+    afterEach(() => {
+      getTextDocsSpy.mockRestore();
+    });
+
+    it('returns an empty array when no props are provided', () => {
+      const componentMeta = stubComponentCompilerMeta();
+
+      expect(generatePropTypes(componentMeta)).toEqual([]);
+    });
+
+    it('returns the correct type information for a single property', () => {
+      const componentMeta = stubComponentCompilerMeta({
+        properties: [stubComponentCompilerProperty()],
+      });
+
+      const expectedTypeInfo: d.TypeInfo = [
+        {
+          jsdoc: '',
+          internal: false,
+          name: 'propName',
+          optional: false,
+          required: false,
+          type: 'UserCustomPropType',
+        },
+      ];
+
+      const actualTypeInfo = generatePropTypes(componentMeta);
+
+      expect(actualTypeInfo).toEqual(expectedTypeInfo);
+    });
+
+    it('returns the correct type information for a single virtual property', () => {
+      const componentMeta = stubComponentCompilerMeta({
+        virtualProperties: [stubComponentCompilerVirtualProperty()],
+      });
+
+      const expectedTypeInfo: d.TypeInfo = [
+        {
+          jsdoc: 'this is a doc string',
+          internal: false,
+          name: 'virtualPropName',
+          optional: true,
+          required: false,
+          type: 'number',
+        },
+      ];
+
+      const actualTypeInfo = generatePropTypes(componentMeta);
+
+      expect(actualTypeInfo).toEqual(expectedTypeInfo);
+    });
+
+    it('returns the correct type information for concrete and virtual properties', () => {
+      const componentMeta = stubComponentCompilerMeta({
+        properties: [stubComponentCompilerProperty()],
+        virtualProperties: [stubComponentCompilerVirtualProperty()],
+      });
+
+      const expectedTypeInfo: d.TypeInfo = [
+        {
+          jsdoc: '',
+          internal: false,
+          name: 'propName',
+          optional: false,
+          required: false,
+          type: 'UserCustomPropType',
+        },
+        {
+          jsdoc: 'this is a doc string',
+          internal: false,
+          name: 'virtualPropName',
+          optional: true,
+          required: false,
+          type: 'number',
+        },
+      ];
+
+      const actualTypeInfo = generatePropTypes(componentMeta);
+
+      expect(actualTypeInfo).toEqual(expectedTypeInfo);
+    });
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The functionality in [`generate-prop-types`](https://github.com/ionic-team/stencil/blob/8feaf0816731d8dc1d880cecf6a432526295d65a/src/compiler/types/generate-prop-types.ts#L1), which is used in the generation of type declaration files for class members decorated with `@Prop()`, is currently not unit tested. There are however, [end to end tests](https://github.com/ionic-team/stencil/blob/8feaf0816731d8dc1d880cecf6a432526295d65a/src/compiler/transformers/test/parse-props.spec.ts#L3) for this functionality.  We add unit tests here to minimize an upcoming bug fix PR down in size and under proper unit testing

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR adds unit tests for `generate-prop-types`

Secondarily, it adds a new stubbing mechanism for Stencil tests.  I intend to write up an Architectural Design Record (ADR) if we choose to adopt this long term, but in short it allows us to create stubs for Stencil types. It focuses on:
1. Being type safe - stubs provide reasonable defaults for all keys in an object literal-like type. Stencil objects can be complex/confusing to test authors (especially if they've never seen a type before) - by providing reasonable defaults, we can guide folks to using properly filled out stubs and away from using type assertions
2. Overrideable - stubs should allow test authors to provide an override key/value for any field in a type (while maintaining type safety)
3. Composable - Stubs can be combined to create more complex types
4. Reusable - Rather than copy-pasting a code snippet to generate an entity, we have one central source of truth per entity.

Please take a look at how these stubs are used in the context of this PR and let me know what you think.

Note: the stubs are intentionally be committed in the same directory as the files that use them currently. if this pattern is more widely adopted by the codebase/team, we will move these stubs out to a more common location

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

- Unit tests pass (no new functionality there)
- Verified `stub` files do not appear in Jest output (we do not attempt to run them as tests, nor do they appear in the code coverage output)
- Verified `stub` files do not appear in the tarball generated using `npm pack`