### PR TITLE
chore(github): set browserstack node to v12

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-node@56337c425554a6be30cdef71bf441f15be286854 # v3.1.1
         with:
-          node-version: '12'
+          node-version: '14'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

when i merged https://github.com/ionic-team/stencil/pull/3332 into `main`, that commit has a newer
author/commit date than the PR in which we dropped v12 support. as a result, when i updated the `v3.0.0-dev`
branch with the latest from `main`, I accidentally overwrote part of the commit dropping node 12 support

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

in https://github.com/ionic-team/stencil/pull/3331, the minimum value of browserstack's node version to v14
accidentally. node v12 is still supported; this commit reverts that
change

this is the same PR as https://github.com/ionic-team/stencil/pull/3332, we need to apply this to the `v3.0.0-dev`
branch now (this is user error on my end)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
browserstack should run successfully with node 14 again, but it doesn't - this is due to how
GH picks up the base node version for the `pull_request_target` trigger. Unfortunately we'll 
have to "just land it" for things to work again