### PR TITLE
change puppeteer supported version ranges

### DIFF
--- a/src/sys/node/node-sys.ts
+++ b/src/sys/node/node-sys.ts
@@ -593,8 +593,8 @@ export function createNodeSys(c: { process?: any } = {}) {
     jest: ['24.9.0', '27.4.5'],
     'jest-cli': ['24.9.0', '27.4.5'],
     pixelmatch: ['4.0.2', '4.0.2'],
-    puppeteer: ['1.19.0', '10.0.0'],
-    'puppeteer-core': ['1.19.0', '5.2.1'],
+    puppeteer: ['10.0.0', '13.5.2'],
+    'puppeteer-core': ['10.0.0', '13.5.2'],
     'workbox-build': ['4.3.1', '4.3.1'],
   });
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): updating the lazy-loaded Puppeteer version that Stencil expects to exclude versions <10


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- changing the versions specified for Puppeteer to remove support for old versions that we don't want to support anymore

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

This is only going to be included in v3, but for apps that migrate to v3, if they are using an older version of Puppeteer (<10) they'll need to upgrade it.

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

I did a little `npm run build && npm link` workflow to test out these changes in a test component repo locally w/ various versions of Puppeteer. I confirmed that:

- a version <10 throws a 'hey this is deprecated!' error
- versions 10, 11, 12, 13 don't, and the (simple!) tests pass