### PR TITLE
test(config): add unit tests to config flags

### DIFF
--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -50,7 +50,7 @@ describe('validation', () => {
         expect(config.devMode).toBe(false);
       });
 
-      it('sets "devMode" to false the user provided flag isn\'t a boolean', () => {
+      it('sets "devMode" to false if the user provided flag isn\'t a boolean', () => {
         // the branch under test explicitly requires a value whose type is not allowed by the type system
         const devMode = 'not-a-bool' as unknown as boolean;
         userConfig = { devMode };

--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -18,6 +18,48 @@ describe('validation', () => {
     };
   });
 
+  describe('flags', () => {
+    it('adds a default "flags" object if none is provided', () => {
+      userConfig.flags = undefined;
+      const { config } = validateConfig(userConfig);
+      expect(config.flags).toEqual({});
+    });
+
+    it('serializes a provided "flags" object', () => {
+      userConfig.flags = { dev: false };
+      const { config } = validateConfig(userConfig);
+      expect(config.flags).toEqual({ dev: false });
+    });
+
+    describe('devMode', () => {
+      it('defaults "devMode" to false when "flag.prod" is truthy', () => {
+        userConfig.flags = { prod: true };
+        const { config } = validateConfig(userConfig);
+        expect(config.devMode).toBe(false);
+      });
+
+      it('defaults "devMode" to true when "flag.dev" is truthy', () => {
+        userConfig.flags = { dev: true };
+        const { config } = validateConfig(userConfig);
+        expect(config.devMode).toBe(true);
+      });
+
+      it('defaults "devMode" to false when "flag.prod" & "flag.dev" are truthy', () => {
+        userConfig.flags = { dev: true, prod: true };
+        const { config } = validateConfig(userConfig);
+        expect(config.devMode).toBe(false);
+      });
+
+      it('sets "devMode" to false the user provided flag isn\'t a boolean', () => {
+        // the branch under test explicitly requires a value whose type is not allowed by the type system
+        const devMode = 'not-a-bool' as unknown as boolean;
+        userConfig = { devMode };
+        const { config } = validateConfig(userConfig);
+        expect(config.devMode).toBe(false);
+      });
+    });
+  });
+
   describe('allowInlineScripts', () => {
     it('set allowInlineScripts true', () => {
       userConfig.allowInlineScripts = true;


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

the initialization of `config.flags` is not tested

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit adds unit tests to the portion of the configuration
validation process for the 'flags' field

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

unit tests pass
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
