### PR TITLE
chore(docs): update BREAKING_CHANGES.md for `assetsDir` backwards compat

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -652,3 +652,20 @@ Stencil v3.0.0 is in development at this time and has not been released. The lis
 change. Further details on each of these items will be included prior to the release.
 
 - [fix(testing): puppeteer v10 support #2934](https://github.com/ionic-team/stencil/pull/2934)
+
+## DEPRECATIONS
+
+### backwards compatibility for `@Component.assetsDir` EOL
+
+The `assetsDir` component prop was [#componentassetsdir](previously deprecated)
+but some backwards compatibility was retained with a warning message. In
+Stencil V3 this backwards compatibility is being removed and Stencil users will
+have to remove all usage of `assetsDir` in favor of `assetsDirs`.
+
+
+```diff
+@Component({
+-  assetsDir: 'resource',
++  assetsDirs: ['resource']
+})
+```

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -657,7 +657,7 @@ change. Further details on each of these items will be included prior to the rel
 
 ### backwards compatibility for `@Component.assetsDir` EOL
 
-The `assetsDir` component prop was [#componentassetsdir](previously deprecated)
+The `assetsDir` component prop was [previous deprecated](#componentassetsdir)
 but some backwards compatibility was retained with a warning message. In
 Stencil V3 this backwards compatibility is being removed and Stencil users will
 have to remove all usage of `assetsDir` in favor of `assetsDirs`.

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -657,7 +657,7 @@ change. Further details on each of these items will be included prior to the rel
 
 ### backwards compatibility for `@Component.assetsDir` EOL
 
-The `assetsDir` component prop was [previous deprecated](#componentassetsdir)
+The `assetsDir` component prop was [previously deprecated](#componentassetsdir)
 but some backwards compatibility was retained with a warning message. In
 Stencil V3 this backwards compatibility is being removed and Stencil users will
 have to remove all usage of `assetsDir` in favor of `assetsDirs`.


### PR DESCRIPTION
In #3341 we removed backwards compatibility for the deprecated
`assetsDir` component decorator prop. This updates the BREAKING_CHANGES
document to reflect that change.

STENCIL-410: Remove Backwards Compatibility for assetDir Field on @component

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?


GitHub Issue Number: N/A


## What is the new behavior?

Update hte `BREAKING_CHANGES` document to add in some documentation for #3341.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
