### PR TITLE
refactor(style): refactor code in compiler/style/css-imports

### DIFF
--- a/src/compiler/optimize/autoprefixer.ts
+++ b/src/compiler/optimize/autoprefixer.ts
@@ -2,8 +2,8 @@ import type * as d from '../../declarations';
 import { IS_NODE_ENV, requireFunc } from '../sys/environment';
 import { Postcss } from 'postcss';
 
-// TODO can we do this in a better way?
-let cssProcessor: ReturnType<Postcss>;
+type CssProcessor = ReturnType<Postcss>;
+let cssProcessor: CssProcessor;
 
 /**
  * Autoprefix a CSS string, adding vendor prefixes to make sure that what
@@ -98,7 +98,7 @@ export const autoprefixCss = async (cssText: string, opts: boolean | null | d.Au
  * @param autoprefixerOpts Options for Autoprefixer
  * @returns postCSS with the Autoprefixer plugin applied
  */
-const getProcessor = (autoprefixerOpts: d.AutoprefixerOptions) => {
+const getProcessor = (autoprefixerOpts: d.AutoprefixerOptions): CssProcessor => {
   const { postcss, autoprefixer } = requireFunc('../sys/node/autoprefixer.js');
   if (!cssProcessor) {
     cssProcessor = postcss([autoprefixer(autoprefixerOpts)]);

--- a/src/compiler/optimize/autoprefixer.ts
+++ b/src/compiler/optimize/autoprefixer.ts
@@ -1,8 +1,9 @@
 import type * as d from '../../declarations';
 import { IS_NODE_ENV, requireFunc } from '../sys/environment';
+import { Postcss } from 'postcss';
 
 // TODO can we do this in a better way?
-let cssProcessor: any;
+let cssProcessor: ReturnType<Postcss>;
 
 /**
  * Autoprefix a CSS string, adding vendor prefixes to make sure that what

--- a/src/compiler/optimize/autoprefixer.ts
+++ b/src/compiler/optimize/autoprefixer.ts
@@ -26,7 +26,7 @@ export const autoprefixCss = async (cssText: string, opts: boolean | null | d.Au
   }
 
   try {
-    const autoprefixerOpts = opts !== null && typeof opts === 'object' ? opts : DEFAULT_AUTOPREFIX_OPTIONS;
+    const autoprefixerOpts = opts != null && typeof opts === 'object' ? opts : DEFAULT_AUTOPREFIX_OPTIONS;
 
     const processor = getProcessor(autoprefixerOpts);
     const result = await processor.process(cssText, { map: null });

--- a/src/compiler/optimize/autoprefixer.ts
+++ b/src/compiler/optimize/autoprefixer.ts
@@ -1,9 +1,21 @@
 import type * as d from '../../declarations';
 import { IS_NODE_ENV, requireFunc } from '../sys/environment';
 
+// TODO can we do this in a better way?
 let cssProcessor: any;
 
-export const autoprefixCss = async (cssText: string, opts: any) => {
+/**
+ * Autoprefix a CSS string, adding vendor prefixes to make sure that what
+ * is written in the CSS will render correctly in our range of supported browsers.
+ * This function uses PostCSS in compbination with the Autoprefix plugin to
+ * automatically add vendor prefixes based on a list of browsers which we want
+ * to support.
+ *
+ * @param cssText the text to be prefixed
+ * @param opts an optional param with options for Autoprefixer
+ * @returns a Promise wrapping some prefixed CSS as well as diagnostics
+ */
+export const autoprefixCss = async (cssText: string, opts: boolean | null | d.AutoprefixerOptions) => {
   const output: d.OptimizeCssOutput = {
     output: cssText,
     diagnostics: [],
@@ -13,7 +25,7 @@ export const autoprefixCss = async (cssText: string, opts: any) => {
   }
 
   try {
-    const autoprefixerOpts = opts != null && typeof opts === 'object' ? opts : DEFAULT_AUTOPREFIX_LEGACY;
+    const autoprefixerOpts = opts !== null && typeof opts === 'object' ? opts : DEFAULT_AUTOPREFIX_OPTIONS;
 
     const processor = getProcessor(autoprefixerOpts);
     const result = await processor.process(cssText, { map: null });
@@ -79,7 +91,13 @@ export const autoprefixCss = async (cssText: string, opts: any) => {
   return output;
 };
 
-const getProcessor = (autoprefixerOpts: any) => {
+/**
+ * Get the processor for PostCSS and the Autoprefixer plugin
+ *
+ * @param autoprefixerOpts Options for Autoprefixer
+ * @returns postCSS with the Autoprefixer plugin applied
+ */
+const getProcessor = (autoprefixerOpts: d.AutoprefixerOptions) => {
   const { postcss, autoprefixer } = requireFunc('../sys/node/autoprefixer.js');
   if (!cssProcessor) {
     cssProcessor = postcss([autoprefixer(autoprefixerOpts)]);
@@ -87,7 +105,19 @@ const getProcessor = (autoprefixerOpts: any) => {
   return cssProcessor;
 };
 
-const DEFAULT_AUTOPREFIX_LEGACY = {
+/**
+ * Default options for the Autoprefixer PostCSS plugin. See the documentation:
+ * https://github.com/postcss/autoprefixer#options for a complete list.
+ *
+ * This default option set will:
+ *
+ * - override the default browser list (`overrideBrowserslist`)
+ * - turn off the visual cascade (`cascade`)
+ * - disable auto-removing outdated prefixes (`remove`)
+ * - set `flexbox` to `"no-2009"`, which limits prefixing for flexbox to the
+ *   final and IE 10 versions of the specification
+ */
+const DEFAULT_AUTOPREFIX_OPTIONS: d.AutoprefixerOptions = {
   overrideBrowserslist: ['last 2 versions', 'iOS >= 9', 'Android >= 4.4', 'Explorer >= 11', 'ExplorerMobile >= 11'],
   cascade: false,
   remove: false,

--- a/src/compiler/optimize/optimize-css.ts
+++ b/src/compiler/optimize/optimize-css.ts
@@ -5,7 +5,7 @@ import { minifyCss } from './minify-css';
 
 /**
  * Optimize a CSS file, optionally running an autoprefixer and a minifier
- * depending on the options set on the input object.
+ * depending on the options set on the input options argument.
  *
  * @param inputOpts input CSS options
  * @returns a promise wrapping the optimized output

--- a/src/compiler/optimize/optimize-css.ts
+++ b/src/compiler/optimize/optimize-css.ts
@@ -3,7 +3,14 @@ import { autoprefixCss } from './autoprefixer';
 import { hasError } from '@utils';
 import { minifyCss } from './minify-css';
 
-export const optimizeCss = async (inputOpts: OptimizeCssInput) => {
+/**
+ * Optimize a CSS file, optionally running an autoprefixer and a minifier
+ * depending on the options set on the input object.
+ *
+ * @param inputOpts input CSS options
+ * @returns a promise wrapping the optimized output
+ */
+export const optimizeCss = async (inputOpts: OptimizeCssInput): Promise<OptimizeCssOutput> => {
   let result: OptimizeCssOutput = {
     output: inputOpts.input,
     diagnostics: [],

--- a/src/compiler/style/css-imports.ts
+++ b/src/compiler/style/css-imports.ts
@@ -6,6 +6,19 @@ import { parseStyleDocs } from '../docs/style-docs';
 import { resolveModuleIdAsync } from '../sys/resolve/resolve-module-async';
 import { stripCssComments } from './style-utils';
 
+/**
+ * Parse CSS imports into an object which contains a manifest of imports and a
+ * stylesheet with all imports resolved and concatenated.
+ *
+ * @param config the current config
+ * @param compilerCtx the compiler context (we need filesystem access)
+ * @param buildCtx the build context, we'll need access to diagnostics
+ * @param srcFilePath the source filepath
+ * @param resolvedFilePath the resolved filepath
+ * @param styleText style text we start with
+ * @param styleDocs optional array of style document objects
+ * @returns an object with concatenated styleText and imports
+ */
 export const parseCssImports = async (
   config: d.Config,
   compilerCtx: d.CompilerCtx,
@@ -14,112 +27,104 @@ export const parseCssImports = async (
   resolvedFilePath: string,
   styleText: string,
   styleDocs?: d.StyleDoc[]
-) => {
+): Promise<ParseCSSReturn> => {
   const isCssEntry = resolvedFilePath.toLowerCase().endsWith('.css');
   const allCssImports: string[] = [];
-  const concatStyleText = await updateCssImports(
-    config,
-    compilerCtx,
-    buildCtx,
-    isCssEntry,
-    srcFilePath,
-    resolvedFilePath,
-    styleText,
-    allCssImports,
-    new Set(),
-    styleDocs
-  );
+
+  // a Set of reviously-resolved file paths that we add to as we traverse the
+  // import tree (to avoid a possible circular dependency and infinite loop)
+  const resolvedFilePaths = new Set();
+
+  const concatStyleText = await resolveAndFlattenImports(srcFilePath, resolvedFilePath, styleText);
+
   return {
     imports: allCssImports,
     styleText: concatStyleText,
   };
-};
 
-const updateCssImports = async (
-  config: d.Config,
-  compilerCtx: d.CompilerCtx,
-  buildCtx: d.BuildCtx,
-  isCssEntry: boolean,
-  srcFilePath: string,
-  resolvedFilePath: string,
-  styleText: string,
-  allCssImports: string[],
-  noLoop: Set<string>,
-  styleDocs?: d.StyleDoc[]
-) => {
-  if (noLoop.has(resolvedFilePath)) {
-    return styleText;
-  }
-  noLoop.add(resolvedFilePath);
-
-  if (styleDocs != null) {
-    parseStyleDocs(styleDocs, styleText);
-  }
-
-  const cssImports = await getCssImports(config, compilerCtx, buildCtx, resolvedFilePath, styleText);
-  if (cssImports.length === 0) {
-    return styleText;
-  }
-
-  for (const cssImport of cssImports) {
-    if (!allCssImports.includes(cssImport.filePath)) {
-      allCssImports.push(cssImport.filePath);
+  /**
+   * Resolve and flatten all imports for a given CSS file, recursively crawling
+   * the tree of imports to resolve them all and produce a concatenated
+   * stylesheet. We declare this function here, within `parseCssImports`, in order
+   * to get access to `compilerCtx`, `buildCtx`, and more without having to pass
+   * a whole bunch of arguments.
+   *
+   * @param srcFilePath the source filepath
+   * @param resolvedFilePath the resolved filepath
+   * @param styleText style text we start with*
+   * @returns concatenated styles assembled from the various imported stylesheets
+   */
+  async function resolveAndFlattenImports(
+    srcFilePath: string,
+    resolvedFilePath: string,
+    styleText: string
+  ): Promise<string> {
+    // if we've seen this path before we early return
+    if (resolvedFilePaths.has(resolvedFilePath)) {
+      return styleText;
     }
-  }
+    resolvedFilePaths.add(resolvedFilePath);
 
-  await Promise.all(
-    cssImports.map(async (cssImportData) => {
-      await concatCssImport(
-        config,
-        compilerCtx,
-        buildCtx,
-        isCssEntry,
-        srcFilePath,
-        cssImportData,
-        allCssImports,
-        noLoop,
-        styleDocs
-      );
-    })
-  );
+    if (styleDocs != null) {
+      parseStyleDocs(styleDocs, styleText);
+    }
 
-  return replaceImportDeclarations(styleText, cssImports, isCssEntry);
-};
+    const cssImports = await getCssImports(config, compilerCtx, buildCtx, resolvedFilePath, styleText);
+    if (cssImports.length === 0) {
+      return styleText;
+    }
 
-const concatCssImport = async (
-  config: d.Config,
-  compilerCtx: d.CompilerCtx,
-  buildCtx: d.BuildCtx,
-  isCssEntry: boolean,
-  srcFilePath: string,
-  cssImportData: d.CssImportData,
-  allCssImports: string[],
-  noLoop: Set<string>,
-  styleDocs?: d.StyleDoc[]
-) => {
-  cssImportData.styleText = await loadStyleText(compilerCtx, cssImportData);
+    // add any newly-found imports to the 'global' list
+    for (const cssImport of cssImports) {
+      if (!allCssImports.includes(cssImport.filePath)) {
+        allCssImports.push(cssImport.filePath);
+      }
+    }
 
-  if (typeof cssImportData.styleText === 'string') {
-    cssImportData.styleText = await updateCssImports(
-      config,
-      compilerCtx,
-      buildCtx,
-      isCssEntry,
-      cssImportData.filePath,
-      cssImportData.filePath,
-      cssImportData.styleText,
-      allCssImports,
-      noLoop,
-      styleDocs
+    // Recur down the tree of CSS imports, resolving all the imports in
+    // the children of the current file (and, by extension, in their children
+    // and so on)
+    await Promise.all(
+      cssImports.map(async (cssImportData) => {
+        cssImportData.styleText = await loadStyleText(compilerCtx, cssImportData);
+
+        if (typeof cssImportData.styleText === 'string') {
+          cssImportData.styleText = await resolveAndFlattenImports(
+            cssImportData.filePath,
+            cssImportData.filePath,
+            cssImportData.styleText
+          );
+        } else {
+          // we had some error loading the file from disk, so write a diagnostic
+          const err = buildError(buildCtx.diagnostics);
+          err.messageText = `Unable to read css import: ${cssImportData.srcImport}`;
+          err.absFilePath = srcFilePath;
+        }
+      })
     );
-  } else {
-    const err = buildError(buildCtx.diagnostics);
-    err.messageText = `Unable to read css import: ${cssImportData.srcImport}`;
-    err.absFilePath = srcFilePath;
+
+    // replace import statements with the actual CSS code in children modules
+    return replaceImportDeclarations(styleText, cssImports, isCssEntry);
   }
 };
 
-const loadStyleText = async (compilerCtx: d.CompilerCtx, cssImportData: d.CssImportData) => {
+/**
+ * Interface describing the return value of `parseCSSImports`
+ */
+interface ParseCSSReturn {
+  imports: string[];
+  styleText: string;
+}
+
+/**
+ * Load the style text for a CSS file from disk, based on the filepaths set in
+ * our import data.
+ *
+ * @param compilerCtx the compiler context
+ * @param cssImportData the import data for the file we want to read
+ * @returns the contents of the file, if it can be read without error
+ */
+const loadStyleText = async (compilerCtx: d.CompilerCtx, cssImportData: d.CssImportData): Promise<string | null> => {
   let styleText: string = null;
 
   try {
@@ -135,6 +140,16 @@ const loadStyleText = async (compilerCtx: d.CompilerCtx, cssImportData: d.CssImp
   return styleText;
 };
 
+/**
+ * Get a manifest of all the CSS imports in a given CSS file
+ *
+ * @param config the current config
+ * @param compilerCtx the compiler context (we need the filesystem)
+ * @param buildCtx the build context, in case we need to set a diagnostic
+ * @param filePath the filepath we're working with
+ * @param styleText the CSS for which we want to retrieve import data
+ * @returns a Promise wrapping a list of CSS import data objects
+ */
 export const getCssImports = async (
   config: d.Config,
   compilerCtx: d.CompilerCtx,
@@ -261,6 +276,16 @@ export const replaceNodeModuleUrl = (
   return relToRoot;
 };
 
+/**
+ * Replace import declarations (like '@import "foobar";') with the actual CSS
+ * written in the imported module, allowing us to produce a single file from a
+ * tree of stylesheets.
+ *
+ * @param styleText the text within which we want to replace @import statements
+ * @param cssImports informaiton about imported modules
+ * @param isCssEntry whether we're dealing with a CSS file
+ * @returns an updated string with the requisite substitions
+ */
 export const replaceImportDeclarations = (styleText: string, cssImports: d.CssImportData[], isCssEntry: boolean) => {
   for (const cssImport of cssImports) {
     if (isCssEntry) {

--- a/src/compiler/style/css-imports.ts
+++ b/src/compiler/style/css-imports.ts
@@ -166,7 +166,7 @@ export const getCssImports = async (
   styleText = stripCssComments(styleText);
 
   const dir = dirname(filePath);
-  const importeeExt = (filePath.split('.').pop() ?? "").toLowerCase();
+  const importeeExt = (filePath.split('.').pop() ?? '').toLowerCase();
 
   let r: RegExpExecArray | null;
   const IMPORT_RE = /(@import)\s+(url\()?\s?(.*?)\s?\)?([^;]*);?/gi;
@@ -174,7 +174,7 @@ export const getCssImports = async (
     const cssImportData: d.CssImportData = {
       srcImport: r[0],
       url: r[4].replace(/[\"\'\)]/g, ''),
-      filePath: ""
+      filePath: '',
     };
 
     if (!isLocalCssImport(cssImportData.srcImport)) {

--- a/src/compiler/style/css-imports.ts
+++ b/src/compiler/style/css-imports.ts
@@ -1,5 +1,5 @@
 import type * as d from '../../declarations';
-import { basename, dirname, isAbsolute, join, relative } from 'path';
+import { basename, dirname, isAbsolute, join } from 'path';
 import { buildError, normalizePath } from '@utils';
 import { getModuleId } from '../sys/resolve/resolve-utils';
 import { parseStyleDocs } from '../docs/style-docs';
@@ -267,23 +267,6 @@ export const isLocalCssImport = (srcImport: string) => {
   }
 
   return true;
-};
-
-export const replaceNodeModuleUrl = (
-  baseCssFilePath: string,
-  moduleId: string,
-  nodeModulePath: string,
-  url: string
-) => {
-  nodeModulePath = normalizePath(dirname(nodeModulePath));
-  url = normalizePath(url);
-
-  const absPathToNodeModuleCss = normalizePath(url.replace(`~${moduleId}`, nodeModulePath));
-
-  const baseCssDir = normalizePath(dirname(baseCssFilePath));
-
-  const relToRoot = normalizePath(relative(baseCssDir, absPathToNodeModuleCss));
-  return relToRoot;
 };
 
 /**

--- a/src/compiler/style/css-imports.ts
+++ b/src/compiler/style/css-imports.ts
@@ -31,7 +31,7 @@ export const parseCssImports = async (
   const isCssEntry = resolvedFilePath.toLowerCase().endsWith('.css');
   const allCssImports: string[] = [];
 
-  // a Set of reviously-resolved file paths that we add to as we traverse the
+  // a Set of previously-resolved file paths that we add to as we traverse the
   // import tree (to avoid a possible circular dependency and infinite loop)
   const resolvedFilePaths = new Set();
 
@@ -286,9 +286,9 @@ export const replaceNodeModuleUrl = (
  * tree of stylesheets.
  *
  * @param styleText the text within which we want to replace @import statements
- * @param cssImports informaiton about imported modules
+ * @param cssImports information about imported modules
  * @param isCssEntry whether we're dealing with a CSS file
- * @returns an updated string with the requisite substitions
+ * @returns an updated string with the requisite substitutions
  */
 export const replaceImportDeclarations = (styleText: string, cssImports: d.CssImportData[], isCssEntry: boolean) => {
   for (const cssImport of cssImports) {

--- a/src/compiler/style/css-imports.ts
+++ b/src/compiler/style/css-imports.ts
@@ -112,7 +112,13 @@ export const parseCssImports = async (
  * Interface describing the return value of `parseCSSImports`
  */
 interface ParseCSSReturn {
+  /**
+   * An array of filepaths to the imported CSS files
+   */
   imports: string[];
+  /**
+   * The actual CSS text itself
+   */
   styleText: string;
 }
 

--- a/src/compiler/style/optimize-css.ts
+++ b/src/compiler/style/optimize-css.ts
@@ -37,7 +37,7 @@ export const optimizeCss = async (
     return cachedContent;
   }
 
-  const minifyResults = await compilerCtx.worker.optimizeCss(opts);
+  const minifyResults = await compilerCtx.worker!.optimizeCss(opts);
   minifyResults.diagnostics.forEach((d) => {
     // collect up any diagnostics from minifying
     diagnostics.push(d);

--- a/src/compiler/style/style-utils.ts
+++ b/src/compiler/style/style-utils.ts
@@ -1,3 +1,9 @@
+/**
+ * Strip out comments from some CSS
+ *
+ * @param input the string we'd like to de-comment
+ * @returns de-commented CSS!
+ */
 export const stripCssComments = (input: string): string => {
   let isInsideString = null;
   let currentCharacter = '';

--- a/src/compiler/style/test/css-imports.spec.ts
+++ b/src/compiler/style/test/css-imports.spec.ts
@@ -15,7 +15,7 @@ describe('css-imports', () => {
   let compilerCtx: d.CompilerCtx;
   let buildCtx: d.BuildCtx;
   let config: d.Config;
-  let readFileMock: jest.SpyInstance<Promise<string>, [string, d.FsReadOptions?]>
+  let readFileMock: jest.SpyInstance<Promise<string>, [string, d.FsReadOptions?]>;
 
   beforeEach(() => {
     compilerCtx = mockCompilerCtx(config);

--- a/src/compiler/style/test/css-imports.spec.ts
+++ b/src/compiler/style/test/css-imports.spec.ts
@@ -1,5 +1,4 @@
 import type * as d from '@stencil/core/declarations';
-import fs from 'graceful-fs';
 import {
   getCssImports,
   isCssNodeModule,
@@ -16,13 +15,12 @@ describe('css-imports', () => {
   let compilerCtx: d.CompilerCtx;
   let buildCtx: d.BuildCtx;
   let config: d.Config;
-  let readFileMock: jest.SpyInstance<ReturnType<d.InMemoryFileSystem['readFile']>, Parameters<typeof fs.readFileSync>>;
+  let readFileMock: jest.SpyInstance<Promise<string>, [string, d.FsReadOptions?]>
 
   beforeEach(() => {
     compilerCtx = mockCompilerCtx(config);
     buildCtx = mockBuildCtx(config, compilerCtx);
     config = mockConfig();
-    // @ts-ignore
     readFileMock = jest.spyOn(compilerCtx.fs, 'readFile');
   });
 

--- a/src/compiler/style/test/css-imports.spec.ts
+++ b/src/compiler/style/test/css-imports.spec.ts
@@ -1,18 +1,33 @@
 import type * as d from '@stencil/core/declarations';
-import { getCssImports, isCssNodeModule, isLocalCssImport, replaceImportDeclarations } from '../css-imports';
+import fs from 'graceful-fs';
+import {
+  getCssImports,
+  isCssNodeModule,
+  isLocalCssImport,
+  parseCssImports,
+  replaceImportDeclarations,
+} from '../css-imports';
 import { mockBuildCtx, mockConfig, mockCompilerCtx } from '@stencil/core/testing';
-import { normalizePath } from '@utils';
+import { buildError, normalizePath } from '@utils';
 import path from 'path';
 
 describe('css-imports', () => {
   const root = path.resolve('/');
-  const config = mockConfig();
   let compilerCtx: d.CompilerCtx;
   let buildCtx: d.BuildCtx;
+  let config: d.Config;
+  let readFileMock: jest.SpyInstance<ReturnType<d.InMemoryFileSystem['readFile']>, Parameters<typeof fs.readFileSync>>;
 
   beforeEach(() => {
     compilerCtx = mockCompilerCtx(config);
     buildCtx = mockBuildCtx(config, compilerCtx);
+    config = mockConfig();
+    // @ts-ignore
+    readFileMock = jest.spyOn(compilerCtx.fs, 'readFile');
+  });
+
+  afterEach(() => {
+    readFileMock.mockClear();
   });
 
   describe('isCssNodeModule', () => {
@@ -88,54 +103,60 @@ describe('css-imports', () => {
   });
 
   describe('isLocalCssImport', () => {
-    it('not local, http w/ spaces url', () => {
-      const i = `@import url(   "  https//stenciljs.com/some.css);`;
-      expect(isLocalCssImport(i)).toBe(false);
-    });
-
-    it('not local, // url', () => {
-      const i = `@import url(//stenciljs.com/some.css);`;
-      expect(isLocalCssImport(i)).toBe(false);
-    });
-
-    it('not local, https url', () => {
-      const i = `@import url(https://stenciljs.com/some.css);`;
-      expect(isLocalCssImport(i)).toBe(false);
-    });
-
-    it('not local, http url, no quotes', () => {
-      const i = `@import url(http://stenciljs.com/some.css);`;
-      expect(isLocalCssImport(i)).toBe(false);
-    });
-
-    it('not local, http url, double quotes', () => {
-      const i = `@import url("http://stenciljs.com/some.css");`;
-      expect(isLocalCssImport(i)).toBe(false);
-    });
-
-    it('not local, http url, single quotes', () => {
-      const i = `@import url('http://stenciljs.com/some.css');`;
-      expect(isLocalCssImport(i)).toBe(false);
-    });
-
-    it('is local, url, single quotes', () => {
-      const i = `@import url('some.css');`;
-      expect(isLocalCssImport(i)).toBe(true);
-    });
-
-    it('is local, url, double quotes', () => {
-      const i = `@import url("some.css");`;
-      expect(isLocalCssImport(i)).toBe(true);
-    });
-
-    it('is local, double quotes', () => {
-      const i = `@import "some.css";`;
-      expect(isLocalCssImport(i)).toBe(true);
-    });
-
-    it('is local, single quotes', () => {
-      const i = `@import 'some.css';`;
-      expect(isLocalCssImport(i)).toBe(true);
+    it.each([
+      {
+        importStmt: '@import url(   "  https//stenciljs.com/some.css);',
+        description: 'not local, http w/ spaces url',
+        expected: false,
+      },
+      {
+        importStmt: `@import url(//stenciljs.com/some.css);`,
+        description: 'not local, // url',
+        expected: false,
+      },
+      {
+        importStmt: `@import url(https://stenciljs.com/some.css);`,
+        description: 'not local, https url',
+        expected: false,
+      },
+      {
+        importStmt: `@import url(http://stenciljs.com/some.css);`,
+        description: 'not local, http url, no quotes',
+        expected: false,
+      },
+      {
+        importStmt: `@import url("http://stenciljs.com/some.css");`,
+        description: 'not local, http url, double quotes',
+        expected: false,
+      },
+      {
+        importStmt: `@import url('http://stenciljs.com/some.css');`,
+        description: 'not local, http url, single quotes',
+        expected: false,
+      },
+      {
+        importStmt: `@import url('some.css');`,
+        description: 'is local, url, single quotes',
+        expected: true,
+      },
+      {
+        importStmt: `@import url("some.css");`,
+        description: 'is local, url, double quotes',
+        expected: true,
+      },
+      {
+        importStmt: `@import "some.css";`,
+        description: 'is local, double quotes',
+        expected: true,
+      },
+      {
+        importStmt: `@import 'some.css';`,
+        description: 'is local, single quotes',
+        expected: true,
+      },
+    ])('should return $expected when $description', (testArgs) => {
+      const { importStmt, expected } = testArgs;
+      expect(isLocalCssImport(importStmt)).toBe(expected);
     });
   });
 
@@ -419,6 +440,55 @@ describe('css-imports', () => {
       const content = `body { color: red; }`;
       const results = await getCssImports(config, compilerCtx, buildCtx, filePath, content);
       expect(results).toEqual([]);
+    });
+  });
+
+  describe('parseCssImports', () => {
+    it('should report an error when a CSS import is missing', async () => {
+      const srcFilePath = normalizePath(path.join(root, 'src', 'file-a.css'));
+      const resolvedFilePath = normalizePath(path.join(root, 'boop', 'file-a.css'));
+      const content = '@import "missing"';
+
+      await parseCssImports(config, compilerCtx, buildCtx, srcFilePath, resolvedFilePath, content, []);
+      expect(buildCtx.diagnostics).toEqual([
+        {
+          ...buildError(),
+          absFilePath: srcFilePath,
+          messageText: 'Unable to read css import: @import "missing"',
+        },
+      ]);
+    });
+
+    it('should merge in imported files w/ child imports', async () => {
+      const mainFilePath = normalizePath(path.join(root, 'src', 'main.css'));
+      const firstImportPath = normalizePath(path.join(root, 'src', 'first.css'));
+      const secondImportPath = normalizePath(path.join(root, 'src', 'second.css'));
+
+      const files = {
+        [mainFilePath]: '@import "first.css"',
+        [firstImportPath]: '@import "second.css"; :host { color: red; }',
+        [secondImportPath]: 'div { display: flex }',
+      };
+
+      readFileMock.mockImplementation(async (path: string) => {
+        if (files[path]) {
+          return files[path];
+        } else {
+          throw new Error('unmatched path!');
+        }
+      });
+
+      const result = await parseCssImports(
+        config,
+        compilerCtx,
+        buildCtx,
+        mainFilePath,
+        mainFilePath,
+        files[mainFilePath],
+        []
+      );
+      // CSS from child and grandchild are merged in
+      expect(result.styleText).toBe('div { display: flex } :host { color: red; }');
     });
   });
 });

--- a/src/compiler/style/test/style.spec.ts
+++ b/src/compiler/style/test/style.spec.ts
@@ -18,34 +18,6 @@ xdescribe('component-styles', () => {
     await compiler.fs.commit();
   });
 
-  it('should escape unicode characters', async () => {
-    await compiler.fs.writeFiles({
-      [path.join(root, 'src', 'cmp-a.css')]: `.myclass:before { content: "\\F113"; }`,
-      [path.join(root, 'src', 'cmp-a.tsx')]: `@Component({ tag: 'cmp-a', styleUrl: 'cmp-a.css' })export class CmpA {}`,
-    });
-    await compiler.fs.commit();
-
-    const r = await compiler.build();
-    expect(r.diagnostics).toHaveLength(0);
-
-    const content = await compiler.fs.readFile(path.join(root, 'www', 'build', 'cmp-a.entry.js'));
-    expect(content).toContain('\\\\F113');
-  });
-
-  it('should escape octal literals', async () => {
-    await compiler.fs.writeFiles({
-      [path.join(root, 'src', 'cmp-a.css')]: `.myclass:before { content: "\\2014 \\00A0"; }`,
-      [path.join(root, 'src', 'cmp-a.tsx')]: `@Component({ tag: 'cmp-a', styleUrl: 'cmp-a.css' }) export class CmpA {}`,
-    });
-    await compiler.fs.commit();
-
-    const r = await compiler.build();
-    expect(r.diagnostics).toHaveLength(0);
-
-    const content = await compiler.fs.readFile(path.join(root, 'www', 'build', 'cmp-a.entry.js'));
-    expect(content).toContain('\\\\2014 \\\\00A0');
-  });
-
   it('should add mode styles to hashed filename/minified builds', async () => {
     compiler.config.minifyJs = true;
     compiler.config.minifyCss = true;
@@ -104,46 +76,5 @@ xdescribe('component-styles', () => {
 
     const content = await compiler.fs.readFile(path.join(root, 'www', 'build', 'p-hashed.entry.js'));
     expect(content).toContain(`body{color:red}`);
-  });
-
-  it('error for missing css import', async () => {
-    compiler.config.minifyJs = true;
-    compiler.config.minifyCss = true;
-    compiler.config.hashFileNames = true;
-    compiler.config.sys.generateContentHash = function () {
-      return 'hashed';
-    };
-
-    await compiler.fs.writeFiles({
-      [path.join(root, 'src', 'cmp-a.tsx')]: `@Component({ tag: 'cmp-a', styleUrl: 'cmp-a.css' }) export class CmpA {}`,
-      [path.join(root, 'src', 'cmp-a.css')]: `@import 'variables.css'; body{color:var(--color)}`,
-    });
-    await compiler.fs.commit();
-
-    const r = await compiler.build();
-    expect(r.diagnostics).toHaveLength(1);
-    expect(r.diagnostics[0].messageText).toContain('Unable to read css import');
-  });
-
-  it('css imports', async () => {
-    compiler.config.minifyJs = true;
-    compiler.config.minifyCss = true;
-    compiler.config.hashFileNames = true;
-    compiler.config.sys.generateContentHash = function () {
-      return 'hashed';
-    };
-
-    await compiler.fs.writeFiles({
-      [path.join(root, 'src', 'cmp-a.tsx')]: `@Component({ tag: 'cmp-a', styleUrl: 'cmp-a.css' }) export class CmpA {}`,
-      [path.join(root, 'src', 'cmp-a.css')]: `@import 'variables.css'; body{color:var(--color)}`,
-      [path.join(root, 'src', 'variables.css')]: `:root{--color:red}`,
-    });
-    await compiler.fs.commit();
-
-    const r = await compiler.build();
-    expect(r.diagnostics).toHaveLength(0);
-
-    const content = await compiler.fs.readFile(path.join(root, 'www', 'build', 'p-hashed.entry.js'));
-    expect(content).toContain(`:root{--color:red}`);
   });
 });

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -2028,9 +2028,9 @@ export interface CssImportData {
   srcImport: string;
   updatedImport?: string;
   url: string;
-  filePath?: string;
+  filePath: string;
   altFilePath?: string;
-  styleText?: string;
+  styleText?: string | null;
 }
 
 export interface CssToEsmImportData {

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -2260,7 +2260,7 @@ export interface OptimizeCssInput {
 /**
  * This is not a real interface describing the options which can
  * be passed to autoprefixer, for that see the docs, here:
- * https://github.com/postcss/autoprefixer#options 
+ * https://github.com/postcss/autoprefixer#options
  *
  * Instead, this basically just serves as a label type to track
  * that arguments are being passed consistently.

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -2243,15 +2243,34 @@ export interface PrerenderResults {
   average: number;
 }
 
+/**
+ * Input for CSS optimization functions, including the input CSS
+ * string and a few boolean options which turn on or off various
+ * optimizations.
+ */
 export interface OptimizeCssInput {
   input: string;
   filePath?: string;
-  autoprefixer?: any;
+  autoprefixer?: boolean | null | AutoprefixerOptions;
   minify?: boolean;
   sourceMap?: boolean;
   resolveUrl?: (url: string) => Promise<string> | string;
 }
 
+/**
+ * This is not a real interface describing the options which can
+ * be passed to autoprefixer, for that see the docs, here:
+ * https://github.com/postcss/autoprefixer#options 
+ *
+ * Instead, this basically just serves as a label type to track
+ * that arguments are being passed consistently.
+ */
+export type AutoprefixerOptions = Object;
+
+/**
+ * Output from CSS optimization functions, wrapping up optimized
+ * CSS and any diagnostics produced during optimization.
+ */
 export interface OptimizeCssOutput {
   output: string;
   diagnostics: Diagnostic[];


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

This refactors and documents some code in the module responsible
for parsing css imports (`src/compiler/style/css-imports.ts`) and adds
some tests to increase coverage.

This commit also makes some edits to the general 'style' spec
(`src/compiler/style/test/style.spec.ts`) which has been skipped for a
while. The tests in this suite were 'end-to-end' unit tests of the style
handling capabilities of the compiler, which we'd like to have again,
but we can't reconstitute them until we get unit testing of the compiler
stood back up again.

So for now this ports a few tests out of `style.spec.ts` and into the
relevant specfiles (like `css-imports.spec.ts`) and deletes a few tests
from `style.spec.ts` which are no longer accurate (like testing for
escaping certain characters).

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

We currently have a file (`src/compiler/style/test/style.spec.ts`) which is skipped and which has a bunch of end-to-end-ish unit tests of the compiler's behavior w/r/t CSS files. We want to bring that back as part of our larger effort to get better unit testing around the compiler in general.

However, the tests in that file right now can't be reconstituted just as they are until we get more general support for unit testing the compiler. In lieu of doing that right now, this PR adds unit tests for some functions (like `parseCssImports`) which are currently untested and whose functionality was testing by some of the skipped tests. The PR also deletes a few tests which were testing what _I believe_ to be functionality that the compiler does not currently have (based on a bit of testing and git spelunking).

This is not the final word on this specfile - once we get unit testing stood up for the whole compiler we'll want to add some more tests like the ones which are currently written in the file, but this moves the needle a little bit on test coverage and on documenting and cleaning up some (slightly) mysterious code.

GitHub Issue Number: N/A


## What is the new behavior?



## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I tested this out locally with an example component and didn't see any issues with it — definitely possible that there is some edge-casey behavior out there though! With refactoring the `parseCssImports` function I tried to do what I could do make sure that I kept the behavior the same, and I feel reasonably confident that I did.