### PR TITLE
chore(github): update github action versions

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -3,8 +3,8 @@ name: BrowserStack
 on:
   pull_request_target:
     branches:
-      - main
-      - v3.0.0-dev
+      - 'main'
+      - 'v3.0.0-dev'
   push:
     branches:
       - 'main'
@@ -21,14 +21,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
         with:
           ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.number) || '' }}
           persist-credentials: false
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@56337c425554a6be30cdef71bf441f15be286854 # v3.1.1
         with:
-          node-version: '12'
+          node-version: '14'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -1,7 +1,7 @@
 name: BrowserStack
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - 'main'
       - 'v3.0.0-dev'

--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -1,7 +1,7 @@
 name: BrowserStack
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - 'main'
       - 'v3.0.0-dev'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
 
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@56337c425554a6be30cdef71bf441f15be286854 # v3.1.1
         with:
           node-version: ${{ matrix.node }}
           cache: 'npm'


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We're using an older version of the setup-node github action in our jobs, and are using a less secure versioning scheme for both setup-node and checkout actions

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the versions of the github actions used by the
browserstack and main workflows:

- checkout is pinned to the v2.4.0 release
- setup-node is upgraded to the v3.1.1 release

in this commit we move to using SHAs instead of the semver string per
the guidance of [github](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)

> Pinning an action to a full length commit SHA is currently the only
> way to use an action as an immutable release. Pinning to a particular
> SHA helps mitigate the risk of a bad actor adding a backdoor to the
> action's repository, as they would need to generate a SHA-1 collision
> for a valid Git object payload.

although we _probably_ can inherently trust github actions that are
authored by github, better safe than sorry.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Tailed the logs from CI to ensure that everything worked as expected

We use the `pull_request_target` trigger instead of `pull_request` for our BrowserStack job. With `pull_request_target` triggers, the versions of GitHub Actions that are used (checkout and setup-node) are pulled from the _target_ branch, (e.g. `main`) rather than the branch associated with the pull request.  To ensure that the changes to the BrowserStack job were working correctly, I temporarily switched our usage of `pull_request_target` to `pull_request` in https://github.com/ionic-team/stencil/pull/3331/commits/db660a1d5b6e0f2bec18a9fa7d66c08ce94c6d1f. This causes a new BrowserStack job to run with the updates.  I used the output from this job to verify my changes, which can be found [here](https://github.com/ionic-team/stencil/runs/6024275166?check_suite_focus=true).

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
