### PR TITLE
fix(types): components.d.ts type resolution for duplicate types

### DIFF
--- a/src/compiler/types/generate-app-types.ts
+++ b/src/compiler/types/generate-app-types.ts
@@ -71,7 +71,7 @@ const generateComponentTypesFile = (config: d.Config, buildCtx: d.BuildCtx, areT
 
   const modules: d.TypesModule[] = components.map((cmp) => {
     typeImportData = updateReferenceTypeImports(typeImportData, allTypes, cmp, cmp.sourceFilePath);
-    return generateComponentTypes(cmp, areTypesInternal);
+    return generateComponentTypes(cmp, typeImportData, areTypesInternal);
   });
 
   c.push(COMPONENTS_DTS_HEADER);

--- a/src/compiler/types/generate-component-types.ts
+++ b/src/compiler/types/generate-component-types.ts
@@ -7,17 +7,22 @@ import { generatePropTypes } from './generate-prop-types';
 /**
  * Generate a string based on the types that are defined within a component
  * @param cmp the metadata for the component that a type definition string is generated for
+ * @param typeImportData locally/imported/globally used type names, which may be used to prevent naming collisions
  * @param areTypesInternal `true` if types being generated are for a project's internal purposes, `false` otherwise
  * @returns the generated types string alongside additional metadata
  */
-export const generateComponentTypes = (cmp: d.ComponentCompilerMeta, areTypesInternal: boolean): d.TypesModule => {
+export const generateComponentTypes = (
+  cmp: d.ComponentCompilerMeta,
+  typeImportData: d.TypesImportData,
+  areTypesInternal: boolean
+): d.TypesModule => {
   const tagName = cmp.tagName.toLowerCase();
   const tagNameAsPascal = dashToPascalCase(tagName);
   const htmlElementName = `HTML${tagNameAsPascal}Element`;
 
-  const propAttributes = generatePropTypes(cmp);
-  const methodAttributes = generateMethodTypes(cmp);
-  const eventAttributes = generateEventTypes(cmp);
+  const propAttributes = generatePropTypes(cmp, typeImportData);
+  const methodAttributes = generateMethodTypes(cmp, typeImportData);
+  const eventAttributes = generateEventTypes(cmp, typeImportData);
 
   const componentAttributes = attributesToMultiLineString(
     [...propAttributes, ...methodAttributes],

--- a/src/compiler/types/generate-event-types.ts
+++ b/src/compiler/types/generate-event-types.ts
@@ -1,17 +1,17 @@
 import type * as d from '../../declarations';
 import { getTextDocs, toTitleCase } from '@utils';
+import { updateTypeIdentifierNames } from './stencil-types';
 
 /**
  * Generates the individual event types for all @Event() decorated events in a component
  * @param cmpMeta component runtime metadata for a single component
+ * @param typeImportData locally/imported/globally used type names, which may be used to prevent naming collisions
  * @returns the generated type metadata
  */
-export const generateEventTypes = (cmpMeta: d.ComponentCompilerMeta): d.TypeInfo => {
+export const generateEventTypes = (cmpMeta: d.ComponentCompilerMeta, typeImportData: d.TypesImportData): d.TypeInfo => {
   return cmpMeta.events.map((cmpEvent) => {
     const name = `on${toTitleCase(cmpEvent.name)}`;
-    const type = cmpEvent.complexType.original
-      ? `(event: CustomEvent<${cmpEvent.complexType.original}>) => void`
-      : `CustomEvent`;
+    const type = getEventType(cmpEvent, typeImportData, cmpMeta.sourceFilePath);
     return {
       name,
       type,
@@ -21,4 +21,28 @@ export const generateEventTypes = (cmpMeta: d.ComponentCompilerMeta): d.TypeInfo
       jsdoc: getTextDocs(cmpEvent.docs),
     };
   });
+};
+
+/**
+ * Determine the correct type name for all type(s) used by a class member annotated with `@Event()`
+ * @param cmpEvent the compiler metadata for a single `@Event()`
+ * @param typeImportData locally/imported/globally used type names, which may be used to prevent naming collisions
+ * @param componentSourcePath the path to the component on disk
+ * @returns the type associated with a `@Event()`
+ */
+const getEventType = (
+  cmpEvent: d.ComponentCompilerEvent,
+  typeImportData: d.TypesImportData,
+  componentSourcePath: string
+): string => {
+  if (!cmpEvent.complexType.original) {
+    return 'CustomEvent';
+  }
+  const updatedTypeName = updateTypeIdentifierNames(
+    cmpEvent.complexType.references,
+    typeImportData,
+    componentSourcePath,
+    cmpEvent.complexType.original
+  );
+  return `(event: CustomEvent<${updatedTypeName}>) => void`;
 };

--- a/src/compiler/types/generate-method-types.ts
+++ b/src/compiler/types/generate-method-types.ts
@@ -1,18 +1,43 @@
 import type * as d from '../../declarations';
 import { getTextDocs } from '@utils';
+import { updateTypeIdentifierNames } from './stencil-types';
 
 /**
  * Generates the individual event types for all @Method() decorated events in a component
  * @param cmpMeta component runtime metadata for a single component
+ * @param typeImportData locally/imported/globally used type names, which may be used to prevent naming collisions
  * @returns the generated type metadata
  */
-export const generateMethodTypes = (cmpMeta: d.ComponentCompilerMeta): d.TypeInfo => {
+export const generateMethodTypes = (
+  cmpMeta: d.ComponentCompilerMeta,
+  typeImportData: d.TypesImportData
+): d.TypeInfo => {
   return cmpMeta.methods.map((cmpMethod) => ({
     name: cmpMethod.name,
-    type: cmpMethod.complexType.signature,
+    type: getType(cmpMethod, typeImportData, cmpMeta.sourceFilePath),
     optional: false,
     required: false,
     internal: cmpMethod.internal,
     jsdoc: getTextDocs(cmpMethod.docs),
   }));
 };
+
+/**
+ * Determine the correct type name for all type(s) used by a class member annotated with `@Method()`
+ * @param cmpMethod the compiler metadata for a single `@Method()`
+ * @param typeImportData locally/imported/globally used type names, which may be used to prevent naming collisions
+ * @param componentSourcePath the path to the component on disk
+ * @returns the type associated with a `@Method()`
+ */
+function getType(
+  cmpMethod: d.ComponentCompilerMethod,
+  typeImportData: d.TypesImportData,
+  componentSourcePath: string
+): string {
+  return updateTypeIdentifierNames(
+    cmpMethod.complexType.references,
+    typeImportData,
+    componentSourcePath,
+    cmpMethod.complexType.signature
+  );
+}

--- a/src/compiler/types/generate-prop-types.ts
+++ b/src/compiler/types/generate-prop-types.ts
@@ -1,16 +1,18 @@
 import type * as d from '../../declarations';
 import { getTextDocs } from '@utils';
+import { updateTypeIdentifierNames } from './stencil-types';
 
 /**
  * Generates the individual event types for all @Prop() decorated events in a component
  * @param cmpMeta component runtime metadata for a single component
+ * @param typeImportData locally/imported/globally used type names, which may be used to prevent naming collisions
  * @returns the generated type metadata
  */
-export const generatePropTypes = (cmpMeta: d.ComponentCompilerMeta): d.TypeInfo => {
+export const generatePropTypes = (cmpMeta: d.ComponentCompilerMeta, typeImportData: d.TypesImportData): d.TypeInfo => {
   return [
     ...cmpMeta.properties.map((cmpProp) => ({
       name: cmpProp.name,
-      type: cmpProp.complexType.original,
+      type: getType(cmpProp, typeImportData, cmpMeta.sourceFilePath),
       optional: cmpProp.optional,
       required: cmpProp.required,
       internal: cmpProp.internal,
@@ -26,3 +28,23 @@ export const generatePropTypes = (cmpMeta: d.ComponentCompilerMeta): d.TypeInfo 
     })),
   ];
 };
+
+/**
+ * Determine the correct type name for all type(s) used by a class member annotated with `@Prop()`
+ * @param cmpProp the compiler metadata for a single `@Prop()`
+ * @param typeImportData locally/imported/globally used type names, which may be used to prevent naming collisions
+ * @param componentSourcePath the path to the component on disk
+ * @returns the type associated with a `@Prop()`
+ */
+function getType(
+  cmpProp: d.ComponentCompilerProperty,
+  typeImportData: d.TypesImportData,
+  componentSourcePath: string
+): string {
+  return updateTypeIdentifierNames(
+    cmpProp.complexType.references,
+    typeImportData,
+    componentSourcePath,
+    cmpProp.complexType.original
+  );
+}

--- a/src/compiler/types/stencil-types.ts
+++ b/src/compiler/types/stencil-types.ts
@@ -1,5 +1,5 @@
 import type * as d from '../../declarations';
-import { dirname, join, relative } from 'path';
+import { dirname, join, relative, resolve } from 'path';
 import { isOutputTargetDistTypes } from '../output-targets/output-utils';
 import { normalizePath } from '@utils';
 
@@ -28,6 +28,81 @@ export const updateStencilTypesImports = (typesDir: string, dtsFilePath: string,
     dtsContent = dtsContent.replace(/(from\s*(:?'|"))@stencil\/core('|")/g, `$1${coreDtsPath}$2`);
   }
   return dtsContent;
+};
+
+/**
+ * Utility for ensuring that naming collisions do not appear in type declaration files for a component's class members
+ * decorated with @Prop, @Event, and @Method
+ * @param typeReferences all type names used by a component class member
+ * @param typeImportData locally/imported/globally used type names, which may be used to prevent naming collisions
+ * @param sourceFilePath the path to the source file of a component using the type being inspected
+ * @param initialType the name of the type that may be updated
+ * @returns the updated type name, which may be the same as the initial type name provided as an argument to this
+ * function
+ */
+export const updateTypeIdentifierNames = (
+  typeReferences: d.ComponentCompilerTypeReferences,
+  typeImportData: d.TypesImportData,
+  sourceFilePath: string,
+  initialType: string
+): string => {
+  let currentTypeName = initialType;
+
+  // iterate over each of the type references, as there may be >1 reference to inspect
+  for (let typeReference of Object.values(typeReferences)) {
+    const importResolvedFile = getTypeImportPath(typeReference.path, sourceFilePath);
+
+    if (!typeImportData.hasOwnProperty(importResolvedFile)) {
+      continue;
+    }
+
+    for (let typesImportDatumElement of typeImportData[importResolvedFile]) {
+      currentTypeName = updateTypeName(currentTypeName, typesImportDatumElement);
+    }
+  }
+  return currentTypeName;
+};
+
+/**
+ * Determine the path of a given type reference, relative to the path of a source file
+ * @param importResolvedFile the path to the file containing the resolve type. may be absolute or relative
+ * @param sourceFilePath the component source file path to resolve against
+ * @returns the path of the type import
+ */
+const getTypeImportPath = (importResolvedFile: string, sourceFilePath: string): string => {
+  const isPathRelative = importResolvedFile && importResolvedFile.startsWith('.');
+  if (isPathRelative) {
+    importResolvedFile = resolve(dirname(sourceFilePath), importResolvedFile);
+  }
+
+  return importResolvedFile;
+};
+
+/**
+ * Determine whether the string representation of a type should be replaced with an alias
+ * @param currentTypeName the current string representation of a type
+ * @param typeAlias a type member and a potential different name associated with the type member
+ * @returns the updated string representation of a type. If the type is not updated, the original type name is returned
+ */
+const updateTypeName = (currentTypeName: string, typeAlias: d.TypesMemberNameData): string => {
+  if (!typeAlias.importName) {
+    return currentTypeName;
+  }
+
+  // TODO(STENCIL-419): Update this functionality to no longer use a regex
+  // negative lookahead specifying that quotes that designate a string in JavaScript cannot follow some expression
+  const endingStrChar = '(?!("|\'|`))';
+  /**
+   * A regular expression that looks at type names along a [word boundary](https://www.regular-expressions.info/wordboundaries.html).
+   * This is used as the best approximation for replacing type collisions, as this stage of compilation has only
+   * 'flattened' type information in the form of a String.
+   *
+   * This regex should be expected to capture types that are found in generics, unions, intersections, etc., but not
+   * those in string literals. We do not check for a starting quote (" | ' | `) here as some browsers do not support
+   * negative lookbehind. This works "well enough" until STENCIL-419 is completed.
+   */
+  const typeNameRegex = new RegExp(`${typeAlias.localName}\\b${endingStrChar}`, 'g');
+  return currentTypeName.replace(typeNameRegex, typeAlias.importName);
 };
 
 /**

--- a/src/compiler/types/stencil-types.ts
+++ b/src/compiler/types/stencil-types.ts
@@ -69,7 +69,7 @@ export const updateTypeIdentifierNames = (
  * @param sourceFilePath the component source file path to resolve against
  * @returns the path of the type import
  */
-const getTypeImportPath = (importResolvedFile: string, sourceFilePath: string): string => {
+const getTypeImportPath = (importResolvedFile: string | undefined, sourceFilePath: string): string => {
   const isPathRelative = importResolvedFile && importResolvedFile.startsWith('.');
   if (isPathRelative) {
     importResolvedFile = resolve(dirname(sourceFilePath), importResolvedFile);

--- a/src/compiler/types/tests/TypesImportData.stub.ts
+++ b/src/compiler/types/tests/TypesImportData.stub.ts
@@ -1,0 +1,18 @@
+import * as d from '@stencil/core/declarations';
+
+/**
+ * Generates a stub {@link TypesImportData}.
+ * @param overrides a partial implementation of `TypesImportData`. Any provided fields will override the defaults
+ * provided by this function.
+ * @returns the stubbed `TypesImportData`
+ */
+export const stubTypesImportData = (overrides: Partial<d.TypesImportData> = {}): d.TypesImportData => {
+  /**
+   * By design, we do not provide any default values. the keys used in this data structure will be highly dependent on
+   * the tests being written, and providing default values may lead to unexpected behavior when enumerating the returned
+   * stub
+   */
+  const defaults: d.TypesImportData = {};
+
+  return { ...defaults, ...overrides };
+};

--- a/src/compiler/types/tests/generate-event-types.spec.ts
+++ b/src/compiler/types/tests/generate-event-types.spec.ts
@@ -1,12 +1,18 @@
 import type * as d from '../../../declarations';
 import { generateEventTypes } from '../generate-event-types';
+import * as StencilTypes from '../stencil-types';
 import * as UtilHelpers from '../../../utils/helpers';
 import * as Util from '../../../utils/util';
 import { stubComponentCompilerMeta } from './ComponentCompilerMeta.stub';
 import { stubComponentCompilerEvent } from './ComponentCompilerEvent.stub';
+import { stubTypesImportData } from './TypesImportData.stub';
 
 describe('generate-event-types', () => {
   describe('generateEventTypes', () => {
+    let updateTypeIdentifierNamesSpy: jest.SpyInstance<
+      ReturnType<typeof StencilTypes.updateTypeIdentifierNames>,
+      Parameters<typeof StencilTypes.updateTypeIdentifierNames>
+    >;
     let getTextDocsSpy: jest.SpyInstance<ReturnType<typeof Util.getTextDocs>, Parameters<typeof Util.getTextDocs>>;
     let toTitleCaseSpy: jest.SpyInstance<
       ReturnType<typeof UtilHelpers.toTitleCase>,
@@ -14,6 +20,17 @@ describe('generate-event-types', () => {
     >;
 
     beforeEach(() => {
+      updateTypeIdentifierNamesSpy = jest.spyOn(StencilTypes, 'updateTypeIdentifierNames');
+      updateTypeIdentifierNamesSpy.mockImplementation(
+        (
+          _typeReferences: d.ComponentCompilerTypeReferences,
+          _cmpMeta: d.ComponentCompilerMeta,
+          _typeImportData: d.TypesImportData,
+          initialType: string,
+          _updateTypeName: (currentTypeName: string, typeAlias: d.TypesMemberNameData) => string
+        ) => initialType
+      );
+
       getTextDocsSpy = jest.spyOn(Util, 'getTextDocs');
       getTextDocsSpy.mockReturnValue('');
 
@@ -22,39 +39,59 @@ describe('generate-event-types', () => {
     });
 
     afterEach(() => {
+      updateTypeIdentifierNamesSpy.mockRestore();
       getTextDocsSpy.mockRestore();
       toTitleCaseSpy.mockRestore();
     });
 
     it('returns an empty array when no events are provided', () => {
+      const stubImportTypes = stubTypesImportData();
       const componentMeta = stubComponentCompilerMeta();
 
-      expect(generateEventTypes(componentMeta)).toEqual([]);
+      expect(generateEventTypes(componentMeta, stubImportTypes)).toEqual([]);
     });
 
     it('prefixes the event name with "on"', () => {
+      const stubImportTypes = stubTypesImportData();
       const componentMeta = stubComponentCompilerMeta({
         events: [stubComponentCompilerEvent()],
       });
 
-      const actualTypeInfo = generateEventTypes(componentMeta);
+      const actualTypeInfo = generateEventTypes(componentMeta, stubImportTypes);
 
       expect(actualTypeInfo).toHaveLength(1);
       expect(actualTypeInfo[0].name).toBe('onMyEvent');
     });
 
     it('derives a generic CustomEvent from the original type', () => {
+      const stubImportTypes = stubTypesImportData();
       const componentMeta = stubComponentCompilerMeta({
         events: [stubComponentCompilerEvent()],
       });
 
-      const actualTypeInfo = generateEventTypes(componentMeta);
+      const actualTypeInfo = generateEventTypes(componentMeta, stubImportTypes);
 
       expect(actualTypeInfo).toHaveLength(1);
       expect(actualTypeInfo[0].type).toBe('(event: CustomEvent<UserImplementedEventType>) => void');
     });
 
+    it('uses an updated type name to avoid naming collisions', () => {
+      const updatedTypeName = 'SomeTypeReturned';
+      updateTypeIdentifierNamesSpy.mockReturnValue(updatedTypeName);
+
+      const stubImportTypes = stubTypesImportData();
+      const componentMeta = stubComponentCompilerMeta({
+        events: [stubComponentCompilerEvent()],
+      });
+
+      const actualTypeInfo = generateEventTypes(componentMeta, stubImportTypes);
+
+      expect(actualTypeInfo).toHaveLength(1);
+      expect(actualTypeInfo[0].type).toBe(`(event: CustomEvent<${updatedTypeName}>) => void`);
+    });
+
     it('derives CustomEvent type when there is no original typing field', () => {
+      const stubImportTypes = stubTypesImportData();
       const componentEvent = stubComponentCompilerEvent({
         complexType: {
           original: '',
@@ -66,7 +103,7 @@ describe('generate-event-types', () => {
         events: [componentEvent],
       });
 
-      const actualTypeInfo = generateEventTypes(componentMeta);
+      const actualTypeInfo = generateEventTypes(componentMeta, stubImportTypes);
 
       expect(actualTypeInfo).toHaveLength(1);
       expect(actualTypeInfo[0].type).toBe('CustomEvent');
@@ -76,6 +113,7 @@ describe('generate-event-types', () => {
       const componentMeta = stubComponentCompilerMeta({
         events: [stubComponentCompilerEvent()],
       });
+      const stubImportTypes = stubTypesImportData();
 
       const expectedTypeInfo: d.TypeInfo = [
         {
@@ -88,7 +126,7 @@ describe('generate-event-types', () => {
         },
       ];
 
-      const actualTypeInfo = generateEventTypes(componentMeta);
+      const actualTypeInfo = generateEventTypes(componentMeta, stubImportTypes);
 
       expect(actualTypeInfo).toEqual(expectedTypeInfo);
     });
@@ -111,6 +149,7 @@ describe('generate-event-types', () => {
       const componentMeta = stubComponentCompilerMeta({
         events: [componentEvent1, componentEvent2],
       });
+      const stubImportTypes = stubTypesImportData();
 
       const expectedTypeInfo: d.TypeInfo = [
         {
@@ -131,7 +170,7 @@ describe('generate-event-types', () => {
         },
       ];
 
-      const actualTypeInfo = generateEventTypes(componentMeta);
+      const actualTypeInfo = generateEventTypes(componentMeta, stubImportTypes);
 
       expect(actualTypeInfo).toEqual(expectedTypeInfo);
     });

--- a/src/compiler/types/tests/generate-method-types.spec.ts
+++ b/src/compiler/types/tests/generate-method-types.spec.ts
@@ -1,29 +1,49 @@
 import type * as d from '../../../declarations';
 import { generateMethodTypes } from '../generate-method-types';
+import * as StencilTypes from '../stencil-types';
 import * as Util from '../../../utils/util';
 import { stubComponentCompilerMeta } from './ComponentCompilerMeta.stub';
 import { stubComponentCompilerMethod } from './ComponentCompilerMethod.stub';
+import { stubTypesImportData } from './TypesImportData.stub';
 
 describe('generate-method-types', () => {
   describe('generateMethodTypes', () => {
+    let updateTypeIdentifierNamesSpy: jest.SpyInstance<
+      ReturnType<typeof StencilTypes.updateTypeIdentifierNames>,
+      Parameters<typeof StencilTypes.updateTypeIdentifierNames>
+    >;
     let getTextDocsSpy: jest.SpyInstance<ReturnType<typeof Util.getTextDocs>, Parameters<typeof Util.getTextDocs>>;
 
     beforeEach(() => {
+      updateTypeIdentifierNamesSpy = jest.spyOn(StencilTypes, 'updateTypeIdentifierNames');
+      updateTypeIdentifierNamesSpy.mockImplementation(
+        (
+          _typeReferences: d.ComponentCompilerTypeReferences,
+          _cmpMeta: d.ComponentCompilerMeta,
+          _typeImportData: d.TypesImportData,
+          initialType: string,
+          _updateTypeName: (currentTypeName: string, typeAlias: d.TypesMemberNameData) => string
+        ) => initialType
+      );
+
       getTextDocsSpy = jest.spyOn(Util, 'getTextDocs');
       getTextDocsSpy.mockReturnValue('');
     });
 
     afterEach(() => {
+      updateTypeIdentifierNamesSpy.mockRestore();
       getTextDocsSpy.mockRestore();
     });
 
     it('returns an empty array when no methods are provided', () => {
+      const stubImportTypes = stubTypesImportData();
       const componentMeta = stubComponentCompilerMeta();
 
-      expect(generateMethodTypes(componentMeta)).toEqual([]);
+      expect(generateMethodTypes(componentMeta, stubImportTypes)).toEqual([]);
     });
 
     it('returns the correct type info for a single method', () => {
+      const stubImportTypes = stubTypesImportData();
       const componentMethod = stubComponentCompilerMethod();
       const componentMeta = stubComponentCompilerMeta({
         methods: [componentMethod],
@@ -40,12 +60,39 @@ describe('generate-method-types', () => {
         },
       ];
 
-      const actualTypeInfo = generateMethodTypes(componentMeta);
+      const actualTypeInfo = generateMethodTypes(componentMeta, stubImportTypes);
+
+      expect(actualTypeInfo).toEqual(expectedTypeInfo);
+    });
+
+    it('uses an updated type name to avoid naming collisions', () => {
+      const updatedTypeName = '(name: SomeTypeReturned) => Promise<void>';
+      updateTypeIdentifierNamesSpy.mockReturnValue(updatedTypeName);
+
+      const stubImportTypes = stubTypesImportData();
+      const componentMethod = stubComponentCompilerMethod();
+      const componentMeta = stubComponentCompilerMeta({
+        methods: [componentMethod],
+      });
+
+      const expectedTypeInfo: d.TypeInfo = [
+        {
+          jsdoc: '',
+          internal: false,
+          name: 'myMethod',
+          optional: false,
+          required: false,
+          type: updatedTypeName,
+        },
+      ];
+
+      const actualTypeInfo = generateMethodTypes(componentMeta, stubImportTypes);
 
       expect(actualTypeInfo).toEqual(expectedTypeInfo);
     });
 
     it('returns the correct type info for multiple methods', () => {
+      const stubImportTypes = stubTypesImportData();
       const componentMethod1 = stubComponentCompilerMethod();
       const componentMethod2 = stubComponentCompilerMethod({
         name: 'myOtherMethod',
@@ -81,7 +128,7 @@ describe('generate-method-types', () => {
         },
       ];
 
-      const actualTypeInfo = generateMethodTypes(componentMeta);
+      const actualTypeInfo = generateMethodTypes(componentMeta, stubImportTypes);
 
       expect(actualTypeInfo).toEqual(expectedTypeInfo);
     });

--- a/src/compiler/types/tests/generate-prop-types.spec.ts
+++ b/src/compiler/types/tests/generate-prop-types.spec.ts
@@ -1,30 +1,50 @@
 import type * as d from '../../../declarations';
 import { generatePropTypes } from '../generate-prop-types';
+import * as StencilTypes from '../stencil-types';
 import * as Util from '../../../utils/util';
 import { stubComponentCompilerMeta } from './ComponentCompilerMeta.stub';
 import { stubComponentCompilerProperty } from './ComponentCompilerProperty.stub';
 import { stubComponentCompilerVirtualProperty } from './ComponentCompilerVirtualProperty.stub';
+import { stubTypesImportData } from './TypesImportData.stub';
 
 describe('generate-prop-types', () => {
   describe('generatePropTypes', () => {
+    let updateTypeIdentifierNamesSpy: jest.SpyInstance<
+      ReturnType<typeof StencilTypes.updateTypeIdentifierNames>,
+      Parameters<typeof StencilTypes.updateTypeIdentifierNames>
+    >;
     let getTextDocsSpy: jest.SpyInstance<ReturnType<typeof Util.getTextDocs>, Parameters<typeof Util.getTextDocs>>;
 
     beforeEach(() => {
+      updateTypeIdentifierNamesSpy = jest.spyOn(StencilTypes, 'updateTypeIdentifierNames');
+      updateTypeIdentifierNamesSpy.mockImplementation(
+        (
+          _typeReferences: d.ComponentCompilerTypeReferences,
+          _cmpMeta: d.ComponentCompilerMeta,
+          _typeImportData: d.TypesImportData,
+          initialType: string,
+          _updateTypeName: (currentTypeName: string, typeAlias: d.TypesMemberNameData) => string
+        ) => initialType
+      );
+
       getTextDocsSpy = jest.spyOn(Util, 'getTextDocs');
       getTextDocsSpy.mockReturnValue('');
     });
 
     afterEach(() => {
+      updateTypeIdentifierNamesSpy.mockRestore();
       getTextDocsSpy.mockRestore();
     });
 
     it('returns an empty array when no props are provided', () => {
+      const stubImportTypes = stubTypesImportData();
       const componentMeta = stubComponentCompilerMeta();
 
-      expect(generatePropTypes(componentMeta)).toEqual([]);
+      expect(generatePropTypes(componentMeta, stubImportTypes)).toEqual([]);
     });
 
     it('returns the correct type information for a single property', () => {
+      const stubImportTypes = stubTypesImportData();
       const componentMeta = stubComponentCompilerMeta({
         properties: [stubComponentCompilerProperty()],
       });
@@ -40,12 +60,38 @@ describe('generate-prop-types', () => {
         },
       ];
 
-      const actualTypeInfo = generatePropTypes(componentMeta);
+      const actualTypeInfo = generatePropTypes(componentMeta, stubImportTypes);
+
+      expect(actualTypeInfo).toEqual(expectedTypeInfo);
+    });
+
+    it('uses an updated type name to avoid naming collisions', () => {
+      const updatedTypeName = 'SomeTypeReturned';
+      updateTypeIdentifierNamesSpy.mockReturnValue(updatedTypeName);
+
+      const stubImportTypes = stubTypesImportData();
+      const componentMeta = stubComponentCompilerMeta({
+        properties: [stubComponentCompilerProperty()],
+      });
+
+      const expectedTypeInfo: d.TypeInfo = [
+        {
+          jsdoc: '',
+          internal: false,
+          name: 'propName',
+          optional: false,
+          required: false,
+          type: updatedTypeName,
+        },
+      ];
+
+      const actualTypeInfo = generatePropTypes(componentMeta, stubImportTypes);
 
       expect(actualTypeInfo).toEqual(expectedTypeInfo);
     });
 
     it('returns the correct type information for a single virtual property', () => {
+      const stubImportTypes = stubTypesImportData();
       const componentMeta = stubComponentCompilerMeta({
         virtualProperties: [stubComponentCompilerVirtualProperty()],
       });
@@ -61,12 +107,13 @@ describe('generate-prop-types', () => {
         },
       ];
 
-      const actualTypeInfo = generatePropTypes(componentMeta);
+      const actualTypeInfo = generatePropTypes(componentMeta, stubImportTypes);
 
       expect(actualTypeInfo).toEqual(expectedTypeInfo);
     });
 
     it('returns the correct type information for concrete and virtual properties', () => {
+      const stubImportTypes = stubTypesImportData();
       const componentMeta = stubComponentCompilerMeta({
         properties: [stubComponentCompilerProperty()],
         virtualProperties: [stubComponentCompilerVirtualProperty()],
@@ -91,7 +138,7 @@ describe('generate-prop-types', () => {
         },
       ];
 
-      const actualTypeInfo = generatePropTypes(componentMeta);
+      const actualTypeInfo = generatePropTypes(componentMeta, stubImportTypes);
 
       expect(actualTypeInfo).toEqual(expectedTypeInfo);
     });

--- a/src/compiler/types/tests/stencil-types.spec.ts
+++ b/src/compiler/types/tests/stencil-types.spec.ts
@@ -1,0 +1,298 @@
+import * as d from '@stencil/core/declarations';
+import path from 'path';
+import { stubComponentCompilerMeta } from './ComponentCompilerMeta.stub';
+import { stubComponentCompilerTypeReference } from './ComponentCompilerTypeReference.stub';
+import { stubTypesImportData } from './TypesImportData.stub';
+import { updateTypeIdentifierNames } from '../stencil-types';
+
+describe('stencil-types', () => {
+  describe('updateTypeMemberNames', () => {
+    let dirnameSpy: jest.SpyInstance<ReturnType<typeof path.dirname>, Parameters<typeof path.dirname>>;
+    let resolveSpy: jest.SpyInstance<ReturnType<typeof path.resolve>, Parameters<typeof path.resolve>>;
+
+    beforeEach(() => {
+      dirnameSpy = jest.spyOn(path, 'dirname');
+      dirnameSpy.mockImplementation((path: string) => path);
+
+      resolveSpy = jest.spyOn(path, 'resolve');
+      resolveSpy.mockImplementation((...pathSegments: string[]) => pathSegments.pop());
+    });
+
+    afterEach(() => {
+      dirnameSpy.mockRestore();
+      resolveSpy.mockRestore();
+    });
+
+    describe('no type transformations', () => {
+      it('returns the provided type when no type references exist', () => {
+        const expectedTypeName = 'CustomType';
+
+        const actualTypeName = updateTypeIdentifierNames(
+          {},
+          {},
+          stubComponentCompilerMeta().sourceFilePath,
+          expectedTypeName
+        );
+
+        expect(actualTypeName).toBe(expectedTypeName);
+      });
+
+      it('returns the provided type when no type reference matches are found in the import data', () => {
+        const typeReferences: d.ComponentCompilerTypeReferences = {
+          AnotherType: stubComponentCompilerTypeReference({ location: 'import', path: 'some/stubbed/path' }),
+        };
+        const expectedTypeName = 'CustomType';
+
+        const actualTypeName = updateTypeIdentifierNames(
+          typeReferences,
+          {},
+          stubComponentCompilerMeta().sourceFilePath,
+          expectedTypeName
+        );
+
+        expect(actualTypeName).toBe(expectedTypeName);
+      });
+
+      it('returns the provided type for imports without a path', () => {
+        const expectedTypeName = 'CustomType';
+        const typeReferences: d.ComponentCompilerTypeReferences = {
+          // pretend that the expected type name is a globally accessible type, and therefore has no path
+          [expectedTypeName]: stubComponentCompilerTypeReference({ location: 'global' }),
+        };
+
+        const actualTypeName = updateTypeIdentifierNames(
+          typeReferences,
+          {},
+          stubComponentCompilerMeta().sourceFilePath,
+          expectedTypeName
+        );
+
+        expect(actualTypeName).toBe(expectedTypeName);
+      });
+
+      it("does not change a simple type when there's no import name to alias", () => {
+        const initialType = 'InitialType';
+        const basePath = '~/some/stubbed/path';
+        const typePath = `${basePath}/my-types`;
+
+        const componentCompilerMeta = stubComponentCompilerMeta({
+          sourceFilePath: `${basePath}/my-component.tsx`,
+        });
+        const typeReferences: d.ComponentCompilerTypeReferences = {
+          [initialType]: stubComponentCompilerTypeReference({ location: 'import', path: typePath }),
+        };
+        const typeImports = stubTypesImportData({
+          [typePath]: [
+            {
+              localName: 'SomeOtherType',
+            },
+          ],
+        });
+
+        const actualTypeName = updateTypeIdentifierNames(
+          typeReferences,
+          typeImports,
+          componentCompilerMeta.sourceFilePath,
+          initialType
+        );
+
+        expect(actualTypeName).toBe(initialType);
+      });
+    });
+
+    describe('path resolution', () => {
+      it('replaces a simple type for a relative path beginning with "."', () => {
+        const initialType = 'InitialType';
+        const expectedType = 'NonCollisionType';
+        const basePath = './some/stubbed/path';
+
+        testTypeTransformForPath(basePath, initialType, expectedType);
+      });
+
+      it('replaces a simple type for a relative path beginning with ".."', () => {
+        const initialType = 'InitialType';
+        const expectedType = 'NonCollisionType';
+        const basePath = '../some/stubbed/path';
+
+        testTypeTransformForPath(basePath, initialType, expectedType);
+      });
+
+      it('replaces a simple type for an absolute path', () => {
+        const initialType = 'InitialType';
+        const expectedType = 'NonCollisionType';
+        const basePath = '~/some/stubbed/path';
+
+        testTypeTransformForPath(basePath, initialType, expectedType);
+      });
+
+      /**
+       * Test helper for performing boilerplate setup to verify some initial type T is transformed to a new type T'.
+       * This helper asserts that the generated type matches T'.
+       *
+       * This helper is meant to be used to test that transformation occurs based on the format/type of `basePath`
+       * provided (e.g. relative vs absolute).
+       *
+       * @param basePath the path to use when running the type resolution
+       * @param initialType the original type found in a class member
+       * @param expectedType the type that is expected to be generated
+       */
+      const testTypeTransformForPath = (basePath: string, initialType: string, expectedType: string): void => {
+        const typePath = `${basePath}/my-types`;
+
+        const componentCompilerMeta = stubComponentCompilerMeta({
+          sourceFilePath: `${basePath}/my-component.tsx`,
+        });
+
+        const typeReferences: d.ComponentCompilerTypeReferences = {
+          [initialType]: stubComponentCompilerTypeReference({ location: 'import', path: typePath }),
+        };
+        const typeImports = stubTypesImportData({
+          [typePath]: [
+            {
+              localName: initialType,
+              importName: expectedType,
+            },
+          ],
+        });
+
+        const actualTypeName = updateTypeIdentifierNames(
+          typeReferences,
+          typeImports,
+          componentCompilerMeta.sourceFilePath,
+          initialType
+        );
+
+        expect(actualTypeName).toBe(expectedType);
+      };
+    });
+
+    it('replaces method signature types', () => {
+      const initialType = '(name: SomeType) => Promise<void>';
+      const expectedType = '(name: SomeOtherType) => Promise<void>';
+      const typeMemberNames = [
+        {
+          localName: 'SomeType',
+          importName: 'SomeOtherType',
+        },
+      ];
+
+      testTypeIsTransformed(initialType, expectedType, typeMemberNames);
+    });
+
+    it('replaces duplicate types', () => {
+      const initialType = '(myVal: Ar) => Promise<Ar>';
+      const expectedType = '(myVal: Ar1) => Promise<Ar1>';
+      const typeMemberNames = [
+        {
+          localName: 'Ar',
+          importName: 'Ar1',
+        },
+      ];
+
+      testTypeIsTransformed(initialType, expectedType, typeMemberNames);
+    });
+
+    it('replaces types that are substrings safely', () => {
+      const initialType = '(ar: Ar) => Promise<Array<Ar>>';
+      const expectedType = '(ar: Ar1) => Promise<Array<Ar1>>';
+      const typeMemberNames = [
+        {
+          localName: 'Ar',
+          importName: 'Ar1',
+        },
+      ];
+
+      testTypeIsTransformed(initialType, expectedType, typeMemberNames);
+    });
+
+    it('replaces union types', () => {
+      const initialType = '(myVal: SomeType | AnotherType) => Promise<SomeType | AnotherType>';
+      const expectedType = '(myVal: SomeType1 | AnotherType1) => Promise<SomeType1 | AnotherType1>';
+      const typeMemberNames = [
+        {
+          localName: 'SomeType',
+          importName: 'SomeType1',
+        },
+        {
+          localName: 'AnotherType',
+          importName: 'AnotherType1',
+        },
+      ];
+
+      testTypeIsTransformed(initialType, expectedType, typeMemberNames);
+    });
+
+    it("doesn't replace string literals in types", () => {
+      const initialType = '(myVal: ReadonlyArray<"SomeType">) => Promise<SomeType>';
+      const expectedType = '(myVal: ReadonlyArray<"SomeType">) => Promise<SomeType1>';
+      const typeMemberNames = [
+        {
+          localName: 'SomeType',
+          importName: 'SomeType1',
+        },
+      ];
+
+      testTypeIsTransformed(initialType, expectedType, typeMemberNames);
+    });
+
+    // TODO(STENCIL-419): Re-enable this test
+    xit("doesn't replace resolved types", () => {
+      /**
+       * Edge case, consider the following scenario:
+       * ```ts
+       * type SomeType = 'OneThing'
+       * const SomeType = 'Something' as const;
+       * type FnType = (myVal: ReadonlyArray<`${typeof SomeType}`>) => Promise<SomeType>;
+       * ```
+       *
+       * - `myVal` will resolve to `readonly 'Something'[]`
+       * - the return type will resolve to Promise<'OneThing'>;
+       */
+      const initialType = '(myVal: ReadonlyArray<`${typeof SomeType}`>) => Promise<SomeType>';
+      const expectedType = '(myVal: ReadonlyArray<`${typeof SomeType}`>) => Promise<SomeType1>';
+      const typeMemberNames = [
+        {
+          localName: 'SomeType',
+          importName: 'SomeType1',
+        },
+      ];
+
+      testTypeIsTransformed(initialType, expectedType, typeMemberNames);
+    });
+
+    /**
+     * Test helper for performing boilerplate setup to verify some initial type T is transformed to a new type T'. This
+     * helper asserts that the generated type matches T'.
+     * @param initialType the original type found in a class member
+     * @param expectedType the type that is expected to be generated
+     * @param typeMemberNames a series of aliases that map a locally used type T to some other type T2
+     */
+    const testTypeIsTransformed = (
+      initialType: string,
+      expectedType: string,
+      typeMemberNames: d.TypesMemberNameData[]
+    ) => {
+      const basePath = '~/some/stubbed/path';
+
+      const componentCompilerMeta = stubComponentCompilerMeta({
+        sourceFilePath: `${basePath}/my-component.tsx`,
+      });
+
+      const typeReferences: d.ComponentCompilerTypeReferences = {
+        [initialType]: stubComponentCompilerTypeReference({ location: 'import', path: `${basePath}/my-types` }),
+      };
+      const typeImports = stubTypesImportData({
+        [`${basePath}/my-types`]: typeMemberNames,
+      });
+
+      const actualTypeName = updateTypeIdentifierNames(
+        typeReferences,
+        typeImports,
+        componentCompilerMeta.sourceFilePath,
+        initialType
+      );
+
+      expect(actualTypeName).toBe(expectedType);
+    };
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See the linked GH Issue below

GitHub Issue Number: https://github.com/ionic-team/stencil/issues/2859


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the type resolution of types used by components when
generating a `components.d.ts` file. types that have been deduplicated
are now piped to functions used to generate the types for class members
that are decorated with `@Prop()`, `@Event()`, and `@Method()`, and used
when generating the types for each.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
Unit tests have been written + passed

Manually we can verify this against the reproduction repo:

First, let's get the baseline setup:
```
git clone https://github.com/jcfranco/stencil-duplicate-types-not-assigned-correctly-in-component-typings sample
cd sample
npm i && git commit -am 'baseline after npm install'
npm i @stencil/core@latest
git commit -am 'install latest stencil version, 2.15.0'
npm run build
git commit -am 'build with stencil v2.15.0'
git add *
git commit -m 'build with stencil v2.15.0'
```

In the generated `src/components.d.ts` file, we can confirm the bug:
```ts
import { Name } from "./components/my-person/resources";
import { Name as Name1 } from "./components/my-pupper/resources";
export namespace Components {
    interface MyComponent {
        "saySomething": (name: Name) => Promise<void>;
    }
    interface MyPupper {
        "saySomething": (name: Name) => Promise<void>;
    }
}
```
Note how `MyPupper`'s `saySomething` method uses `Name`, not `Name1`.

By checking out this branch, running `npm ci && npm build && npm pack`, we can generated a tarball with the changes included in this PR, we can install the tarball in the reproduction repo + rebuild
```
npm i <PATH_TO_TAR>
npm run build
```
which generates:
```ts
import { Name } from "./components/my-person/resources";
import { Name as Name1 } from "./components/my-pupper/resources";
export namespace Components {
    interface MyComponent {
        "saySomething": (name: Name) => Promise<void>;
    }
    interface MyPupper {
        "saySomething": (name: Name1) => Promise<void>;
    }
}
```
## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
