### PR TITLE
refactor(cli): refactor parse-flags module

### DIFF
--- a/scripts/bundles/cli.ts
+++ b/scripts/bundles/cli.ts
@@ -45,23 +45,6 @@ export async function cli(opts: BuildOptions): Promise<ReadonlyArray<RollupOptio
   dts = dts.replace('@stencil/core/internal', '../internal/index');
   await fs.writeFile(join(opts.output.cliDir, dtsFilename), dts);
 
-  // bundle config-flags.js
-  const esConfigFlagsOutput: OutputOptions = {
-    format: 'es',
-    file: join(outputDir, 'config-flags.js'),
-    preferConst: true,
-    sourcemap: true,
-    banner: getBanner(opts, `Stencil CLI Config Flags`, true),
-  };
-
-  const cjsConfigFlagsOutput: OutputOptions = {
-    format: 'cjs',
-    file: join(outputDir, 'config-flags.cjs'),
-    preferConst: true,
-    sourcemap: true,
-    banner: getBanner(opts, `Stencil CLI Config Flags (CommonJS)`, true),
-  };
-
   // copy config-flags.d.ts
   let configDts = await fs.readFile(join(inputDir, 'config-flags.d.ts'), 'utf8');
   configDts = configDts.replace('@stencil/core/declarations', '../internal/index');
@@ -78,7 +61,7 @@ export async function cli(opts: BuildOptions): Promise<ReadonlyArray<RollupOptio
 
   const cliBundle: RollupOptions = {
     input: join(inputDir, 'index.js'),
-    output: [esOutput, cjsOutput, esConfigFlagsOutput, cjsConfigFlagsOutput],
+    output: [esOutput, cjsOutput],
     external: ['path'],
     plugins: [
       relativePathPlugin('@stencil/core/testing', '../testing/index.js'),

--- a/scripts/bundles/cli.ts
+++ b/scripts/bundles/cli.ts
@@ -62,7 +62,6 @@ export async function cli(opts: BuildOptions): Promise<ReadonlyArray<RollupOptio
     banner: getBanner(opts, `Stencil CLI Config Flags (CommonJS)`, true),
   };
 
-
   // copy config-flags.d.ts
   let configDts = await fs.readFile(join(inputDir, 'config-flags.d.ts'), 'utf8');
   configDts = configDts.replace('@stencil/core/declarations', '../internal/index');

--- a/scripts/bundles/cli.ts
+++ b/scripts/bundles/cli.ts
@@ -48,15 +48,15 @@ export async function cli(opts: BuildOptions): Promise<ReadonlyArray<RollupOptio
   // copy config-flags.js
   const configFlags: OutputOptions = {
     format: 'es',
-    file: join(outputDir, "config-flags.js"),
+    file: join(outputDir, 'config-flags.js'),
     preferConst: true,
     sourcemap: true,
     banner: getBanner(opts, `Stencil CLI Config Flags`, true),
-  }
+  };
 
   // copy config-flags.d.ts
   let configDts = await fs.readFile(join(inputDir, 'config-flags.d.ts'), 'utf8');
-  configDts = configDts.replace('@stencil/core/internal', '../internal/index');
+  configDts = configDts.replace('@stencil/core/declarations', '../internal/index');
   await fs.writeFile(join(opts.output.cliDir, 'config-flags.d.ts'), configDts);
 
   // write @stencil/core/compiler/package.json

--- a/scripts/bundles/cli.ts
+++ b/scripts/bundles/cli.ts
@@ -45,6 +45,20 @@ export async function cli(opts: BuildOptions): Promise<ReadonlyArray<RollupOptio
   dts = dts.replace('@stencil/core/internal', '../internal/index');
   await fs.writeFile(join(opts.output.cliDir, dtsFilename), dts);
 
