### PR TITLE
remove unused exports on output utils

### DIFF
--- a/src/compiler/config/outputs/index.ts
+++ b/src/compiler/config/outputs/index.ts
@@ -1,6 +1,10 @@
 import type * as d from '../../../declarations';
 import { buildError, buildWarn } from '@utils';
-import { DIST_CUSTOM_ELEMENTS_BUNDLE, VALID_TYPES } from '../../output-targets/output-utils';
+import {
+  DIST_CUSTOM_ELEMENTS_BUNDLE,
+  isValidConfigOutputTarget,
+  VALID_CONFIG_OUTPUT_TARGETS,
+} from '../../output-targets/output-utils';
 import { validateCollection } from './validate-collection';
 import { validateCustomElement } from './validate-custom-element';
 import { validateCustomOutput } from './validate-custom-output';
@@ -17,11 +21,11 @@ export const validateOutputTargets = (config: d.UnvalidatedConfig, diagnostics: 
   const userOutputs = (config.outputTargets || []).slice();
 
   userOutputs.forEach((outputTarget) => {
-    if (!VALID_TYPES.includes(outputTarget.type)) {
+    if (!isValidConfigOutputTarget(outputTarget.type)) {
       const err = buildError(diagnostics);
       err.messageText = `Invalid outputTarget type "${
         outputTarget.type
-      }". Valid outputTarget types include: ${VALID_TYPES.map((t) => `"${t}"`).join(', ')}`;
+      }". Valid outputTarget types include: ${VALID_CONFIG_OUTPUT_TARGETS.map((t) => `"${t}"`).join(', ')}`;
     } else if (outputTarget.type === DIST_CUSTOM_ELEMENTS_BUNDLE) {
       // TODO(STENCIL-260): Remove this check when the 'dist-custom-elements-bundle' is removed
       const warning = buildWarn(diagnostics);

--- a/src/compiler/config/outputs/validate-angular.ts
+++ b/src/compiler/config/outputs/validate-angular.ts
@@ -1,8 +1,9 @@
 import type * as d from '../../../declarations';
 import { isOutputTargetAngular } from '../../output-targets/output-utils';
 import { isAbsolute, join } from 'path';
+import {OutputTargetAngular} from '../../../declarations';
 
-export const validateAngular = (userConfig: d.Config, userOutputs: d.OutputTarget[]) => {
+export const validateAngular = (userConfig: d.Config, userOutputs: d.OutputTarget[]): OutputTargetAngular[] => {
   const angularOutputTargets = userOutputs.filter(isOutputTargetAngular);
   return angularOutputTargets.map((outputTarget) => {
     let directivesProxyFile = outputTarget.directivesProxyFile;

--- a/src/compiler/config/outputs/validate-angular.ts
+++ b/src/compiler/config/outputs/validate-angular.ts
@@ -1,7 +1,7 @@
 import type * as d from '../../../declarations';
 import { isOutputTargetAngular } from '../../output-targets/output-utils';
 import { isAbsolute, join } from 'path';
-import {OutputTargetAngular} from '../../../declarations';
+import { OutputTargetAngular } from '../../../declarations';
 
 export const validateAngular = (userConfig: d.Config, userOutputs: d.OutputTarget[]): OutputTargetAngular[] => {
   const angularOutputTargets = userOutputs.filter(isOutputTargetAngular);

--- a/src/compiler/output-targets/output-utils.ts
+++ b/src/compiler/output-targets/output-utils.ts
@@ -129,9 +129,11 @@ type ValidConfigOutputTarget = typeof VALID_CONFIG_OUTPUT_TARGETS[number];
  * @returns whether or not the targetType is a valid, configurable output target.
  */
 export function isValidConfigOutputTarget(targetType: string): targetType is ValidConfigOutputTarget {
-  // unfortunately `includes` is typed on `Array<T>` as `(el: T):
+  // unfortunately `includes` is typed on `ReadonlyArray<T>` as `(el: T):
   // boolean` so a `string` cannot be passed to `includes` on a
   // `ReadonlyArray` 😢 thus we `as any`
+  //
+  // see microsoft/TypeScript#31018 for some discussion of this
   return VALID_CONFIG_OUTPUT_TARGETS.includes(targetType as any);
 }
 

--- a/src/compiler/output-targets/output-utils.ts
+++ b/src/compiler/output-targets/output-utils.ts
@@ -124,6 +124,9 @@ type ValidConfigOutputTarget = typeof VALID_CONFIG_OUTPUT_TARGETS[number];
 
 /**
  * Check whether a given output target is a valid one to be set in a Stencil config
+ *
+ * @param targetType the type which we want to check
+ * @returns whether or not the targetType is a valid, configurable output target.
  */
 export function isValidConfigOutputTarget(targetType: string): targetType is ValidConfigOutputTarget {
   // unfortunately `includes` is typed on `Array<T>` as `(el: T):

--- a/src/compiler/output-targets/output-utils.ts
+++ b/src/compiler/output-targets/output-utils.ts
@@ -14,36 +14,6 @@ export const relativeImport = (pathFrom: string, pathTo: string, ext?: string, a
   return normalizePath(`${relativePath}/${basename(pathTo, ext)}`);
 };
 
-export const getDistEsmDir = (outputTarget: d.OutputTargetDist, sourceTarget?: d.SourceTarget) =>
-  join(outputTarget.buildDir, 'esm', sourceTarget || '');
-
-export const getDistEsmComponentsDir = (outputTarget: d.OutputTargetDist, sourceTarget: d.SourceTarget) =>
-  join(getDistEsmDir(outputTarget, sourceTarget), 'build');
-
-export const getDistEsmIndexPath = (outputTarget: d.OutputTargetDist, sourceTarget?: d.SourceTarget) =>
-  join(getDistEsmDir(outputTarget, sourceTarget), 'index.js');
-
-export const getDefineCustomElementsPath = (
-  config: d.Config,
-  outputTarget: d.OutputTargetDist,
-  sourceTarget: d.SourceTarget
-) => join(getDistEsmDir(outputTarget, sourceTarget), getDefineEsmFilename(config));
-
-export const getComponentsEsmBuildPath = (
-  config: d.Config,
-  outputTarget: d.OutputTargetDist,
-  sourceTarget: d.SourceTarget
-) => join(getDistEsmDir(outputTarget, sourceTarget), getComponentsEsmFileName(config));
-
-export const getCoreEsmFileName = (config: d.Config) => `${config.fsNamespace}.core.js`;
-
-export const getDefineEsmFilename = (config: d.Config) => `${config.fsNamespace}.define.js`;
-
-export const getComponentsEsmFileName = (config: d.Config) => `${config.fsNamespace}.components.js`;
-
-export const getLoaderEsmPath = (outputTarget: d.OutputTargetDist) =>
-  join(outputTarget.buildDir, outputTarget.esmLoaderPath);
-
 export const getComponentsDtsSrcFilePath = (config: d.Config) => join(config.srcDir, GENERATED_DTS);
 
 export const getComponentsDtsTypesFilePath = (outputTarget: d.OutputTargetDist | d.OutputTargetDistTypes) =>
@@ -99,40 +69,35 @@ export const isOutputTargetDistTypes = (o: d.OutputTarget): o is d.OutputTargetD
 export const getComponentsFromModules = (moduleFiles: d.Module[]) =>
   sortBy(flatOne(moduleFiles.map((m) => m.cmps)), (c: d.ComponentCompilerMeta) => c.tagName);
 
-export const canSkipOutputTargets = (buildCtx: d.BuildCtx) => {
-  if (buildCtx.components.length === 0) {
-    return true;
-  }
-  if (buildCtx.requiresFullBuild) {
-    return false;
-  }
-  if (buildCtx.isRebuild && (buildCtx.hasScriptChanges || buildCtx.hasStyleChanges || buildCtx.hasHtmlChanges)) {
-    return false;
-  }
-  return true;
-};
-
-export const ANGULAR = `angular`;
+export const ANGULAR = 'angular';
 export const COPY = 'copy';
-export const CUSTOM = `custom`;
-export const DIST = `dist`;
-export const DIST_COLLECTION = `dist-collection`;
-export const DIST_CUSTOM_ELEMENTS = `dist-custom-elements`;
-export const DIST_CUSTOM_ELEMENTS_BUNDLE = `dist-custom-elements-bundle`;
+export const CUSTOM = 'custom';
+export const DIST = 'dist';
+export const DIST_COLLECTION = 'dist-collection';
+export const DIST_CUSTOM_ELEMENTS = 'dist-custom-elements';
+export const DIST_CUSTOM_ELEMENTS_BUNDLE = 'dist-custom-elements-bundle';
 
-export const DIST_TYPES = `dist-types`;
-export const DIST_HYDRATE_SCRIPT = `dist-hydrate-script`;
-export const DIST_LAZY = `dist-lazy`;
-export const DIST_LAZY_LOADER = `dist-lazy-loader`;
+export const DIST_TYPES = 'dist-types';
+export const DIST_HYDRATE_SCRIPT = 'dist-hydrate-script';
+export const DIST_LAZY = 'dist-lazy';
+export const DIST_LAZY_LOADER = 'dist-lazy-loader';
 export const DIST_GLOBAL_STYLES = 'dist-global-styles';
 export const DOCS_CUSTOM = 'docs-custom';
-export const DOCS_JSON = `docs-json`;
-export const DOCS_README = `docs-readme`;
-export const DOCS_VSCODE = `docs-vscode`;
-export const STATS = `stats`;
-export const WWW = `www`;
+export const DOCS_JSON = 'docs-json';
+export const DOCS_README = 'docs-readme';
+export const DOCS_VSCODE = 'docs-vscode';
+export const STATS = 'stats';
+export const WWW = 'www';
 
-export const VALID_TYPES = [
+/**
+ * Valid output targets to specify in a Stencil config.
+ *
+ * Note that there are some output targets (e.g. `DIST_TYPES`) which are
+ * programmatically set as output targets by the compiler when other output
+ * targets (in that case `DIST`) are set, but which are _not_ supported in a
+ * Stencil config. This is enforced in the output target validation code.
+ */
+export const VALID_CONFIG_OUTPUT_TARGETS = [
   // DIST
   WWW,
   DIST,
@@ -153,6 +118,18 @@ export const VALID_TYPES = [
   COPY,
   CUSTOM,
   STATS,
-];
+] as const;
+
+type ValidConfigOutputTarget = typeof VALID_CONFIG_OUTPUT_TARGETS[number];
+
+/**
+ * Check whether a given output target is a valid one to be set in a Stencil config
+ */
+export function isValidConfigOutputTarget(targetType: string): targetType is ValidConfigOutputTarget {
+  // unfortunately `includes` is typed on `Array<T>` as `(el: T):
+  // boolean` so a `string` cannot be passed to `includes` on a
+  // `ReadonlyArray` 😢 thus we `as any`
+  return VALID_CONFIG_OUTPUT_TARGETS.includes(targetType as any);
+}
 
 export const GENERATED_DTS = 'components.d.ts';

--- a/src/compiler/output-targets/test/output-utils.spec.ts
+++ b/src/compiler/output-targets/test/output-utils.spec.ts
@@ -1,0 +1,16 @@
+import { DIST_TYPES, isValidConfigOutputTarget, VALID_CONFIG_OUTPUT_TARGETS } from '../output-utils';
+
+describe('output-utils tests', () => {
+  describe('isValidConfigOutputTarget', () => {
+    it.each(VALID_CONFIG_OUTPUT_TARGETS)('should return true for valid output types', (outputTargetType) => {
+      expect(isValidConfigOutputTarget(outputTargetType)).toBe(true);
+    });
+
+    it.each(['', 'my-target-that-i-made-up', DIST_TYPES])(
+      'should return false for invalid config output types',
+      (outputTargetType) => {
+        expect(isValidConfigOutputTarget(outputTargetType)).toBe(false);
+      }
+    );
+  });
+});

--- a/src/compiler/output-targets/test/output-utils.spec.ts
+++ b/src/compiler/output-targets/test/output-utils.spec.ts
@@ -2,12 +2,12 @@ import { DIST_TYPES, isValidConfigOutputTarget, VALID_CONFIG_OUTPUT_TARGETS } fr
 
 describe('output-utils tests', () => {
   describe('isValidConfigOutputTarget', () => {
-    it.each(VALID_CONFIG_OUTPUT_TARGETS)('should return true for valid output types', (outputTargetType) => {
+    it.each(VALID_CONFIG_OUTPUT_TARGETS)('should return true for valid output type "%s"', (outputTargetType) => {
       expect(isValidConfigOutputTarget(outputTargetType)).toBe(true);
     });
 
     it.each(['', 'my-target-that-i-made-up', DIST_TYPES])(
-      'should return false for invalid config output types',
+      'should return false for invalid config output type "%s"',
       (outputTargetType) => {
         expect(isValidConfigOutputTarget(outputTargetType)).toBe(false);
       }

--- a/src/compiler/types/tests/validate-package-json.spec.ts
+++ b/src/compiler/types/tests/validate-package-json.spec.ts
@@ -2,6 +2,7 @@ import type * as d from '@stencil/core/declarations';
 import { mockBuildCtx, mockCompilerCtx, mockConfig } from '@stencil/core/testing';
 import * as v from '../validate-build-package-json';
 import path from 'path';
+import { DIST_CUSTOM_ELEMENTS_BUNDLE } from '../../output-targets/output-utils';
 
 describe('validate-package-json', () => {
   let config: d.Config;
@@ -90,7 +91,7 @@ describe('validate-package-json', () => {
     it('validate custom elements module', async () => {
       config.outputTargets = [
         {
-          type: 'dist-custom-elements-bundle',
+          type: DIST_CUSTOM_ELEMENTS_BUNDLE,
           dir: path.join(root, 'custom-elements'),
         },
       ];
@@ -109,7 +110,7 @@ describe('validate-package-json', () => {
     it('missing dist module, but has custom elements output', async () => {
       config.outputTargets = [
         {
-          type: 'dist-custom-elements-bundle',
+          type: DIST_CUSTOM_ELEMENTS_BUNDLE,
           dir: path.join(root, 'custom-elements'),
         },
       ];


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): removing unused exports


## What is the current behavior?


GitHub Issue Number: N/A


## What is the new behavior?


This removes unused exports from `src/compiler/output-targets/output-utils.ts`, just to move the needle a little bit on our unused exports tech debt burndown. It also fixes some strict null checks compiler errors that were a bit incidental to this, and makes a few (small) code changes in the output-utils file.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Tests are passing, could be good to validate some of this just by building a compiler and running it on some example stuff.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
