### PR TITLE
refactor(utils): remove unused getFileExtension utilities

### DIFF
--- a/src/utils/test/util.spec.ts
+++ b/src/utils/test/util.spec.ts
@@ -145,30 +145,6 @@ describe('util', () => {
     });
   });
 
-  describe('hasFileExtension', () => {
-    it('should return true for .scss and .sass files', () => {
-      expect(util.hasFileExtension('.scss', ['scss', 'sass'])).toEqual(true);
-      expect(util.hasFileExtension('foo.scss', ['scss', 'sass'])).toEqual(true);
-      expect(util.hasFileExtension('foo/bar.scss', ['scss', 'sass'])).toEqual(true);
-      expect(util.hasFileExtension('.sass', ['scss', 'sass'])).toEqual(true);
-      expect(util.hasFileExtension('foo.sass', ['scss', 'sass'])).toEqual(true);
-      expect(util.hasFileExtension('foo/bar.sass', ['scss', 'sass'])).toEqual(true);
-    });
-
-    it('should return false for other types of files', () => {
-      expect(util.hasFileExtension('.stss', ['scss', 'sass'])).toEqual(false);
-      expect(util.hasFileExtension('foo.html', ['scss', 'sass'])).toEqual(false);
-      expect(util.hasFileExtension('foo/bar.css', ['scss', 'sass'])).toEqual(false);
-    });
-
-    it('should be case insensitive', () => {
-      expect(util.hasFileExtension('.sCss', ['scss', 'sass'])).toEqual(true);
-      expect(util.hasFileExtension('foo.SCSS', ['scss', 'sass'])).toEqual(true);
-      expect(util.hasFileExtension('.sAss', ['scss', 'sass'])).toEqual(true);
-      expect(util.hasFileExtension('foo/bar.saSS', ['scss', 'sass'])).toEqual(true);
-    });
-  });
-
   it('createJsVarName', () => {
     expect(util.createJsVarName('./scoped-style-import.css?tag=my-button&encapsulation=scoped')).toBe(
       'scopedStyleImportCss'

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -25,16 +25,6 @@ export const createJsVarName = (fileName: string) => {
   return fileName;
 };
 
-export const getFileExt = (fileName: string) => {
-  if (typeof fileName === 'string') {
-    const parts = fileName.split('.');
-    if (parts.length > 1) {
-      return parts[parts.length - 1].toLowerCase();
-    }
-  }
-  return null;
-};
-
 /**
  * Test if a file is a typescript source file, such as .ts or .tsx.
  * However, d.ts files and spec.ts files return false.

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -80,11 +80,6 @@ export const isJsFile = (filePath: string) => {
   return false;
 };
 
-export const hasFileExtension = (filePath: string, extensions: string[]) => {
-  filePath = filePath.toLowerCase();
-  return extensions.some((ext) => filePath.endsWith('.' + ext));
-};
-
 /**
  * Generate the preamble to be placed atop the main file of the build
  * @param config the Stencil configuration file


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The code that is removed in this PR is never used

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit removes the unused getFileExtension and getFileExt functions from stencil's
utilities and their related test code

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Unit tests pass locally

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
