### PR TITLE
test(methods): add unit tests to method type generation

### DIFF
--- a/src/compiler/types/generate-component-types.ts
+++ b/src/compiler/types/generate-component-types.ts
@@ -16,7 +16,7 @@ export const generateComponentTypes = (cmp: d.ComponentCompilerMeta, areTypesInt
   const htmlElementName = `HTML${tagNameAsPascal}Element`;
 
   const propAttributes = generatePropTypes(cmp);
-  const methodAttributes = generateMethodTypes(cmp.methods);
+  const methodAttributes = generateMethodTypes(cmp);
   const eventAttributes = generateEventTypes(cmp.events);
 
   const componentAttributes = attributesToMultiLineString(

--- a/src/compiler/types/generate-method-types.ts
+++ b/src/compiler/types/generate-method-types.ts
@@ -7,14 +7,12 @@ import { getTextDocs } from '@utils';
  * @returns the generated type metadata
  */
 export const generateMethodTypes = (cmpMeta: d.ComponentCompilerMeta): d.TypeInfo => {
-  return [
-    ...cmpMeta.methods.map((cmpMethod) => ({
-      name: cmpMethod.name,
-      type: cmpMethod.complexType.signature,
-      optional: false,
-      required: false,
-      internal: cmpMethod.internal,
-      jsdoc: getTextDocs(cmpMethod.docs),
-    })),
-  ];
+  return cmpMeta.methods.map((cmpMethod) => ({
+    name: cmpMethod.name,
+    type: cmpMethod.complexType.signature,
+    optional: false,
+    required: false,
+    internal: cmpMethod.internal,
+    jsdoc: getTextDocs(cmpMethod.docs),
+  }));
 };

--- a/src/compiler/types/generate-method-types.ts
+++ b/src/compiler/types/generate-method-types.ts
@@ -1,13 +1,20 @@
 import type * as d from '../../declarations';
 import { getTextDocs } from '@utils';
 
-export const generateMethodTypes = (cmpMethods: d.ComponentCompilerMethod[]): d.TypeInfo => {
-  return cmpMethods.map((cmpMethod) => ({
-    name: cmpMethod.name,
-    type: cmpMethod.complexType.signature,
-    optional: false,
-    required: false,
-    internal: cmpMethod.internal,
-    jsdoc: getTextDocs(cmpMethod.docs),
-  }));
+/**
+ * Generates the individual event types for all @Method() decorated events in a component
+ * @param cmpMeta component runtime metadata for a single component
+ * @returns the generated type metadata
+ */
+export const generateMethodTypes = (cmpMeta: d.ComponentCompilerMeta): d.TypeInfo => {
+  return [
+    ...cmpMeta.methods.map((cmpMethod) => ({
+      name: cmpMethod.name,
+      type: cmpMethod.complexType.signature,
+      optional: false,
+      required: false,
+      internal: cmpMethod.internal,
+      jsdoc: getTextDocs(cmpMethod.docs),
+    })),
+  ];
 };

--- a/src/compiler/types/tests/ComponentCompilerMethod.stub.ts
+++ b/src/compiler/types/tests/ComponentCompilerMethod.stub.ts
@@ -1,0 +1,26 @@
+import * as d from '@stencil/core/declarations';
+
+/**
+ * Generates a stub {@link ComponentCompilerMethod}. This function uses sensible defaults for the initial stub. However,
+ * any field in the object may be overridden via the `overrides` argument.
+ * @param overrides a partial implementation of `ComponentCompilerMethod`. Any provided fields will override the
+ * defaults provided by this function.
+ * @returns the stubbed `ComponentCompilerMethod`
+ */
+export const stubComponentCompilerMethod = (
+  overrides: Partial<d.ComponentCompilerMethod> = {}
+): d.ComponentCompilerMethod => {
+  const defaults: d.ComponentCompilerMethod = {
+    name: 'myMethod',
+    internal: false,
+    complexType: {
+      parameters: [{ tags: [], text: '' }],
+      references: { Foo: { location: 'import', path: './resources' } },
+      return: 'Promise<void>',
+      signature: '(name: Foo) => Promise<void>',
+    },
+    docs: undefined,
+  };
+
+  return { ...defaults, ...overrides };
+};

--- a/src/compiler/types/tests/generate-method-types.spec.ts
+++ b/src/compiler/types/tests/generate-method-types.spec.ts
@@ -1,0 +1,89 @@
+import type * as d from '../../../declarations';
+import { generateMethodTypes } from '../generate-method-types';
+import * as Util from '../../../utils/util';
+import { stubComponentCompilerMeta } from './ComponentCompilerMeta.stub';
+import { stubComponentCompilerMethod } from './ComponentCompilerMethod.stub';
+
+describe('generate-method-types', () => {
+  describe('generateMethodTypes', () => {
+    let getTextDocsSpy: jest.SpyInstance<ReturnType<typeof Util.getTextDocs>, Parameters<typeof Util.getTextDocs>>;
+
+    beforeEach(() => {
+      getTextDocsSpy = jest.spyOn(Util, 'getTextDocs');
+      getTextDocsSpy.mockReturnValue('');
+    });
+
+    afterEach(() => {
+      getTextDocsSpy.mockRestore();
+    });
+
+    it('returns an empty array when no methods are provided', () => {
+      const componentMeta = stubComponentCompilerMeta();
+
+      expect(generateMethodTypes(componentMeta)).toEqual([]);
+    });
+
+    it('returns the correct type info for a single method', () => {
+      const componentMethod = stubComponentCompilerMethod();
+      const componentMeta = stubComponentCompilerMeta({
+        methods: [componentMethod],
+      });
+
+      const expectedTypeInfo: d.TypeInfo = [
+        {
+          jsdoc: '',
+          internal: false,
+          name: 'myMethod',
+          optional: false,
+          required: false,
+          type: '(name: Foo) => Promise<void>',
+        },
+      ];
+
+      const actualTypeInfo = generateMethodTypes(componentMeta);
+
+      expect(actualTypeInfo).toEqual(expectedTypeInfo);
+    });
+
+    it('returns the correct type info for multiple methods', () => {
+      const componentMethod1 = stubComponentCompilerMethod();
+      const componentMethod2 = stubComponentCompilerMethod({
+        name: 'myOtherMethod',
+        internal: true,
+        complexType: {
+          parameters: [{ tags: [], text: '' }],
+          references: { Bar: { location: 'local', path: './other-resources' } },
+          return: 'Promise<boolean>',
+          signature: '(age: Bar) => Promise<boolean>',
+        },
+        docs: undefined,
+      });
+      const componentMeta = stubComponentCompilerMeta({
+        methods: [componentMethod1, componentMethod2],
+      });
+
+      const expectedTypeInfo: d.TypeInfo = [
+        {
+          jsdoc: '',
+          internal: false,
+          name: 'myMethod',
+          optional: false,
+          required: false,
+          type: '(name: Foo) => Promise<void>',
+        },
+        {
+          jsdoc: '',
+          internal: true,
+          name: 'myOtherMethod',
+          optional: false,
+          required: false,
+          type: '(age: Bar) => Promise<boolean>',
+        },
+      ];
+
+      const actualTypeInfo = generateMethodTypes(componentMeta);
+
+      expect(actualTypeInfo).toEqual(expectedTypeInfo);
+    });
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The functionality in [`generate-method-types`](https://github.com/ionic-team/stencil/blob/8feaf0816731d8dc1d880cecf6a432526295d65a/src/compiler/types/generate-method-types.ts#L1), which is used in the generation of type declaration files for class members decorated with `@Method()`, is currently not unit tested. There are however, [end to end tests](https://github.com/ionic-team/stencil/blob/8feaf0816731d8dc1d880cecf6a432526295d65a/src/compiler/transformers/test/parse-methods.spec.ts#L3) for this functionality.  We add unit tests here to minimize an upcoming bug fix PR down in size and under proper unit testing


GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit adds unit testing to the generation of `@Method` decorated
class members - specifically how we generate type information that will
be used in a type declaration file (`d.ts` file).

this commit changes the interface of the internal `generateMethodTypes`
function, requiring that `ComponentCompilerMeta` be passed to the
function rather than just the `ComponentCompilerMethod` metadata found
on the former object. this change is for a future effort where we will
be using additional information from the component metadata to avoid
naming collisions in type declaration file generation. although the
author would have liked to have made this interface change then, adding
the change now simplifies the future pr.

this pr continues to build on the stub usage explained in #3315 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Existing + new unit tests pass. Integration + karma tests pass

## Other information

This commit relies on #3315, please do not merge until the parent has landed 