+  // copy config-flags.js
+  const configFlags: OutputOptions = {
+    format: 'es',
+    file: join(outputDir, "config-flags.js"),
+    preferConst: true,
+    sourcemap: true,
+    banner: getBanner(opts, `Stencil CLI Config Flags`, true),
+  }
+
+  // copy config-flags.d.ts
+  let configDts = await fs.readFile(join(inputDir, 'config-flags.d.ts'), 'utf8');
+  configDts = configDts.replace('@stencil/core/internal', '../internal/index');
+  await fs.writeFile(join(opts.output.cliDir, 'config-flags.d.ts'), configDts);
+
   // write @stencil/core/compiler/package.json
   writePkgJson(opts, opts.output.cliDir, {
     name: '@stencil/core/cli',
@@ -56,7 +70,7 @@ export async function cli(opts: BuildOptions): Promise<ReadonlyArray<RollupOptio
 
   const cliBundle: RollupOptions = {
     input: join(inputDir, 'index.js'),
-    output: [esOutput, cjsOutput],
+    output: [esOutput, cjsOutput, configFlags],
     external: ['path'],
     plugins: [
       relativePathPlugin('@stencil/core/testing', '../testing/index.js'),

--- a/scripts/bundles/cli.ts
+++ b/scripts/bundles/cli.ts
@@ -45,14 +45,23 @@ export async function cli(opts: BuildOptions): Promise<ReadonlyArray<RollupOptio
   dts = dts.replace('@stencil/core/internal', '../internal/index');
   await fs.writeFile(join(opts.output.cliDir, dtsFilename), dts);
 
-  // copy config-flags.js
-  const configFlags: OutputOptions = {
+  // bundle config-flags.js
+  const esConfigFlagsOutput: OutputOptions = {
     format: 'es',
     file: join(outputDir, 'config-flags.js'),
     preferConst: true,
     sourcemap: true,
     banner: getBanner(opts, `Stencil CLI Config Flags`, true),
   };
+
+  const cjsConfigFlagsOutput: OutputOptions = {
+    format: 'cjs',
+    file: join(outputDir, 'config-flags.cjs'),
+    preferConst: true,
+    sourcemap: true,
+    banner: getBanner(opts, `Stencil CLI Config Flags (CommonJS)`, true),
+  };
+
 
   // copy config-flags.d.ts
   let configDts = await fs.readFile(join(inputDir, 'config-flags.d.ts'), 'utf8');
@@ -70,7 +79,7 @@ export async function cli(opts: BuildOptions): Promise<ReadonlyArray<RollupOptio
 
   const cliBundle: RollupOptions = {
     input: join(inputDir, 'index.js'),
-    output: [esOutput, cjsOutput, configFlags],
+    output: [esOutput, cjsOutput, esConfigFlagsOutput, cjsConfigFlagsOutput],
     external: ['path'],
     plugins: [
       relativePathPlugin('@stencil/core/testing', '../testing/index.js'),

--- a/src/cli/config-flags.ts
+++ b/src/cli/config-flags.ts
@@ -108,17 +108,17 @@ type ObjectFromKeys<K extends ReadonlyArray<string>, T> = {
  */
 type BooleanConfigFlags = ObjectFromKeys<typeof BOOLEAN_CLI_ARGS, boolean>;
 /**
- * Type containing the possible Boolean configuration flags, to be included
+ * Type containing the possible String configuration flags, to be included
  * in ConfigFlags, below
  */
 type StringConfigFlags = ObjectFromKeys<typeof STRING_CLI_ARGS, string>;
 /**
- * Type containing the possible Boolean configuration flags, to be included
+ * Type containing the possible numeric configuration flags, to be included
  * in ConfigFlags, below
  */
 type NumberConfigFlags = ObjectFromKeys<typeof NUMBER_CLI_ARGS, number>;
 /**
- * Type containing the possible Boolean configuration flags, to be included
+ * Type containing the possible LogLevel configuration flags, to be included
  * in ConfigFlags, below
  */
 type LogLevelFlags = ObjectFromKeys<typeof LOG_LEVEL_CLI_ARGS, LogLevel>;

--- a/src/cli/config-flags.ts
+++ b/src/cli/config-flags.ts
@@ -45,7 +45,7 @@ export const NUMBER_CLI_ARGS = ['maxWorkers', 'port'] as const;
 /**
  * All the String options supported by the Stencil CLI
  */
-export const STRING_CLI_ARGS = ['address', 'config', 'docsJson', 'emulate', 'root', 'screenshotConnector'] as const;
+export const STRING_CLI_ARGS = ['address', 'config', 'docsJson', 'emulate', 'root', 'screenshotConnector', 'docsApi'] as const;
 
 /**
  * All the LogLevel-type options supported by the Stencil CLI

--- a/src/cli/config-flags.ts
+++ b/src/cli/config-flags.ts
@@ -90,7 +90,7 @@ export const CLI_ARG_ALIASES: AliasMap = {
  * mostly optional keys, we make all the properties option (w/ `'?'`)
  */
 type ObjectFromKeys<K extends ReadonlyArray<string>, T> = {
-  [key in K[number]]?: T;
+  [key in K[number]]?: T | null;
 };
 
 type BooleanConfigFlags = ObjectFromKeys<typeof BOOLEAN_CLI_ARGS, boolean>;
@@ -113,7 +113,7 @@ type LogLevelFlags = ObjectFromKeys<typeof LOG_LEVEL_CLI_ARGS, LogLevel>;
  * on actual flags passed by the user.
  */
 export interface ConfigFlags extends BooleanConfigFlags, StringConfigFlags, NumberConfigFlags, LogLevelFlags {
-  task?: TaskCommand;
+  task?: TaskCommand| null;
   args?: string[];
   knownArgs?: string[];
   unknownArgs?: string[];

--- a/src/cli/config-flags.ts
+++ b/src/cli/config-flags.ts
@@ -1,5 +1,3 @@
-import { LogLevel, TaskCommand } from '../declarations';
-
 /**
  * All the boolean options supported by the Stencil CLI
  */
@@ -81,40 +79,3 @@ export const CLI_ARG_ALIASES: AliasMap = {
   port: 'p',
   version: 'v',
 };
-
-/**
- * Given two types `K` and `T` where `K` extends `ReadonlyArray<string>`,
- * construct a type which maps the strings in `K` as keys to values of type `T`.
- *
- * Becase we use this type to construct an interface (`ConfigFlags`) which has
- * mostly optional keys, we make all the properties option (w/ `'?'`)
- */
-type ObjectFromKeys<K extends ReadonlyArray<string>, T> = {
-  [key in K[number]]?: T | null;
-};
-
-type BooleanConfigFlags = ObjectFromKeys<typeof BOOLEAN_CLI_ARGS, boolean>;
-type StringConfigFlags = ObjectFromKeys<typeof STRING_CLI_ARGS, string>;
-type NumberConfigFlags = ObjectFromKeys<typeof NUMBER_CLI_ARGS, number>;
-type LogLevelFlags = ObjectFromKeys<typeof LOG_LEVEL_CLI_ARGS, LogLevel>;
-
-/**
- * The configuration flags which can be set by the user on the command line.
- * This interface captures both known arguments (which are enumerated and then
- * parsed according to their types) and unknown arguments which the user may
- * pass at the CLI.
- *
- * Note that this interface is constructed by extending `BooleanConfigFlags`,
- * `StringConfigFlags`, etc. These types are in turn constructed from types
- * extending `ReadonlyArray<string>` which we declare here in this file. This
- * allows us to record our known CLI arguments in one place, using a
- * `ReadonlyArray<string>` to get both a type-level representation of what CLI
- * options we support and a runtime list of strings which can be used to match
- * on actual flags passed by the user.
- */
-export interface ConfigFlags extends BooleanConfigFlags, StringConfigFlags, NumberConfigFlags, LogLevelFlags {
-  task?: TaskCommand | null;
-  args?: string[];
-  knownArgs?: string[];
-  unknownArgs?: string[];
-}

--- a/src/cli/config-flags.ts
+++ b/src/cli/config-flags.ts
@@ -48,11 +48,11 @@ export const NUMBER_CLI_ARGS = ['maxWorkers', 'port'] as const;
 export const STRING_CLI_ARGS = [
   'address',
   'config',
+  'docsApi',
   'docsJson',
   'emulate',
   'root',
   'screenshotConnector',
-  'docsApi',
 ] as const;
 
 /**

--- a/src/cli/config-flags.ts
+++ b/src/cli/config-flags.ts
@@ -1,3 +1,5 @@
+import type { LogLevel, TaskCommand } from '@stencil/core/declarations';
+
 /**
  * All the boolean options supported by the Stencil CLI
  */
@@ -79,3 +81,57 @@ export const CLI_ARG_ALIASES: AliasMap = {
   port: 'p',
   version: 'v',
 };
+
+/**
+ * Given two types `K` and `T` where `K` extends `ReadonlyArray<string>`,
+ * construct a type which maps the strings in `K` as keys to values of type `T`.
+ *
+ * Becase we use this type to construct an interface (`ConfigFlags`) which has
+ * mostly optional keys, we make all the properties optional (w/ `'?'`) and
+ * possibly null.
+ */
+type ObjectFromKeys<K extends ReadonlyArray<string>, T> = {
+  [key in K[number]]?: T | null;
+};
+
+/**
+ * Type containing the possible Boolean configuration flags, to be included
+ * in ConfigFlags, below
+ */
+type BooleanConfigFlags = ObjectFromKeys<typeof BOOLEAN_CLI_ARGS, boolean>;
+/**
+ * Type containing the possible Boolean configuration flags, to be included
+ * in ConfigFlags, below
+ */
+type StringConfigFlags = ObjectFromKeys<typeof STRING_CLI_ARGS, string>;
+/**
+ * Type containing the possible Boolean configuration flags, to be included
+ * in ConfigFlags, below
+ */
+type NumberConfigFlags = ObjectFromKeys<typeof NUMBER_CLI_ARGS, number>;
+/**
+ * Type containing the possible Boolean configuration flags, to be included
+ * in ConfigFlags, below
+ */
+type LogLevelFlags = ObjectFromKeys<typeof LOG_LEVEL_CLI_ARGS, LogLevel>;
+
+/**
+ * The configuration flags which can be set by the user on the command line.
+ * This interface captures both known arguments (which are enumerated and then
+ * parsed according to their types) and unknown arguments which the user may
+ * pass at the CLI.
+ *
+ * Note that this interface is constructed by extending `BooleanConfigFlags`,
+ * `StringConfigFlags`, etc. These types are in turn constructed from types
+ * extending `ReadonlyArray<string>` which we declare in another module. This
+ * allows us to record our known CLI arguments in one place, using a
+ * `ReadonlyArray<string>` to get both a type-level representation of what CLI
+ * options we support and a runtime list of strings which can be used to match
+ * on actual flags passed by the user.
+ */
+export interface ConfigFlags extends BooleanConfigFlags, StringConfigFlags, NumberConfigFlags, LogLevelFlags {
+  task?: TaskCommand | null;
+  args?: string[];
+  knownArgs?: string[];
+  unknownArgs?: string[];
+}

--- a/src/cli/config-flags.ts
+++ b/src/cli/config-flags.ts
@@ -113,7 +113,7 @@ type LogLevelFlags = ObjectFromKeys<typeof LOG_LEVEL_CLI_ARGS, LogLevel>;
  * on actual flags passed by the user.
  */
 export interface ConfigFlags extends BooleanConfigFlags, StringConfigFlags, NumberConfigFlags, LogLevelFlags {
-  task?: TaskCommand| null;
+  task?: TaskCommand | null;
   args?: string[];
   knownArgs?: string[];
   unknownArgs?: string[];

--- a/src/cli/config-flags.ts
+++ b/src/cli/config-flags.ts
@@ -1,7 +1,7 @@
 import type { LogLevel, TaskCommand } from '@stencil/core/declarations';
 
 /**
- * All the boolean options supported by the Stencil CLI
+ * All the Boolean options supported by the Stencil CLI
  */
 export const BOOLEAN_CLI_ARGS = [
   'build',
@@ -38,17 +38,17 @@ export const BOOLEAN_CLI_ARGS = [
 ] as const;
 
 /**
- * All the number options supported by the Stencil CLI
+ * All the Number options supported by the Stencil CLI
  */
 export const NUMBER_CLI_ARGS = ['maxWorkers', 'port'] as const;
 
 /**
- * All the string options supported by the Stencil CLI
+ * All the String options supported by the Stencil CLI
  */
 export const STRING_CLI_ARGS = ['address', 'config', 'docsJson', 'emulate', 'root', 'screenshotConnector'] as const;
 
 /**
- * All the log level-type options supported by the Stencil CLI
+ * All the LogLevel-type options supported by the Stencil CLI
  *
  * This is a bit silly since there's only one such argument atm,
  * but this approach lets us make sure that we're handling all
@@ -86,9 +86,9 @@ export const CLI_ARG_ALIASES: AliasMap = {
  * Given two types `K` and `T` where `K` extends `ReadonlyArray<string>`,
  * construct a type which maps the strings in `K` as keys to values of type `T`.
  *
- * Becase we use this type to construct an interface (`ConfigFlags`) which has
- * mostly optional keys, we make all the properties optional (w/ `'?'`) and
- * possibly null.
+ * Because we use types derived this way to construct an interface (`ConfigFlags`)
+ * for which we want optional keys, we make all the properties optional (w/ `'?'`)
+ * and possibly null.
  */
 type ObjectFromKeys<K extends ReadonlyArray<string>, T> = {
   [key in K[number]]?: T | null;

--- a/src/cli/config-flags.ts
+++ b/src/cli/config-flags.ts
@@ -45,7 +45,15 @@ export const NUMBER_CLI_ARGS = ['maxWorkers', 'port'] as const;
 /**
  * All the String options supported by the Stencil CLI
  */
-export const STRING_CLI_ARGS = ['address', 'config', 'docsJson', 'emulate', 'root', 'screenshotConnector', 'docsApi'] as const;
+export const STRING_CLI_ARGS = [
+  'address',
+  'config',
+  'docsJson',
+  'emulate',
+  'root',
+  'screenshotConnector',
+  'docsApi',
+] as const;
 
 /**
  * All the LogLevel-type options supported by the Stencil CLI

--- a/src/cli/config-flags.ts
+++ b/src/cli/config-flags.ts
@@ -1,0 +1,120 @@
+import { LogLevel, TaskCommand } from '../declarations';
+
+/**
+ * All the boolean options supported by the Stencil CLI
+ */
+export const BOOLEAN_CLI_ARGS = [
+  'build',
+  'cache',
+  'checkVersion',
+  'ci',
+  'compare',
+  'debug',
+  'dev',
+  'devtools',
+  'docs',
+  'e2e',
+  'es5',
+  'esm',
+  'headless',
+  'help',
+  'log',
+  'open',
+  'prerender',
+  'prerenderExternal',
+  'prod',
+  'profile',
+  'serviceWorker',
+  'screenshot',
+  'serve',
+  'skipNodeCheck',
+  'spec',
+  'ssr',
+  'stats',
+  'updateScreenshot',
+  'verbose',
+  'version',
+  'watch',
+] as const;
+
+/**
+ * All the number options supported by the Stencil CLI
+ */
+export const NUMBER_CLI_ARGS = ['maxWorkers', 'port'] as const;
+
+/**
+ * All the string options supported by the Stencil CLI
+ */
+export const STRING_CLI_ARGS = ['address', 'config', 'docsJson', 'emulate', 'root', 'screenshotConnector'] as const;
+
+/**
+ * All the log level-type options supported by the Stencil CLI
+ *
+ * This is a bit silly since there's only one such argument atm,
+ * but this approach lets us make sure that we're handling all
+ * our arguments in a type-safe way.
+ */
+export const LOG_LEVEL_CLI_ARGS = ['logLevel'] as const;
+
+/**
+ * A type which gives the members of a `ReadonlyArray<string>` as
+ * an enum-like type which can be used for e.g. keys in a `Record`
+ * (as in the `AliasMap` type below)
+ */
+type ArrayValuesAsUnion<T extends ReadonlyArray<string>> = T[number];
+
+export type BooleanCLIArg = ArrayValuesAsUnion<typeof BOOLEAN_CLI_ARGS>;
+export type StringCLIArg = ArrayValuesAsUnion<typeof STRING_CLI_ARGS>;
+export type NumberCLIArg = ArrayValuesAsUnion<typeof NUMBER_CLI_ARGS>;
+export type LogCLIArg = ArrayValuesAsUnion<typeof LOG_LEVEL_CLI_ARGS>;
+
+type KnownCLIArg = BooleanCLIArg | StringCLIArg | NumberCLIArg | LogCLIArg;
+
+type AliasMap = Partial<Record<KnownCLIArg, string>>;
+
+/**
+ * For a small subset of CLI options we support a short alias e.g. `'h'` for `'help'`
+ */
+export const CLI_ARG_ALIASES: AliasMap = {
+  config: 'c',
+  help: 'h',
+  port: 'p',
+  version: 'v',
+};
+
+/**
+ * Given two types `K` and `T` where `K` extends `ReadonlyArray<string>`,
+ * construct a type which maps the strings in `K` as keys to values of type `T`.
+ *
+ * Becase we use this type to construct an interface (`ConfigFlags`) which has
+ * mostly optional keys, we make all the properties option (w/ `'?'`)
+ */
+type ObjectFromKeys<K extends ReadonlyArray<string>, T> = {
+  [key in K[number]]?: T;
+};
+
+type BooleanConfigFlags = ObjectFromKeys<typeof BOOLEAN_CLI_ARGS, boolean>;
+type StringConfigFlags = ObjectFromKeys<typeof STRING_CLI_ARGS, string>;
+type NumberConfigFlags = ObjectFromKeys<typeof NUMBER_CLI_ARGS, number>;
+type LogLevelFlags = ObjectFromKeys<typeof LOG_LEVEL_CLI_ARGS, LogLevel>;
+
+/**
+ * The configuration flags which can be set by the user on the command line.
+ * This interface captures both known arguments (which are enumerated and then
+ * parsed according to their types) and unknown arguments which the user may
+ * pass at the CLI.
+ *
+ * Note that this interface is constructed by extending `BooleanConfigFlags`,
+ * `StringConfigFlags`, etc. These types are in turn constructed from types
+ * extending `ReadonlyArray<string>` which we declare here in this file. This
+ * allows us to record our known CLI arguments in one place, using a
+ * `ReadonlyArray<string>` to get both a type-level representation of what CLI
+ * options we support and a runtime list of strings which can be used to match
+ * on actual flags passed by the user.
+ */
+export interface ConfigFlags extends BooleanConfigFlags, StringConfigFlags, NumberConfigFlags, LogLevelFlags {
+  task?: TaskCommand;
+  args?: string[];
+  knownArgs?: string[];
+  unknownArgs?: string[];
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,2 +1,3 @@
 export { parseFlags } from './parse-flags';
 export { run, runTask } from './run';
+export { ConfigFlags } from './config-flags';

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -1,4 +1,5 @@
-import type { Config, Logger, ConfigFlags, CompilerSystem, TaskCommand } from '../declarations';
+import type { Config, Logger, CompilerSystem, TaskCommand } from '../declarations';
+import type { ConfigFlags } from './config-flags';
 import type { CoreCompiler } from './load-compiler';
 
 export const startupLog = (logger: Logger, task: TaskCommand) => {

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -1,5 +1,4 @@
-import type { Config, Logger, CompilerSystem, TaskCommand } from '../declarations';
-import { ConfigFlags } from './config-flags';
+import type { Config, Logger, ConfigFlags, CompilerSystem, TaskCommand } from '../declarations';
 import type { CoreCompiler } from './load-compiler';
 
 export const startupLog = (logger: Logger, task: TaskCommand) => {

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -1,4 +1,5 @@
-import type { Config, Logger, ConfigFlags, CompilerSystem, TaskCommand } from '../declarations';
+import type { Config, Logger, CompilerSystem, TaskCommand } from '../declarations';
+import { ConfigFlags } from './config-flags';
 import type { CoreCompiler } from './load-compiler';
 
 export const startupLog = (logger: Logger, task: TaskCommand) => {

--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -1,4 +1,4 @@
-import type { CompilerSystem, LogLevel, TaskCommand } from '../declarations';
+import { CompilerSystem, LogLevel, LOG_LEVELS, TaskCommand } from '../declarations';
 import { dashToPascalCase, toDashCase } from '@utils';
 import {
   ConfigFlags,
@@ -243,7 +243,12 @@ const getEqualsValue = (commandArgument: string) => commandArgument.split('=').s
  * @returns whether this is a `LogLevel`
  */
 const isLogLevel = (maybeLogLevel: string): maybeLogLevel is LogLevel =>
-  ['info', 'warn', 'error', 'debug'].includes(maybeLogLevel);
+  // unfortunately `includes` is typed on `ReadonlyArray<T>` as `(el: T):
+  // boolean` so a `string` cannot be passed to `includes` on a
+  // `ReadonlyArray` 😢 thus we `as any`
+  //
+  // see microsoft/TypeScript#31018 for some discussion of this
+  LOG_LEVELS.includes(maybeLogLevel as any);
 
 const getNpmConfigEnvArgs = (sys: CompilerSystem) => {
   // process.env.npm_config_argv

--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -199,8 +199,10 @@ const parseLogLevelArg = (flags: ConfigFlags, args: string[], configCaseName: Lo
  *
  * @param args the CLI args we're dealing with
  * @param configCaseName the ConfigFlag key which we're looking to pull out a value for
+ * @returns the value for the flag as well as the exact string which it matched from
+ * the user input.
  */
-const getValue = (args: string[], configCaseName: StringCLIArg | NumberCLIArg | LogCLIArg) => {
+const getValue = (args: string[], configCaseName: StringCLIArg | NumberCLIArg | LogCLIArg): CLIArgValue => {
   // for some CLI args we have a short alias, like 'c' for 'config'
   const alias = CLI_ARG_ALIASES[configCaseName];
   // we support supplying arguments in both dash-case and configCase
@@ -228,6 +230,13 @@ const getValue = (args: string[], configCaseName: StringCLIArg | NumberCLIArg | 
   });
   return { value, matchingArg };
 };
+
+interface CLIArgValue {
+  // the concrete value pulled from the CLI args
+  value: string,
+  // the matching argument key
+  matchingArg: string
+}
 
 /**
  * When a parameter is set in the format `--foobar=12` at the CLI (as opposed to

--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -1,6 +1,25 @@
-import type { CompilerSystem, ConfigFlags, TaskCommand } from '../declarations';
-import { dashToPascalCase } from '@utils';
+import type { CompilerSystem, LogLevel, TaskCommand } from '../declarations';
+import { dashToPascalCase, toDashCase } from '@utils';
+import {
+  CLI_ARG_ALIASES,
+  BooleanCLIArg,
+  BOOLEAN_CLI_ARGS,
+  ConfigFlags,
+  LogCLIArg,
+  LOG_LEVEL_CLI_ARGS,
+  NumberCLIArg,
+  NUMBER_CLI_ARGS,
+  StringCLIArg,
+  STRING_CLI_ARGS,
+} from './config-flags';
 
+/**
+ * Parse command line arguments into a structured `ConfigFlags` object
+ *
+ * @param args an array of config flags
+ * @sys an optional compiler system
+ * @returns a structured ConfigFlags object
+ */
 export const parseFlags = (args: string[], sys?: CompilerSystem): ConfigFlags => {
   const flags: ConfigFlags = {
     task: null,
@@ -14,11 +33,11 @@ export const parseFlags = (args: string[], sys?: CompilerSystem): ConfigFlags =>
   if (flags.args.length > 0 && flags.args[0] && !flags.args[0].startsWith('-')) {
     flags.task = flags.args[0] as TaskCommand;
   }
-  parseArgs(flags, flags.args, flags.knownArgs);
+  parseArgs(flags, flags.args);
 
   if (sys && sys.name === 'node') {
     const envArgs = getNpmConfigEnvArgs(sys);
-    parseArgs(flags, envArgs, flags.knownArgs);
+    parseArgs(flags, envArgs);
 
     envArgs.forEach((envArg) => {
       if (!flags.args.includes(envArg)) {
@@ -42,196 +61,191 @@ export const parseFlags = (args: string[], sys?: CompilerSystem): ConfigFlags =>
 };
 
 /**
- * Parse command line arguments that are whitelisted via the BOOLEAN_ARG_OPTS,
- * STRING_ARG_OPTS, and NUMBER_ARG_OPTS arrays in this file. Handles leading
- * dashes on arguments, aliases that are defined for a small number of argument
- * types, and parsing values for non-boolean arguments (e.g. port number).
+ * Parse command line arguments that are enumerated in the BOOLEAN_ARG_OPTS,
+ * STRING_ARG_OPTS, NUMBER_ARG_OPTS, and LOG_LEVEL_OPTS arrays in the
+ * `config-flags` module. Handles leading dashes on arguments, aliases that
+ * are defined for a small number of argument types, and parsing values for
+ * non-boolean arguments (e.g. port number).
  *
  * @param flags     a ConfigFlags object
  * @param args      an array of command-line arguments to parse
  * @param knownArgs an array to which all recognized, legal arguments are added
  */
-const parseArgs = (flags: any, args: string[], knownArgs: string[]) => {
-  BOOLEAN_ARG_OPTS.forEach((booleanName) => {
-    const alias = ARG_OPTS_ALIASES[booleanName];
-    const flagKey = configCase(booleanName);
+const parseArgs = (flags: ConfigFlags, args: string[]) => {
+  BOOLEAN_CLI_ARGS.forEach((argName) => parseBooleanArg(flags, args, argName));
+  STRING_CLI_ARGS.forEach((argName) => parseStringArg(flags, args, argName));
+  NUMBER_CLI_ARGS.forEach((argName) => parseNumberArg(flags, args, argName));
+  LOG_LEVEL_CLI_ARGS.forEach((argName) => parseLogLevelArg(flags, args, argName));
+};
 
-    if (typeof flags[flagKey] !== 'boolean') {
-      flags[flagKey] = null;
+/**
+ * Parse a boolean CLI argument. For these, we support the following formats:
+ *
+ * - `--booleanArg`
+ * - `--boolean-arg`
+ * - `--noBooleanArg`
+ * - `--no-boolean-arg`
+ *
+ * @param flags the config flags object, while we'll modify
+ * @param args our CLI arguments
+ * @param configCaseName the argument we want to look at right now
+ */
+const parseBooleanArg = (flags: ConfigFlags, args: string[], configCaseName: BooleanCLIArg) => {
+  // we support both dash-case and PascalCase versions of the parameter
+  // argName is 'configCase' version which can be found in BOOLEAN_ARG_OPTS
+  const alias = CLI_ARG_ALIASES[configCaseName];
+  const dashCaseName = toDashCase(configCaseName);
+
+  if (typeof flags[configCaseName] !== 'boolean') {
+    flags[configCaseName] = null;
+  }
+
+  args.forEach((cmdArg) => {
+    let value;
+
+    if (cmdArg === `--${configCaseName}` || cmdArg === `--${dashCaseName}`) {
+      value = true;
+    } else if (cmdArg === `--no-${dashCaseName}` || cmdArg === `--no${dashToPascalCase(dashCaseName)}`) {
+      value = false;
+    } else if (alias && cmdArg === `-${alias}`) {
+      value = true;
     }
 
-    args.forEach((cmdArg) => {
-      if (cmdArg === `--${booleanName}`) {
-        flags[flagKey] = true;
-        knownArgs.push(cmdArg);
-      } else if (cmdArg === `--${flagKey}`) {
-        flags[flagKey] = true;
-        knownArgs.push(cmdArg);
-      } else if (cmdArg === `--no-${booleanName}`) {
-        flags[flagKey] = false;
-        knownArgs.push(cmdArg);
-      } else if (cmdArg === `--no${dashToPascalCase(booleanName)}`) {
-        flags[flagKey] = false;
-        knownArgs.push(cmdArg);
-      } else if (alias && cmdArg === `-${alias}`) {
-        flags[flagKey] = true;
-        knownArgs.push(cmdArg);
-      }
-    });
-  });
-
-  STRING_ARG_OPTS.forEach((stringName) => {
-    const alias = ARG_OPTS_ALIASES[stringName];
-    const flagKey = configCase(stringName);
-
-    if (typeof flags[flagKey] !== 'string') {
-      flags[flagKey] = null;
-    }
-
-    for (let i = 0; i < args.length; i++) {
-      const cmdArg = args[i];
-
-      if (cmdArg.startsWith(`--${stringName}=`)) {
-        const values = cmdArg.split('=');
-        values.shift();
-        flags[flagKey] = values.join('=');
-        knownArgs.push(cmdArg);
-      } else if (cmdArg === `--${stringName}`) {
-        flags[flagKey] = args[i + 1];
-        knownArgs.push(cmdArg);
-        knownArgs.push(args[i + 1]);
-      } else if (cmdArg === `--${flagKey}`) {
-        flags[flagKey] = args[i + 1];
-        knownArgs.push(cmdArg);
-        knownArgs.push(args[i + 1]);
-      } else if (cmdArg.startsWith(`--${flagKey}=`)) {
-        const values = cmdArg.split('=');
-        values.shift();
-        flags[flagKey] = values.join('=');
-        knownArgs.push(cmdArg);
-      } else if (alias) {
-        if (cmdArg.startsWith(`-${alias}=`)) {
-          const values = cmdArg.split('=');
-          values.shift();
-          flags[flagKey] = values.join('=');
-          knownArgs.push(cmdArg);
-        } else if (cmdArg === `-${alias}`) {
-          flags[flagKey] = args[i + 1];
-          knownArgs.push(args[i + 1]);
-        }
-      }
-    }
-  });
-
-  NUMBER_ARG_OPTS.forEach((numberName) => {
-    const alias = ARG_OPTS_ALIASES[numberName];
-    const flagKey = configCase(numberName);
-
-    if (typeof flags[flagKey] !== 'number') {
-      flags[flagKey] = null;
-    }
-
-    for (let i = 0; i < args.length; i++) {
-      const cmdArg = args[i];
-
-      if (cmdArg.startsWith(`--${numberName}=`)) {
-        const values = cmdArg.split('=');
-        values.shift();
-        flags[flagKey] = parseInt(values.join(''), 10);
-        knownArgs.push(cmdArg);
-      } else if (cmdArg === `--${numberName}`) {
-        flags[flagKey] = parseInt(args[i + 1], 10);
-        knownArgs.push(args[i + 1]);
-      } else if (cmdArg.startsWith(`--${flagKey}=`)) {
-        const values = cmdArg.split('=');
-        values.shift();
-        flags[flagKey] = parseInt(values.join(''), 10);
-        knownArgs.push(cmdArg);
-      } else if (cmdArg === `--${flagKey}`) {
-        flags[flagKey] = parseInt(args[i + 1], 10);
-        knownArgs.push(args[i + 1]);
-      } else if (alias) {
-        if (cmdArg.startsWith(`-${alias}=`)) {
-          const values = cmdArg.split('=');
-          values.shift();
-          flags[flagKey] = parseInt(values.join(''), 10);
-          knownArgs.push(cmdArg);
-        } else if (cmdArg === `-${alias}`) {
-          flags[flagKey] = parseInt(args[i + 1], 10);
-          knownArgs.push(args[i + 1]);
-        }
-      }
+    if (value !== undefined) {
+      flags[configCaseName] = value;
+      flags.knownArgs.push(cmdArg);
     }
   });
 };
 
-const configCase = (prop: string) => {
-  prop = dashToPascalCase(prop);
-  return prop.charAt(0).toLowerCase() + prop.slice(1);
+/**
+ * Parse a string CLI argument
+ *
+ * @param flags the config flags object, while we'll modify
+ * @param args our CLI arguments
+ * @param configCaseName the argument we want to look at right now
+ */
+const parseStringArg = (flags: ConfigFlags, args: string[], configCaseName: StringCLIArg) => {
+  if (typeof flags[configCaseName] !== 'string') {
+    flags[configCaseName] = null;
+  }
+
+  const { value, matchingArg } = getValue(args, configCaseName);
+
+  if (value !== undefined) {
+    flags[configCaseName] = value;
+    flags.knownArgs.push(matchingArg);
+    flags.knownArgs.push(value);
+  }
 };
 
-type ArrayValuesAsUnion<T extends ReadonlyArray<string>> = T[number];
+/**
+ * Parse a number CLI argument
+ *
+ * @param flags the config flags object, while we'll modify
+ * @param args our CLI arguments
+ * @param configCaseName the argument we want to look at right now
+ */
+const parseNumberArg = (flags: ConfigFlags, args: string[], configCaseName: NumberCLIArg) => {
+  if (typeof flags[configCaseName] !== 'number') {
+    flags[configCaseName] = null;
+  }
 
-const BOOLEAN_ARG_OPTS = [
-  'build',
-  'cache',
-  'check-version',
-  'ci',
-  'compare',
-  'debug',
-  'dev',
-  'devtools',
-  'docs',
-  'e2e',
-  'es5',
-  'esm',
-  'headless',
-  'help',
-  'log',
-  'open',
-  'prerender',
-  'prerender-external',
-  'prod',
-  'profile',
-  'service-worker',
-  'screenshot',
-  'serve',
-  'skip-node-check',
-  'spec',
-  'ssr',
-  'stats',
-  'update-screenshot',
-  'verbose',
-  'version',
-  'watch',
-] as const;
+  const { value, matchingArg } = getValue(args, configCaseName);
 
-type BooleanArgOpt = ArrayValuesAsUnion<typeof BOOLEAN_ARG_OPTS>;
-
-const NUMBER_ARG_OPTS = ['max-workers', 'port'] as const;
-
-type NumberArgOpt = ArrayValuesAsUnion<typeof NUMBER_ARG_OPTS>;
-
-const STRING_ARG_OPTS = [
-  'address',
-  'config',
-  'docs-json',
-  'emulate',
-  'log-level',
-  'root',
-  'screenshot-connector',
-] as const;
-
-type StringArgOpt = ArrayValuesAsUnion<typeof STRING_ARG_OPTS>;
-
-type AliasMap = Partial<Record<BooleanArgOpt | NumberArgOpt | StringArgOpt, string>>;
-
-const ARG_OPTS_ALIASES: AliasMap = {
-  config: 'c',
-  help: 'h',
-  port: 'p',
-  version: 'v',
+  if (value) {
+    flags[configCaseName] = parseInt(value, 10);
+    flags.knownArgs.push(matchingArg);
+    flags.knownArgs.push(value);
+  }
 };
+
+/**
+ * Parse a LogLevel CLI argument. These can be only a specific
+ * set of strings, so this function takes care of validating that
+ * the value is correct.
+ *
+ * @param flags the config flags object, while we'll modify
+ * @param args our CLI arguments
+ * @param configCaseName the argument we want to look at right now
+ */
+const parseLogLevelArg = (flags: ConfigFlags, args: string[], configCaseName: LogCLIArg) => {
+  if (typeof flags[configCaseName] !== 'string') {
+    flags[configCaseName] = null;
+  }
+
+  const { value, matchingArg } = getValue(args, configCaseName);
+
+  if (isLogLevel(value)) {
+    flags[configCaseName] = value;
+    flags.knownArgs.push(matchingArg);
+    flags.knownArgs.push(value);
+  }
+};
+
+/**
+ * Helper for pulling values out from the raw array of CLI arguments. This logic
+ * is shared between a few different types of CLI args.
+ *
+ * We look for arguments in the following formats:
+ *
+ * - `--my-cli-argument value`
+ * - `--my-cli-argument=value`
+ * - `--myCliArgument value`
+ * - `--myCliArgument=value`
+ *
+ * We also check for shortened aliases, which we define for a few arguments.
+ *
+ * @param args the CLI args we're dealing with
+ * @configCaseName the ConfigFlag key which we're looking to pull out a value for
+ */
+const getValue = (args: string[], configCaseName: StringCLIArg | NumberCLIArg | LogCLIArg) => {
+  // for some CLI args we have a short alias, like 'c' for 'config'
+  const alias = CLI_ARG_ALIASES[configCaseName];
+  // we support supplying arguments in both dash-case and configCase
+  // for ease of use
+  const dashCaseName = toDashCase(configCaseName);
+
+  let value;
+  let matchingArg;
+  args.forEach((arg, i) => {
+    if (arg.startsWith(`--${dashCaseName}=`) || arg.startsWith(`--${configCaseName}=`)) {
+      value = getEqualsValue(arg);
+      matchingArg = arg;
+    } else if (arg === `--${dashCaseName}` || arg === `--${configCaseName}`) {
+      value = args[i + 1];
+      matchingArg = arg;
+    } else if (alias) {
+      if (arg.startsWith(`-${alias}=`)) {
+        value = getEqualsValue(arg);
+        matchingArg = arg;
+      } else if (arg === `-${alias}`) {
+        value = args[i + 1];
+        matchingArg = arg;
+      }
+    }
+  });
+  return { value, matchingArg };
+};
+
+/**
+ * When a parameter is set in the format `--foobar=12` at the CLI (as opposed to
+ * `--foobar 12`) we want to get the value after the `=` sign
+ *
+ * @param commandArgument the arg in question
+ * @returns the value after the `=`
+ */
+const getEqualsValue = (commandArgument: string) => commandArgument.split('=').slice(1).join('=');
+
+/**
+ * Small helper for getting type-system-level assurance that a `string` can be
+ * narrowed to a `LogLevel`
+ *
+ * @param maybeLogLevel the string to check
+ * @returns whether this is a `LogLevel`
+ */
+const isLogLevel = (maybeLogLevel: string): maybeLogLevel is LogLevel =>
+  ['info', 'warn', 'error', 'debug'].includes(maybeLogLevel);
 
 const getNpmConfigEnvArgs = (sys: CompilerSystem) => {
   // process.env.npm_config_argv

--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -61,11 +61,10 @@ export const parseFlags = (args: string[], sys?: CompilerSystem): ConfigFlags =>
 };
 
 /**
- * Parse command line arguments that are enumerated in the BOOLEAN_ARG_OPTS,
- * STRING_ARG_OPTS, NUMBER_ARG_OPTS, and LOG_LEVEL_OPTS arrays in the
- * `config-flags` module. Handles leading dashes on arguments, aliases that
- * are defined for a small number of argument types, and parsing values for
- * non-boolean arguments (e.g. port number).
+ * Parse command line arguments that are enumerated in the `config-flags`
+ * module. Handles leading dashes on arguments, aliases that are defined for a
+ * small number of arguments, and parsing values for non-boolean arguments
+ * (e.g. port number for the dev server).
  *
  * @param flags a ConfigFlags object to which parsed arguments will be added
  * @param args  an array of command-line arguments to parse

--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -84,6 +84,9 @@ const parseArgs = (flags: ConfigFlags, args: string[]) => {
  * - `--noBooleanArg`
  * - `--no-boolean-arg`
  *
+ * The final two variants should be parsed to a value of `false` on the config
+ * object.
+ *
  * @param flags the config flags object, while we'll modify
  * @param args our CLI arguments
  * @param configCaseName the argument we want to look at right now

--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -1,6 +1,7 @@
-import type { CompilerSystem, LogLevel, TaskCommand, ConfigFlags } from '../declarations';
+import type { CompilerSystem, LogLevel, TaskCommand } from '../declarations';
 import { dashToPascalCase, toDashCase } from '@utils';
 import {
+  ConfigFlags,
   BooleanCLIArg,
   LogCLIArg,
   NumberCLIArg,

--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -233,9 +233,9 @@ const getValue = (args: string[], configCaseName: StringCLIArg | NumberCLIArg | 
 
 interface CLIArgValue {
   // the concrete value pulled from the CLI args
-  value: string,
+  value: string;
   // the matching argument key
-  matchingArg: string
+  matchingArg: string;
 }
 
 /**

--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -29,7 +29,7 @@ export const parseFlags = (args: string[], sys?: CompilerSystem): ConfigFlags =>
   };
 
   // cmd line has more priority over npm scripts cmd
-  flags.args = args.slice();
+  flags.args = Array.isArray(args) ? args.slice() : [];
   if (flags.args.length > 0 && flags.args[0] && !flags.args[0].startsWith('-')) {
     flags.task = flags.args[0] as TaskCommand;
   }

--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -17,7 +17,7 @@ import {
  * Parse command line arguments into a structured `ConfigFlags` object
  *
  * @param args an array of config flags
- * @sys an optional compiler system
+ * @param sys an optional compiler system
  * @returns a structured ConfigFlags object
  */
 export const parseFlags = (args: string[], sys?: CompilerSystem): ConfigFlags => {
@@ -67,9 +67,8 @@ export const parseFlags = (args: string[], sys?: CompilerSystem): ConfigFlags =>
  * are defined for a small number of argument types, and parsing values for
  * non-boolean arguments (e.g. port number).
  *
- * @param flags     a ConfigFlags object
- * @param args      an array of command-line arguments to parse
- * @param knownArgs an array to which all recognized, legal arguments are added
+ * @param flags a ConfigFlags object to which parsed arguments will be added
+ * @param args  an array of command-line arguments to parse
  */
 const parseArgs = (flags: ConfigFlags, args: string[]) => {
   BOOLEAN_CLI_ARGS.forEach((argName) => parseBooleanArg(flags, args, argName));
@@ -197,7 +196,7 @@ const parseLogLevelArg = (flags: ConfigFlags, args: string[], configCaseName: Lo
  * We also check for shortened aliases, which we define for a few arguments.
  *
  * @param args the CLI args we're dealing with
- * @configCaseName the ConfigFlag key which we're looking to pull out a value for
+ * @param configCaseName the ConfigFlag key which we're looking to pull out a value for
  */
 const getValue = (args: string[], configCaseName: StringCLIArg | NumberCLIArg | LogCLIArg) => {
   // for some CLI args we have a short alias, like 'c' for 'config'

--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -25,7 +25,7 @@ export const parseFlags = (args: string[], sys?: CompilerSystem): ConfigFlags =>
     task: null,
     args: [],
     knownArgs: [],
-    unknownArgs: null,
+    unknownArgs: [],
   };
 
   // cmd line has more priority over npm scripts cmd
@@ -40,8 +40,8 @@ export const parseFlags = (args: string[], sys?: CompilerSystem): ConfigFlags =>
     parseArgs(flags, envArgs);
 
     envArgs.forEach((envArg) => {
-      if (!flags.args.includes(envArg)) {
-        flags.args.push(envArg);
+      if (!flags.args!.includes(envArg)) {
+        flags.args!.push(envArg);
       }
     });
   }
@@ -54,7 +54,7 @@ export const parseFlags = (args: string[], sys?: CompilerSystem): ConfigFlags =>
   }
 
   flags.unknownArgs = flags.args.filter((arg: string) => {
-    return !flags.knownArgs.includes(arg);
+    return !flags.knownArgs!.includes(arg);
   });
 
   return flags;
@@ -110,9 +110,9 @@ const parseBooleanArg = (flags: ConfigFlags, args: string[], configCaseName: Boo
       value = true;
     }
 
-    if (value !== undefined) {
+    if (value !== undefined && cmdArg !== undefined) {
       flags[configCaseName] = value;
-      flags.knownArgs.push(cmdArg);
+      flags.knownArgs!.push(cmdArg);
     }
   });
 };
@@ -131,10 +131,10 @@ const parseStringArg = (flags: ConfigFlags, args: string[], configCaseName: Stri
 
   const { value, matchingArg } = getValue(args, configCaseName);
 
-  if (value !== undefined) {
+  if (value !== undefined && matchingArg !== undefined) {
     flags[configCaseName] = value;
-    flags.knownArgs.push(matchingArg);
-    flags.knownArgs.push(value);
+    flags.knownArgs!.push(matchingArg);
+    flags.knownArgs!.push(value);
   }
 };
 
@@ -152,10 +152,10 @@ const parseNumberArg = (flags: ConfigFlags, args: string[], configCaseName: Numb
 
   const { value, matchingArg } = getValue(args, configCaseName);
 
-  if (value) {
+  if (value !== undefined && matchingArg !== undefined) {
     flags[configCaseName] = parseInt(value, 10);
-    flags.knownArgs.push(matchingArg);
-    flags.knownArgs.push(value);
+    flags.knownArgs!.push(matchingArg);
+    flags.knownArgs!.push(value);
   }
 };
 
@@ -175,10 +175,10 @@ const parseLogLevelArg = (flags: ConfigFlags, args: string[], configCaseName: Lo
 
   const { value, matchingArg } = getValue(args, configCaseName);
 
-  if (isLogLevel(value)) {
+  if (value !== undefined && matchingArg !== undefined && isLogLevel(value)) {
     flags[configCaseName] = value;
-    flags.knownArgs.push(matchingArg);
-    flags.knownArgs.push(value);
+    flags.knownArgs!.push(matchingArg);
+    flags.knownArgs!.push(value);
   }
 };
 

--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -1,15 +1,14 @@
-import type { CompilerSystem, LogLevel, TaskCommand } from '../declarations';
+import type { CompilerSystem, LogLevel, TaskCommand, ConfigFlags } from '../declarations';
 import { dashToPascalCase, toDashCase } from '@utils';
 import {
-  CLI_ARG_ALIASES,
   BooleanCLIArg,
-  BOOLEAN_CLI_ARGS,
-  ConfigFlags,
   LogCLIArg,
-  LOG_LEVEL_CLI_ARGS,
   NumberCLIArg,
-  NUMBER_CLI_ARGS,
   StringCLIArg,
+  CLI_ARG_ALIASES,
+  BOOLEAN_CLI_ARGS,
+  LOG_LEVEL_CLI_ARGS,
+  NUMBER_CLI_ARGS,
   STRING_CLI_ARGS,
 } from './config-flags';
 
@@ -205,8 +204,8 @@ const getValue = (args: string[], configCaseName: StringCLIArg | NumberCLIArg | 
   // for ease of use
   const dashCaseName = toDashCase(configCaseName);
 
-  let value;
-  let matchingArg;
+  let value: string | undefined;
+  let matchingArg: string | undefined;
   args.forEach((arg, i) => {
     if (arg.startsWith(`--${dashCaseName}=`) || arg.startsWith(`--${configCaseName}=`)) {
       value = getEqualsValue(arg);

--- a/src/cli/public.ts
+++ b/src/cli/public.ts
@@ -1,4 +1,5 @@
-import type { CliInitOptions, CompilerSystem, Config, ConfigFlags, Logger, TaskCommand } from '@stencil/core/internal';
+import type { CliInitOptions, CompilerSystem, Config, Logger, TaskCommand } from '@stencil/core/internal';
+import { ConfigFlags } from './config-flags';
 
 /**
  * Runs the CLI with the given options. This is used by Stencil's default `bin/stencil` file,

--- a/src/cli/public.ts
+++ b/src/cli/public.ts
@@ -1,5 +1,5 @@
 import type { CliInitOptions, CompilerSystem, Config, Logger, TaskCommand } from '@stencil/core/internal';
-import { ConfigFlags } from './config-flags';
+import { ConfigFlags } from '../declarations';
 
 /**
  * Runs the CLI with the given options. This is used by Stencil's default `bin/stencil` file,

--- a/src/cli/public.ts
+++ b/src/cli/public.ts
@@ -1,5 +1,5 @@
 import type { CliInitOptions, CompilerSystem, Config, Logger, TaskCommand } from '@stencil/core/internal';
-import { ConfigFlags } from '../declarations';
+import type { ConfigFlags } from './config-flags';
 
 /**
  * Runs the CLI with the given options. This is used by Stencil's default `bin/stencil` file,

--- a/src/cli/test/parse-flags.spec.ts
+++ b/src/cli/test/parse-flags.spec.ts
@@ -309,25 +309,25 @@ describe('parseFlags', () => {
   });
 
   it.each<LogLevel>(['info', 'warn', 'error', 'debug'])("should parse '--logLevel %s'", (level) => {
-    let args = ['--logLevel', level];
+    const args = ['--logLevel', level];
     const flags = parseFlags(args, sys);
     expect(flags.logLevel).toBe(level);
   });
 
   it.each<LogLevel>(['info', 'warn', 'error', 'debug'])('should parse --logLevel=%s', (level) => {
-    let args = [`--logLevel=${level}`];
+    const args = [`--logLevel=${level}`];
     const flags = parseFlags(args, sys);
     expect(flags.logLevel).toBe(level);
   });
 
   it.each<LogLevel>(['info', 'warn', 'error', 'debug'])("should parse '--log-level %s'", (level) => {
-    let args = ['--log-level', level];
+    const args = ['--log-level', level];
     const flags = parseFlags(args, sys);
     expect(flags.logLevel).toBe(level);
   });
 
   it.each<LogLevel>(['info', 'warn', 'error', 'debug'])('should parse --log-level=%s', (level) => {
-    let args = [`--log-level=${level}`];
+    const args = [`--log-level=${level}`];
     const flags = parseFlags(args, sys);
     expect(flags.logLevel).toBe(level);
   });

--- a/src/cli/test/parse-flags.spec.ts
+++ b/src/cli/test/parse-flags.spec.ts
@@ -1,12 +1,13 @@
 import type * as d from '../../declarations';
+import { LogLevel } from '../../declarations';
 import { parseFlags } from '../parse-flags';
 
 describe('parseFlags', () => {
-  const args: string[] = [];
+  let args: string[] = [];
   let sys: d.CompilerSystem = {} as any;
 
   beforeEach(() => {
-    args.length = 0;
+    args = [];
     sys = {
       name: 'node',
     } as any;
@@ -41,6 +42,7 @@ describe('parseFlags', () => {
     expect(flags.task).toBe('serve');
     expect(flags.address).toBe('127.0.0.1');
     expect(flags.port).toBe(4444);
+    expect(flags.knownArgs).toEqual(['--address', '127.0.0.1', '--port', '4444']);
   });
 
   it('should use cli args first, then npm cmds', () => {
@@ -125,6 +127,11 @@ describe('parseFlags', () => {
     args[1] = '--no-build';
     const flags = parseFlags(args, sys);
     expect(flags.build).toBe(false);
+  });
+
+  it('should parse --no-prerender-external', () => {
+    const flags = parseFlags(['--no-prerender-external'], sys);
+    expect(flags.prerenderExternal).toBe(false);
   });
 
   it('should not parse build flag, default null', () => {
@@ -301,24 +308,28 @@ describe('parseFlags', () => {
     expect(flags.headless).toBe(true);
   });
 
-  it('should parse --logLevel', () => {
-    args[0] = '--logLevel';
-    args[1] = 'error';
+  it.each<LogLevel>(['info', 'warn', 'error', 'debug'])("should parse '--logLevel %s'", (level) => {
+    let args = ['--logLevel', level];
     const flags = parseFlags(args, sys);
-    expect(flags.logLevel).toBe('error');
+    expect(flags.logLevel).toBe(level);
   });
 
-  it('should parse --logLevel=error', () => {
-    args[0] = '--logLevel=error';
+  it.each<LogLevel>(['info', 'warn', 'error', 'debug'])('should parse --logLevel=%s', (level) => {
+    let args = [`--logLevel=${level}`];
     const flags = parseFlags(args, sys);
-    expect(flags.logLevel).toBe('error');
+    expect(flags.logLevel).toBe(level);
   });
 
-  it('should parse --log-level', () => {
-    args[0] = '--log-level';
-    args[1] = 'error';
+  it.each<LogLevel>(['info', 'warn', 'error', 'debug'])("should parse '--log-level %s'", (level) => {
+    let args = ['--log-level', level];
     const flags = parseFlags(args, sys);
-    expect(flags.logLevel).toBe('error');
+    expect(flags.logLevel).toBe(level);
+  });
+
+  it.each<LogLevel>(['info', 'warn', 'error', 'debug'])('should parse --log-level=%s', (level) => {
+    let args = [`--log-level=${level}`];
+    const flags = parseFlags(args, sys);
+    expect(flags.logLevel).toBe(level);
   });
 
   it('should parse --log', () => {

--- a/src/compiler/config/config-utils.ts
+++ b/src/compiler/config/config-utils.ts
@@ -1,6 +1,7 @@
 import type * as d from '../../declarations';
 import { isAbsolute, join } from 'path';
 import { isBoolean } from '@utils';
+import type { ConfigFlags } from '../../cli/config-flags';
 
 export const getAbsolutePath = (config: d.Config | d.UnvalidatedConfig, dir: string) => {
   if (!isAbsolute(dir)) {
@@ -25,8 +26,8 @@ export const getAbsolutePath = (config: d.Config | d.UnvalidatedConfig, dir: str
  */
 export const setBooleanConfig = <K extends keyof d.Config>(
   config: d.UnvalidatedConfig,
-  configName: (K & keyof d.ConfigFlags) | K,
-  flagName: keyof d.ConfigFlags | null,
+  configName: (K & keyof ConfigFlags) | K,
+  flagName: keyof ConfigFlags | null,
   defaultValue: d.Config[K]
 ) => {
   if (flagName) {

--- a/src/compiler/config/config-utils.ts
+++ b/src/compiler/config/config-utils.ts
@@ -1,7 +1,6 @@
 import type * as d from '../../declarations';
 import { isAbsolute, join } from 'path';
 import { isBoolean } from '@utils';
-import { ConfigFlags } from '../../cli/config-flags'
 
 export const getAbsolutePath = (config: d.Config | d.UnvalidatedConfig, dir: string) => {
   if (!isAbsolute(dir)) {
@@ -26,8 +25,8 @@ export const getAbsolutePath = (config: d.Config | d.UnvalidatedConfig, dir: str
  */
 export const setBooleanConfig = <K extends keyof d.Config>(
   config: d.UnvalidatedConfig,
-  configName: (K & keyof ConfigFlags) | K,
-  flagName: keyof ConfigFlags | null,
+  configName: (K & keyof d.ConfigFlags) | K,
+  flagName: keyof d.ConfigFlags | null,
   defaultValue: d.Config[K]
 ) => {
   if (flagName) {

--- a/src/compiler/config/config-utils.ts
+++ b/src/compiler/config/config-utils.ts
@@ -1,6 +1,7 @@
 import type * as d from '../../declarations';
 import { isAbsolute, join } from 'path';
 import { isBoolean } from '@utils';
+import { ConfigFlags } from 'src/cli/config-flags';
 
 export const getAbsolutePath = (config: d.Config | d.UnvalidatedConfig, dir: string) => {
   if (!isAbsolute(dir)) {
@@ -25,8 +26,8 @@ export const getAbsolutePath = (config: d.Config | d.UnvalidatedConfig, dir: str
  */
 export const setBooleanConfig = <K extends keyof d.Config>(
   config: d.UnvalidatedConfig,
-  configName: (K & keyof d.ConfigFlags) | K,
-  flagName: keyof d.ConfigFlags | null,
+  configName: (K & keyof ConfigFlags) | K,
+  flagName: keyof ConfigFlags | null,
   defaultValue: d.Config[K]
 ) => {
   if (flagName) {

--- a/src/compiler/config/config-utils.ts
+++ b/src/compiler/config/config-utils.ts
@@ -1,7 +1,7 @@
 import type * as d from '../../declarations';
 import { isAbsolute, join } from 'path';
 import { isBoolean } from '@utils';
-import { ConfigFlags } from 'src/cli/config-flags';
+import { ConfigFlags } from '../../cli/config-flags'
 
 export const getAbsolutePath = (config: d.Config | d.UnvalidatedConfig, dir: string) => {
   if (!isAbsolute(dir)) {

--- a/src/compiler/config/test/load-config.spec.ts
+++ b/src/compiler/config/test/load-config.spec.ts
@@ -3,6 +3,7 @@ import { createSystem } from '../../../compiler/sys/stencil-sys';
 import { loadConfig } from '../load-config';
 import { normalizePath } from '../../../utils';
 import path from 'path';
+import { ConfigFlags } from '../../../cli/config-flags';
 
 describe('load config', () => {
   const configPath = require.resolve('./fixtures/stencil.config.ts');
@@ -38,7 +39,7 @@ describe('load config', () => {
     expect(actualConfig).toBeDefined();
     expect(actualConfig.hashedFileNameLength).toEqual(9);
     // these fields are defined in the config file on disk, and should be present
-    expect<d.ConfigFlags>(actualConfig.flags).toEqual({ dev: true });
+    expect<ConfigFlags>(actualConfig.flags).toEqual({ dev: true });
     expect(actualConfig.extras).toBeDefined();
     expect(actualConfig.extras!.experimentalImportInjection).toBe(true);
   });
@@ -59,7 +60,7 @@ describe('load config', () => {
     // this field is defined in the config file on disk, and should be present
     expect(actualConfig.hashedFileNameLength).toBe(13);
     // this field should default to an empty object literal, since it wasn't present in the config file
-    expect<d.ConfigFlags>(actualConfig.flags).toEqual({});
+    expect<ConfigFlags>(actualConfig.flags).toEqual({});
   });
 
   describe('empty initialization argument', () => {

--- a/src/compiler/output-targets/output-utils.ts
+++ b/src/compiler/output-targets/output-utils.ts
@@ -120,6 +120,9 @@ export const VALID_CONFIG_OUTPUT_TARGETS = [
   STATS,
 ] as const;
 
+// Given a ReadonlyArray of strings we can derive a union type from them
+// by getting `typeof ARRAY[number]`, i.e. the type of all values returns
+// by number keys.
 type ValidConfigOutputTarget = typeof VALID_CONFIG_OUTPUT_TARGETS[number];
 
 /**

--- a/src/compiler/prerender/prerender-main.ts
+++ b/src/compiler/prerender/prerender-main.ts
@@ -173,6 +173,7 @@ const runPrerenderOutputTarget = async (
     };
 
     if (!config.flags.ci && !manager.isDebug) {
+      config.flags.esm;
       manager.progressLogger = await config.logger.createLineUpdater();
     }
 

--- a/src/compiler/prerender/prerender-main.ts
+++ b/src/compiler/prerender/prerender-main.ts
@@ -173,7 +173,6 @@ const runPrerenderOutputTarget = async (
     };
 
     if (!config.flags.ci && !manager.isDebug) {
-      config.flags.esm;
       manager.progressLogger = await config.logger.createLineUpdater();
     }
 

--- a/src/compiler/sys/logger/terminal-logger.ts
+++ b/src/compiler/sys/logger/terminal-logger.ts
@@ -1,4 +1,12 @@
-import { Diagnostic, Logger, LogLevel, LoggerTimeSpan, PrintLine, LoggerLineUpdater } from '../../../declarations';
+import {
+  Diagnostic,
+  Logger,
+  LogLevel,
+  LOG_LEVELS,
+  LoggerTimeSpan,
+  PrintLine,
+  LoggerLineUpdater,
+} from '../../../declarations';
 import ansiColor, { bgRed, blue, bold, cyan, dim, gray, green, magenta, red, yellow } from 'ansi-colors';
 
 /**
@@ -510,26 +518,6 @@ export interface TerminalLoggerSys {
   writeLogs: (logFilePath: string, log: string, append: boolean) => void;
   createLineUpdater: () => Promise<LoggerLineUpdater>;
 }
-
-/**
- * This sets the log level hierarchy for our terminal logger, ranging from
- * most to least verbose.
- *
- * Ordering the levels like this lets us easily check whether we should log a
- * message at a given time. For instance, if the log level is set to `'warn'`,
- * then anything passed to the logger with level `'warn'` or `'error'` should
- * be logged, but we should _not_ log anything with level `'info'` or `'debug'`.
- *
- * If we have a current log level `currentLevel` and a message with level
- * `msgLevel` is passed to the logger, we can determine whether or not we should
- * log it by checking if the log level on the message is further up or at the
- * same level in the hierarchy than `currentLevel`, like so:
- *
- * ```ts
- * LOG_LEVELS.indexOf(msgLevel) >= LOG_LEVELS.indexOf(currentLevel)
- * ```
- */
-export const LOG_LEVELS: ReadonlyArray<LogLevel> = ['debug', 'info', 'warn', 'error'];
 
 /**
  * Helper function to determine, based on the current log level setting, whether

--- a/src/compiler/sys/logger/test/terminal-logger.spec.ts
+++ b/src/compiler/sys/logger/test/terminal-logger.spec.ts
@@ -1,6 +1,6 @@
-import { LogLevel } from '@stencil/core/declarations';
+import { LogLevel, LOG_LEVELS } from '../../../../declarations';
 import { createNodeLoggerSys } from '../../../../sys/node/node-logger';
-import { createTerminalLogger, LOG_LEVELS, shouldLog } from '../terminal-logger';
+import { createTerminalLogger, shouldLog } from '../terminal-logger';
 import { bgRed, blue, bold, cyan, dim, gray, green, magenta, red, yellow } from 'ansi-colors';
 
 describe('terminal-logger', () => {

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1,6 +1,6 @@
 import type { JsonDocs } from './stencil-public-docs';
 import type { PrerenderUrlResults } from '../internal';
-import { ConfigFlags } from '../cli/config-flags';
+import type { BooleanCLIArg, StringCLIArg, NumberCLIArg, LogCLIArg } from '../cli/config-flags';
 export * from './stencil-public-docs';
 
 /**
@@ -2469,4 +2469,46 @@ export interface CliInitOptions {
   args: string[];
   logger: Logger;
   sys: CompilerSystem;
+}
+
+/**
+ * Type containing the possible Boolean configuration flags, to be
+ * included in ConfigFlags, below
+ */
+type BooleanConfigFlags = { [key in BooleanCLIArg]?: boolean | null };
+/**
+ * Type containing the possible String configuration flags, to be
+ * included in ConfigFlags, below
+ */
+type StringConfigFlags = { [key in StringCLIArg]?: string | null };
+/**
+ * Type containing the possible Number configuration flags, to be
+ * included in ConfigFlags, below
+ */
+type NumberConfigFlags = { [key in NumberCLIArg]?: number | null };
+/**
+ * Type containing the possible LogLevel configuration flags, to be
+ * included in ConfigFlags, below
+ */
+type LogLevelFlags = { [key in LogCLIArg]?: LogLevel | null };
+
+/**
+ * The configuration flags which can be set by the user on the command line.
+ * This interface captures both known arguments (which are enumerated and then
+ * parsed according to their types) and unknown arguments which the user may
+ * pass at the CLI.
+ *
+ * Note that this interface is constructed by extending `BooleanConfigFlags`,
+ * `StringConfigFlags`, etc. These types are in turn constructed from types
+ * extending `ReadonlyArray<string>` which we declare here in this file. This
+ * allows us to record our known CLI arguments in one place, using a
+ * `ReadonlyArray<string>` to get both a type-level representation of what CLI
+ * options we support and a runtime list of strings which can be used to match
+ * on actual flags passed by the user.
+ */
+export interface ConfigFlags extends BooleanConfigFlags, StringConfigFlags, NumberConfigFlags, LogLevelFlags {
+  task?: TaskCommand | null;
+  args?: string[];
+  knownArgs?: string[];
+  unknownArgs?: string[];
 }

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1,6 +1,6 @@
 import type { JsonDocs } from './stencil-public-docs';
 import type { PrerenderUrlResults } from '../internal';
-import { BOOLEAN_CLI_ARGS, LOG_LEVEL_CLI_ARGS, NUMBER_CLI_ARGS, STRING_CLI_ARGS} from '../cli/config-flags'
+import type { ConfigFlags } from '../cli/config-flags';
 export * from './stencil-public-docs';
 
 /**
@@ -2470,41 +2470,3 @@ export interface CliInitOptions {
   logger: Logger;
   sys: CompilerSystem;
 }
-
-/**
- * Given two types `K` and `T` where `K` extends `ReadonlyArray<string>`,
- * construct a type which maps the strings in `K` as keys to values of type `T`.
- *
- * Becase we use this type to construct an interface (`ConfigFlags`) which has
- * mostly optional keys, we make all the properties optional (w/ `'?'`) and
- * possibly null.
- */
-type ObjectFromKeys<K extends ReadonlyArray<string>, T> = {
-  [key in K[number]]?: T | null;
-};
-
-export type BooleanConfigFlags = ObjectFromKeys<typeof BOOLEAN_CLI_ARGS, boolean>;
-export type StringConfigFlags = ObjectFromKeys<typeof STRING_CLI_ARGS, string>;
-export type NumberConfigFlags = ObjectFromKeys<typeof NUMBER_CLI_ARGS, number>;
-export type LogLevelFlags = ObjectFromKeys<typeof LOG_LEVEL_CLI_ARGS, LogLevel>;
-
-/**
- * The configuration flags which can be set by the user on the command line.
- * This interface captures both known arguments (which are enumerated and then
- * parsed according to their types) and unknown arguments which the user may
- * pass at the CLI.
- *
- * Note that this interface is constructed by extending `BooleanConfigFlags`,
- * `StringConfigFlags`, etc. These types are in turn constructed from types
- * extending `ReadonlyArray<string>` which we declare in another module. This
- * allows us to record our known CLI arguments in one place, using a
- * `ReadonlyArray<string>` to get both a type-level representation of what CLI
- * options we support and a runtime list of strings which can be used to match
- * on actual flags passed by the user.
- */
-export interface ConfigFlags extends BooleanConfigFlags, StringConfigFlags, NumberConfigFlags, LogLevelFlags {
-  task?: TaskCommand | null;
-  args?: string[];
-  knownArgs?: string[];
-  unknownArgs?: string[];
-};

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1,6 +1,6 @@
 import type { JsonDocs } from './stencil-public-docs';
 import type { PrerenderUrlResults } from '../internal';
-import type { BooleanCLIArg, StringCLIArg, NumberCLIArg, LogCLIArg } from '../cli/config-flags';
+import { BOOLEAN_CLI_ARGS, LOG_LEVEL_CLI_ARGS, NUMBER_CLI_ARGS, STRING_CLI_ARGS} from '../cli/config-flags'
 export * from './stencil-public-docs';
 
 /**
@@ -2472,25 +2472,21 @@ export interface CliInitOptions {
 }
 
 /**
- * Type containing the possible Boolean configuration flags, to be
- * included in ConfigFlags, below
+ * Given two types `K` and `T` where `K` extends `ReadonlyArray<string>`,
+ * construct a type which maps the strings in `K` as keys to values of type `T`.
+ *
+ * Becase we use this type to construct an interface (`ConfigFlags`) which has
+ * mostly optional keys, we make all the properties optional (w/ `'?'`) and
+ * possibly null.
  */
-type BooleanConfigFlags = { [key in BooleanCLIArg]?: boolean | null };
-/**
- * Type containing the possible String configuration flags, to be
- * included in ConfigFlags, below
- */
-type StringConfigFlags = { [key in StringCLIArg]?: string | null };
-/**
- * Type containing the possible Number configuration flags, to be
- * included in ConfigFlags, below
- */
-type NumberConfigFlags = { [key in NumberCLIArg]?: number | null };
-/**
- * Type containing the possible LogLevel configuration flags, to be
- * included in ConfigFlags, below
- */
-type LogLevelFlags = { [key in LogCLIArg]?: LogLevel | null };
+type ObjectFromKeys<K extends ReadonlyArray<string>, T> = {
+  [key in K[number]]?: T | null;
+};
+
+export type BooleanConfigFlags = ObjectFromKeys<typeof BOOLEAN_CLI_ARGS, boolean>;
+export type StringConfigFlags = ObjectFromKeys<typeof STRING_CLI_ARGS, string>;
+export type NumberConfigFlags = ObjectFromKeys<typeof NUMBER_CLI_ARGS, number>;
+export type LogLevelFlags = ObjectFromKeys<typeof LOG_LEVEL_CLI_ARGS, LogLevel>;
 
 /**
  * The configuration flags which can be set by the user on the command line.
@@ -2500,7 +2496,7 @@ type LogLevelFlags = { [key in LogCLIArg]?: LogLevel | null };
  *
  * Note that this interface is constructed by extending `BooleanConfigFlags`,
  * `StringConfigFlags`, etc. These types are in turn constructed from types
- * extending `ReadonlyArray<string>` which we declare here in this file. This
+ * extending `ReadonlyArray<string>` which we declare in another module. This
  * allows us to record our known CLI arguments in one place, using a
  * `ReadonlyArray<string>` to get both a type-level representation of what CLI
  * options we support and a runtime list of strings which can be used to match
@@ -2511,4 +2507,4 @@ export interface ConfigFlags extends BooleanConfigFlags, StringConfigFlags, Numb
   args?: string[];
   knownArgs?: string[];
   unknownArgs?: string[];
-}
+};

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1,5 +1,6 @@
 import type { JsonDocs } from './stencil-public-docs';
 import type { PrerenderUrlResults } from '../internal';
+import { ConfigFlags } from 'src/cli/config-flags';
 export * from './stencil-public-docs';
 
 /**
@@ -546,52 +547,6 @@ export interface DevServerEditor {
   name?: string;
   supported?: boolean;
   priority?: number;
-}
-
-export interface ConfigFlags {
-  task?: TaskCommand;
-  args?: string[];
-  knownArgs?: string[];
-  unknownArgs?: string[];
-  address?: string;
-  build?: boolean;
-  cache?: boolean;
-  checkVersion?: boolean;
-  ci?: boolean;
-  compare?: boolean;
-  config?: string;
-  debug?: boolean;
-  dev?: boolean;
-  docs?: boolean;
-  docsApi?: string;
-  docsJson?: string;
-  e2e?: boolean;
-  emulate?: string;
-  es5?: boolean;
-  esm?: boolean;
-  headless?: boolean;
-  help?: boolean;
-  log?: boolean;
-  logLevel?: LogLevel;
-  verbose?: boolean;
-  maxWorkers?: number;
-  open?: boolean;
-  port?: number;
-  prerender?: boolean;
-  prod?: boolean;
-  profile?: boolean;
-  root?: string;
-  screenshot?: boolean;
-  screenshotConnector?: string;
-  serve?: boolean;
-  serviceWorker?: boolean;
-  spec?: boolean;
-  ssr?: boolean;
-  stats?: boolean;
-  updateScreenshot?: boolean;
-  version?: boolean;
-  watch?: boolean;
-  devtools?: boolean;
 }
 
 export type TaskCommand =

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1748,7 +1748,30 @@ export interface EmulateViewport {
   isLandscape?: boolean;
 }
 
-export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+/**
+ * This sets the log level hierarchy for our terminal logger, ranging from
+ * most to least verbose.
+ *
+ * Ordering the levels like this lets us easily check whether we should log a
+ * message at a given time. For instance, if the log level is set to `'warn'`,
+ * then anything passed to the logger with level `'warn'` or `'error'` should
+ * be logged, but we should _not_ log anything with level `'info'` or `'debug'`.
+ *
+ * If we have a current log level `currentLevel` and a message with level
+ * `msgLevel` is passed to the logger, we can determine whether or not we should
+ * log it by checking if the log level on the message is further up or at the
+ * same level in the hierarchy than `currentLevel`, like so:
+ *
+ * ```ts
+ * LOG_LEVELS.indexOf(msgLevel) >= LOG_LEVELS.indexOf(currentLevel)
+ * ```
+ *
+ * NOTE: for the reasons described above, do not change the order of the entries
+ * in this array without good reason!
+ */
+export const LOG_LEVELS = ['debug', 'info', 'warn', 'error'] as const;
+
+export type LogLevel = typeof LOG_LEVELS[number];
 
 /**
  * Common logger to be used by the compiler, dev-server and CLI. The CLI will use a

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1,6 +1,6 @@
 import type { JsonDocs } from './stencil-public-docs';
 import type { PrerenderUrlResults } from '../internal';
-import { ConfigFlags } from 'src/cli/config-flags';
+import { ConfigFlags } from '../cli/config-flags';
 export * from './stencil-public-docs';
 
 /**

--- a/src/testing/jest/jest-runner.ts
+++ b/src/testing/jest/jest-runner.ts
@@ -2,7 +2,6 @@ import type * as d from '@stencil/core/internal';
 import { buildJestArgv, getProjectListFromCLIArgs } from './jest-config';
 import { setScreenshotEmulateData } from '../puppeteer/puppeteer-emulate';
 import type { AggregatedResult } from '@jest/test-result';
-import { ConfigFlags } from '../../cli/config-flags'
 
 export async function runJest(config: d.Config, env: d.E2EProcessEnv) {
   let success = false;
@@ -104,7 +103,7 @@ export function includeTestFile(testPath: string, env: d.E2EProcessEnv) {
   return false;
 }
 
-export function getEmulateConfigs(testing: d.TestingConfig, flags: ConfigFlags) {
+export function getEmulateConfigs(testing: d.TestingConfig, flags: d.ConfigFlags) {
   let emulateConfigs = testing.emulate.slice();
 
   if (typeof flags.emulate === 'string') {

--- a/src/testing/jest/jest-runner.ts
+++ b/src/testing/jest/jest-runner.ts
@@ -2,7 +2,7 @@ import type * as d from '@stencil/core/internal';
 import { buildJestArgv, getProjectListFromCLIArgs } from './jest-config';
 import { setScreenshotEmulateData } from '../puppeteer/puppeteer-emulate';
 import type { AggregatedResult } from '@jest/test-result';
-import { ConfigFlags } from 'src/cli/config-flags';
+import { ConfigFlags } from '../../cli/config-flags'
 
 export async function runJest(config: d.Config, env: d.E2EProcessEnv) {
   let success = false;

--- a/src/testing/jest/jest-runner.ts
+++ b/src/testing/jest/jest-runner.ts
@@ -2,6 +2,7 @@ import type * as d from '@stencil/core/internal';
 import { buildJestArgv, getProjectListFromCLIArgs } from './jest-config';
 import { setScreenshotEmulateData } from '../puppeteer/puppeteer-emulate';
 import type { AggregatedResult } from '@jest/test-result';
+import { ConfigFlags } from 'src/cli/config-flags';
 
 export async function runJest(config: d.Config, env: d.E2EProcessEnv) {
   let success = false;
@@ -103,7 +104,7 @@ export function includeTestFile(testPath: string, env: d.E2EProcessEnv) {
   return false;
 }
 
-export function getEmulateConfigs(testing: d.TestingConfig, flags: d.ConfigFlags) {
+export function getEmulateConfigs(testing: d.TestingConfig, flags: ConfigFlags) {
   let emulateConfigs = testing.emulate.slice();
 
   if (typeof flags.emulate === 'string') {

--- a/src/testing/jest/jest-runner.ts
+++ b/src/testing/jest/jest-runner.ts
@@ -2,6 +2,7 @@ import type * as d from '@stencil/core/internal';
 import { buildJestArgv, getProjectListFromCLIArgs } from './jest-config';
 import { setScreenshotEmulateData } from '../puppeteer/puppeteer-emulate';
 import type { AggregatedResult } from '@jest/test-result';
+import type { ConfigFlags } from '../../cli/config-flags';
 
 export async function runJest(config: d.Config, env: d.E2EProcessEnv) {
   let success = false;
@@ -103,7 +104,7 @@ export function includeTestFile(testPath: string, env: d.E2EProcessEnv) {
   return false;
 }
 
-export function getEmulateConfigs(testing: d.TestingConfig, flags: d.ConfigFlags) {
+export function getEmulateConfigs(testing: d.TestingConfig, flags: ConfigFlags) {
   let emulateConfigs = testing.emulate.slice();
 
   if (typeof flags.emulate === 'string') {

--- a/src/testing/jest/test/jest-runner.spec.ts
+++ b/src/testing/jest/test/jest-runner.spec.ts
@@ -1,4 +1,5 @@
 import type * as d from '@stencil/core/declarations';
+import { ConfigFlags } from '../../../cli/config-flags';
 import { getEmulateConfigs, includeTestFile } from '../jest-runner';
 
 describe('jest-runner', () => {
@@ -74,7 +75,7 @@ describe('jest-runner', () => {
     const testing: d.TestingConfig = {
       emulate: [{ device: 'anDroiD' }, { device: 'iphone' }],
     };
-    const flags: d.ConfigFlags = {
+    const flags: ConfigFlags = {
       emulate: 'Android',
     };
     const emulateConfigs = getEmulateConfigs(testing, flags);
@@ -86,7 +87,7 @@ describe('jest-runner', () => {
     const testing: d.TestingConfig = {
       emulate: [{ userAgent: 'Mozilla/Android' }, { userAgent: 'SomeUserAgent/iPhone X' }],
     };
-    const flags: d.ConfigFlags = {
+    const flags: ConfigFlags = {
       emulate: 'android',
     };
     const emulateConfigs = getEmulateConfigs(testing, flags);
@@ -98,7 +99,7 @@ describe('jest-runner', () => {
     const testing: d.TestingConfig = {
       emulate: [{ device: 'android' }, { device: 'iphone' }],
     };
-    const flags: d.ConfigFlags = {};
+    const flags: ConfigFlags = {};
     const emulateConfigs = getEmulateConfigs(testing, flags);
     expect(emulateConfigs).toHaveLength(2);
   });

--- a/src/testing/jest/test/jest-runner.spec.ts
+++ b/src/testing/jest/test/jest-runner.spec.ts
@@ -1,5 +1,4 @@
 import type * as d from '@stencil/core/declarations';
-import { ConfigFlags } from '../../../cli/config-flags';
 import { getEmulateConfigs, includeTestFile } from '../jest-runner';
 
 describe('jest-runner', () => {
@@ -75,7 +74,7 @@ describe('jest-runner', () => {
     const testing: d.TestingConfig = {
       emulate: [{ device: 'anDroiD' }, { device: 'iphone' }],
     };
-    const flags: ConfigFlags = {
+    const flags: d.ConfigFlags = {
       emulate: 'Android',
     };
     const emulateConfigs = getEmulateConfigs(testing, flags);
@@ -87,7 +86,7 @@ describe('jest-runner', () => {
     const testing: d.TestingConfig = {
       emulate: [{ userAgent: 'Mozilla/Android' }, { userAgent: 'SomeUserAgent/iPhone X' }],
     };
-    const flags: ConfigFlags = {
+    const flags: d.ConfigFlags = {
       emulate: 'android',
     };
     const emulateConfigs = getEmulateConfigs(testing, flags);
@@ -99,7 +98,7 @@ describe('jest-runner', () => {
     const testing: d.TestingConfig = {
       emulate: [{ device: 'android' }, { device: 'iphone' }],
     };
-    const flags: ConfigFlags = {};
+    const flags: d.ConfigFlags = {};
     const emulateConfigs = getEmulateConfigs(testing, flags);
     expect(emulateConfigs).toHaveLength(2);
   });

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,17 +1,29 @@
 export const isDef = (v: any) => v != null;
 
-export const toLowerCase = (str: string) => str.toLowerCase();
+/**
+ * Convert a string from PascalCase to dash-case
+ *
+ * @param str the string to convert
+ * @returns a converted string
+ */
+export const toDashCase = (str: string): string =>
+  str
+    .replace(/([A-Z0-9])/g, (match) => ` ${match[0]}`)
+    .trim()
+    .split(' ')
+    .join('-')
+    .toLowerCase();
 
-export const toDashCase = (str: string) =>
-  toLowerCase(
-    str
-      .replace(/([A-Z0-9])/g, (g) => ' ' + g[0])
-      .trim()
-      .replace(/ /g, '-')
-  );
-
-export const dashToPascalCase = (str: string) =>
-  toLowerCase(str)
+/**
+ * Convert a string from dash-case / kebab-case to PascalCase (or CamelCase,
+ * or whatever you call it!)
+ *
+ * @param str a string to convert
+ * @returns a converted string
+ */
+export const dashToPascalCase = (str: string): string =>
+  str
+    .toLowerCase()
     .split('-')
     .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
     .join('');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -51,6 +51,7 @@
     "src/app-globals/index.ts",
     "src/cli/index.ts",
     "src/cli/public.ts",
+    "src/cli/config-flags.ts",
     "src/client/index.ts",
     "src/client/client-patch-browser.ts",
     "src/client/client-patch-esm.ts",


### PR DESCRIPTION
this refactors the parse-flags module, removing some code duplication
and changing how the `ConfigFlags` interface is declared.

Now the ConfigFlags interface is generated based on the content of a few
read-only arrays of strings. This means that config flags are listed in
one and only one placed and cannot drift / get out of sync.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

Currently we define a `ConfigFlags` object which defines CLI arguments that Stencil supports. We also have lists of supported CLI arguments in `src/cli/parse-flags.ts`. Although those lists of arguments (basically `ReadonlyArray<string>`) are actually used to construct the `ConfigFlags` object, we don't currently have a type-system-level guarantee of consistency between what is actually pulled out and stuck onto the `ConfigFlags` object and what is actually declared as a member of the `ConfigFlags` interface. This creates the possibility of subtle and confusing bugs when there is drift between the `ConfigFlags` object and our CLI arg parsing code in `src/cli/parse-flags.ts`.

I wrote more about this here: #3404 that PR fixed a bug that was introduced precisely because of a drift between these two things.


## What is the new behavior?

This PR changes the definition of the `ConfigFlags` object so that it is instead derived from our lists of supported arguments. This means that we used these arrays of strings at runtime to match arguments _and_ we push them into the type system, letting us ensure that things are consistent and that we declare supported arguments in one place.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I took some care to ensure that this refactor does not change any functionality. I don't believe I have changed anything - my confidence in that is helped by the fact that the test suite for the relevant module is passing with no modifications (I just added a few tests) and some smoke testing. But it should probably be tested locally more thoroughly!

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
