### PR TITLE
fix(sys): tweak NodeLazyRequire logic around too-high-versions errors

### DIFF
--- a/src/sys/node/node-lazy-require.ts
+++ b/src/sys/node/node-lazy-require.ts
@@ -73,7 +73,7 @@ export class NodeLazyRequire implements d.LazyRequire {
           const installedVersionIsGood = maxVersion
             ? // if maxVersion, check that `minVersion <= installedVersion <= maxVersion`
               satisfies(installedPkgJson.version, `${minVersion} - ${major(maxVersion)}.x`)
-            : // else, just heck that `minVersion <= installedVersion`
+            : // else, just check that `minVersion <= installedVersion`
               semverLte(minVersion, installedPkgJson.version);
 
           if (installedVersionIsGood) {

--- a/src/sys/node/node-sys.ts
+++ b/src/sys/node/node-sys.ts
@@ -588,14 +588,13 @@ export function createNodeSys(c: { process?: any } = {}) {
   const nodeResolve = new NodeResolveModule();
 
   sys.lazyRequire = new NodeLazyRequire(nodeResolve, {
-    // [minimumVersion, recommendedVersion]
-    '@types/jest': ['24.9.1', '27.0.3'],
-    jest: ['24.9.0', '27.4.5'],
-    'jest-cli': ['24.9.0', '27.4.5'],
-    pixelmatch: ['4.0.2', '4.0.2'],
-    puppeteer: ['1.19.0', '10.0.0'],
-    'puppeteer-core': ['1.19.0', '5.2.1'],
-    'workbox-build': ['4.3.1', '4.3.1'],
+    '@types/jest': { minVersion: '24.9.1', recommendedVersion: '27.0.3', maxVersion: '27.0.0' },
+    jest: { minVersion: '24.9.1', recommendedVersion: '27.0.3', maxVersion: '27.0.0' },
+    'jest-cli': { minVersion: '24.9.0', recommendedVersion: '27.4.5', maxVersion: '27.0.0' },
+    pixelmatch: { minVersion: '4.0.2', recommendedVersion: '4.0.2' },
+    puppeteer: { minVersion: '1.19.0', recommendedVersion: '10.0.0' },
+    'puppeteer-core': { minVersion: '1.19.0', recommendedVersion: '5.2.1' },
+    'workbox-build': { minVersion: '4.3.1', recommendedVersion: '4.3.1' },
   });
 
   prcs.on('SIGINT', runInterruptsCallbacks);

--- a/src/sys/node/test/node-lazy-require.spec.ts
+++ b/src/sys/node/test/node-lazy-require.spec.ts
@@ -1,4 +1,4 @@
-import { NodeLazyRequire } from '../node-lazy-require';
+import { LazyDependencies, NodeLazyRequire } from '../node-lazy-require';
 import { buildError } from '@utils';
 import { NodeResolveModule } from '../node-resolve-module';
 import fs from 'graceful-fs';
@@ -21,45 +21,63 @@ describe('node-lazy-require', () => {
         readFSMock.mockClear();
       });
 
-      function setup() {
+      const jestTestRange = (maxVersion = '38.0.1'): LazyDependencies => ({
+        jest: {
+          minVersion: '2.0.7',
+          recommendedVersion: '36.0.1',
+          maxVersion,
+        },
+      });
+
+      function setup(versionRange: LazyDependencies) {
         const resolveModule = new NodeResolveModule();
-        const nodeLazyRequire = new NodeLazyRequire(resolveModule, {
-          jest: ['2.0.7', '38.0.1'],
-        });
+        const nodeLazyRequire = new NodeLazyRequire(resolveModule, versionRange);
         return nodeLazyRequire;
       }
 
       it.each(['2.0.7', '10.10.10', '38.0.1', '38.0.2', '38.5.17'])(
         'should not error if installed package has a suitable major version (%p)',
         async (testVersion) => {
-          const nodeLazyRequire = setup();
+          const nodeLazyRequire = setup(jestTestRange());
           readFSMock.mockReturnValue(mockPackageJson(testVersion));
           let diagnostics = await nodeLazyRequire.ensure('.', ['jest']);
           expect(diagnostics.length).toBe(0);
         }
       );
 
-      it('should error if the installed version of a package is too low', async () => {
-        const nodeLazyRequire = setup();
+      it.each(['2.0.7', '10.10.10', '36.0.1', '38.0.2', '38.5.17'])(
+        'should never error with versions above minVersion if there is no maxVersion supplied (%p)',
+        async (testVersion) => {
+          const nodeLazyRequire = setup(jestTestRange(undefined));
+          readFSMock.mockReturnValue(mockPackageJson(testVersion));
+          let diagnostics = await nodeLazyRequire.ensure('.', ['jest']);
+          expect(diagnostics.length).toBe(0);
+        }
+      );
+
+      it.each(['38', undefined])('should error w/ installed version too low and maxVersion=%p', async (maxVersion) => {
+        const range = jestTestRange(maxVersion);
+        const nodeLazyRequire = setup(range);
         readFSMock.mockReturnValue(mockPackageJson('1.1.1'));
         let [error] = await nodeLazyRequire.ensure('.', ['jest']);
         expect(error).toEqual({
           ...buildError([]),
           header: 'Please install supported versions of dev dependencies with either npm or yarn.',
-          messageText: 'npm install --save-dev jest@38.0.1',
+          messageText: `npm install --save-dev jest@${range.jest.recommendedVersion}`,
         });
       });
 
       it.each(['100.1.1', '38.0.1-alpha.0'])(
         'should error if the installed version of a package is too high (%p)',
         async (version) => {
-          const nodeLazyRequire = setup();
+          const range = jestTestRange();
+          const nodeLazyRequire = setup(range);
           readFSMock.mockReturnValue(mockPackageJson(version));
           let [error] = await nodeLazyRequire.ensure('.', ['jest']);
           expect(error).toEqual({
             ...buildError([]),
             header: 'Please install supported versions of dev dependencies with either npm or yarn.',
-            messageText: 'npm install --save-dev jest@38.0.1',
+            messageText: `npm install --save-dev jest@${range.jest.recommendedVersion}`,
           });
         }
       );


### PR DESCRIPTION
This changes the logic that we use in the `NodeLazyRequire` class to
error out in fewer situations. The changes are:

- the data structure for specifying our version ranges is changed from
  `[string, string]` (`[minVersion, recommendedVersion]`) to an object
  with `minVersion` `recommendedVersion` required properties and an
  optional `maxVersion` property.
- in the `ensure` method on `NodeLazyRequire` we check if `maxVersion`
  is defined on a given version range requirement.
    - If so, we check that the installed version is greater than or
      equal to `minVersion` and less than the major version of
      `maxVersion`.
    - If not, we just check that `minVersion <= installedVersion`

This should give us the flexibility to mark certain versions of packages
as incompatible (for instance jest@28) without having to do that for all
packages that we lazy require. This is helpful because for most of them
we just want to set a minimum version and don't have a need for an
enforced maximum version.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A

In #3346 we added a check that packages that we lazy require for testing and whatnot (basically, `jest` and a few other things) were between the specified minimum version and the recommended version. This will cause an error at runtime if these requirements are not met.

On further reflection this isn't quite the behavior that we want. We only want to enforce a maximum version right now for Jest, not for the other packages we load in this manner, but the implementation in #3346 doesn't have any granularity to it.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- the data structure for specifying our version ranges is changed from
  `[string, string]` (`[minVersion, recommendedVersion]`) to an object
  with `minVersion` `recommendedVersion` required properties and an
  optional `maxVersion` property.
- in the `ensure` method on `NodeLazyRequire` we check if `maxVersion`
  is defined on a given version range requirement.
    - If so, we check that the installed version is greater than or
      equal to `minVersion` and less than the major version of
      `maxVersion`.
    - If not, we just check that `minVersion <= installedVersion`

This should give us the flexibility to mark certain versions of packages
as incompatible (for instance jest@28) without having to do that for all
packages that we lazy require. This is helpful because for most of them
we just want to set a minimum version and don't have a need for an
enforced maximum version.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Unit testing, I also built and tried this out in a test component repo and confirmed that we get errors for Jest but not for other dependencies like puppeteer.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
