### PR TITLE
test(compiler): remove strictNullChecks errors from validate-dist.ts

### DIFF
--- a/src/compiler/config/outputs/validate-dist.ts
+++ b/src/compiler/config/outputs/validate-dist.ts
@@ -128,7 +128,7 @@ const validateOutputTargetDist = (config: d.Config, o: d.OutputTargetDist): Requ
     ...o,
     dir: getAbsolutePath(config, o.dir || DEFAULT_DIR),
     buildDir: isString(o.buildDir) ? o.buildDir : DEFAULT_BUILD_DIR,
-    collectionDir: isString(o.collectionDir) ? o.collectionDir : DEFAULT_COLLECTION_DIR,
+    collectionDir: o.collectionDir !== undefined ? o.collectionDir : DEFAULT_COLLECTION_DIR,
     typesDir: o.typesDir || DEFAULT_TYPES_DIR,
     esmLoaderPath: o.esmLoaderPath || DEFAULT_ESM_LOADER_DIR,
     copy: validateCopy(o.copy ?? [], []),

--- a/src/compiler/config/outputs/validate-dist.ts
+++ b/src/compiler/config/outputs/validate-dist.ts
@@ -132,7 +132,7 @@ const validateOutputTargetDist = (config: d.Config, o: d.OutputTargetDist): Requ
     typesDir: o.typesDir || DEFAULT_TYPES_DIR,
     esmLoaderPath: o.esmLoaderPath || DEFAULT_ESM_LOADER_DIR,
     copy: validateCopy(o.copy ?? [], []),
-    polyfills: isBoolean(o.polyfills) ? o.polyfills : false,
+    polyfills: isBoolean(o.polyfills) ? o.polyfills : undefined,
     empty: isBoolean(o.empty) ? o.empty : true,
   };
 

--- a/src/compiler/config/outputs/validate-dist.ts
+++ b/src/compiler/config/outputs/validate-dist.ts
@@ -11,7 +11,7 @@ import {
   isOutputTargetDist,
 } from '../../output-targets/output-utils';
 import { isAbsolute, join, resolve } from 'path';
