### PR TITLE
chore(tests): fix end to end .d.ts file

### DIFF
--- a/test/end-to-end/src/components.d.ts
+++ b/test/end-to-end/src/components.d.ts
@@ -65,6 +65,14 @@ export namespace Components {
     interface StateCmp {
     }
 }
+export interface CarListCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLCarListElement;
+}
+export interface EventCmpCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLEventCmpElement;
+}
 declare global {
     interface HTMLAppRootElement extends Components.AppRoot, HTMLStencilElement {
     }
@@ -219,7 +227,7 @@ declare namespace LocalJSX {
     }
     interface CarList {
         "cars"?: CarData[];
-        "onCarSelected"?: (event: CustomEvent<CarData>) => void;
+        "onCarSelected"?: (event: CarListCustomEvent<CarData>) => void;
         "selected"?: CarData;
     }
     interface DomApi {
@@ -233,9 +241,9 @@ declare namespace LocalJSX {
     interface EnvData {
     }
     interface EventCmp {
-        "onMy-event-with-options"?: (event: CustomEvent<{ mph: number }>) => void;
-        "onMyDocumentEvent"?: (event: CustomEvent<any>) => void;
-        "onMyWindowEvent"?: (event: CustomEvent<number>) => void;
+        "onMy-event-with-options"?: (event: EventCmpCustomEvent<{ mph: number }>) => void;
+        "onMyDocumentEvent"?: (event: EventCmpCustomEvent<any>) => void;
+        "onMyWindowEvent"?: (event: EventCmpCustomEvent<number>) => void;
     }
     interface ImportAssets {
     }


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): I didn't mark this as a 'fix' in the pr summary, since its not a fix that affects end users (and shouldn't show up in the generated changelog)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

our `components.d.ts` file is out of date, see the 'new behavior' section for why and
how we'll mitigate in the future

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit checks in changes to `test/end-to-end/src/components.d.ts`
that are generated starting with 846740fa1f074e401fa20be90d64e87f8db99c88
(https://github.com/ionic-team/stencil/pull/3296)

we missed this as a result of relying on ci to run the end to end tests
for us, rather than ever running them locally. the changes found in this
commit were generated by running `npm run test.end-to-end` on the commit
immediately preceding this one.

to avoid issues like this in the future, stencil-451 has been created
and added to the backlog

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

N/A

