### PR TITLE
chore(test): restore doNotExpectFiles

### DIFF
--- a/src/compiler/output-targets/test/output-targets-dist.spec.ts
+++ b/src/compiler/output-targets/test/output-targets-dist.spec.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { expectFilesDoNotExist, expectFiles } from '../../../testing/testing-utils';
+import { expectFilesDoNotExist, expectFilesExist } from '../../../testing/testing-utils';
 import { Compiler, Config } from '@stencil/core/compiler';
 import { mockConfig } from '@stencil/core/testing';
 import path from 'path';
@@ -53,7 +53,7 @@ xdescribe('outputTarget, dist', () => {
     const r = await compiler.build();
     expect(r.diagnostics).toHaveLength(0);
 
-    expectFiles(compiler.fs, [
+    expectFilesExist(compiler.fs, [
       path.join(root, 'User', 'testing', 'dist', 'index.js'),
       path.join(root, 'User', 'testing', 'dist', 'index.mjs'),
       path.join(root, 'User', 'testing', 'dist', 'index.js.map'),

--- a/src/compiler/output-targets/test/output-targets-dist.spec.ts
+++ b/src/compiler/output-targets/test/output-targets-dist.spec.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { doNotExpectFiles, expectFiles } from '../../../testing/testing-utils';
+import { expectFilesDoNotExist, expectFiles } from '../../../testing/testing-utils';
 import { Compiler, Config } from '@stencil/core/compiler';
 import { mockConfig } from '@stencil/core/testing';
 import path from 'path';
@@ -82,7 +82,7 @@ xdescribe('outputTarget, dist', () => {
       path.join(root, 'User', 'testing', 'src', 'components.d.ts'),
     ]);
 
-    doNotExpectFiles(compiler.fs, [
+    expectFilesDoNotExist(compiler.fs, [
       path.join(root, 'User', 'testing', 'build'),
       path.join(root, 'User', 'testing', 'esm'),
       path.join(root, 'User', 'testing', 'es5'),

--- a/src/compiler/output-targets/test/output-targets-www-dist.spec.ts
+++ b/src/compiler/output-targets/test/output-targets-www-dist.spec.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import type * as d from '@stencil/core/declarations';
-import { expectFilesDoNotExist, expectFiles } from '../../../testing/testing-utils';
+import { expectFilesDoNotExist, expectFilesExist } from '../../../testing/testing-utils';
 import { Compiler, Config } from '@stencil/core/compiler';
 import { mockConfig } from '@stencil/core/testing';
 import path from 'path';
@@ -61,7 +61,7 @@ xdescribe('outputTarget, www / dist / docs', () => {
     const r = await compiler.build();
     expect(r.diagnostics).toHaveLength(0);
 
-    expectFiles(compiler.fs, [
+    expectFilesExist(compiler.fs, [
       path.join(root, 'User', 'testing', 'custom-dist', 'cjs'),
       path.join(root, 'User', 'testing', 'custom-dist', 'esm', 'polyfills', 'index.js'),
       path.join(root, 'User', 'testing', 'custom-dist', 'esm', 'polyfills', 'index.js.map'),

--- a/src/compiler/output-targets/test/output-targets-www-dist.spec.ts
+++ b/src/compiler/output-targets/test/output-targets-www-dist.spec.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import type * as d from '@stencil/core/declarations';
-import { doNotExpectFiles, expectFiles } from '../../../testing/testing-utils';
+import { expectFilesDoNotExist, expectFiles } from '../../../testing/testing-utils';
 import { Compiler, Config } from '@stencil/core/compiler';
 import { mockConfig } from '@stencil/core/testing';
 import path from 'path';
@@ -67,7 +67,7 @@ xdescribe('outputTarget, www / dist / docs', () => {
       path.join(root, 'User', 'testing', 'custom-dist', 'esm', 'polyfills', 'index.js.map'),
     ]);
 
-    doNotExpectFiles(compiler.fs, [
+    expectFilesDoNotExist(compiler.fs, [
       path.join(root, 'User', 'testing', 'www', '/'),
       path.join(root, 'User', 'testing', 'www', 'index.html'),
       path.join(root, 'User', 'testing', 'www', 'custom-index.htm'),

--- a/src/compiler/output-targets/test/output-targets-www.spec.ts
+++ b/src/compiler/output-targets/test/output-targets-www.spec.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { expectFilesDoNotExist, expectFiles } from '../../../testing/testing-utils';
+import { expectFilesDoNotExist, expectFilesExist } from '../../../testing/testing-utils';
 import { Compiler, Config } from '@stencil/core/compiler';
 import { mockConfig } from '@stencil/core/testing';
 import path from 'path';
@@ -34,7 +34,7 @@ xdescribe('outputTarget, www', () => {
     const r = await compiler.build();
     expect(r.diagnostics).toHaveLength(0);
 
-    expectFiles(compiler.fs, [
+    expectFilesExist(compiler.fs, [
       path.join(root, 'User', 'testing', 'www'),
       path.join(root, 'User', 'testing', 'www', 'build'),
       path.join(root, 'User', 'testing', 'www', 'build', 'app.js'),

--- a/src/compiler/output-targets/test/output-targets-www.spec.ts
+++ b/src/compiler/output-targets/test/output-targets-www.spec.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { doNotExpectFiles, expectFiles } from '../../../testing/testing-utils';
+import { expectFilesDoNotExist, expectFiles } from '../../../testing/testing-utils';
 import { Compiler, Config } from '@stencil/core/compiler';
 import { mockConfig } from '@stencil/core/testing';
 import path from 'path';
@@ -48,7 +48,7 @@ xdescribe('outputTarget, www', () => {
       path.join(root, 'User', 'testing', 'src', 'components.d.ts'),
     ]);
 
-    doNotExpectFiles(compiler.fs, [
+    expectFilesDoNotExist(compiler.fs, [
       path.join(root, 'User', 'testing', 'src', 'components', 'cmp-a.js'),
 
       path.join(root, 'User', 'testing', 'dist', '/'),

--- a/src/testing/test/testing-utils.spec.ts
+++ b/src/testing/test/testing-utils.spec.ts
@@ -97,5 +97,18 @@ describe('testing-utils', () => {
 
       expect(() => expectFilesDoNotExist(fs, [MOCK_FILE_PATH, anotherFilePath])).toThrow(expectedErrorMessage);
     });
+
+    it('throws an error only for file paths provided as an argument', async () => {
+      await fs.writeFile(MOCK_FILE_PATH, MOCK_FILE_CONTENTS);
+
+      // write this file to the filesystem, but don't check for it
+      const anotherFilePath = path.join('another', 'mock', 'file', 'path', 'to', 'some-file.ts');
+      await fs.writeFile(anotherFilePath, MOCK_FILE_CONTENTS);
+
+      const expectedErrorMessage = `The following files were expected to not exist, but do:
+-${MOCK_FILE_PATH}`;
+
+      expect(() => expectFilesDoNotExist(fs, [MOCK_FILE_PATH])).toThrow(expectedErrorMessage);
+    });
   });
 });

--- a/src/testing/test/testing-utils.spec.ts
+++ b/src/testing/test/testing-utils.spec.ts
@@ -1,14 +1,14 @@
 import * as d from '@stencil/core/declarations';
 import { createTestingSystem } from '../testing-sys';
 import { createInMemoryFs } from '../../compiler/sys/in-memory-fs';
-import { expectFilesDoNotExist, expectFiles } from '../testing-utils';
+import { expectFilesDoNotExist, expectFilesExist } from '../testing-utils';
 import path from 'path';
 
 describe('testing-utils', () => {
   const MOCK_FILE_PATH = path.join('mock', 'file', 'path', 'to', 'file.ts');
   const MOCK_FILE_CONTENTS = "console.log('hello world!');";
 
-  describe('expectFiles', () => {
+  describe('expectFilesExist', () => {
     let fs: d.InMemoryFileSystem;
 
     beforeEach(() => {
@@ -19,13 +19,13 @@ describe('testing-utils', () => {
     it('does not throw when no file paths are provided', async () => {
       await fs.writeFile(MOCK_FILE_PATH, MOCK_FILE_CONTENTS);
 
-      expect(() => expectFiles(fs, [])).not.toThrow();
+      expect(() => expectFilesExist(fs, [])).not.toThrow();
     });
 
     it('does not throw when a provided file path is found', async () => {
       await fs.writeFile(MOCK_FILE_PATH, MOCK_FILE_CONTENTS);
 
-      expect(() => expectFiles(fs, [MOCK_FILE_PATH])).not.toThrow();
+      expect(() => expectFilesExist(fs, [MOCK_FILE_PATH])).not.toThrow();
     });
 
     it('does not throw when the provided file paths are found', async () => {
@@ -34,14 +34,14 @@ describe('testing-utils', () => {
       const anotherFilePath = path.join('another', 'mock', 'file', 'path', 'to', 'some-file.ts');
       await fs.writeFile(anotherFilePath, "console.log('hello world, again!');");
 
-      expect(() => expectFiles(fs, [MOCK_FILE_PATH, anotherFilePath])).not.toThrow();
+      expect(() => expectFilesExist(fs, [MOCK_FILE_PATH, anotherFilePath])).not.toThrow();
     });
 
     it('throws an error when an expected file cannot be found', () => {
       const expectedErrorMessage = `The following files were expected, but could not be found:
 -${MOCK_FILE_PATH}`;
 
-      expect(() => expectFiles(fs, [MOCK_FILE_PATH])).toThrow(expectedErrorMessage);
+      expect(() => expectFilesExist(fs, [MOCK_FILE_PATH])).toThrow(expectedErrorMessage);
     });
 
     it('throws an error when multiple files cannot be found', () => {
@@ -51,7 +51,7 @@ describe('testing-utils', () => {
 -${MOCK_FILE_PATH}
 -${anotherFilePath}`;
 
-      expect(() => expectFiles(fs, [MOCK_FILE_PATH, anotherFilePath])).toThrow(expectedErrorMessage);
+      expect(() => expectFilesExist(fs, [MOCK_FILE_PATH, anotherFilePath])).toThrow(expectedErrorMessage);
     });
   });
 

--- a/src/testing/test/testing-utils.spec.ts
+++ b/src/testing/test/testing-utils.spec.ts
@@ -1,7 +1,7 @@
 import * as d from '@stencil/core/declarations';
 import { createTestingSystem } from '../testing-sys';
 import { createInMemoryFs } from '../../compiler/sys/in-memory-fs';
-import { doNotExpectFiles, expectFiles } from '../testing-utils';
+import { expectFilesDoNotExist, expectFiles } from '../testing-utils';
 import path from 'path';
 
 describe('testing-utils', () => {
@@ -55,7 +55,7 @@ describe('testing-utils', () => {
     });
   });
 
-  describe('doNotExpectFiles', () => {
+  describe('expectFilesDoNotExist', () => {
     let fs: d.InMemoryFileSystem;
 
     beforeEach(() => {
@@ -66,15 +66,15 @@ describe('testing-utils', () => {
     it('does not throw when no file paths are provided', async () => {
       await fs.writeFile(MOCK_FILE_PATH, MOCK_FILE_CONTENTS);
 
-      expect(() => doNotExpectFiles(fs, [])).not.toThrow();
+      expect(() => expectFilesDoNotExist(fs, [])).not.toThrow();
     });
 
     it('does not throw when a provided file path is not found on the file system', () => {
-      expect(() => doNotExpectFiles(fs, [MOCK_FILE_PATH])).not.toThrow();
+      expect(() => expectFilesDoNotExist(fs, [MOCK_FILE_PATH])).not.toThrow();
     });
 
     it('does not throw when the provided file paths are not found on the file system', () => {
-      expect(() => doNotExpectFiles(fs, [MOCK_FILE_PATH, 'mock/file/path/to/nowhere.ts'])).not.toThrow();
+      expect(() => expectFilesDoNotExist(fs, [MOCK_FILE_PATH, 'mock/file/path/to/nowhere.ts'])).not.toThrow();
     });
 
     it('throws an error when a file is found on the file system', async () => {
@@ -83,7 +83,7 @@ describe('testing-utils', () => {
       const expectedErrorMessage = `The following files were expected to not exist, but do:
 -${MOCK_FILE_PATH}`;
 
-      expect(() => doNotExpectFiles(fs, [MOCK_FILE_PATH])).toThrow(expectedErrorMessage);
+      expect(() => expectFilesDoNotExist(fs, [MOCK_FILE_PATH])).toThrow(expectedErrorMessage);
     });
 
     it('throws an error when multiple files are found on the file system', async () => {
@@ -95,7 +95,7 @@ describe('testing-utils', () => {
 -${MOCK_FILE_PATH}
 -${anotherFilePath}`;
 
-      expect(() => doNotExpectFiles(fs, [MOCK_FILE_PATH, anotherFilePath])).toThrow(expectedErrorMessage);
+      expect(() => expectFilesDoNotExist(fs, [MOCK_FILE_PATH, anotherFilePath])).toThrow(expectedErrorMessage);
     });
   });
 });

--- a/src/testing/testing-utils.ts
+++ b/src/testing/testing-utils.ts
@@ -31,10 +31,7 @@ export function shuffleArray(array: any[]) {
  * @throws when one or more of the provided file paths cannot be found
  */
 export function expectFiles(fs: d.InMemoryFileSystem, filePaths: string[]): void {
-  const notFoundFiles: ReadonlyArray<string> = filePaths.filter(
-    (filePath: string) => !fs.statSync(filePath).exists,
-    []
-  );
+  const notFoundFiles: ReadonlyArray<string> = filePaths.filter((filePath: string) => !fs.statSync(filePath).exists);
 
   if (notFoundFiles.length > 0) {
     throw new Error(
@@ -53,7 +50,7 @@ export function expectFiles(fs: d.InMemoryFileSystem, filePaths: string[]): void
  * @throws when one or more of the provided file paths is found
  */
 export function doNotExpectFiles(fs: d.InMemoryFileSystem, filePaths: string[]): void {
-  const existentFiles: ReadonlyArray<string> = filePaths.filter((filePath: string) => fs.statSync(filePath).exists, []);
+  const existentFiles: ReadonlyArray<string> = filePaths.filter((filePath: string) => fs.statSync(filePath).exists);
 
   if (existentFiles.length > 0) {
     throw new Error(

--- a/src/testing/testing-utils.ts
+++ b/src/testing/testing-utils.ts
@@ -49,7 +49,7 @@ export function expectFiles(fs: d.InMemoryFileSystem, filePaths: string[]): void
  * @param filePaths the paths to validate
  * @throws when one or more of the provided file paths is found
  */
-export function doNotExpectFiles(fs: d.InMemoryFileSystem, filePaths: string[]): void {
+export function expectFilesDoNotExist(fs: d.InMemoryFileSystem, filePaths: string[]): void {
   const existentFiles: ReadonlyArray<string> = filePaths.filter((filePath: string) => fs.statSync(filePath).exists);
 
   if (existentFiles.length > 0) {

--- a/src/testing/testing-utils.ts
+++ b/src/testing/testing-utils.ts
@@ -30,7 +30,7 @@ export function shuffleArray(array: any[]) {
  * @param filePaths the paths to validate
  * @throws when one or more of the provided file paths cannot be found
  */
-export function expectFiles(fs: d.InMemoryFileSystem, filePaths: string[]): void {
+export function expectFilesExist(fs: d.InMemoryFileSystem, filePaths: string[]): void {
   const notFoundFiles: ReadonlyArray<string> = filePaths.filter((filePath: string) => !fs.statSync(filePath).exists);
 
   if (notFoundFiles.length > 0) {

--- a/src/testing/testing-utils.ts
+++ b/src/testing/testing-utils.ts
@@ -45,18 +45,23 @@ export function expectFiles(fs: d.InMemoryFileSystem, filePaths: string[]): void
   }
 }
 
-export function doNotExpectFiles(fs: d.InMemoryFileSystem, filePaths: string[]) {
-  filePaths.forEach((filePath) => {
-    try {
-      fs.sys.statSync(filePath);
-    } catch (e) {
-      return;
-    }
+/**
+ * Testing utility to validate the non-existence of some provided file paths using a specific file system
+ *
+ * @param fs the file system to use to validate the non-existence of some files
+ * @param filePaths the paths to validate
+ * @throws when one or more of the provided file paths is found
+ */
+export function doNotExpectFiles(fs: d.InMemoryFileSystem, filePaths: string[]): void {
+  const existentFiles: ReadonlyArray<string> = filePaths.filter((filePath: string) => fs.statSync(filePath).exists, []);
 
-    if (fs.accessSync(filePath)) {
-      throw new Error(`did not expect access: ${filePath}`);
-    }
-  });
+  if (existentFiles.length > 0) {
+    throw new Error(
+      `The following files were expected to not exist, but do:\n${existentFiles
+        .map((result: string) => '-' + result)
+        .join('\n')}`
+    );
+  }
 }
 
 export function getAppScriptUrl(config: d.Config, browserUrl: string) {


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix (Internal)
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `doNotExpectFiles` utility function does not work/behave as expected

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
this commit restores the `doNotExpectFiles` utility helper under test.
this commit is compliment to aee5287e1594086c0253030c03b62f9429d3ec7a,
which got the `expectFiles` testing utility under test.

this commit makes a few assumptions about how we will use this utility
function. namely, it only throws an exception if one or more files
provided by a caller are found. it does not check the permissions on the
file path (it appears that a previous implementation would take this
into account). should we decide to re-implement file access, we can do
so at a later date.

similar to aee5287e1594086c0253030c03b62f9429d3ec7a, this
re-implementation throws instead of using jest's `fail()` utility for
ease of testing the utility function (and doesn't couple the utility to
jest itself)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

New unit tests pass 
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
