### PR TITLE
test(json-parsing): add unit tests 

### DIFF
--- a/src/dev-server/test/Diagnostic.stub.ts
+++ b/src/dev-server/test/Diagnostic.stub.ts
@@ -1,0 +1,22 @@
+import * as d from '@stencil/core/declarations';
+
+/**
+ * Generates a stub {@link d.Diagnostic}. This function uses sensible defaults for the initial stub. However,
+ * any field in the object may be overridden via the `overrides` argument.
+ * @param overrides a partial implementation of `Diagnostic`. Any provided fields will override the defaults provided
+ * by this function.
+ * @returns the stubbed `Diagnostic`
+ */
+export const stubDiagnostic = (overrides: Partial<d.Diagnostic> = {}): d.Diagnostic => {
+  const defaults: d.Diagnostic = {
+    absFilePath: null,
+    header: 'Mock Error',
+    level: 'error',
+    lines: [],
+    messageText: 'mock error',
+    relFilePath: null,
+    type: 'mock',
+  };
+
+  return { ...defaults, ...overrides };
+};

--- a/src/utils/test/util.spec.ts
+++ b/src/utils/test/util.spec.ts
@@ -156,14 +156,6 @@ describe('util', () => {
   describe('parsePackageJson', () => {
     const mockPackageJsonPath = '/mock/path/package.json';
 
-    it('returns null if the path to package.json is not a string', () => {
-      // code paths exist where the path argument is provided by a Stencil config file. Because this is user-provided
-      // input, the path may not be a valid string, requiring a type assertion for the second argument
-      const diagnostic = util.parsePackageJson('{ "someJson": "value"}', null as unknown as string);
-
-      expect(diagnostic).toBeNull();
-    });
-
     it('returns a parse error if parsing cannot complete', () => {
       // improperly formatted JSON - note the lack of ':'
       const diagnostic = util.parsePackageJson('{ "someJson" "value"}', mockPackageJsonPath);
@@ -179,6 +171,24 @@ describe('util', () => {
         diagnostic: expectedDiagnostic,
         data: null,
         filePath: mockPackageJsonPath,
+      });
+    });
+
+    it('returns a parse error if parsing cannot complete for undefined package path', () => {
+      // improperly formatted JSON - note the lack of ':'
+      const diagnostic = util.parsePackageJson('{ "someJson" "value"}', undefined);
+
+      const expectedDiagnostic: d.Diagnostic = stubDiagnostic({
+        absFilePath: undefined,
+        header: 'Error Parsing JSON',
+        messageText: 'Unexpected string in JSON at position 13', // due to missing colon in input
+        type: 'build',
+      });
+
+      expect(diagnostic).toEqual<ParsePackageJsonResult>({
+        diagnostic: expectedDiagnostic,
+        data: null,
+        filePath: undefined,
       });
     });
 

--- a/src/utils/test/util.spec.ts
+++ b/src/utils/test/util.spec.ts
@@ -1,6 +1,8 @@
 import type * as d from '../../declarations';
 import { mockConfig, mockBuildCtx } from '@stencil/core/testing';
 import * as util from '../util';
+import { stubDiagnostic } from '../../dev-server/test/Diagnostic.stub';
+import { ParsePackageJsonResult } from '../util';
 
 describe('util', () => {
   describe('generatePreamble', () => {
@@ -149,5 +151,64 @@ describe('util', () => {
     expect(util.createJsVarName('    ')).toBe('');
     expect(util.createJsVarName('')).toBe('');
     expect(util.createJsVarName(null)).toBe(null);
+  });
+
+  describe('parsePackageJson', () => {
+    const mockPackageJsonPath = '/mock/path/package.json';
+
+    it('returns null if the path to package.json is not a string', () => {
+      // code paths exist where the path argument is provided by a Stencil config file. Because this is user-provided
+      // input, the path may not be a valid string, requiring a type assertion for the second argument
+      const diagnostic = util.parsePackageJson('{ "someJson": "value"}', null as unknown as string);
+
+      expect(diagnostic).toBeNull();
+    });
+
+    it('returns a parse error if the json is not a string', () => {
+      const expectedDiagnostic: d.Diagnostic = stubDiagnostic({
+        absFilePath: mockPackageJsonPath,
+        header: 'Error Parsing JSON',
+        messageText: 'Invalid JSON input to parse',
+        type: 'build',
+      });
+
+      const diagnostic = util.parsePackageJson(null, mockPackageJsonPath);
+
+      expect(diagnostic).toEqual<ParsePackageJsonResult>({
+        diagnostic: expectedDiagnostic,
+        data: null,
+        filePath: mockPackageJsonPath,
+      });
+    });
+
+    it('returns a parse error if parsing cannot complete', () => {
+      // improperly formatted JSON - note the lack of ':'
+      const diagnostic = util.parsePackageJson('{ "someJson" "value"}', mockPackageJsonPath);
+
+      const expectedDiagnostic: d.Diagnostic = stubDiagnostic({
+        absFilePath: mockPackageJsonPath,
+        header: 'Error Parsing JSON',
+        messageText: 'Unexpected string in JSON at position 13', // due to missing colon in input
+        type: 'build',
+      });
+
+      expect(diagnostic).toEqual<ParsePackageJsonResult>({
+        diagnostic: expectedDiagnostic,
+        data: null,
+        filePath: mockPackageJsonPath,
+      });
+    });
+
+    it('returns the parsed data from the provided json', () => {
+      const diagnostic = util.parsePackageJson('{ "someJson": "value"}', mockPackageJsonPath);
+
+      expect(diagnostic).toEqual<ParsePackageJsonResult>({
+        diagnostic: null,
+        data: {
+          someJson: 'value',
+        },
+        filePath: mockPackageJsonPath,
+      });
+    });
   });
 });

--- a/src/utils/test/util.spec.ts
+++ b/src/utils/test/util.spec.ts
@@ -164,23 +164,6 @@ describe('util', () => {
       expect(diagnostic).toBeNull();
     });
 
-    it('returns a parse error if the json is not a string', () => {
-      const expectedDiagnostic: d.Diagnostic = stubDiagnostic({
-        absFilePath: mockPackageJsonPath,
-        header: 'Error Parsing JSON',
-        messageText: 'Invalid JSON input to parse',
-        type: 'build',
-      });
-
-      const diagnostic = util.parsePackageJson(null, mockPackageJsonPath);
-
-      expect(diagnostic).toEqual<ParsePackageJsonResult>({
-        diagnostic: expectedDiagnostic,
-        data: null,
-        filePath: mockPackageJsonPath,
-      });
-    });
-
     it('returns a parse error if parsing cannot complete', () => {
       // improperly formatted JSON - note the lack of ':'
       const diagnostic = util.parsePackageJson('{ "someJson" "value"}', mockPackageJsonPath);

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -117,20 +117,38 @@ export const readPackageJson = async (config: d.Config, compilerCtx: d.CompilerC
   }
 };
 
-export const parsePackageJson = (
-  pkgJsonStr: string,
-  pkgJsonFilePath: string
-): { diagnostic: d.Diagnostic; data: d.PackageJsonData; filePath: string } => {
+/**
+ * A type that describes the result of parsing a `package.json` file's contents
+ */
+export type ParsePackageJsonResult = {
+  diagnostic: d.Diagnostic | null;
+  data: any | null;
+  filePath: string;
+};
+
+/**
+ * Parse a string read from a `package.json` file
+ * @param pkgJsonStr the string read from a `package.json` file
+ * @param pkgJsonFilePath the path to the already read `package.json` file
+ * @returns the results of parsing the provided contents of the `package.json` file
+ */
+export const parsePackageJson = (pkgJsonStr: string, pkgJsonFilePath: string): ParsePackageJsonResult | null => {
   if (isString(pkgJsonFilePath)) {
     return parseJson(pkgJsonStr, pkgJsonFilePath);
   }
   return null;
 };
 
-export const parseJson = (jsonStr: string, filePath?: string) => {
-  const rtn = {
-    diagnostic: null as d.Diagnostic,
-    data: null as any,
+/**
+ * Parse a string read from a `package.json` file
+ * @param jsonStr the string read from a `package.json` file
+ * @param filePath the path to the already read `package.json` file
+ * @returns the results of parsing the provided contents of the `package.json` file
+ */
+const parseJson = (jsonStr: string, filePath: string): ParsePackageJsonResult => {
+  const rtn: ParsePackageJsonResult = {
+    diagnostic: null,
+    data: null,
     filePath,
   };
 

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -132,11 +132,8 @@ export type ParsePackageJsonResult = {
  * @param pkgJsonFilePath the path to the already read `package.json` file
  * @returns the results of parsing the provided contents of the `package.json` file
  */
-export const parsePackageJson = (pkgJsonStr: string, pkgJsonFilePath: string): ParsePackageJsonResult | null => {
-  if (isString(pkgJsonFilePath)) {
-    return parseJson(pkgJsonStr, pkgJsonFilePath);
-  }
-  return null;
+export const parsePackageJson = (pkgJsonStr: string, pkgJsonFilePath: string): ParsePackageJsonResult => {
+  return parseJson(pkgJsonStr, pkgJsonFilePath);
 };
 
 /**

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -138,22 +138,22 @@ export const parsePackageJson = (pkgJsonStr: string, pkgJsonFilePath: string): P
 
 /**
  * Parse a string read from a `package.json` file
- * @param jsonStr the string read from a `package.json` file
- * @param filePath the path to the already read `package.json` file
+ * @param pkgJsonStr the string read from a `package.json` file
+ * @param pkgJsonFilePath the path to the already read `package.json` file
  * @returns the results of parsing the provided contents of the `package.json` file
  */
-const parseJson = (jsonStr: string, filePath: string): ParsePackageJsonResult => {
+const parseJson = (pkgJsonStr: string, pkgJsonFilePath: string): ParsePackageJsonResult => {
   const rtn: ParsePackageJsonResult = {
     diagnostic: null,
     data: null,
-    filePath,
+    filePath: pkgJsonFilePath,
   };
 
   try {
-    rtn.data = JSON.parse(jsonStr);
+    rtn.data = JSON.parse(pkgJsonStr);
   } catch (e) {
     rtn.diagnostic = buildError();
-    rtn.diagnostic.absFilePath = isString(filePath) ? filePath : undefined;
+    rtn.diagnostic.absFilePath = isString(pkgJsonFilePath) ? pkgJsonFilePath : undefined;
     rtn.diagnostic.header = `Error Parsing JSON`;
     if (e instanceof Error) {
       rtn.diagnostic.messageText = e.message;

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -152,22 +152,15 @@ const parseJson = (jsonStr: string, filePath: string): ParsePackageJsonResult =>
     filePath,
   };
 
-  if (isString(jsonStr)) {
-    try {
-      rtn.data = JSON.parse(jsonStr);
-    } catch (e) {
-      rtn.diagnostic = buildError();
-      rtn.diagnostic.absFilePath = filePath;
-      rtn.diagnostic.header = `Error Parsing JSON`;
-      if (e instanceof Error) {
-        rtn.diagnostic.messageText = e.message;
-      }
-    }
-  } else {
+  try {
+    rtn.data = JSON.parse(jsonStr);
+  } catch (e) {
     rtn.diagnostic = buildError();
     rtn.diagnostic.absFilePath = filePath;
     rtn.diagnostic.header = `Error Parsing JSON`;
-    rtn.diagnostic.messageText = `Invalid JSON input to parse`;
+    if (e instanceof Error) {
+      rtn.diagnostic.messageText = e.message;
+    }
   }
 
   return rtn;

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -156,7 +156,7 @@ const parseJson = (jsonStr: string, filePath: string): ParsePackageJsonResult =>
     rtn.data = JSON.parse(jsonStr);
   } catch (e) {
     rtn.diagnostic = buildError();
-    rtn.diagnostic.absFilePath = filePath;
+    rtn.diagnostic.absFilePath = isString(filePath) ? filePath : undefined;
     rtn.diagnostic.header = `Error Parsing JSON`;
     if (e instanceof Error) {
       rtn.diagnostic.messageText = e.message;

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -133,24 +133,24 @@ export type ParsePackageJsonResult = {
  * @returns the results of parsing the provided contents of the `package.json` file
  */
 export const parsePackageJson = (pkgJsonStr: string, pkgJsonFilePath: string): ParsePackageJsonResult => {
-  const rtn: ParsePackageJsonResult = {
+  const parseResult: ParsePackageJsonResult = {
     diagnostic: null,
     data: null,
     filePath: pkgJsonFilePath,
   };
 
   try {
-    rtn.data = JSON.parse(pkgJsonStr);
+    parseResult.data = JSON.parse(pkgJsonStr);
   } catch (e) {
-    rtn.diagnostic = buildError();
-    rtn.diagnostic.absFilePath = isString(pkgJsonFilePath) ? pkgJsonFilePath : undefined;
-    rtn.diagnostic.header = `Error Parsing JSON`;
+    parseResult.diagnostic = buildError();
+    parseResult.diagnostic.absFilePath = isString(pkgJsonFilePath) ? pkgJsonFilePath : undefined;
+    parseResult.diagnostic.header = `Error Parsing JSON`;
     if (e instanceof Error) {
-      rtn.diagnostic.messageText = e.message;
+      parseResult.diagnostic.messageText = e.message;
     }
   }
 
-  return rtn;
+  return parseResult;
 };
 
 const SKIP_DEPS = ['@stencil/core'];

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -133,16 +133,6 @@ export type ParsePackageJsonResult = {
  * @returns the results of parsing the provided contents of the `package.json` file
  */
 export const parsePackageJson = (pkgJsonStr: string, pkgJsonFilePath: string): ParsePackageJsonResult => {
-  return parseJson(pkgJsonStr, pkgJsonFilePath);
-};
-
-/**
- * Parse a string read from a `package.json` file
- * @param pkgJsonStr the string read from a `package.json` file
- * @param pkgJsonFilePath the path to the already read `package.json` file
- * @returns the results of parsing the provided contents of the `package.json` file
- */
-const parseJson = (pkgJsonStr: string, pkgJsonFilePath: string): ParsePackageJsonResult => {
   const rtn: ParsePackageJsonResult = {
     diagnostic: null,
     data: null,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

the `parseJson` utility was unnecessarily exported. while looking at the 
code, I took half an hour to clean it up a bit, add tests, etc.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
this commit adds testing around the `parsePackageJson` function. it
calls an internal function `parseJson`, which was orginally
unnecessarily exported and removing the `export` keyword from this
function was the impetus for this work.

some types were tightened/changed:
- a concrete type, `ParsePackageJsonResult` was created to describe the
  return type of `parsePackageJson` and `parseJson`. this type
  explicitly marks the `diagnostic` and `data` fields as the union of
  their original type and `null`, allowing us to remove type assertions
  in `parseJson`.
- the second parameter of `parseJson` has been narrowed to no longer be
  optional, as no code path exists where a this function is called
  without a second argument.

this commit removes a check if the json that has been passed to
`parseJson` is a string or not. looking at the single caller of it's
wrapper function, we verify that this argument is of type string
already. i'm going to add a comment to discuss what we want to here
with respect to defensive programming

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

- Unit tests were added + passed
