### PR TITLE
chore(github): set stale issue sweep to 30 days

### DIFF
--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -71,7 +71,7 @@ noReproduction:
   dryRun: false
 
 stale:
-  days: 180
+  days: 30
   maxIssuesPerRun: 100
   exemptLabels:
     - "Bug: Validated"


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Ionitron configuration


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Ionitron waits 6 months (180 days) to mark an issue as stale - IMO this is too
long - context gets lost, conversations drop, etc. By shortening this
period, we have a better chance at catching truly important issues, and
can close those that folks may not have a desire to participate in
anymore.


GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit drops the number of days it takes for the repo's bot,
ionitron, to mark an issue as stale (which closes the issue and locks
conversation on the issue) from 180 days to 30.

the reason for this is that six months to mark an issue as stale is too
long - context gets lost, conversations drop, etc. by shortening this
period, we have a better chance at catching truly important issues, and
can close those that folks may not have a desire to participate in
anymore.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

this commit was tested by derviving a url against the `exemptLabels`
values for this action. https://github.com/ionic-team/stencil/issues?q=is%3Aissue+is%3Aopen+-label%3A%22Bug%3A+Validated%22+-label%3A%22triage%22+-label%3A%22Feature%3A+Want+this%3F+Upvote+it%21%22+-label%3A%22good+first+issue%22+-label%3A%22help+wanted%22+-label%3A%22Reply+Received%22+-label%3A%22Request+for+Comments%22+-label%3A%22Resolution%3A+Needs+Investigation%22+-label%3A%22Resolution%3A+Refine%22+

right before we merge this, we should do one final check against this URL