### PR TITLE
chore(lint): add initial eslint jsdoc @param rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
+  plugins: ['@typescript-eslint', 'jsdoc'],
   extends: [
     // including prettier here ensures that we don't set any rules which will conflict
     // with Prettier's formatting. Keep it last in the list so that nothing else messes
@@ -12,8 +12,32 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': ['error', {
       "argsIgnorePattern": "^_",
       // TODO(STENCIL-452): Investigate using eslint-plugin-react to remove the need for varsIgnorePattern
-      "varsIgnorePattern": "^(h|Fragment)$" 
+      "varsIgnorePattern": "^(h|Fragment)$"
     }],
+    /**
+     * Configuration for the JSDoc plugin rules can be found at:
+     * https://github.com/gajus/eslint-plugin-jsdoc
+     */
+    // validates that the name immediately following `@param` matches the parameter name in the function signature
+    // this works in conjunction with "jsdoc/require-param"
+    "jsdoc/check-param-names": [
+      "error", {
+      // if `checkStructured` is `true`, it asks that the JSDoc describe the fields being destructured.
+      // turn this off to not leak function internals/discourage describing them
+      checkDestructured: false,
+    }],
+    // require that jsdoc attached to a method/function require one `@param` per parameter
+    "jsdoc/require-param": [
+      "error", {
+        // if `checkStructured` is `true`, it asks that the JSDoc describe the fields being destructured.
+        // turn this off to not leak function internals/discourage describing them
+        checkDestructured: false,
+        // always check setters as they should require a parameter (by definition)
+        checkSetters: true
+      }],
+    // rely on TypeScript types to be the source of truth, minimize verbosity in comments
+    "jsdoc/require-param-type": ["off"],
+    "jsdoc/require-param-description": ["error"],
     'prefer-const': 'error',
     'no-var': 'error',
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "dts-bundle-generator": "~5.3.0",
         "eslint": "^8.13.0",
         "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-jsdoc": "^39.3.1",
         "execa": "4.1.0",
         "exit": "^0.1.2",
         "fast-deep-equal": "3.1.3",
