### PR TITLE
feat(telemetry): add stencil config to telemetry object

### DIFF
--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -195,6 +195,7 @@ export const anonymizeConfigForTelemetry = (config: d.Config): d.Config => {
     baseUrl: 'omitted',
   }));
 
+  // TODO(STENCIL-469): Investigate improving anonymization for tsCompilerOptions and devServer
   const propsToDelete: Array<keyof d.Config> = ['sys', 'logger', 'tsCompilerOptions', 'devServer'];
 
   for (const prop of propsToDelete) {

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -151,8 +151,6 @@ export const prepareData = async (
   };
 };
 
-// Get keys in `d.Config` which map to a value of type `string`
-//
 // Setting a key type to `never` excludes it from a mapped type, so we
 // can get only keys which map to a string value by excluding all keys `K`
 // where `d.Config[K]` does not extend `string`.
@@ -189,8 +187,9 @@ export const anonymizeConfigForTelemtry = (config: d.Config): d.Config => {
 
   anonymizedConfig.outputTargets = config.outputTargets.map((target) => ({
     ...target,
-    dir: `actual value for dir omitted`,
+    dir: 'omitted',
     typesDir: 'omitted',
+    baseUrl: 'omitted',
   }));
 
   const propsToDelete: Array<keyof d.Config> = ['sys', 'logger'];

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -127,7 +127,7 @@ export const prepareData = async (
   const cpu_model = sys.details.cpuModel;
   const build = coreCompiler.buildId || 'unknown';
   const has_app_pwa_config = hasAppTarget(config);
-  const anonymizedConfig = anonymizeConfigForTelemtry(config);
+  const anonymizedConfig = anonymizeConfigForTelemetry(config);
 
   return {
     yarn,
@@ -160,14 +160,14 @@ type ConfigStringKeys = keyof {
 };
 
 /**
- * Anonymize the config for telemtry, replacing potentially revealing config props
+ * Anonymize the config for telemetry, replacing potentially revealing config props
  * with a placeholder string if they are present (this lets us still track how frequently
  * these config options are being used)
  *
  * @param config the config to anonymize
  * @returns an anonymized copy of the same config
  */
-export const anonymizeConfigForTelemtry = (config: d.Config): d.Config => {
+export const anonymizeConfigForTelemetry = (config: d.Config): d.Config => {
   const anonymizedConfig = { ...config };
   const propsToAnonymize: ConfigStringKeys[] = [
     'rootDir',

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -164,7 +164,7 @@ type ConfigStringKeys = keyof {
 // preparing a config for telemetry
 //
 // we omit the values of all other fields on output targets.
-const OUTPUT_TARGET_KEYS_TO_KEEP = ['type'] as const;
+const OUTPUT_TARGET_KEYS_TO_KEEP: ReadonlyArray<string> = ['type'];
 
 // top-level config props that we anonymize for telemetry
 const CONFIG_PROPS_TO_ANONYMIZE: ReadonlyArray<ConfigStringKeys> = [

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -192,7 +192,7 @@ export const anonymizeConfigForTelemetry = (config: d.Config): d.Config => {
   }
 
   // Anonymize the outputTargets on our configuration, taking advantage of the
-  // optional 2nd argument to JSON.parse. If anything is not a string or number
+  // optional 2nd argument to `JSON.stringify`. If anything is not a string or number
   // we retain it so that any nested properties are handled, else we check
   // whether it's in our 'keep' list to decide whether to keep it or replace it
   // with `"omitted"`.

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -164,12 +164,7 @@ type ConfigStringKeys = keyof {
 // preparing a config for telemetry
 //
 // we omit the values of all other fields on output targets.
-const OUTPUT_TARGET_KEYS_TO_KEEP = [
-  'type',
-  'external',
-  'autoDefineCustomElements',
-  'generateTypeDeclarations',
-] as const;
+const OUTPUT_TARGET_KEYS_TO_KEEP = ['type'] as const;
 
 // top-level config props that we anonymize for telemetry
 const CONFIG_PROPS_TO_ANONYMIZE: ReadonlyArray<ConfigStringKeys> = [

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -215,7 +215,7 @@ export const anonymizeConfigForTelemetry = (config: d.Config): d.Config => {
     // with `"omitted"`.
     const anonymizedOT = JSON.parse(
       JSON.stringify(target, (key, value) => {
-        if (!['string', 'number'].includes(typeof value)) {
+        if (!(typeof value === "string")) {
           return value;
         }
         if (OUTPUT_TARGET_KEYS_TO_KEEP.includes(key)) {

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -215,7 +215,7 @@ export const anonymizeConfigForTelemetry = (config: d.Config): d.Config => {
     // with `"omitted"`.
     const anonymizedOT = JSON.parse(
       JSON.stringify(target, (key, value) => {
-        if (!(typeof value === "string")) {
+        if (!(typeof value === 'string')) {
           return value;
         }
         if (OUTPUT_TARGET_KEYS_TO_KEEP.includes(key)) {

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -154,7 +154,7 @@ export const prepareData = async (
 // Setting a key type to `never` excludes it from a mapped type, so we
 // can get only keys which map to a string value by excluding all keys `K`
 // where `d.Config[K]` does not extend `string`.
-type ConfigStringKeys = keyof { [K in keyof d.Config as d.Config[K] extends string ? K : never]: d.Config[K] };
+type ConfigStringKeys = keyof { [K in keyof d.Config as Required<d.Config>[K] extends string ? K : never]: d.Config[K] };
 
 /**
  * Anonymize the config for telemtry, replacing potentially revealing config props
@@ -185,7 +185,7 @@ export const anonymizeConfigForTelemtry = (config: d.Config): d.Config => {
     }
   }
 
-  anonymizedConfig.outputTargets = config.outputTargets.map((target) => ({
+  anonymizedConfig.outputTargets = (config.outputTargets ?? []).map((target) => ({
     ...target,
     dir: 'omitted',
     typesDir: 'omitted',

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -204,7 +204,7 @@ export const anonymizeConfigForTelemetry = (config: d.Config): d.Config => {
 
   anonymizedConfig.outputTargets = (config.outputTargets ?? []).map((target) => {
     // Anonymize the outputTargets on our configuration, taking advantage of the
-    // optional 2nd argument to `JSON.stringify`. If anything is not a string or number
+    // optional 2nd argument to `JSON.stringify`. If anything is not a string
     // we retain it so that any nested properties are handled, else we check
     // whether it's in our 'keep' list to decide whether to keep it or replace it
     // with `"omitted"`.

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -195,25 +195,10 @@ export const anonymizeConfigForTelemetry = (config: d.Config): d.Config => {
     baseUrl: 'omitted',
   }));
 
-  const propsToDelete: Array<keyof d.Config> = ['sys', 'logger'];
+  const propsToDelete: Array<keyof d.Config> = ['sys', 'logger', 'tsCompilerOptions', 'devServer'];
 
   for (const prop of propsToDelete) {
     delete anonymizedConfig[prop];
-  }
-
-  if (config.devServer) {
-    anonymizedConfig.devServer = {
-      ...config.devServer,
-      srcIndexHtml: 'omitted',
-      root: 'omitted',
-    };
-  }
-
-  if (config.tsCompilerOptions) {
-    anonymizedConfig.tsCompilerOptions = {
-      ...config.tsCompilerOptions,
-      configFilePath: 'omitted',
-    };
   }
 
   return anonymizedConfig;

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -163,7 +163,7 @@ type ConfigStringKeys = keyof {
 const OUTPUT_TARGET_KEYS_TO_KEEP = ['type', 'typesDir', 'baseUrl'];
 
 /**
- * Anonymize the config for telemetry, replacing potentially revealing configprops
+ * Anonymize the config for telemetry, replacing potentially revealing config props
  * with a placeholder string if they are present (this lets us still track how frequently
  * these config options are being used)
  *

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -154,7 +154,9 @@ export const prepareData = async (
 // Setting a key type to `never` excludes it from a mapped type, so we
 // can get only keys which map to a string value by excluding all keys `K`
 // where `d.Config[K]` does not extend `string`.
-type ConfigStringKeys = keyof { [K in keyof d.Config as Required<d.Config>[K] extends string ? K : never]: d.Config[K] };
+type ConfigStringKeys = keyof {
+  [K in keyof d.Config as Required<d.Config>[K] extends string ? K : never]: d.Config[K];
+};
 
 /**
  * Anonymize the config for telemtry, replacing potentially revealing config props

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -107,6 +107,7 @@ export async function getActiveTargets(config: d.Config): Promise<string[]> {
  * @param sys the compiler system instance in use
  * @param duration_ms the duration of the action being tracked
  * @param component_count the number of components being built (optional)
+ * @returns a Promise wrapping data for the telemetry endpoint
  */
 export const prepareData = async (
   coreCompiler: CoreCompiler,

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -5,7 +5,7 @@ import { createSystem } from '../../../compiler/sys/stencil-sys';
 import { mockLogger } from '@stencil/core/testing';
 import * as coreCompiler from '@stencil/core/compiler';
 import { anonymizeConfigForTelemetry } from '../telemetry';
-import { DIST, DIST_CUSTOM_ELEMENTS, DIST_HYDRATE_SCRIPT, WWW } from 'src/compiler/output-targets/output-utils';
+import { DIST, DIST_CUSTOM_ELEMENTS, DIST_HYDRATE_SCRIPT, WWW } from '../../../compiler/output-targets/output-utils';
 
 describe('telemetryBuildFinishedAction', () => {
   const config: d.Config = {

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -189,7 +189,7 @@ describe('prepareData', () => {
         },
         outputTargets: [
           {
-            baseUrl: 'https://example.com',
+            baseUrl: 'omitted',
             serviceWorker: {
               swDest: 'omitted',
             },
@@ -235,7 +235,7 @@ describe('prepareData', () => {
         },
         outputTargets: [
           {
-            baseUrl: 'https://example.com',
+            baseUrl: 'omitted',
             serviceWorker: {
               swDest: 'omitted',
             },
@@ -293,14 +293,20 @@ describe('anonymizeConfigForTelemetry', () => {
     const anonymizedConfig = anonymizeConfigForTelemetry({
       outputTargets: [
         { type: 'www', baseUrl: 'https://example.com' },
+        { type: 'dist-hydrate-script', external: ['beep', 'boop'], dir: 'shoud/go/away' },
+        { type: 'dist-custom-elements', autoDefineCustomElements: false },
+        { type: 'dist-custom-elements', generateTypeDeclarations: true },
         { type: 'dist', typesDir: 'my-types' },
       ],
     });
 
     expect(anonymizedConfig).toEqual({
       outputTargets: [
-        { type: 'www', baseUrl: 'https://example.com' },
-        { type: 'dist', typesDir: 'my-types' },
+        { type: 'www', baseUrl: 'omitted' },
+        { type: 'dist-hydrate-script', external: ['beep', 'boop'], dir: 'omitted' },
+        { type: 'dist-custom-elements', autoDefineCustomElements: false },
+        { type: 'dist-custom-elements', generateTypeDeclarations: true },
+        { type: 'dist', typesDir: 'omitted' },
       ],
     });
   });

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -4,7 +4,7 @@ import * as shouldTrack from '../shouldTrack';
 import { createSystem } from '../../../compiler/sys/stencil-sys';
 import { mockLogger } from '@stencil/core/testing';
 import * as coreCompiler from '@stencil/core/compiler';
-import { anonymizeConfigForTelemtry } from '../telemetry';
+import { anonymizeConfigForTelemetry } from '../telemetry';
 
 describe('telemetryBuildFinishedAction', () => {
   const config: d.Config = {
@@ -266,7 +266,7 @@ describe('prepareData', () => {
   });
 });
 
-describe('anonymizeConfigForTelemtry', () => {
+describe('anonymizeConfigForTelemetry', () => {
   it.each([
     'rootDir',
     'fsNamespace',
@@ -279,19 +279,19 @@ describe('anonymizeConfigForTelemtry', () => {
     'configPath',
     'tsconfig',
   ])("should anonymize top-level string prop '%s'", (prop: string) => {
-    const anonymizedConfig = anonymizeConfigForTelemtry({ [prop]: "shouldn't see this!", outputTargets: [] });
+    const anonymizedConfig = anonymizeConfigForTelemetry({ [prop]: "shouldn't see this!", outputTargets: [] });
     expect(anonymizedConfig).toEqual({ [prop]: 'omitted', outputTargets: [] });
   });
 
   it.each(['sys', 'logger'])("should remove objects under prop '%s'", (prop: string) => {
-    const anonymizedConfig = anonymizeConfigForTelemtry({ [prop]: {}, outputTargets: [] });
+    const anonymizedConfig = anonymizeConfigForTelemetry({ [prop]: {}, outputTargets: [] });
     expect(anonymizedConfig).toEqual({
       outputTargets: [],
     });
   });
 
   it('should anonymize the devServer config', () => {
-    const anonymizedConfig = anonymizeConfigForTelemtry({
+    const anonymizedConfig = anonymizeConfigForTelemetry({
       outputTargets: [],
       devServer: {
         protocol: 'http',
@@ -310,7 +310,7 @@ describe('anonymizeConfigForTelemtry', () => {
   });
 
   it('should anonymize the typescript compiler options', () => {
-    const anonymizedConfig = anonymizeConfigForTelemtry({
+    const anonymizedConfig = anonymizeConfigForTelemetry({
       outputTargets: [],
       tsCompilerOptions: {
         anotherOption: 'should see this!',

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -5,6 +5,7 @@ import { createSystem } from '../../../compiler/sys/stencil-sys';
 import { mockLogger } from '@stencil/core/testing';
 import * as coreCompiler from '@stencil/core/compiler';
 import { anonymizeConfigForTelemetry } from '../telemetry';
+import { DIST, DIST_CUSTOM_ELEMENTS, DIST_HYDRATE_SCRIPT, WWW } from 'src/compiler/output-targets/output-utils';
 
 describe('telemetryBuildFinishedAction', () => {
   const config: d.Config = {
@@ -103,28 +104,28 @@ describe('hasAppTarget', () => {
   });
 
   it('Result is correct when outputTargets contains www with no baseUrl or serviceWorker', () => {
-    const config = { outputTargets: [{ type: 'www' }] } as d.Config;
+    const config = { outputTargets: [{ type: WWW }] } as d.Config;
     expect(telemetry.hasAppTarget(config)).toBe(false);
   });
 
   it('Result is correct when outputTargets contains www with default baseUrl value', () => {
-    const config = { outputTargets: [{ type: 'www', baseUrl: '/' }] } as d.Config;
+    const config = { outputTargets: [{ type: WWW, baseUrl: '/' }] } as d.Config;
     expect(telemetry.hasAppTarget(config)).toBe(false);
   });
 
   it('Result is correct when outputTargets contains www with serviceWorker', () => {
-    const config = { outputTargets: [{ type: 'www', serviceWorker: { swDest: './tmp' } }] } as d.Config;
+    const config = { outputTargets: [{ type: WWW, serviceWorker: { swDest: './tmp' } }] } as d.Config;
     expect(telemetry.hasAppTarget(config)).toBe(true);
   });
 
   it('Result is correct when outputTargets contains www with baseUrl', () => {
-    const config = { outputTargets: [{ type: 'www', baseUrl: 'https://example.com' }] } as d.Config;
+    const config = { outputTargets: [{ type: WWW, baseUrl: 'https://example.com' }] } as d.Config;
     expect(telemetry.hasAppTarget(config)).toBe(true);
   });
 
   it('Result is correct when outputTargets contains www with serviceWorker and baseUrl', () => {
     const config = {
-      outputTargets: [{ type: 'www', baseUrl: 'https://example.com', serviceWorker: { swDest: './tmp' } }],
+      outputTargets: [{ type: WWW, baseUrl: 'https://example.com', serviceWorker: { swDest: './tmp' } }],
     } as d.Config;
     expect(telemetry.hasAppTarget(config)).toBe(true);
   });
@@ -239,7 +240,7 @@ describe('prepareData', () => {
             serviceWorker: {
               swDest: 'omitted',
             },
-            type: 'www',
+            type: WWW,
           },
         ],
       },
@@ -292,21 +293,21 @@ describe('anonymizeConfigForTelemetry', () => {
   it('should retain outputTarget props on the keep list', () => {
     const anonymizedConfig = anonymizeConfigForTelemetry({
       outputTargets: [
-        { type: 'www', baseUrl: 'https://example.com' },
-        { type: 'dist-hydrate-script', external: ['beep', 'boop'], dir: 'shoud/go/away' },
-        { type: 'dist-custom-elements', autoDefineCustomElements: false },
-        { type: 'dist-custom-elements', generateTypeDeclarations: true },
-        { type: 'dist', typesDir: 'my-types' },
+        { type: WWW, baseUrl: 'https://example.com' },
+        { type: DIST_HYDRATE_SCRIPT, external: ['beep', 'boop'], dir: 'shoud/go/away' },
+        { type: DIST_CUSTOM_ELEMENTS, autoDefineCustomElements: false },
+        { type: DIST_CUSTOM_ELEMENTS, generateTypeDeclarations: true },
+        { type: DIST, typesDir: 'my-types' },
       ],
     });
 
     expect(anonymizedConfig).toEqual({
       outputTargets: [
-        { type: 'www', baseUrl: 'omitted' },
-        { type: 'dist-hydrate-script', external: ['beep', 'boop'], dir: 'omitted' },
-        { type: 'dist-custom-elements', autoDefineCustomElements: false },
-        { type: 'dist-custom-elements', generateTypeDeclarations: true },
-        { type: 'dist', typesDir: 'omitted' },
+        { type: WWW, baseUrl: 'omitted' },
+        { type: DIST_HYDRATE_SCRIPT, external: ['beep', 'boop'], dir: 'omitted' },
+        { type: DIST_CUSTOM_ELEMENTS, autoDefineCustomElements: false },
+        { type: DIST_CUSTOM_ELEMENTS, generateTypeDeclarations: true },
+        { type: DIST, typesDir: 'omitted' },
       ],
     });
   });

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -189,13 +189,11 @@ describe('prepareData', () => {
         },
         outputTargets: [
           {
-            baseUrl: 'omitted',
-            dir: 'omitted',
+            baseUrl: 'https://example.com',
             serviceWorker: {
-              swDest: './tmp',
+              swDest: 'omitted',
             },
             type: 'www',
-            typesDir: 'omitted',
           },
         ],
       },
@@ -237,13 +235,11 @@ describe('prepareData', () => {
         },
         outputTargets: [
           {
-            baseUrl: 'omitted',
-            dir: 'omitted',
+            baseUrl: 'https://example.com',
             serviceWorker: {
-              swDest: './tmp',
+              swDest: 'omitted',
             },
             type: 'www',
-            typesDir: 'omitted',
           },
         ],
       },
@@ -292,4 +288,20 @@ describe('anonymizeConfigForTelemetry', () => {
       });
     }
   );
+
+  it('should retain outputTarget props on the keep list', () => {
+    const anonymizedConfig = anonymizeConfigForTelemetry({
+      outputTargets: [
+        { type: 'www', baseUrl: 'https://example.com' },
+        { type: 'dist', typesDir: 'my-types' },
+      ],
+    });
+
+    expect(anonymizedConfig).toEqual({
+      outputTargets: [
+        { type: 'www', baseUrl: 'https://example.com' },
+        { type: 'dist', typesDir: 'my-types' },
+      ],
+    });
+  });
 });

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -283,46 +283,13 @@ describe('anonymizeConfigForTelemetry', () => {
     expect(anonymizedConfig).toEqual({ [prop]: 'omitted', outputTargets: [] });
   });
 
-  it.each(['sys', 'logger'])("should remove objects under prop '%s'", (prop: string) => {
-    const anonymizedConfig = anonymizeConfigForTelemetry({ [prop]: {}, outputTargets: [] });
-    expect(anonymizedConfig).toEqual({
-      outputTargets: [],
-    });
-  });
-
-  it('should anonymize the devServer config', () => {
-    const anonymizedConfig = anonymizeConfigForTelemetry({
-      outputTargets: [],
-      devServer: {
-        protocol: 'http',
-        srcIndexHtml: "shouldn't see this!",
-        root: "shouldn't see this!",
-      },
-    });
-    expect(anonymizedConfig).toEqual({
-      outputTargets: [],
-      devServer: {
-        protocol: 'http',
-        srcIndexHtml: 'omitted',
-        root: 'omitted',
-      },
-    });
-  });
-
-  it('should anonymize the typescript compiler options', () => {
-    const anonymizedConfig = anonymizeConfigForTelemetry({
-      outputTargets: [],
-      tsCompilerOptions: {
-        anotherOption: 'should see this!',
-        configFilePath: "shouldn't see this!",
-      },
-    });
-    expect(anonymizedConfig).toEqual({
-      outputTargets: [],
-      tsCompilerOptions: {
-        anotherOption: 'should see this!',
-        configFilePath: 'omitted',
-      },
-    });
-  });
+  it.each(['sys', 'logger', 'devServer', 'tsCompilerOptions'])(
+    "should remove objects under prop '%s'",
+    (prop: string) => {
+      const anonymizedConfig = anonymizeConfigForTelemetry({ [prop]: {}, outputTargets: [] });
+      expect(anonymizedConfig).toEqual({
+        outputTargets: [],
+      });
+    }
+  );
 });

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -294,7 +294,7 @@ describe('anonymizeConfigForTelemtry', () => {
     const anonymizedConfig = anonymizeConfigForTelemtry({
       outputTargets: [],
       devServer: {
-        anotherOption: 'should see this!',
+        protocol: 'http',
         srcIndexHtml: "shouldn't see this!",
         root: "shouldn't see this!",
       },
@@ -302,7 +302,7 @@ describe('anonymizeConfigForTelemtry', () => {
     expect(anonymizedConfig).toEqual({
       outputTargets: [],
       devServer: {
-        anotherOption: 'should see this!',
+        protocol: 'http',
         srcIndexHtml: 'omitted',
         root: 'omitted',
       },

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -2635,6 +2635,7 @@ export interface TrackableData {
   build: string;
   stencil: string;
   has_app_pwa_config: boolean;
+  config: Config;
 }
 
 /**


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

This adds an anonymized copy of the Stencil configuration to the
telemetry object, so that various configuration options can be tracked
and observed over time.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Telemetry change!


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This adds a function to anonymize the Stencil configuration and basically adds that anonymized object in to the object that we ship to the telemetry API endpoint.

The main thing to review here is whether the anonymization makes sense! I went through the output and removed everything I could think of that would have a filepath in it that might contain the current username, an internal URL, or something of that type.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I have added tests around the anonymization function and updated the other unit tests for the module to account for the changes, I'm not sure if we need / want to test anything else. I've also run a dev build based on these changes locally and confirmed that the data is shipping to where it's supposed to.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
