### PR TITLE
chore(lint): add lint for @returns

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,11 @@ module.exports = {
     // rely on TypeScript types to be the source of truth, minimize verbosity in comments
     "jsdoc/require-param-type": ["off"],
     "jsdoc/require-param-description": ["error"],
+    "jsdoc/require-returns-check": ["error"],
+    "jsdoc/require-returns-description": ["error"],
+    // rely on TypeScript types to be the source of truth, minimize verbosity in comments
+    "jsdoc/require-returns-type": ["off"],
+    "jsdoc/require-returns": ["error"],
     'prefer-const': 'error',
     'no-var': 'error',
     'prefer-rest-params': 'error',

--- a/src/cli/task-generate.ts
+++ b/src/cli/task-generate.ts
@@ -251,7 +251,8 @@ export class ${toPascalCase(tagName)} {
 };
 
 /**
- * Get the boilerplate for style.
+ * Get the boilerplate for style for a generated component
+ * @returns a boilerplate CSS block
  */
 const getStyleUrlBoilerplate = (): string =>
   `:host {

--- a/src/client/polyfills/css-shim/css-parser.ts
+++ b/src/client/polyfills/css-shim/css-parser.ts
@@ -34,7 +34,7 @@ export function parse(text: string): StyleNode {
 /**
  * Remove text that may hinder parsing, such as comments and `@import` statements
  * @param cssText the CSS to remove unnecessary bit from
- * @return the 'cleaned' css string
+ * @returns the 'cleaned' css string
  */
 function clean(cssText: string): string {
   return cssText.replace(RX.comments, '').replace(RX.port, '');
@@ -119,7 +119,7 @@ function parseCss(node: StyleNode, text: string): StyleNode {
  * Conversion of unicode escapes with spaces like `\33 ` (and longer) into
  * expanded form that doesn't require trailing space -> `\000033`
  * @param s the unicode escape sequence to expand
- * @return the expanded escape sequence
+ * @returns the expanded escape sequence
  */
 function _expandUnicodeEscapes(s: string): string {
   return s.replace(/\\([0-9a-f]{1,6})\s/gi, function () {
@@ -136,10 +136,10 @@ function _expandUnicodeEscapes(s: string): string {
 /**
  * Stringify some parsed CSS.
  * @param node the CSS root node to stringify
- * @param  preserveProperties if `false`, custom CSS properties will be removed from the CSS. If `true`, they will be
+ * @param preserveProperties if `false`, custom CSS properties will be removed from the CSS. If `true`, they will be
  * preserved.
- * @param  text an optional string to append the stringified CSS to
- * @return the stringified CSS.
+ * @param text an optional string to append the stringified CSS to
+ * @returns the stringified CSS.
  */
 export function stringify(node: StyleNode, preserveProperties: boolean, text = ''): string {
   // calc rule cssText
@@ -174,7 +174,7 @@ export function stringify(node: StyleNode, preserveProperties: boolean, text = '
 /**
  * Determines if a parsed CSS node has a selector that begins with '--' or not
  * @param rules the rules to evaluate. only the first rule in the provided list will be tested.
- * @return `true` if a selector that begins with '--' is found, `false` otherwise.
+ * @returns `true` if a selector that begins with '--' is found, `false` otherwise.
  */
 function _hasMixinRules(rules: ReadonlyArray<StyleNode>): boolean {
   const r = rules[0];
@@ -184,7 +184,7 @@ function _hasMixinRules(rules: ReadonlyArray<StyleNode>): boolean {
 /**
  * Helper function to remove custom properties from CSS
  * @param cssText the stringified CSS to remove custom properties from
- * @return the sanitized CSS
+ * @returns the sanitized CSS
  */
 function removeCustomProps(cssText: string): string {
   cssText = removeCustomPropAssignment(cssText);
@@ -194,7 +194,7 @@ function removeCustomProps(cssText: string): string {
 /**
  *
  * @param cssText the stringified CSS to remove custom properties from
- * @return the sanitized CSS
+ * @returns the sanitized CSS
  */
 export function removeCustomPropAssignment(cssText: string): string {
   return cssText.replace(RX.customProp, '').replace(RX.mixinProp, '');
@@ -203,7 +203,7 @@ export function removeCustomPropAssignment(cssText: string): string {
 /**
  *
  * @param cssText the stringified CSS to remove custom properties from
- * @return the sanitized CSS
+ * @returns the sanitized CSS
  */
 function removeCustomPropApply(cssText: string): string {
   return cssText.replace(RX.mixinApply, '').replace(RX.varApply, '');

--- a/src/compiler/sys/resolve/resolve-module-sync.ts
+++ b/src/compiler/sys/resolve/resolve-module-sync.ts
@@ -159,7 +159,7 @@ export const createCustomResolverSync = (
  * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d121716ed123957f6a86f8985eb013fcaddab345/types/node/globals.d.ts#L183-L188
  * in mind.
  * @param err the entity to check the type of
- * @return true if the provided value is an instance of `ErrnoException`, `false` otherwise
+ * @returns true if the provided value is an instance of `ErrnoException`, `false` otherwise
  */
 function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
   return err instanceof Error && err.hasOwnProperty('code');

--- a/src/runtime/test/fixtures/cmp-a.tsx
+++ b/src/runtime/test/fixtures/cmp-a.tsx
@@ -73,9 +73,6 @@ export class CmpA {
   // * Method Definitions *
   // **********************
 
-  /**
-   * Method initialize
-   */
   @Method()
   init(): Promise<void> {
     return Promise.resolve(this._init());

--- a/src/sys/node/node-logger.ts
+++ b/src/sys/node/node-logger.ts
@@ -14,9 +14,6 @@ export const createNodeLogger = (context: { process: NodeJS.Process }): Logger =
   return logger;
 };
 
-const MIN_COLUMNS = 60;
-const MAX_COLUMNS = 120;
-
 /**
  * Create a logger sys object for use in a Node.js environment
  *
@@ -34,11 +31,15 @@ export function createNodeLoggerSys(prcs: NodeJS.Process): TerminalLoggerSys {
 
   /**
    * Get the number of columns for the terminal to use when printing
-   * This is basically clamped to between MIN_COLUMNS and MAX_COLUMNS
+   * @returns the number of columns to use
    */
   const getColumns = () => {
-    const terminalWidth = prcs?.stdout?.columns ?? 80;
-    return Math.max(Math.min(MAX_COLUMNS, terminalWidth), MIN_COLUMNS);
+    const min_columns = 60;
+    const max_columns = 120;
+    const defaultWidth = 80;
+
+    const terminalWidth = prcs?.stdout?.columns ?? defaultWidth;
+    return Math.max(Math.min(terminalWidth, max_columns), min_columns);
   };
 
   const memoryUsage = () => prcs.memoryUsage().rss;

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -42,7 +42,7 @@ export const isDtsFile = (filePath: string): boolean => {
 /**
  * Generate the preamble to be placed atop the main file of the build
  * @param config the Stencil configuration file
- * @return the generated preamble
+ * @returns the generated preamble
  */
 export const generatePreamble = (config: d.Config): string => {
   const { preamble } = config;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit enables multiple lint rules provided by the jsdoc plugin
regarding `@returns` in jsdocs.

the intent behind this commit is to ensure that jsdocs have a documented
`@returns` field and description where applicable, to catch missing ones
in ci rather than in code review.

there is one known limitation of these rules - when adding a jsdoc to a
function that also has a decorator applied:

```typescript
// This will error, since SomeDecorator must return a value, and 
// getLuckyNumber doesn't
/**
 * Prints a lucky number
 */
 @SomeDecorator()
 function getLuckyNumber(): void {
   console.log(7);
 }
```

the rule will error based on the return type of the decorator, rather
than the function.

there was only a single violation of this in all of stencil's code,
which was removed. i'm inclined to use this rule and use 'eslint-ignore'
directives if absolutely necessary, but would be open to arguments
against it

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Lint passes 
## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Prettier doesn't appear to be running against the `.eslintrc.js` file. I'll save that for another day