### PR TITLE
fix(runtime): importing custom elements build in lazy build

### DIFF
--- a/src/client/client-host-ref.ts
+++ b/src/client/client-host-ref.ts
@@ -14,6 +14,7 @@ export const registerHost = (elm: d.HostElement, cmpMeta: d.ComponentRuntimeMeta
     $flags$: 0,
     $hostElement$: elm,
     $cmpMeta$: cmpMeta,
+    $lazyInstance$: cmpMeta.$customElement$ ? elm : undefined,
     $instanceValues$: new Map(),
   };
   if (BUILD.isDev) {

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -1660,6 +1660,7 @@ export interface ComponentRuntimeMeta {
   $attrsToReflect$?: [string, string][];
   $watchers$?: ComponentConstructorWatchers;
   $lazyBundleId$?: string;
+  $customElement$?: boolean;
 }
 
 export interface ComponentRuntimeMembers {

--- a/src/runtime/bootstrap-custom-element.ts
+++ b/src/runtime/bootstrap-custom-element.ts
@@ -17,6 +17,7 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
   const cmpMeta: d.ComponentRuntimeMeta = {
     $flags$: compactMeta[0],
     $tagName$: compactMeta[1],
+    $customElement$: true,
   };
   if (BUILD.member) {
     cmpMeta.$members$ = compactMeta[2];

--- a/src/runtime/connected-callback.ts
+++ b/src/runtime/connected-callback.ts
@@ -104,7 +104,9 @@ export const connectedCallback = (elm: d.HostElement) => {
       addHostEventListeners(elm, hostRef, cmpMeta.$listeners$, false);
 
       // fire off connectedCallback() on component instance
-      fireConnectedCallback(hostRef.$lazyInstance$);
+      if (!cmpMeta.$customElement$) {
+        fireConnectedCallback(hostRef.$lazyInstance$);
+      }
     }
 
     endConnected();

--- a/src/runtime/disconnected-callback.ts
+++ b/src/runtime/disconnected-callback.ts
@@ -21,7 +21,7 @@ export const disconnectedCallback = (elm: d.HostElement) => {
       plt.$cssShim$.removeHost(elm);
     }
 
-    if (BUILD.lazyLoad && BUILD.disconnectedCallback) {
+    if (BUILD.lazyLoad && BUILD.disconnectedCallback && !hostRef.$cmpMeta$.$customElement$) {
       safeCall(instance, 'disconnectedCallback');
     }
     if (BUILD.cmpDidUnload) {

--- a/src/runtime/initialize-component.ts
+++ b/src/runtime/initialize-component.ts
@@ -21,7 +21,7 @@ export const initializeComponent = async (
     (BUILD.lazyLoad || BUILD.hydrateServerSide || BUILD.style) &&
     (hostRef.$flags$ & HOST_FLAGS.hasInitializedComponent) === 0
   ) {
-    if (BUILD.lazyLoad || BUILD.hydrateClientSide) {
+    if ((BUILD.lazyLoad || BUILD.hydrateClientSide) && !cmpMeta.$customElement$) {
       // we haven't initialized this element yet
       hostRef.$flags$ |= HOST_FLAGS.hasInitializedComponent;
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

You are unable to import and use a custom elements build within a lazy-hydrated bundle Stencil project. When trying to use a Stencil compiled library within another Stencil project, you will receive numerous exceptions & the component will fail to render.

GitHub Issue Number: #2531, #3233

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Stencil libraries can be consumed within other Stencil libraries. For example, developers can use `@ionic/core/components` within their own Stencil libraries. 

- Hydrated web component behavior is skipped when the element being rendered is a custom element
- Introduces `$customElement$` flag on the compiler metadata for the component, so that the runtime can make decisions based on if the component being rendered is a custom element or part of the lazy/hydrated build.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

You can either clone this repository: https://github.com/sean-perkins/stencil-ce-project or follow these steps:

1. Create a new Stencil project `npm stencil init`
2. Install another Stencil library as a dependency, i.e. `@ionic/core`
3. For Ionic, you will need a global script to initialize required functionality:
```ts
// src/global/app.ts
import { initialize } from '@ionic/core/components';

initialize();
```
 4. Update `stencil.config.ts` to use the global script:
```ts
// stencil.config.ts
{
  ...
  globalScript: './src/global/app.ts'
}
```
 5. In your new Stencil project, use an Ionic component from the custom elements bundle
```tsx
// src/components/my-component/my-component.tsx
import { defineCustomElement  } from '@ionic/core/components/ion-button.js';

@Component(...) 
export class MyComponent {
  connectedCallback() {
    defineCustomElement();
  }

  render() {
    return (
       <ion-button>Default</ion-button>
    );
  }
}
```
  6. Run the project locally and notice the following exception in the console:
```
Trying to lazily load component <ion-button> with style mode "undefined", but it does not exist.

Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'then')
    at initializeComponent
```
  7. Locally build this PR and install the .tgz
  8. See that the component renders correctly

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

These changes were inspired from [MarkChrisLevy's](https://github.com/MarkChrisLevy) fork: https://github.com/CODE-AND-MORE/stencil/commits/codeandmore-2.12.1 and tested in an isolated project. After running into the issue and diagnosing a solution, I found that my approach aligned extremely similar to his. 

There is likely additional considerations that need to take place to handle mixing custom elements & the hydrated build, but the current state is completely broken, incrementally improving the experience to initialize the components seems valuable to the community. Also by fixing this issue, I will be able to identify other issues with the build and work to report and resolve those. 