@@ -661,6 +662,20 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.31.0.tgz",
+      "integrity": "sha512-tc1/iuQcnaiSIUVad72PBierDFpsxdUHtEF/OrfqvM1CBAsIoMP51j52jTMb3dXriwhieTo289InzZj72jL3EQ==",
+      "dev": true,
+      "dependencies": {
+        "comment-parser": "1.3.1",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "~3.1.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || ^17 || ^18"
+      }
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.1",
@@ -3631,6 +3646,15 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
+    "node_modules/comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -4903,6 +4927,71 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "39.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.1.tgz",
+      "integrity": "sha512-EVee7DW7mIKjQ+i86O3sV8n1BdXXiBo0gqY7S7TYTMEBzZoo4B/xNg0fl+b9ktIJtj6H0einhO3eMpwY2jyJRg==",
+      "dev": true,
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.31.0",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.4.0",
+        "semver": "^7.3.7",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "engines": {
+        "node": "^14 || ^16 || ^17 || ^18"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-scope": {
@@ -8002,6 +8091,15 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+      "integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/jsdom": {
@@ -13649,6 +13747,17 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@es-joy/jsdoccomment": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.31.0.tgz",
+      "integrity": "sha512-tc1/iuQcnaiSIUVad72PBierDFpsxdUHtEF/OrfqvM1CBAsIoMP51j52jTMb3dXriwhieTo289InzZj72jL3EQ==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "1.3.1",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "~3.1.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
@@ -16042,6 +16151,12 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
+    "comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -17199,6 +17314,47 @@
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
       "dev": true,
       "requires": {}
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "39.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.1.tgz",
+      "integrity": "sha512-EVee7DW7mIKjQ+i86O3sV8n1BdXXiBo0gqY7S7TYTMEBzZoo4B/xNg0fl+b9ktIJtj6H0einhO3eMpwY2jyJRg==",
+      "dev": true,
+      "requires": {
+        "@es-joy/jsdoccomment": "~0.31.0",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.4.0",
+        "semver": "^7.3.7",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
     },
     "eslint-scope": {
       "version": "4.0.3",
@@ -19508,6 +19664,12 @@
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
+    },
+    "jsdoc-type-pratt-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+      "integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
+      "dev": true
     },
     "jsdom": {
       "version": "16.7.0",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "dts-bundle-generator": "~5.3.0",
     "eslint": "^8.13.0",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-jsdoc": "^39.3.1",
     "execa": "4.1.0",
     "exit": "^0.1.2",
     "fast-deep-equal": "3.1.3",

--- a/src/cli/task-generate.ts
+++ b/src/cli/task-generate.ts
@@ -216,7 +216,10 @@ export const getBoilerplateByExtension = (tagName: string, extension: GenerableE
 };
 
 /**
- * Get the boilerplate for a component.
+ * Get the boilerplate for a file containing the definition of a component
+ * @param tagName the name of the tag to give the component
+ * @param hasStyle designates if the component has an external stylesheet or not
+ * @returns the contents of a file that defines a component
  */
 const getComponentBoilerplate = (tagName: string, hasStyle: boolean): string => {
   const decorator = [`{`];
@@ -254,7 +257,9 @@ const getStyleUrlBoilerplate = (): string =>
 `;
 
 /**
- * Get the boilerplate for a spec test.
+ * Get the boilerplate for a file containing a spec (unit) test for a component
+ * @param tagName the name of the tag associated with the component under test
+ * @returns the contents of a file that unit tests a component
  */
 const getSpecTestBoilerplate = (tagName: string): string =>
   `import { newSpecPage } from '@stencil/core/testing';
@@ -278,17 +283,19 @@ describe('${tagName}', () => {
 `;
 
 /**
- * Get the boilerplate for an E2E test.
+ * Get the boilerplate for a file containing an end-to-end (E2E) test for a component
+ * @param tagName the name of the tag associated with the component under test
+ * @returns the contents of a file that E2E tests a component
  */
-const getE2eTestBoilerplate = (name: string): string =>
+const getE2eTestBoilerplate = (tagName: string): string =>
   `import { newE2EPage } from '@stencil/core/testing';
 
-describe('${name}', () => {
+describe('${tagName}', () => {
   it('renders', async () => {
     const page = await newE2EPage();
-    await page.setContent('<${name}></${name}>');
+    await page.setContent('<${tagName}></${tagName}>');
 
-    const element = await page.find('${name}');
+    const element = await page.find('${tagName}');
     expect(element).toHaveClass('hydrated');
   });
 });
@@ -296,6 +303,8 @@ describe('${name}', () => {
 
 /**
  * Convert a dash case string to pascal case.
+ * @param str the string to convert
+ * @returns the converted input as pascal case
  */
 const toPascalCase = (str: string): string =>
   str.split('-').reduce((res, part) => res + part[0].toUpperCase() + part.slice(1), '');

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -141,10 +141,12 @@ export const prepareData = async (
 };
 
 /**
- * Reads package-lock.json, yarn.lock, and package.json files in order to cross reference
+ * Reads package-lock.json, yarn.lock, and package.json files in order to cross-reference
  * the dependencies and devDependencies properties. Pulls up the current installed version
  * of each package under the @stencil, @ionic, and @capacitor scopes.
- * @returns string[]
+ * @param sys the system instance where telemetry is invoked
+ * @param config the Stencil configuration associated with the current task that triggered telemetry
+ * @returns an object listing all dev and production dependencies under the aforementioned scopes
  */
 async function getInstalledPackages(
   sys: d.CompilerSystem,
@@ -238,7 +240,12 @@ function sanitizeDeclaredVersion(version: string): string {
 }
 
 /**
- * If telemetry is enabled, send a metric via IPC to a forked process for uploading.
+ * If telemetry is enabled, send a metric to an external data store
+ * @param sys the system instance where telemetry is invoked
+ * @param config the Stencil configuration associated with the current task that triggered telemetry
+ * @param name the name of a trackable metric. Note this name is not necessarily a scalar value to track, like
+ * "Stencil Version". For example, "stencil_cli_command" is a name that is used to track all CLI command information.
+ * @param value the data to send to the external data store under the provided name argument
  */
 export async function sendMetric(
   sys: d.CompilerSystem,

--- a/src/cli/test/task-generate.spec.ts
+++ b/src/cli/test/task-generate.spec.ts
@@ -37,9 +37,11 @@ const setup = async () => {
 
 /**
  * Little test helper function which just temporarily silences
- * console.log calls so we can avoid spewing a bunch of stuff.
+ * console.log calls, so we can avoid spewing a bunch of stuff.
+ * @param coreCompiler the core compiler instance to forward to `taskGenerate`
+ * @param config the user-supplied config to forward to `taskGenerate`
  */
-async function silentGenerate(coreCompiler: CoreCompiler, config: d.Config) {
+async function silentGenerate(coreCompiler: CoreCompiler, config: d.Config): Promise<void> {
   const tmp = console.log;
   console.log = jest.fn();
   await taskGenerate(coreCompiler, config);

--- a/src/client/polyfills/css-shim/css-parser.ts
+++ b/src/client/polyfills/css-shim/css-parser.ts
@@ -21,31 +21,32 @@ export class StyleNode {
   parsedSelector = '';
 }
 
-// given a string of css, return a simple rule tree
 /**
- * @param {string} text
- * @return {StyleNode}
+ * Given a string of CSS, return a simple rule tree
+ * @param text the CSS to generate a tree from
+ * @returns the generated tree
  */
-export function parse(text: string) {
+export function parse(text: string): StyleNode {
   text = clean(text);
   return parseCss(lex(text), text);
 }
 
-// remove stuff we don't care about that may hinder parsing
 /**
- * @param {string} cssText
- * @return {string}
+ * Remove text that may hinder parsing, such as comments and `@import` statements
+ * @param cssText the CSS to remove unnecessary bit from
+ * @return the 'cleaned' css string
  */
-function clean(cssText: string) {
+function clean(cssText: string): string {
   return cssText.replace(RX.comments, '').replace(RX.port, '');
 }
 
-// super simple {...} lexer that returns a node tree
 /**
- * @param {string} text
- * @return {StyleNode}
+ * Create a `StyleNode` for the given text. This function is a super simple lexer against the provided text to capture
+ * CSS rules between curly braces.
+ * @param text the text to parse containing CSS rules
+ * @returns a new `StyleNode` with the parsed styles attached to it
  */
-function lex(text: string) {
+function lex(text: string): StyleNode {
   const root = new StyleNode();
   root['start'] = 0;
   root['end'] = text.length;
@@ -70,13 +71,13 @@ function lex(text: string) {
   return root;
 }
 
-// add selectors/cssText to node tree
 /**
- * @param {StyleNode} node
- * @param {string} text
- * @return {StyleNode}
+ * Add selectors/cssText to a style node
+ * @param node the CSS node to add styles to
+ * @param text the selectors to add to the style node
+ * @returns the updated style node
  */
-function parseCss(node: StyleNode, text: string) {
+function parseCss(node: StyleNode, text: string): StyleNode {
   let t = text.substring(node['start'], node['end'] - 1);
   node['parsedCssText'] = node['cssText'] = t.trim();
   if (node.parent) {
@@ -115,12 +116,12 @@ function parseCss(node: StyleNode, text: string) {
 }
 
 /**
- * conversion of sort unicode escapes with spaces like `\33 ` (and longer) into
- * expanded form that doesn't require trailing space `\000033`
- * @param {string} s
- * @return {string}
+ * Conversion of unicode escapes with spaces like `\33 ` (and longer) into
+ * expanded form that doesn't require trailing space -> `\000033`
+ * @param s the unicode escape sequence to expand
+ * @return the expanded escape sequence
  */
-function _expandUnicodeEscapes(s: string) {
+function _expandUnicodeEscapes(s: string): string {
   return s.replace(/\\([0-9a-f]{1,6})\s/gi, function () {
     let code = arguments[1],
       repeat = 6 - code.length;
@@ -132,13 +133,14 @@ function _expandUnicodeEscapes(s: string) {
 }
 
 /**
- * stringify parsed css.
- * @param {StyleNode} node
- * @param {boolean=} preserveProperties
- * @param {string=} text
- * @return {string}
+ * Stringify some parsed CSS.
+ * @param node the CSS root node to stringify
+ * @param  preserveProperties if `false`, custom CSS properties will be removed from the CSS. If `true`, they will be
+ * preserved.
+ * @param  text an optional string to append the stringified CSS to
+ * @return the stringified CSS.
  */
-export function stringify(node: StyleNode, preserveProperties: any, text = '') {
+export function stringify(node: StyleNode, preserveProperties: boolean, text = '') {
   // calc rule cssText
   let cssText = '';
   if (node['cssText'] || node['rules']) {
@@ -169,17 +171,19 @@ export function stringify(node: StyleNode, preserveProperties: any, text = '') {
 }
 
 /**
- * @param {Array<StyleNode>} rules
- * @return {boolean}
+ * Determines if a parsed CSS node has a selector that begins with '--' or not
+ * @param rules the rules to evaluate. only the first rule in the provided list will be tested.
+ * @return `true` if a selector that begins with '--' is found, `false` otherwise.
  */
-function _hasMixinRules(rules: any) {
+function _hasMixinRules(rules: ReadonlyArray<StyleNode>): boolean {
   const r = rules[0];
   return Boolean(r) && Boolean(r['selector']) && r['selector'].indexOf(VAR_START) === 0;
 }
 
 /**
- * @param {string} cssText
- * @return {string}
+ * Helper function to remove custom properties from CSS
+ * @param cssText the stringified CSS to remove custom properties from
+ * @return the sanitized CSS
  */
 function removeCustomProps(cssText: string) {
   cssText = removeCustomPropAssignment(cssText);
@@ -187,16 +191,18 @@ function removeCustomProps(cssText: string) {
 }
 
 /**
- * @param {string} cssText
- * @return {string}
+ *
+ * @param cssText the stringified CSS to remove custom properties from
+ * @return the sanitized CSS
  */
-export function removeCustomPropAssignment(cssText: string) {
+export function removeCustomPropAssignment(cssText: string): string {
   return cssText.replace(RX.customProp, '').replace(RX.mixinProp, '');
 }
 
 /**
- * @param {string} cssText
- * @return {string}
+ *
+ * @param cssText the stringified CSS to remove custom properties from
+ * @return the sanitized CSS
  */
 function removeCustomPropApply(cssText: string) {
   return cssText.replace(RX.mixinApply, '').replace(RX.varApply, '');

--- a/src/compiler/build/build-stats.ts
+++ b/src/compiler/build/build-stats.ts
@@ -78,10 +78,13 @@ export function generateBuildStats(
 /**
  * Writes the files from the stats config to the file system
  * @param config the project build configuration
- * @param buildCtx An instance of the build which holds the details about the build
- * @returns
+ * @param data the information to write out to disk (as specified by each stats output target specified in the provided
+ * config)
  */
-export async function writeBuildStats(config: d.Config, data: d.CompilerBuildStats | { diagnostics: d.Diagnostic[] }) {
+export async function writeBuildStats(
+  config: d.Config,
+  data: d.CompilerBuildStats | { diagnostics: d.Diagnostic[] }
+): Promise<void> {
   const statsTargets = config.outputTargets.filter(isOutputTargetStats);
 
   await Promise.all(

--- a/src/compiler/sys/in-memory-fs.ts
+++ b/src/compiler/sys/in-memory-fs.ts
@@ -44,11 +44,18 @@ export const createInMemoryFs = (sys: d.CompilerSystem) => {
   };
 
   /**
-   * Synchronous!!! Do not use!!!
+   * **Synchronous!!! Do not use!!!**
    * (Only typescript transpiling is allowed to use)
-   * @param filePath
+   *
+   * Synchronously get information about a file from a provided path. This function will attempt to use an in-memory
+   * cache before performing a blocking read.
+   *
+   * In the event of a cache hit, the content from the cache will be returned and skip the read.
+   *
+   * @param filePath the path to the file to read
+   * @returns `true` if the file exists, `false` otherwise
    */
-  const accessSync = (filePath: string) => {
+  const accessSync = (filePath: string): boolean => {
     const item = getItem(filePath);
     if (typeof item.exists !== 'boolean') {
       const s = statSync(filePath);
@@ -244,11 +251,21 @@ export const createInMemoryFs = (sys: d.CompilerSystem) => {
   };
 
   /**
-   * Synchronous!!! Do not use!!!
+   * **Synchronous!!! Do not use!!!**
    * (Only typescript transpiling is allowed to use)
-   * @param filePath
+   *
+   * Synchronously read a file from a provided path. This function will attempt to use an in-memory cache before
+   * performing a blocking read in the following circumstances:
+   * - no `opts` are provided
+   * - the `useCache` member on `opts` is set to `true`, or is not set
+   *
+   * In the event of a cache hit, the content from the cache will be returned and skip the read.
+   *
+   * @param filePath the path to the file to read
+   * @param opts a configuration to use when reading a file
+   * @returns the contents of the file (read from either disk or the cache).
    */
-  const readFileSync = (filePath: string, opts?: d.FsReadOptions) => {
+  const readFileSync = (filePath: string, opts?: d.FsReadOptions): string => {
     if (opts == null || opts.useCache === true || opts.useCache === undefined) {
       const item = getItem(filePath);
       if (item.exists && typeof item.fileText === 'string') {
@@ -347,12 +364,15 @@ export const createInMemoryFs = (sys: d.CompilerSystem) => {
   };
 
   /**
-   * Synchronous!!! Do not use!!!
-   * Always returns an object, does not throw errors.
+   * **Synchronous!!! Do not use!!!**
    * (Only typescript transpiling is allowed to use)
-   * @param itemPath
+   *
+   * Searches an in-memory cache for an item at the provided path. Always returns an object, **does not throw errors**.
+   *
+   * @param itemPath the path to the file to read
+   * @returns an object describing the item found at the provided `itemPath`
    */
-  const statSync = (itemPath: string) => {
+  const statSync = (itemPath: string): { isFile: boolean; isDirectory: boolean; exists: boolean } => {
     const item = getItem(itemPath);
     if (typeof item.isDirectory !== 'boolean' || typeof item.isFile !== 'boolean') {
       const stat = sys.statSync(itemPath);

--- a/src/compiler/transformers/add-static-style.ts
+++ b/src/compiler/transformers/add-static-style.ts
@@ -7,15 +7,21 @@ import ts from 'typescript';
 
 /**
  * Adds static "style" getter within the class
+ * ```typescript
  * const MyComponent = class {
  *   static get style() { return "styles"; }
  * }
+ * ```
+ * @param classMembers a class to existing members of a class. **this parameter will be mutated** rather than returning
+ * a cloned version
+ * @param cmp the metadata associated with the component being evaluated
+ * @param commentOriginalSelector if `true`, add a comment with the original CSS selector to the style.
  */
 export const addStaticStyleGetterWithinClass = (
   classMembers: ts.ClassElement[],
   cmp: d.ComponentCompilerMeta,
   commentOriginalSelector: boolean
-) => {
+): void => {
   const styleLiteral = getStyleLiteral(cmp, commentOriginalSelector);
   if (styleLiteral) {
     classMembers.push(createStaticGetter('style', styleLiteral));
@@ -24,15 +30,15 @@ export const addStaticStyleGetterWithinClass = (
 
 /**
  * Adds static "style" property to the class variable.
+ * ```typescript
  * const MyComponent = class {}
  * MyComponent.style = "styles";
+ * ```
+ * @param styleStatements a list of statements containing style assignments to a class
+ * @param cmp the metadata associated with the component being evaluated
  */
-export const addStaticStylePropertyToClass = (
-  styleStatements: ts.Statement[],
-  cmp: d.ComponentCompilerMeta,
-  commentOriginalSelector: boolean
-) => {
-  const styleLiteral = getStyleLiteral(cmp, commentOriginalSelector);
+export const addStaticStylePropertyToClass = (styleStatements: ts.Statement[], cmp: d.ComponentCompilerMeta): void => {
+  const styleLiteral = getStyleLiteral(cmp, false);
   if (styleLiteral) {
     const statement = ts.createStatement(
       ts.createAssignment(ts.createPropertyAccess(ts.createIdentifier(cmp.componentClassName), 'style'), styleLiteral)

--- a/src/compiler/transformers/component-lazy/lazy-component.ts
+++ b/src/compiler/transformers/component-lazy/lazy-component.ts
@@ -34,7 +34,7 @@ const updateLazyComponentMembers = (
   transformHostData(classMembers, moduleFile);
 
   if (transformOpts.style === 'static') {
-    addStaticStylePropertyToClass(styleStatements, cmp, false);
+    addStaticStylePropertyToClass(styleStatements, cmp);
   }
 
   return classMembers;

--- a/src/compiler/transformers/component-native/add-define-custom-element-function.ts
+++ b/src/compiler/transformers/component-native/add-define-custom-element-function.ts
@@ -227,6 +227,7 @@ const addDefineCustomElementFunction = (
  * ```typescript
  * defineCustomElement(MyPrincipalComponent);
  * ```
+ * @param componentName the component's class name to use as the first argument to `defineCustomElement`
  * @returns the expression statement described above
  */
 function createAutoDefinitionExpression(componentName: string): ts.ExpressionStatement {

--- a/src/compiler/transpile/transpile-module.ts
+++ b/src/compiler/transpile/transpile-module.ts
@@ -13,8 +13,16 @@ import ts from 'typescript';
 
 /**
  * Stand-alone compiling of a single string
+ * @param config the Stencil configuration to use in the compilation process
+ * @param input the string to compile
+ * @param transformOpts a configuration object for how the string is compiled
+ * @returns the results of compiling the provided input string
  */
-export const transpileModule = (config: d.Config, input: string, transformOpts: d.TransformOptions) => {
+export const transpileModule = (
+  config: d.Config,
+  input: string,
+  transformOpts: d.TransformOptions
+): d.TranspileModuleResults => {
   if (!config.logger) {
     config = {
       ...config,

--- a/src/mock-doc/window.ts
+++ b/src/mock-doc/window.ts
@@ -846,6 +846,7 @@ export function cloneDocument(srcDoc: Document) {
 /**
  * Constrain setTimeout() to 1ms, but still async. Also
  * only allow setInterval() to fire once, also constrained to 1ms.
+ * @param win TODO
  */
 export function constrainTimeouts(win: any) {
   (win as MockWindow).__allowInterval = false;

--- a/src/mock-doc/window.ts
+++ b/src/mock-doc/window.ts
@@ -843,10 +843,11 @@ export function cloneDocument(srcDoc: Document) {
   return dstWin.document;
 }
 
+// TODO(STENCIL-345) - Evaluate reconciling MockWindow, Window differences
 /**
  * Constrain setTimeout() to 1ms, but still async. Also
  * only allow setInterval() to fire once, also constrained to 1ms.
- * @param win TODO
+ * @param win the mock window instance to update
  */
 export function constrainTimeouts(win: any) {
   (win as MockWindow).__allowInterval = false;

--- a/src/utils/is-root-path.ts
+++ b/src/utils/is-root-path.ts
@@ -1,5 +1,8 @@
 /**
- * Checks if the path is the OS root path, such as "/" or "C:\"
+ * Checks if the path is the Operating System (OS) root path, such as "/" or "C:\". This function does not take the OS
+ * the code is running on into account when performing this evaluation.
+ * @param p the path to check
+ * @returns `true` if the path is an OS root path, `false` otherwise
  */
 export const isRootPath = (p: string) => p === '/' || windowsPathRegex.test(p);
 

--- a/src/utils/normalize-path.ts
+++ b/src/utils/normalize-path.ts
@@ -3,8 +3,10 @@
  * Forward-slash paths can be used in Windows as long as they're not
  * extended-length paths and don't contain any non-ascii characters.
  * This was created since the path methods in Node.js outputs \\ paths on Windows.
+ * @param path the Windows-based path to convert
+ * @returns the converted path
  */
-export const normalizePath = (path: string) => {
+export const normalizePath = (path: string): string => {
   if (typeof path !== 'string') {
     throw new Error(`invalid path to normalize`);
   }
@@ -149,8 +151,10 @@ const pathComponents = (path: string, rootLength: number) => {
 };
 
 /**
- * Same as normalizePath(), expect it'll also strip any querystrings
+ * Same as normalizePath(), expect it'll also strip any query strings
  * from the path name. So /dir/file.css?tag=cmp-a becomes /dir/file.css
+ * @param p the path to normalize
+ * @returns the normalized path, sans any query strings
  */
 export const normalizeFsPath = (p: string) => normalizePath(p.split('?')[0].replace(/\0/g, ''));
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

One thing that's come up during reviews is the need to add JSDocs to functions. 
This commit looks to remove those types of comments from our review process by
having the linter warn us about missing `@param`s

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit adds the first pass at enforcing @param usage in jsdocs.
configuring how jsdoc's are enforced often involves setting up multiple
rules at once to get a desired affect. rather than toil with the
_perfect_ setup, this commit is designed to get an initial take on this
in front of the team to use and iterate on over time.

the choice of rules revolves around the general desire that each jsdoc
includes:
- the `@param` jsdoc keyword
- the name of the parameter
- a description of the parameter

it does not however:
- get enforced in every context (yet) - there are future discussions to
  decide whether arrow functions, anonymous functions, etc. are included
  or not
- get invoked if a context we _do_ enforce doesn't have a jsdoc (where
  we will continue to "clean up" the code as we go, adding jsdocs to
  functions we touch, just require `@param`s on them more formally)

the `.eslintrc.js` file is currently documented such that each
configuration option is explained/justified. (please call out anything 
that needs more details!)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Linting, tests pass