-import { isBoolean } from '@utils';
+import { isBoolean, isString } from '@utils';
 import { validateCopy } from '../validate-copy';
 
 /**
@@ -58,7 +58,6 @@ export const validateDist = (config: d.Config, userOutputs: d.OutputTarget[]): d
       type: DIST_TYPES,
       dir: distOutputTarget.dir,
       typesDir: distOutputTarget.typesDir,
-      empty: distOutputTarget.empty,
     });
 
     if (config.buildDist) {
@@ -128,8 +127,8 @@ const validateOutputTargetDist = (config: d.Config, o: d.OutputTargetDist): Requ
   const outputTarget = {
     ...o,
     dir: getAbsolutePath(config, o.dir || DEFAULT_DIR),
-    buildDir: o.buildDir || DEFAULT_BUILD_DIR,
-    collectionDir: o.collectionDir || DEFAULT_COLLECTION_DIR,
+    buildDir: isString(o.buildDir) ? o.buildDir : DEFAULT_BUILD_DIR,
+    collectionDir: isString(o.collectionDir) ? o.collectionDir : DEFAULT_COLLECTION_DIR,
     typesDir: o.typesDir || DEFAULT_TYPES_DIR,
     esmLoaderPath: o.esmLoaderPath || DEFAULT_ESM_LOADER_DIR,
     copy: validateCopy(o.copy ?? [], []),
@@ -149,7 +148,7 @@ const validateOutputTargetDist = (config: d.Config, o: d.OutputTargetDist): Requ
     outputTarget.esmLoaderPath = resolve(outputTarget.dir, outputTarget.esmLoaderPath);
   }
 
-  if (!isAbsolute(outputTarget.typesDir) && outputTarget.dir !== undefined) {
+  if (!isAbsolute(outputTarget.typesDir)) {
     outputTarget.typesDir = join(outputTarget.dir, outputTarget.typesDir);
   }
 

--- a/src/compiler/config/outputs/validate-dist.ts
+++ b/src/compiler/config/outputs/validate-dist.ts
@@ -11,12 +11,21 @@ import {
   isOutputTargetDist,
 } from '../../output-targets/output-utils';
 import { isAbsolute, join, resolve } from 'path';
-import { isBoolean, isString } from '@utils';
+import { isBoolean } from '@utils';
 import { validateCopy } from '../validate-copy';
 
-export const validateDist = (config: d.Config, userOutputs: d.OutputTarget[]) => {
+/**
+ * Validate that the "dist" output targets are valid and ready to go.
+ *
+ * This function will also add in additional output targets to its output, based on the input supplied.
+ *
+ * @param config the compiler config, what else?
+ * @param userOutputs a user-supplied list of output targets.
+ * @returns a list of OutputTargets which have been validated for us.
+ */
+export const validateDist = (config: d.Config, userOutputs: d.OutputTarget[]): d.OutputTarget[] => {
   const distOutputTargets = userOutputs.filter(isOutputTargetDist);
-  return distOutputTargets.reduce((outputs, o) => {
+  return distOutputTargets.reduce((outputs: d.OutputTarget[], o: d.OutputTargetDist) => {
     const distOutputTarget = validateOutputTargetDist(config, o);
     outputs.push(distOutputTarget);
 
@@ -38,7 +47,7 @@ export const validateDist = (config: d.Config, userOutputs: d.OutputTarget[]) =>
       type: COPY,
       dir: lazyDir,
       copyAssets: 'dist',
-      copy: [...distOutputTarget.copy],
+      copy: (distOutputTarget.copy ?? []).concat(),
     });
     outputs.push({
       type: DIST_GLOBAL_STYLES,
@@ -102,49 +111,48 @@ export const validateDist = (config: d.Config, userOutputs: d.OutputTarget[]) =>
   }, []);
 };
 
-const validateOutputTargetDist = (config: d.Config, o: d.OutputTargetDist) => {
+/**
+ * Validate that an OutputTargetDist object has what it needs to do it's job.
+ * To enforce this, we have this function return
+ * `Required<d.OutputTargetDist>`, giving us a compile-time check that all
+ * properties are defined (with either user-supplied or default values).
+ *
+ * @param config the current config
+ * @param o the OutputTargetDist object we want to validate
+ * @returns `Required<d.OutputTargetDist>`, i.e. `d.OutputTargetDist` with all
+ * optional properties rendered un-optional.
+ */
+const validateOutputTargetDist = (config: d.Config, o: d.OutputTargetDist): Required<d.OutputTargetDist> => {
+  // we need to create an object with a bunch of default values here so that
+  // the typescript compiler can infer their types correctly
   const outputTarget = {
     ...o,
     dir: getAbsolutePath(config, o.dir || DEFAULT_DIR),
+    buildDir: o.buildDir || DEFAULT_BUILD_DIR,
+    collectionDir: o.collectionDir || DEFAULT_COLLECTION_DIR,
+    typesDir: o.typesDir || DEFAULT_TYPES_DIR,
+    esmLoaderPath: o.esmLoaderPath || DEFAULT_ESM_LOADER_DIR,
+    copy: validateCopy(o.copy ?? [], []),
+    polyfills: isBoolean(o.polyfills) ? o.polyfills : false,
+    empty: isBoolean(o.empty) ? o.empty : true,
   };
-
-  if (!isString(outputTarget.buildDir)) {
-    outputTarget.buildDir = DEFAULT_BUILD_DIR;
-  }
 
   if (!isAbsolute(outputTarget.buildDir)) {
     outputTarget.buildDir = join(outputTarget.dir, outputTarget.buildDir);
-  }
-
-  if (outputTarget.collectionDir === undefined) {
-    outputTarget.collectionDir = DEFAULT_COLLECTION_DIR;
   }
 
   if (outputTarget.collectionDir && !isAbsolute(outputTarget.collectionDir)) {
     outputTarget.collectionDir = join(outputTarget.dir, outputTarget.collectionDir);
   }
 
-  if (!outputTarget.esmLoaderPath) {
-    outputTarget.esmLoaderPath = DEFAULT_ESM_LOADER_DIR;
-  }
-
   if (!isAbsolute(outputTarget.esmLoaderPath)) {
     outputTarget.esmLoaderPath = resolve(outputTarget.dir, outputTarget.esmLoaderPath);
   }
 
-  if (!outputTarget.typesDir) {
-    outputTarget.typesDir = DEFAULT_TYPES_DIR;
-  }
-
-  if (!isAbsolute(outputTarget.typesDir)) {
+  if (!isAbsolute(outputTarget.typesDir) && outputTarget.dir !== undefined) {
     outputTarget.typesDir = join(outputTarget.dir, outputTarget.typesDir);
   }
 
-  if (!isBoolean(outputTarget.empty)) {
-    outputTarget.empty = true;
-  }
-
-  outputTarget.copy = validateCopy(outputTarget.copy, []);
   return outputTarget;
 };
 

--- a/src/compiler/config/test/validate-output-dist.spec.ts
+++ b/src/compiler/config/test/validate-output-dist.spec.ts
@@ -30,6 +30,7 @@ describe('validateDistOutputTarget', () => {
         empty: false,
         esmLoaderPath: path.join(rootDir, 'my-dist', 'loader'),
         type: 'dist',
+        polyfills: false,
         typesDir: path.join(rootDir, 'my-dist', 'types'),
       },
       {
@@ -37,7 +38,7 @@ describe('validateDistOutputTarget', () => {
         empty: false,
         isBrowserBuild: true,
         legacyLoaderFile: path.join(rootDir, 'my-dist', 'my-build', 'testing.js'),
-        polyfills: true,
+        polyfills: false,
         systemDir: undefined,
         systemLoaderFile: undefined,
         type: 'dist-lazy',

--- a/src/compiler/config/test/validate-output-dist.spec.ts
+++ b/src/compiler/config/test/validate-output-dist.spec.ts
@@ -30,7 +30,7 @@ describe('validateDistOutputTarget', () => {
         empty: false,
         esmLoaderPath: path.join(rootDir, 'my-dist', 'loader'),
         type: 'dist',
-        polyfills: false,
+        polyfills: undefined,
         typesDir: path.join(rootDir, 'my-dist', 'types'),
       },
       {
@@ -38,7 +38,7 @@ describe('validateDistOutputTarget', () => {
         empty: false,
         isBrowserBuild: true,
         legacyLoaderFile: path.join(rootDir, 'my-dist', 'my-build', 'testing.js'),
-        polyfills: false,
+        polyfills: true,
         systemDir: undefined,
         systemLoaderFile: undefined,
         type: 'dist-lazy',

--- a/src/compiler/config/test/validate-output-dist.spec.ts
+++ b/src/compiler/config/test/validate-output-dist.spec.ts
@@ -55,7 +55,6 @@ describe('validateDistOutputTarget', () => {
       },
       {
         dir: path.join(rootDir, 'my-dist'),
-        empty: false,
         type: 'dist-types',
         typesDir: path.join(rootDir, 'my-dist', 'types'),
       },

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1810,14 +1810,14 @@ export interface OutputTargetDist extends OutputTargetBase {
 
 export interface OutputTargetDistCollection extends OutputTargetBase {
   type: 'dist-collection';
-
+  empty: boolean;
   dir: string;
   collectionDir: string;
 }
 
 export interface OutputTargetDistTypes extends OutputTargetBase {
   type: 'dist-types';
-
+  empty: boolean;
   dir: string;
   typesDir: string;
 }
@@ -1836,6 +1836,7 @@ export interface OutputTargetDistLazy extends OutputTargetBase {
   esmIndexFile?: string;
   cjsIndexFile?: string;
   systemLoaderFile?: string;
+  legacyLoaderFile?: string;
   empty?: boolean;
 }
 
@@ -1849,7 +1850,7 @@ export interface OutputTargetDistLazyLoader extends OutputTargetBase {
   dir: string;
 
   esmDir: string;
-  esmEs5Dir: string;
+  esmEs5Dir?: string;
   cjsDir: string;
   componentDts: string;
 

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1810,7 +1810,7 @@ export interface OutputTargetDist extends OutputTargetBase {
 
 export interface OutputTargetDistCollection extends OutputTargetBase {
   type: 'dist-collection';
-  empty: boolean;
+  empty?: boolean;
   dir: string;
   collectionDir: string;
 }

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1817,7 +1817,6 @@ export interface OutputTargetDistCollection extends OutputTargetBase {
 
 export interface OutputTargetDistTypes extends OutputTargetBase {
   type: 'dist-types';
-  empty: boolean;
   dir: string;
   typesDir: string;
 }


### PR DESCRIPTION
this makes changes necessary to fix the errors from compiling w/
`strictNullChecks` set to `true` in
src/compiler/config/outputs/validate-dist.ts.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior? What is the new behavior?

On the main branch turning on `strictNullChecks` produces 2229 errors. With the changes on this branch we get 2182, so we've fixed 47. Gotta start somewhere!

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Tests should all pass! The typechecker too.

You can also run `npx tsc --strictNullChecks` locally and verify that you get fewer errors than on `main`. You could also change that value in `tsconfig.json` temporarily and check that you don't get any compile errors in the file when opening it in your editor, or check the output to make sure there aren't any errors in `validate-dist.ts`.