### PR TITLE
chore(tests): silence console.{log|warn|error} messages during tests

### DIFF
--- a/src/compiler/style/test/optimize-css.spec.ts
+++ b/src/compiler/style/test/optimize-css.spec.ts
@@ -3,7 +3,6 @@ import { optimizeCss } from '../optimize-css';
 import { mockCompilerCtx, mockConfig } from '@stencil/core/testing';
 import path from 'path';
 import os from 'os';
-import { setupConsoleMocker } from '../../../testing/testing-utils';
 
 describe('optimizeCss', () => {
   let config: d.Config;
@@ -11,14 +10,11 @@ describe('optimizeCss', () => {
   let diagnostics: d.Diagnostic[];
   jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
 
-  const setupConsoleMocks = setupConsoleMocker();
-
   beforeEach(() => {
     config = mockConfig();
     config.maxConcurrentWorkers = 0;
     compilerCtx = mockCompilerCtx(config);
     diagnostics = [];
-    setupConsoleMocks();
   });
 
   it('handles error', async () => {

--- a/src/compiler/style/test/optimize-css.spec.ts
+++ b/src/compiler/style/test/optimize-css.spec.ts
@@ -3,6 +3,7 @@ import { optimizeCss } from '../optimize-css';
 import { mockCompilerCtx, mockConfig } from '@stencil/core/testing';
 import path from 'path';
 import os from 'os';
+import { setupConsoleMocker } from '../../../testing/testing-utils';
 
 describe('optimizeCss', () => {
   let config: d.Config;
@@ -10,11 +11,14 @@ describe('optimizeCss', () => {
   let diagnostics: d.Diagnostic[];
   jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
 
+  const setupConsoleMocks = setupConsoleMocker();
+
   beforeEach(() => {
     config = mockConfig();
     config.maxConcurrentWorkers = 0;
     compilerCtx = mockCompilerCtx(config);
     diagnostics = [];
+    setupConsoleMocks();
   });
 
   it('handles error', async () => {

--- a/src/compiler/sys/logger/test/terminal-logger.spec.ts
+++ b/src/compiler/sys/logger/test/terminal-logger.spec.ts
@@ -2,6 +2,7 @@ import { LogLevel, LOG_LEVELS } from '../../../../declarations';
 import { createNodeLoggerSys } from '../../../../sys/node/node-logger';
 import { createTerminalLogger, shouldLog } from '../terminal-logger';
 import { bgRed, blue, bold, cyan, dim, gray, green, magenta, red, yellow } from 'ansi-colors';
+import { setupConsoleMocker } from '../../../../testing/testing-utils';
 
 describe('terminal-logger', () => {
   describe('shouldLog helper', () => {
@@ -38,24 +39,10 @@ describe('terminal-logger', () => {
   });
 
   describe('basic logging functionality', () => {
-    const originalLog = console.log;
-    const originalWarn = console.warn;
-    const originalError = console.error;
-
-    afterAll(() => {
-      console.log = originalLog;
-      console.warn = originalWarn;
-      console.error = originalError;
-    });
+    const setupConsoleMocks = setupConsoleMocker();
 
     function setup() {
-      const logMock = jest.fn();
-      const warnMock = jest.fn();
-      const errorMock = jest.fn();
-
-      console.log = logMock;
-      console.warn = warnMock;
-      console.error = errorMock;
+      const { logMock, warnMock, errorMock } = setupConsoleMocks();
 
       const loggerSys = createNodeLoggerSys(process);
 

--- a/src/runtime/test/hydrate-prop-types.spec.tsx
+++ b/src/runtime/test/hydrate-prop-types.spec.tsx
@@ -1,7 +1,14 @@
 import { Component, Host, Prop, h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
+import { setupConsoleMocker } from '../../testing/testing-utils';
 
 describe('hydrate prop types', () => {
+  const consoleMockSetup = setupConsoleMocker();
+
+  beforeEach(() => {
+    consoleMockSetup();
+  });
+
   it('number', async () => {
     @Component({ tag: 'cmp-a' })
     class CmpA {

--- a/src/runtime/test/hydrate-prop-types.spec.tsx
+++ b/src/runtime/test/hydrate-prop-types.spec.tsx
@@ -5,13 +5,12 @@ describe('hydrate prop types', () => {
   it('number', async () => {
     @Component({ tag: 'cmp-a' })
     class CmpA {
-      @Prop() num: number;
-
+      @Prop({ mutable: true }) num: number;
 
       render() {
-        const numToRender =  this.num + 100;
+        this.num += 100;
 
-        return <Host>{numToRender}</Host>;
+        return <Host>{this.num}</Host>;
       }
     }
     // @ts-ignore

--- a/src/runtime/test/hydrate-prop-types.spec.tsx
+++ b/src/runtime/test/hydrate-prop-types.spec.tsx
@@ -7,9 +7,13 @@ describe('hydrate prop types', () => {
     class CmpA {
       @Prop({ mutable: true }) num: number;
 
-      render() {
-        this.num += 100;
+      componentWillRender() {
+        if ( this.num < 100) {
+          this.num += 100
+        }
+      }
 
+      render() {
         return <Host>{this.num}</Host>;
       }
     }

--- a/src/runtime/test/hydrate-prop-types.spec.tsx
+++ b/src/runtime/test/hydrate-prop-types.spec.tsx
@@ -1,23 +1,17 @@
 import { Component, Host, Prop, h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
-import { setupConsoleMocker } from '../../testing/testing-utils';
 
 describe('hydrate prop types', () => {
-  const consoleMockSetup = setupConsoleMocker();
-
-  beforeEach(() => {
-    consoleMockSetup();
-  });
-
   it('number', async () => {
     @Component({ tag: 'cmp-a' })
     class CmpA {
       @Prop() num: number;
 
-      render() {
-        this.num += 100;
 
-        return <Host>{this.num}</Host>;
+      render() {
+        const numToRender =  this.num + 100;
+
+        return <Host>{numToRender}</Host>;
       }
     }
     // @ts-ignore

--- a/src/runtime/test/hydrate-prop-types.spec.tsx
+++ b/src/runtime/test/hydrate-prop-types.spec.tsx
@@ -8,8 +8,8 @@ describe('hydrate prop types', () => {
       @Prop({ mutable: true }) num: number;
 
       componentWillRender() {
-        if ( this.num < 100) {
-          this.num += 100
+        if (this.num < 100) {
+          this.num += 100;
         }
       }
 

--- a/src/runtime/test/lifecycle-sync.spec.tsx
+++ b/src/runtime/test/lifecycle-sync.spec.tsx
@@ -1,14 +1,7 @@
 import { Component, Element, Host, Method, Prop, Watch, h, forceUpdate } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
-import { setupConsoleMocker } from '../../testing/testing-utils';
 
 describe('lifecycle sync', () => {
-  const setupConsoleMocks = setupConsoleMocker();
-
-  beforeEach(() => {
-    setupConsoleMocks();
-  });
-
   it('should fire connected/disconnected when removed', async () => {
     let connectedCallback = 0;
     let disconnectedCallback = 0;
@@ -306,8 +299,8 @@ describe('lifecycle sync', () => {
 
     @Component({ tag: 'cmp-root' })
     class CmpRoot {
-      @Prop() value = 100;
-      @Prop() value2 = 100;
+      @Prop({ mutable: true }) value = 100;
+      @Prop({ mutable: true }) value2 = 100;
 
       @Method()
       next() {

--- a/src/runtime/test/lifecycle-sync.spec.tsx
+++ b/src/runtime/test/lifecycle-sync.spec.tsx
@@ -1,7 +1,14 @@
 import { Component, Element, Host, Method, Prop, Watch, h, forceUpdate } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
+import { setupConsoleMocker } from '../../testing/testing-utils';
 
 describe('lifecycle sync', () => {
+  const setupConsoleMocks = setupConsoleMocker();
+
+  beforeEach(() => {
+    setupConsoleMocks();
+  });
+
   it('should fire connected/disconnected when removed', async () => {
     let connectedCallback = 0;
     let disconnectedCallback = 0;

--- a/src/runtime/test/render-vdom.spec.tsx
+++ b/src/runtime/test/render-vdom.spec.tsx
@@ -1,14 +1,8 @@
 import { Component, Element, setErrorHandler, Host, Prop, State, forceUpdate, getRenderingRef, h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
-import { setupConsoleMocker } from '../../testing/testing-utils';
+import { withSilentWarn } from '../../testing/testing-utils';
 
 describe('render-vdom', () => {
-  const setupConsoleMocks = setupConsoleMocker();
-
-  beforeEach(() => {
-    // setupConsoleMocks();
-  });
-
   describe('build conditionals', () => {
     it('vdomText', async () => {
       @Component({ tag: 'cmp-a' })
@@ -391,11 +385,12 @@ describe('render-vdom', () => {
     });
   });
 
-  it.only('rerender on ref mutation', async () => {
+  it('rerender on ref mutation', async () => {
     @Component({ tag: 'cmp-a' })
     class CmpA {
       private nuRender = 0;
       @State() valid = false;
+
       render() {
         this.nuRender++;
         return (
@@ -405,17 +400,20 @@ describe('render-vdom', () => {
         );
       }
     }
-    const { root } = await newSpecPage({
-      components: [CmpA],
-      html: `<cmp-a></cmp-a>`,
-    });
+
+    const { root } = await withSilentWarn(() =>
+      newSpecPage({
+        components: [CmpA],
+        html: `<cmp-a></cmp-a>`,
+      })
+    );
 
     expect(root).toEqualHtml(`
       <cmp-a><div>true - 2</div></cmp-a>
     `);
   });
 
-  xit('not rerender on render() mutation', async () => {
+  it('not rerender on render() mutation', async () => {
     @Component({ tag: 'cmp-a' })
     class CmpA {
       private nuRender = 0;
@@ -430,10 +428,13 @@ describe('render-vdom', () => {
         );
       }
     }
-    const { root } = await newSpecPage({
-      components: [CmpA],
-      html: `<cmp-a></cmp-a>`,
-    });
+
+    const { root } = await withSilentWarn(() =>
+      newSpecPage({
+        components: [CmpA],
+        html: `<cmp-a></cmp-a>`,
+      })
+    );
 
     expect(root).toEqualHtml(`
       <cmp-a><div>true - 1</div></cmp-a>

--- a/src/runtime/test/render-vdom.spec.tsx
+++ b/src/runtime/test/render-vdom.spec.tsx
@@ -6,7 +6,7 @@ describe('render-vdom', () => {
   const setupConsoleMocks = setupConsoleMocker();
 
   beforeEach(() => {
-    setupConsoleMocks();
+    // setupConsoleMocks();
   });
 
   describe('build conditionals', () => {
@@ -390,7 +390,7 @@ describe('render-vdom', () => {
     });
   });
 
-  it('rerender on ref mutation', async () => {
+  it.only('rerender on ref mutation', async () => {
     @Component({ tag: 'cmp-a' })
     class CmpA {
       private nuRender = 0;
@@ -414,7 +414,7 @@ describe('render-vdom', () => {
     `);
   });
 
-  it('not rerender on render() mutation', async () => {
+  xit('not rerender on render() mutation', async () => {
     @Component({ tag: 'cmp-a' })
     class CmpA {
       private nuRender = 0;

--- a/src/runtime/test/render-vdom.spec.tsx
+++ b/src/runtime/test/render-vdom.spec.tsx
@@ -122,6 +122,7 @@ describe('render-vdom', () => {
         vdomText: false,
       });
     });
+
     it('vdomStyle', async () => {
       @Component({ tag: 'cmp-a' })
       class CmpA {

--- a/src/runtime/test/render-vdom.spec.tsx
+++ b/src/runtime/test/render-vdom.spec.tsx
@@ -1,7 +1,14 @@
 import { Component, Element, setErrorHandler, Host, Prop, State, forceUpdate, getRenderingRef, h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
+import { setupConsoleMocker } from '../../testing/testing-utils';
 
 describe('render-vdom', () => {
+  const setupConsoleMocks = setupConsoleMocker();
+
+  beforeEach(() => {
+    setupConsoleMocks();
+  });
+
   describe('build conditionals', () => {
     it('vdomText', async () => {
       @Component({ tag: 'cmp-a' })

--- a/src/runtime/test/watch.spec.tsx
+++ b/src/runtime/test/watch.spec.tsx
@@ -1,7 +1,14 @@
 import { Component, Method, Prop, State, Watch } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
+import { setupConsoleMocker } from '../../testing/testing-utils';
 
 describe('watch', () => {
+  const setupConsoleMocks = setupConsoleMocker();
+
+  beforeEach(() => {
+    setupConsoleMocks();
+  });
+
   it('watch is called each time a prop changes', async () => {
     @Component({ tag: 'cmp-a' })
     class CmpA {

--- a/src/runtime/test/watch.spec.tsx
+++ b/src/runtime/test/watch.spec.tsx
@@ -1,14 +1,8 @@
 import { Component, Method, Prop, State, Watch } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
-import { setupConsoleMocker } from '../../testing/testing-utils';
+import { withSilentWarn } from '../../testing/testing-utils';
 
 describe('watch', () => {
-  const setupConsoleMocks = setupConsoleMocker();
-
-  beforeEach(() => {
-    setupConsoleMocks();
-  });
-
   it('watch is called each time a prop changes', async () => {
     @Component({ tag: 'cmp-a' })
     class CmpA {
@@ -67,9 +61,9 @@ describe('watch', () => {
     class CmpA {
       watchCalled = 0;
 
-      @Prop() prop = 10;
-      @Prop() value = 10;
-      @State() someState = 'default';
+      @Prop({ mutable: true }) prop = 10;
+      @Prop({ mutable: true }) value = 10;
+      @State({ mutable: true }) someState = 'default';
 
       @Watch('prop')
       @Watch('value')
@@ -101,10 +95,13 @@ describe('watch', () => {
       }
     }
 
-    const { root, rootInstance } = await newSpecPage({
-      components: [CmpA],
-      html: `<cmp-a prop="123"></cmp-a>`,
-    });
+    const { root, rootInstance } = await withSilentWarn(() =>
+      newSpecPage({
+        components: [CmpA],
+        html: `<cmp-a prop="123"></cmp-a>`,
+      })
+    );
+
     expect(rootInstance.watchCalled).toBe(6);
     spyOn(rootInstance, 'method');
 
@@ -160,10 +157,12 @@ describe('watch', () => {
       }
     }
 
-    const { root, waitForChanges } = await newSpecPage({
-      components: [CmpA],
-      html: `<cmp-a></cmp-a>`,
-    });
+    const { root, waitForChanges } = await withSilentWarn(() =>
+      newSpecPage({
+        components: [CmpA],
+        html: `<cmp-a></cmp-a>`,
+      })
+    );
 
     expect(root).toEqualHtml(`<cmp-a>2 4 4</cmp-a>`);
     await waitForChanges();

--- a/src/testing/testing-utils.ts
+++ b/src/testing/testing-utils.ts
@@ -185,7 +185,7 @@ export async function withSilentWarn<T>(cb: SilentWarnFunc<T>): Promise<T> {
   const realWarn = console.warn;
   const warnMock = jest.fn();
   console.warn = warnMock;
-  const retval = await cb(warnMock);
+  const retVal = await cb(warnMock);
   console.warn = realWarn;
-  return retval;
+  return retVal;
 }

--- a/src/testing/testing-utils.ts
+++ b/src/testing/testing-utils.ts
@@ -95,3 +95,72 @@ function getAppUrl(config: d.Config, browserUrl: string, appFileName: string) {
 
   return browserUrl;
 }
+
+/**
+ * Utility for silencing `console` functions in tests.
+ *
+ * When this function is first called it grabs a reference to the `log`,
+ * `error`, and `warn` functions on `console` and then returns a per-test setup
+ * function which sets up a fresh set of mocks (via `jest.fn()`) and then
+ * assigns them to each of these functions. This setup function will return a
+ * reference to each of the three mock functions so tests can make assertions
+ * about their calls and so on.
+ *
+ * Because references to the original `.log`, `.error`, and `.warn` functions
+ * exist in closure within the function, it can use an `afterAll` call to clean
+ * up after itself and ensure that the original implementations are restored
+ * after the test suite finishes.
+ *
+ * An example of using this to silence log statements in a single test could look
+ * like this:
+ *
+ * ```ts
+ * describe("my-test-suite", () => {
+ *   const setupConsoleMocks = setupConsoleMocker()
+ *
+ *   it("should log a message", () => {
+ *     const { logMock } = setupConsoleMocks();
+ *     myFunctionWhichLogs(foo, bar);
+ *     expect(logMock).toBeCalledWith('my log message');
+ *   })
+ * })
+ * ```
+ *
+ * @returns a per-test mock setup function
+ */
+export function setupConsoleMocker(): ConsoleMocker {
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+
+  afterAll(() => {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    console.error = originalError;
+  });
+
+  function setupConsoleMocks() {
+    const logMock = jest.fn();
+    const warnMock = jest.fn();
+    const errorMock = jest.fn();
+
+    console.log = logMock;
+    console.warn = warnMock;
+    console.error = errorMock;
+
+    return {
+      logMock,
+      warnMock,
+      errorMock,
+    };
+  }
+  return setupConsoleMocks;
+}
+
+interface ConsoleMocker {
+  (): {
+    logMock: jest.Mock<typeof console.log>;
+    warnMock: jest.Mock<typeof console.warn>;
+    errorMock: jest.Mock<typeof console.error>;
+  };
+}

--- a/src/testing/testing-utils.ts
+++ b/src/testing/testing-utils.ts
@@ -164,3 +164,30 @@ interface ConsoleMocker {
     errorMock: jest.Mock<typeof console.error>;
   };
 }
+
+// export function withSilentWarn<T extends () => Promise<any>>(
+
+/**
+ * the callback that `withSilentWarn` expects to receive. Basically receives a mock
+ * as its argument and returns a `Promise`, the value of which is returns by `withSilentWarn`
+ * as well.
+ */
+type SilentWarnFunc<T> = (mock: jest.Mock<typeof console.warn>) => Promise<T>;
+
+/**
+ * Wrap a single callback with a silent `console.warn`. The callback passed in
+ * receives the mocking function as an argument, so you can easily make assertions
+ * that it is called if necessary.
+ *
+ * @param cb a callback which `withSilentWarn` will call after replacing `console.warn`
+ * with a mock.
+ * @returns a Promise wrapping the return value of the callback
+ */
+export async function withSilentWarn<T>(cb: SilentWarnFunc<T>): Promise<T> {
+  const realWarn = console.warn;
+  const warnMock = jest.fn();
+  console.warn = warnMock;
+  const retval = await cb(warnMock);
+  console.warn = realWarn;
+  return retval;
+}

--- a/src/testing/testing-utils.ts
+++ b/src/testing/testing-utils.ts
@@ -165,8 +165,6 @@ interface ConsoleMocker {
   };
 }
 
-// export function withSilentWarn<T extends () => Promise<any>>(
-
 /**
  * the callback that `withSilentWarn` expects to receive. Basically receives a mock
  * as its argument and returns a `Promise`, the value of which is returns by `withSilentWarn`


### PR DESCRIPTION
this adds a little utility for replacing the `console` functions with
mocks to silence any error messages and get our jest output under
control.

This function calls `afterAll` internally, so it will clean up after
itself by restoring the original functions for `console.log`, `.error`,
etc.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): testing quality-of-life improvement


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?

Gaze upon this and feel at peace:


https://user-images.githubusercontent.com/6207644/174887868-ec9d7eb7-6862-471a-8cf0-91fec3ebdfa1.mov



## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

This is just a testing change anyhow, so I think if tests are passing we are all good.

I did confirm that this setup does not inadvertently silence tests outside of the suites in which it's called.


