### PR TITLE
refactor(tests): update load-config tests

### DIFF
--- a/src/compiler/config/test/fixtures/stencil.config2.ts
+++ b/src/compiler/config/test/fixtures/stencil.config2.ts
@@ -2,4 +2,10 @@ import { Config } from '../../../../declarations';
 
 export const config: Config = {
   hashedFileNameLength: 27,
+  flags: {
+    dev: true,
+  },
+  extras: {
+    experimentalImportInjection: true,
+  },
 };

--- a/src/compiler/config/test/load-config.spec.ts
+++ b/src/compiler/config/test/load-config.spec.ts
@@ -21,8 +21,8 @@ describe('load config', () => {
     sys.writeFileSync(indexPath, `console.log('fixture');`);
   });
 
-  it('merge users config', async () => {
-    const c = await loadConfig({
+  it("merges a user's configuration with a stencil.config file on disk", async () => {
+    const loadedConfig = await loadConfig({
       configPath: configPath2,
       sys,
       config: {
@@ -30,40 +30,97 @@ describe('load config', () => {
       },
       initTsConfig: true,
     });
-    expect(c.diagnostics).toHaveLength(0);
-    expect(c.config).toBeDefined();
-    expect(c.config.hashedFileNameLength).toBe(9);
+
+    expect(loadedConfig.diagnostics).toHaveLength(0);
+
+    const actualConfig = loadedConfig.config;
+    // this field is defined on the `init` argument, and should override the value found in the config on disk
+    expect(actualConfig).toBeDefined();
+    expect(actualConfig.hashedFileNameLength).toEqual(9);
+    // these fields are defined in the config file on disk, and should be present
+    expect<d.ConfigFlags>(actualConfig.flags).toEqual({ dev: true });
+    expect(actualConfig.extras).toBeDefined();
+    expect(actualConfig.extras!.experimentalImportInjection).toBe(true);
   });
 
-  it('read fixture configPath', async () => {
-    const c = await loadConfig({
+  it('uses the provided config path when no initial config provided', async () => {
+    const loadedConfig = await loadConfig({
       configPath,
       sys,
       initTsConfig: true,
     });
-    expect(c.diagnostics).toHaveLength(0);
-    expect(c.config.configPath).toBe(normalizePath(configPath));
-    expect(c.config).toBeDefined();
-    expect(c.config.hashedFileNameLength).toBe(13);
+
+    expect(loadedConfig.diagnostics).toHaveLength(0);
+
+    const actualConfig = loadedConfig.config;
+    expect(actualConfig).toBeDefined();
+    // set the config path based on the one provided in the init object
+    expect(actualConfig.configPath).toBe(normalizePath(configPath));
+    // this field is defined in the config file on disk, and should be present
+    expect(actualConfig.hashedFileNameLength).toBe(13);
+    // this field should default to an empty object literal, since it wasn't present in the config file
+    expect<d.ConfigFlags>(actualConfig.flags).toEqual({});
   });
 
-  it('empty init, no error cuz created tsconfig, warn no files', async () => {
-    const c = await loadConfig({ initTsConfig: true });
-    expect(c.diagnostics.filter((d) => d.level === 'error')).toHaveLength(0);
-    expect(c.diagnostics.filter((d) => d.level === 'warn')).toHaveLength(1);
-    expect(c.config).toBeDefined();
-    expect(c.config.sys).toBeDefined();
-    expect(c.config.logger).toBeDefined();
-    expect(c.config.configPath).toBe(null);
+  describe('empty initialization argument', () => {
+    it('provides sensible default values with no config', async () => {
+      const loadedConfig = await loadConfig({ initTsConfig: true });
+
+      const actualConfig = loadedConfig.config;
+      expect(actualConfig).toBeDefined();
+      expect(actualConfig.sys).toBeDefined();
+      expect(actualConfig.logger).toBeDefined();
+      expect(actualConfig.configPath).toBe(null);
+    });
+
+    it('warns that a tsconfig file could not be found when "initTsConfig" set', async () => {
+      const loadedConfig = await loadConfig({ initTsConfig: true });
+
+      expect(loadedConfig.diagnostics).toHaveLength(1);
+      expect<d.Diagnostic>(loadedConfig.diagnostics[0]).toEqual({
+        absFilePath: '/tsconfig.json',
+        code: '18003',
+        header: 'TypeScript',
+        language: 'typescript',
+        level: 'warn',
+        lines: [],
+        messageText:
+          "No inputs were found in config file '/tsconfig.json'. Specified 'include' paths were '[\"src\"]' and 'exclude' paths were '[]'.",
+        relFilePath: null,
+        type: 'typescript',
+      });
+    });
+
+    it('errors that a tsconfig file could not be created when "initTsConfig" isn\'t present', async () => {
+      const loadedConfig = await loadConfig({});
+      expect(loadedConfig.diagnostics).toHaveLength(1);
+      expect<d.Diagnostic>(loadedConfig.diagnostics[0]).toEqual({
+        absFilePath: null,
+        header: 'Missing tsconfig.json',
+        level: 'error',
+        lines: [],
+        messageText:
+          'Unable to load TypeScript config file. Please create a "tsconfig.json" file within the "/" directory.',
+        relFilePath: null,
+        type: 'build',
+      });
+    });
   });
 
-  it('empty init, error cuz didnt auto create tsconfig', async () => {
-    const c = await loadConfig({});
-    expect(c.diagnostics).toHaveLength(1);
-  });
-
-  it('no init', async () => {
-    const c = await loadConfig();
-    expect(c.diagnostics).toHaveLength(1);
+  describe('no initialization argument', () => {
+    it('errors that a tsconfig file could not be created', async () => {
+      const loadConfigResults = await loadConfig();
+      expect(loadConfigResults.diagnostics).toHaveLength(1);
+      expect<d.Diagnostic>(loadConfigResults.diagnostics[0]).toEqual({
+        absFilePath: null,
+        header: 'Missing tsconfig.json',
+        level: 'error',
+        lines: [],
+        messageText:
+          'Unable to load TypeScript config file. Please create a "tsconfig.json" file within the "/" directory.',
+        relFilePath: null,
+        type: 'build',
+      });
+    });
   });
 });


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

the existing tests for `load-config` were a little terse, making it tricky to see what
was actually under test/covered

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the unit tests for loading a user configuration. it
does not seek to be comprehensive of the entire load pipeline. rather,
it seeks to improve the readability & assertions of existing tests.

this is being done as a part of a larger effort to attempt to make
configuration validation slightly stricter. by updating these tests
first, we can have greater confidence in changes that we shall make as a
part of the larger effort

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

unit tests continue to pass 🎉 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

I expect there to be 2 new `strictNullChecks` violations in this PR. This is a consequence of new assertions in the test suite that call through `config.flags.*`. I am working on a PR that makes `flags` a required field on a new config type that will get rid of these.