### PR TITLE
refactor(config): add internal strict configuration type

### DIFF
--- a/src/cli/check-version.ts
+++ b/src/cli/check-version.ts
@@ -1,7 +1,7 @@
-import type { Config } from '../declarations';
+import type { InternalStrictConfig } from '../declarations';
 import { isFunction } from '@utils';
 
-export const startCheckVersion = async (config: Config, currentVersion: string) => {
+export const startCheckVersion = async (config: InternalStrictConfig, currentVersion: string) => {
   if (config.devMode && !config.flags.ci && !currentVersion.includes('-dev.') && isFunction(config.sys.checkVersion)) {
     return config.sys.checkVersion(config.logger, currentVersion);
   }

--- a/src/cli/check-version.ts
+++ b/src/cli/check-version.ts
@@ -1,7 +1,7 @@
-import type { InternalStrictConfig } from '../declarations';
+import type { ValidatedConfig } from '../declarations';
 import { isFunction } from '@utils';
 
-export const startCheckVersion = async (config: InternalStrictConfig, currentVersion: string) => {
+export const startCheckVersion = async (config: ValidatedConfig, currentVersion: string) => {
   if (config.devMode && !config.flags.ci && !currentVersion.includes('-dev.') && isFunction(config.sys.checkVersion)) {
     return config.sys.checkVersion(config.logger, currentVersion);
   }

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -15,7 +15,7 @@ import { taskServe } from './task-serve';
 import { taskTest } from './task-test';
 import { taskTelemetry } from './task-telemetry';
 import { telemetryAction } from './telemetry/telemetry';
-import { InternalStrictConfig } from '../declarations';
+import { ValidatedConfig } from '../declarations';
 
 export const run = async (init: d.CliInitOptions) => {
   const { args, logger, sys } = init;
@@ -118,7 +118,7 @@ export const runTask = async (
   task: d.TaskCommand,
   sys?: d.CompilerSystem
 ) => {
-  const strictConfig: InternalStrictConfig = { ...config, flags: { ...config.flags } ?? { task } };
+  const strictConfig: ValidatedConfig = { ...config, flags: { ...config.flags } ?? { task } };
   strictConfig.outputTargets = strictConfig.outputTargets || [];
 
   switch (task) {

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -37,8 +37,7 @@ export const run = async (init: d.CliInitOptions) => {
     }
 
     if (task === 'help' || flags.help) {
-      // TODO(NOW): As we expand this type with more strict values, this temp config will grow :-(
-      await taskHelp({ flags: { task: 'help', args }, outputTargets: [] }, logger, sys);
+      await taskHelp({ task: 'help', args }, logger, sys);
       return;
     }
 
@@ -120,7 +119,7 @@ export const runTask = async (
   sys?: d.CompilerSystem
 ) => {
   config.flags = config.flags || { task };
-  const strictConfig: InternalStrictConfig = {...config, flags: {...config.flags} ?? { task }};
+  const strictConfig: InternalStrictConfig = { ...config, flags: { ...config.flags } ?? { task } };
 
   config.outputTargets = config.outputTargets || [];
   strictConfig.outputTargets = strictConfig.outputTargets || [];
@@ -140,7 +139,7 @@ export const runTask = async (
       break;
 
     case 'help':
-      await taskHelp(strictConfig, config.logger, sys);
+      await taskHelp(strictConfig.flags, config.logger, sys);
       break;
 
     case 'prerender':
@@ -154,7 +153,7 @@ export const runTask = async (
     case 'telemetry':
       // TODO(STENCIL-148) make this parameter no longer optional, remove the surrounding if statement
       if (sys) {
-        await taskTelemetry(strictConfig, sys, config.logger);
+        await taskTelemetry(strictConfig.flags, sys, config.logger);
       }
       break;
 
@@ -168,7 +167,7 @@ export const runTask = async (
 
     default:
       config.logger.error(`${config.logger.emoji('❌ ')}Invalid stencil command, please see the options below:`);
-      await taskHelp(strictConfig, config.logger, sys);
+      await taskHelp(strictConfig.flags, config.logger, sys);
       return config.sys.exit(1);
   }
 };

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -118,10 +118,7 @@ export const runTask = async (
   task: d.TaskCommand,
   sys?: d.CompilerSystem
 ) => {
-  config.flags = config.flags || { task };
   const strictConfig: InternalStrictConfig = { ...config, flags: { ...config.flags } ?? { task } };
-
-  config.outputTargets = config.outputTargets || [];
   strictConfig.outputTargets = strictConfig.outputTargets || [];
 
   switch (task) {

--- a/src/cli/task-build.ts
+++ b/src/cli/task-build.ts
@@ -6,7 +6,7 @@ import { startupCompilerLog } from './logs';
 import { taskWatch } from './task-watch';
 import { telemetryBuildFinishedAction } from './telemetry/telemetry';
 
-export const taskBuild = async (coreCompiler: CoreCompiler, config: d.Config, sys?: d.CompilerSystem) => {
+export const taskBuild = async (coreCompiler: CoreCompiler, config: d.InternalStrictConfig, sys?: d.CompilerSystem) => {
   if (config.flags.watch) {
     // watch build
     await taskWatch(coreCompiler, config);

--- a/src/cli/task-build.ts
+++ b/src/cli/task-build.ts
@@ -6,7 +6,7 @@ import { startupCompilerLog } from './logs';
 import { taskWatch } from './task-watch';
 import { telemetryBuildFinishedAction } from './telemetry/telemetry';
 
-export const taskBuild = async (coreCompiler: CoreCompiler, config: d.InternalStrictConfig, sys?: d.CompilerSystem) => {
+export const taskBuild = async (coreCompiler: CoreCompiler, config: d.ValidatedConfig, sys?: d.CompilerSystem) => {
   if (config.flags.watch) {
     // watch build
     await taskWatch(coreCompiler, config);

--- a/src/cli/task-docs.ts
+++ b/src/cli/task-docs.ts
@@ -1,9 +1,9 @@
-import type { InternalStrictConfig } from '../declarations';
+import type { ValidatedConfig } from '../declarations';
 import type { CoreCompiler } from './load-compiler';
 import { isOutputTargetDocs } from '../compiler/output-targets/output-utils';
 import { startupCompilerLog } from './logs';
 
-export const taskDocs = async (coreCompiler: CoreCompiler, config: InternalStrictConfig) => {
+export const taskDocs = async (coreCompiler: CoreCompiler, config: ValidatedConfig) => {
   config.devServer = null;
   config.outputTargets = config.outputTargets.filter(isOutputTargetDocs);
   config.devMode = true;

--- a/src/cli/task-docs.ts
+++ b/src/cli/task-docs.ts
@@ -1,9 +1,9 @@
-import type { Config } from '../declarations';
+import type { InternalStrictConfig } from '../declarations';
 import type { CoreCompiler } from './load-compiler';
 import { isOutputTargetDocs } from '../compiler/output-targets/output-utils';
 import { startupCompilerLog } from './logs';
 
-export const taskDocs = async (coreCompiler: CoreCompiler, config: Config) => {
+export const taskDocs = async (coreCompiler: CoreCompiler, config: InternalStrictConfig) => {
   config.devServer = null;
   config.outputTargets = config.outputTargets.filter(isOutputTargetDocs);
   config.devMode = true;

--- a/src/cli/task-generate.ts
+++ b/src/cli/task-generate.ts
@@ -1,4 +1,4 @@
-import type { Config } from '../declarations';
+import type { Config, InternalStrictConfig } from '../declarations';
 import type { CoreCompiler } from './load-compiler';
 import { IS_NODE_ENV } from '../compiler/sys/environment';
 import { validateComponentTag } from '@utils';
@@ -13,7 +13,7 @@ import { validateComponentTag } from '@utils';
  * mainly accessing the `path` module
  * @param config the user-supplied config, which we need here to access `.sys`.
  */
-export const taskGenerate = async (coreCompiler: CoreCompiler, config: Config): Promise<void> => {
+export const taskGenerate = async (coreCompiler: CoreCompiler, config: InternalStrictConfig): Promise<void> => {
   if (!IS_NODE_ENV) {
     config.logger.error(`"generate" command is currently only implemented for a NodeJS environment`);
     return config.sys.exit(1);

--- a/src/cli/task-generate.ts
+++ b/src/cli/task-generate.ts
@@ -1,4 +1,4 @@
-import type { Config, InternalStrictConfig } from '../declarations';
+import type { Config, ValidatedConfig } from '../declarations';
 import type { CoreCompiler } from './load-compiler';
 import { IS_NODE_ENV } from '../compiler/sys/environment';
 import { validateComponentTag } from '@utils';
@@ -13,7 +13,7 @@ import { validateComponentTag } from '@utils';
  * mainly accessing the `path` module
  * @param config the user-supplied config, which we need here to access `.sys`.
  */
-export const taskGenerate = async (coreCompiler: CoreCompiler, config: InternalStrictConfig): Promise<void> => {
+export const taskGenerate = async (coreCompiler: CoreCompiler, config: ValidatedConfig): Promise<void> => {
   if (!IS_NODE_ENV) {
     config.logger.error(`"generate" command is currently only implemented for a NodeJS environment`);
     return config.sys.exit(1);

--- a/src/cli/task-help.ts
+++ b/src/cli/task-help.ts
@@ -1,7 +1,14 @@
 import type * as d from '../declarations';
 import { taskTelemetry } from './task-telemetry';
 
-export const taskHelp = async (config: d.InternalStrictConfig, logger: d.Logger, sys?: d.CompilerSystem) => {
+/**
+ * Entrypoint for the Help task, providing Stencil usage context to the user
+ * @param flags configuration flags provided to Stencil when a task was call (either this task or a task that invokes
+ * telemetry)
+ * @param logger a logging implementation to log the results out to the user
+ * @param sys the abstraction for interfacing with the operating system
+ */
+export const taskHelp = async (flags: d.ConfigFlags, logger: d.Logger, sys?: d.CompilerSystem): Promise<void> => {
   const prompt = logger.dim(sys.details.platform === 'windows' ? '>' : '$');
 
   console.log(`
@@ -36,7 +43,7 @@ export const taskHelp = async (config: d.InternalStrictConfig, logger: d.Logger,
 
   // TODO(STENCIL-148) make this parameter no longer optional, remove the surrounding if statement
   if (sys) {
-    await taskTelemetry(config, sys, logger);
+    await taskTelemetry(flags, sys, logger);
   }
 
   console.log(`

--- a/src/cli/task-help.ts
+++ b/src/cli/task-help.ts
@@ -1,4 +1,5 @@
 import type * as d from '../declarations';
+import { ConfigFlags } from './config-flags';
 import { taskTelemetry } from './task-telemetry';
 
 /**
@@ -8,7 +9,7 @@ import { taskTelemetry } from './task-telemetry';
  * @param logger a logging implementation to log the results out to the user
  * @param sys the abstraction for interfacing with the operating system
  */
-export const taskHelp = async (flags: d.ConfigFlags, logger: d.Logger, sys?: d.CompilerSystem): Promise<void> => {
+export const taskHelp = async (flags: ConfigFlags, logger: d.Logger, sys?: d.CompilerSystem): Promise<void> => {
   const prompt = logger.dim(sys.details.platform === 'windows' ? '>' : '$');
 
   console.log(`

--- a/src/cli/task-help.ts
+++ b/src/cli/task-help.ts
@@ -1,7 +1,7 @@
 import type * as d from '../declarations';
 import { taskTelemetry } from './task-telemetry';
 
-export const taskHelp = async (config: d.Config, logger: d.Logger, sys?: d.CompilerSystem) => {
+export const taskHelp = async (config: d.InternalStrictConfig, logger: d.Logger, sys?: d.CompilerSystem) => {
   const prompt = logger.dim(sys.details.platform === 'windows' ? '>' : '$');
 
   console.log(`

--- a/src/cli/task-prerender.ts
+++ b/src/cli/task-prerender.ts
@@ -1,9 +1,9 @@
-import type { BuildResultsComponentGraph, Diagnostic, InternalStrictConfig } from '../declarations';
+import type { BuildResultsComponentGraph, Diagnostic, ValidatedConfig } from '../declarations';
 import type { CoreCompiler } from './load-compiler';
 import { catchError } from '@utils';
 import { startupCompilerLog } from './logs';
 
-export const taskPrerender = async (coreCompiler: CoreCompiler, config: InternalStrictConfig) => {
+export const taskPrerender = async (coreCompiler: CoreCompiler, config: ValidatedConfig) => {
   startupCompilerLog(coreCompiler, config);
 
   const hydrateAppFilePath = config.flags.unknownArgs[0];
@@ -25,7 +25,7 @@ export const taskPrerender = async (coreCompiler: CoreCompiler, config: Internal
 
 export const runPrerenderTask = async (
   coreCompiler: CoreCompiler,
-  config: InternalStrictConfig,
+  config: ValidatedConfig,
   hydrateAppFilePath: string,
   componentGraph: BuildResultsComponentGraph,
   srcIndexHtmlPath: string

--- a/src/cli/task-prerender.ts
+++ b/src/cli/task-prerender.ts
@@ -1,9 +1,9 @@
-import type { BuildResultsComponentGraph, Config, Diagnostic } from '../declarations';
+import type { BuildResultsComponentGraph, Diagnostic, InternalStrictConfig } from '../declarations';
 import type { CoreCompiler } from './load-compiler';
 import { catchError } from '@utils';
 import { startupCompilerLog } from './logs';
 
-export const taskPrerender = async (coreCompiler: CoreCompiler, config: Config) => {
+export const taskPrerender = async (coreCompiler: CoreCompiler, config: InternalStrictConfig) => {
   startupCompilerLog(coreCompiler, config);
 
   const hydrateAppFilePath = config.flags.unknownArgs[0];
@@ -25,7 +25,7 @@ export const taskPrerender = async (coreCompiler: CoreCompiler, config: Config) 
 
 export const runPrerenderTask = async (
   coreCompiler: CoreCompiler,
-  config: Config,
+  config: InternalStrictConfig,
   hydrateAppFilePath: string,
   componentGraph: BuildResultsComponentGraph,
   srcIndexHtmlPath: string

--- a/src/cli/task-serve.ts
+++ b/src/cli/task-serve.ts
@@ -1,7 +1,7 @@
-import type { InternalStrictConfig } from '../declarations';
+import type { ValidatedConfig } from '../declarations';
 import { isString } from '@utils';
 
-export const taskServe = async (config: InternalStrictConfig) => {
+export const taskServe = async (config: ValidatedConfig) => {
   config.suppressLogs = true;
 
   config.flags.serve = true;

--- a/src/cli/task-serve.ts
+++ b/src/cli/task-serve.ts
@@ -1,7 +1,7 @@
-import type { Config } from '../declarations';
+import type { InternalStrictConfig } from '../declarations';
 import { isString } from '@utils';
 
-export const taskServe = async (config: Config) => {
+export const taskServe = async (config: InternalStrictConfig) => {
   config.suppressLogs = true;
 
   config.flags.serve = true;

--- a/src/cli/task-telemetry.ts
+++ b/src/cli/task-telemetry.ts
@@ -1,10 +1,17 @@
 import type * as d from '../declarations';
 import { checkTelemetry, disableTelemetry, enableTelemetry } from './telemetry/telemetry';
 
-export const taskTelemetry = async (config: d.InternalStrictConfig, sys: d.CompilerSystem, logger: d.Logger) => {
+/**
+ * Entrypoint for the Telemetry task
+ * @param flags configuration flags provided to Stencil when a task was call (either this task or a task that invokes
+ * telemetry)
+ * @param sys the abstraction for interfacing with the operating system
+ * @param logger a logging implementation to log the results out to the user
+ */
+export const taskTelemetry = async (flags: d.ConfigFlags, sys: d.CompilerSystem, logger: d.Logger): Promise<void> => {
   const prompt = logger.dim(sys.details.platform === 'windows' ? '>' : '$');
-  const isEnabling = config.flags.args.includes('on');
-  const isDisabling = config.flags.args.includes('off');
+  const isEnabling = flags.args.includes('on');
+  const isDisabling = flags.args.includes('off');
   const INFORMATION = `Opt in or our of telemetry. Information about the data we collect is available on our website: ${logger.bold(
     'https://stenciljs.com/telemetry'
   )}`;

--- a/src/cli/task-telemetry.ts
+++ b/src/cli/task-telemetry.ts
@@ -4,7 +4,7 @@ import { checkTelemetry, disableTelemetry, enableTelemetry } from './telemetry/t
 
 /**
  * Entrypoint for the Telemetry task
- * @param flags configuration flags provided to Stencil when a task was call (either this task or a task that invokes
+ * @param flags configuration flags provided to Stencil when a task was called (either this task or a task that invokes
  * telemetry)
  * @param sys the abstraction for interfacing with the operating system
  * @param logger a logging implementation to log the results out to the user

--- a/src/cli/task-telemetry.ts
+++ b/src/cli/task-telemetry.ts
@@ -1,4 +1,5 @@
 import type * as d from '../declarations';
+import { ConfigFlags } from './config-flags';
 import { checkTelemetry, disableTelemetry, enableTelemetry } from './telemetry/telemetry';
 
 /**
@@ -8,7 +9,7 @@ import { checkTelemetry, disableTelemetry, enableTelemetry } from './telemetry/t
  * @param sys the abstraction for interfacing with the operating system
  * @param logger a logging implementation to log the results out to the user
  */
-export const taskTelemetry = async (flags: d.ConfigFlags, sys: d.CompilerSystem, logger: d.Logger): Promise<void> => {
+export const taskTelemetry = async (flags: ConfigFlags, sys: d.CompilerSystem, logger: d.Logger): Promise<void> => {
   const prompt = logger.dim(sys.details.platform === 'windows' ? '>' : '$');
   const isEnabling = flags.args.includes('on');
   const isDisabling = flags.args.includes('off');

--- a/src/cli/task-telemetry.ts
+++ b/src/cli/task-telemetry.ts
@@ -1,7 +1,7 @@
 import type * as d from '../declarations';
 import { checkTelemetry, disableTelemetry, enableTelemetry } from './telemetry/telemetry';
 
-export const taskTelemetry = async (config: d.Config, sys: d.CompilerSystem, logger: d.Logger) => {
+export const taskTelemetry = async (config: d.InternalStrictConfig, sys: d.CompilerSystem, logger: d.Logger) => {
   const prompt = logger.dim(sys.details.platform === 'windows' ? '>' : '$');
   const isEnabling = config.flags.args.includes('on');
   const isDisabling = config.flags.args.includes('off');

--- a/src/cli/task-test.ts
+++ b/src/cli/task-test.ts
@@ -1,11 +1,11 @@
-import type { InternalStrictConfig, TestingRunOptions } from '../declarations';
+import type { ValidatedConfig, TestingRunOptions } from '../declarations';
 import { IS_NODE_ENV } from '../compiler/sys/environment';
 
 /**
  * Entrypoint for any Stencil tests
  * @param config a validated Stencil configuration entity
  */
-export const taskTest = async (config: InternalStrictConfig): Promise<void> => {
+export const taskTest = async (config: ValidatedConfig): Promise<void> => {
   if (!IS_NODE_ENV) {
     config.logger.error(`"test" command is currently only implemented for a NodeJS environment`);
     return config.sys.exit(1);

--- a/src/cli/task-test.ts
+++ b/src/cli/task-test.ts
@@ -1,7 +1,7 @@
-import type { Config, TestingRunOptions } from '../declarations';
+import type { InternalStrictConfig, TestingRunOptions } from '../declarations';
 import { IS_NODE_ENV } from '../compiler/sys/environment';
 
-export const taskTest = async (config: Config) => {
+export const taskTest = async (config: InternalStrictConfig) => {
   if (!IS_NODE_ENV) {
     config.logger.error(`"test" command is currently only implemented for a NodeJS environment`);
     return config.sys.exit(1);

--- a/src/cli/task-test.ts
+++ b/src/cli/task-test.ts
@@ -1,7 +1,11 @@
 import type { InternalStrictConfig, TestingRunOptions } from '../declarations';
 import { IS_NODE_ENV } from '../compiler/sys/environment';
 
-export const taskTest = async (config: InternalStrictConfig) => {
+/**
+ * Entrypoint for any Stencil tests
+ * @param config a validated Stencil configuration entity
+ */
+export const taskTest = async (config: InternalStrictConfig): Promise<void> => {
   if (!IS_NODE_ENV) {
     config.logger.error(`"test" command is currently only implemented for a NodeJS environment`);
     return config.sys.exit(1);

--- a/src/cli/task-watch.ts
+++ b/src/cli/task-watch.ts
@@ -1,9 +1,9 @@
-import type { Config, DevServer } from '../declarations';
+import type { DevServer, InternalStrictConfig } from '../declarations';
 import type { CoreCompiler } from './load-compiler';
 import { startCheckVersion, printCheckVersionResults } from './check-version';
 import { startupCompilerLog } from './logs';
 
-export const taskWatch = async (coreCompiler: CoreCompiler, config: Config) => {
+export const taskWatch = async (coreCompiler: CoreCompiler, config: InternalStrictConfig) => {
   let devServer: DevServer = null;
   let exitCode = 0;
 

--- a/src/cli/task-watch.ts
+++ b/src/cli/task-watch.ts
@@ -1,9 +1,9 @@
-import type { DevServer, InternalStrictConfig } from '../declarations';
+import type { DevServer, ValidatedConfig } from '../declarations';
 import type { CoreCompiler } from './load-compiler';
 import { startCheckVersion, printCheckVersionResults } from './check-version';
 import { startupCompilerLog } from './logs';
 
-export const taskWatch = async (coreCompiler: CoreCompiler, config: InternalStrictConfig) => {
+export const taskWatch = async (coreCompiler: CoreCompiler, config: ValidatedConfig) => {
   let devServer: DevServer = null;
   let exitCode = 0;
 

--- a/src/cli/telemetry/helpers.ts
+++ b/src/cli/telemetry/helpers.ts
@@ -1,4 +1,5 @@
 import type * as d from '../../declarations';
+import { ConfigFlags } from '../config-flags';
 
 export const tryFn = async <T extends (...args: any[]) => Promise<R>, R>(fn: T, ...args: any[]): Promise<R | null> => {
   try {
@@ -12,7 +13,7 @@ export const tryFn = async <T extends (...args: any[]) => Promise<R>, R>(fn: T, 
 
 export declare const TERMINAL_INFO: d.TerminalInfo;
 
-export const isInteractive = (sys: d.CompilerSystem, flags: d.ConfigFlags, object?: d.TerminalInfo): boolean => {
+export const isInteractive = (sys: d.CompilerSystem, flags: ConfigFlags, object?: d.TerminalInfo): boolean => {
   const terminalInfo =
     object ||
     Object.freeze({
@@ -54,7 +55,7 @@ export async function readJson(sys: d.CompilerSystem, path: string): Promise<any
  * @param flags The configuration flags passed into the Stencil command
  * @returns true if --debug has been passed, otherwise false
  */
-export function hasDebug(flags: d.ConfigFlags) {
+export function hasDebug(flags: ConfigFlags) {
   return flags.debug;
 }
 
@@ -63,6 +64,6 @@ export function hasDebug(flags: d.ConfigFlags) {
  * @param flags The configuration flags passed into the Stencil command
  * @returns true if both --debug and --verbose have been passed, otherwise false
  */
-export function hasVerbose(flags: d.ConfigFlags) {
+export function hasVerbose(flags: ConfigFlags) {
   return flags.verbose && hasDebug(flags);
 }

--- a/src/cli/telemetry/helpers.ts
+++ b/src/cli/telemetry/helpers.ts
@@ -12,7 +12,11 @@ export const tryFn = async <T extends (...args: any[]) => Promise<R>, R>(fn: T, 
 
 export declare const TERMINAL_INFO: d.TerminalInfo;
 
-export const isInteractive = (sys: d.CompilerSystem, config: d.Config, object?: d.TerminalInfo): boolean => {
+export const isInteractive = (
+  sys: d.CompilerSystem,
+  config: d.InternalStrictConfig,
+  object?: d.TerminalInfo
+): boolean => {
   const terminalInfo =
     object ||
     Object.freeze({
@@ -20,7 +24,7 @@ export const isInteractive = (sys: d.CompilerSystem, config: d.Config, object?: 
       ci:
         ['CI', 'BUILD_ID', 'BUILD_NUMBER', 'BITBUCKET_COMMIT', 'CODEBUILD_BUILD_ARN'].filter(
           (v) => !!sys.getEnvironmentVar(v)
-        ).length > 0 || !!config.flags?.ci,
+        ).length > 0 || !!config.flags.ci,
     });
 
   return terminalInfo.tty && !terminalInfo.ci;
@@ -54,7 +58,7 @@ export async function readJson(sys: d.CompilerSystem, path: string): Promise<any
  * @param config The config passed into the Stencil command
  * @returns true if --debug has been passed, otherwise false
  */
-export function hasDebug(config: d.Config) {
+export function hasDebug(config: d.InternalStrictConfig) {
   return config.flags.debug;
 }
 
@@ -63,6 +67,6 @@ export function hasDebug(config: d.Config) {
  * @param config The config passed into the Stencil command
  * @returns true if both --debug and --verbose have been passed, otherwise false
  */
-export function hasVerbose(config: d.Config) {
+export function hasVerbose(config: d.InternalStrictConfig) {
   return config.flags.verbose && hasDebug(config);
 }

--- a/src/cli/telemetry/helpers.ts
+++ b/src/cli/telemetry/helpers.ts
@@ -12,11 +12,7 @@ export const tryFn = async <T extends (...args: any[]) => Promise<R>, R>(fn: T, 
 
 export declare const TERMINAL_INFO: d.TerminalInfo;
 
-export const isInteractive = (
-  sys: d.CompilerSystem,
-  config: d.InternalStrictConfig,
-  object?: d.TerminalInfo
-): boolean => {
+export const isInteractive = (sys: d.CompilerSystem, flags: d.ConfigFlags, object?: d.TerminalInfo): boolean => {
   const terminalInfo =
     object ||
     Object.freeze({
@@ -24,7 +20,7 @@ export const isInteractive = (
       ci:
         ['CI', 'BUILD_ID', 'BUILD_NUMBER', 'BITBUCKET_COMMIT', 'CODEBUILD_BUILD_ARN'].filter(
           (v) => !!sys.getEnvironmentVar(v)
-        ).length > 0 || !!config.flags.ci,
+        ).length > 0 || !!flags.ci,
     });
 
   return terminalInfo.tty && !terminalInfo.ci;
@@ -55,18 +51,18 @@ export async function readJson(sys: d.CompilerSystem, path: string): Promise<any
 
 /**
  * Does the command have the debug flag?
- * @param config The config passed into the Stencil command
+ * @param flags The configuration flags passed into the Stencil command
  * @returns true if --debug has been passed, otherwise false
  */
-export function hasDebug(config: d.InternalStrictConfig) {
-  return config.flags.debug;
+export function hasDebug(flags: d.ConfigFlags) {
+  return flags.debug;
 }
 
 /**
  * Does the command have the verbose and debug flags?
- * @param config The config passed into the Stencil command
+ * @param flags The configuration flags passed into the Stencil command
  * @returns true if both --debug and --verbose have been passed, otherwise false
  */
-export function hasVerbose(config: d.InternalStrictConfig) {
-  return config.flags.verbose && hasDebug(config);
+export function hasVerbose(flags: d.ConfigFlags) {
+  return flags.verbose && hasDebug(flags);
 }

--- a/src/cli/telemetry/shouldTrack.ts
+++ b/src/cli/telemetry/shouldTrack.ts
@@ -9,6 +9,6 @@ import { checkTelemetry } from './telemetry';
  * @param ci whether or not the process is running in a Continuous Integration (CI) environment
  * @returns true if telemetry should be sent, false otherwise
  */
-export async function shouldTrack(config: d.InternalStrictConfig, sys: d.CompilerSystem, ci?: boolean) {
+export async function shouldTrack(config: d.ValidatedConfig, sys: d.CompilerSystem, ci?: boolean) {
   return !ci && isInteractive(sys, config.flags) && (await checkTelemetry(sys));
 }

--- a/src/cli/telemetry/shouldTrack.ts
+++ b/src/cli/telemetry/shouldTrack.ts
@@ -9,6 +9,6 @@ import { checkTelemetry } from './telemetry';
  * @param ci whether or not the process is running in a Continuous Integration (CI) environment
  * @returns true if telemetry should be sent, false otherwise
  */
-export async function shouldTrack(config: d.Config, sys: d.CompilerSystem, ci?: boolean) {
+export async function shouldTrack(config: d.InternalStrictConfig, sys: d.CompilerSystem, ci?: boolean) {
   return !ci && isInteractive(sys, config) && (await checkTelemetry(sys));
 }

--- a/src/cli/telemetry/shouldTrack.ts
+++ b/src/cli/telemetry/shouldTrack.ts
@@ -10,5 +10,5 @@ import { checkTelemetry } from './telemetry';
  * @returns true if telemetry should be sent, false otherwise
  */
 export async function shouldTrack(config: d.InternalStrictConfig, sys: d.CompilerSystem, ci?: boolean) {
-  return !ci && isInteractive(sys, config) && (await checkTelemetry(sys));
+  return !ci && isInteractive(sys, config.flags) && (await checkTelemetry(sys));
 }

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -16,7 +16,7 @@ import { isOutputTargetHydrate, WWW } from '../../compiler/output-targets/output
  */
 export async function telemetryBuildFinishedAction(
   sys: d.CompilerSystem,
-  config: d.InternalStrictConfig,
+  config: d.ValidatedConfig,
   logger: d.Logger,
   coreCompiler: CoreCompiler,
   result: d.CompilerBuildResults
@@ -47,7 +47,7 @@ export async function telemetryBuildFinishedAction(
  */
 export async function telemetryAction(
   sys: d.CompilerSystem,
-  config: d.InternalStrictConfig,
+  config: d.ValidatedConfig,
   logger: d.Logger,
   coreCompiler: CoreCompiler,
   action?: d.TelemetryCallback
@@ -112,7 +112,7 @@ export async function getActiveTargets(config: d.Config): Promise<string[]> {
  */
 export const prepareData = async (
   coreCompiler: CoreCompiler,
-  config: d.InternalStrictConfig,
+  config: d.ValidatedConfig,
   sys: d.CompilerSystem,
   duration_ms: number,
   component_count: number = undefined
@@ -250,7 +250,7 @@ export const anonymizeConfigForTelemetry = (config: d.Config): d.Config => {
  */
 async function getInstalledPackages(
   sys: d.CompilerSystem,
-  config: d.InternalStrictConfig
+  config: d.ValidatedConfig
 ): Promise<{ packages: string[]; packagesNoVersions: string[] }> {
   let packages: string[] = [];
   let packagesNoVersions: string[] = [];
@@ -350,7 +350,7 @@ function sanitizeDeclaredVersion(version: string): string {
  */
 export async function sendMetric(
   sys: d.CompilerSystem,
-  config: d.InternalStrictConfig,
+  config: d.ValidatedConfig,
   name: string,
   value: d.TrackableData
 ): Promise<void> {
@@ -388,7 +388,7 @@ async function getTelemetryToken(sys: d.CompilerSystem) {
  * @param config The config passed into the Stencil command
  * @param data Data to be tracked
  */
-async function sendTelemetry(sys: d.CompilerSystem, config: d.InternalStrictConfig, data: d.Metric): Promise<void> {
+async function sendTelemetry(sys: d.CompilerSystem, config: d.ValidatedConfig, data: d.Metric): Promise<void> {
   try {
     const now = new Date().toISOString();
 

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -288,7 +288,7 @@ async function getInstalledPackages(
 
     return { packages, packagesNoVersions };
   } catch (err) {
-    hasDebug(config) && console.error(err);
+    hasDebug(config.flags) && console.error(err);
     return { packages, packagesNoVersions };
   }
 }
@@ -406,15 +406,15 @@ async function sendTelemetry(sys: d.CompilerSystem, config: d.InternalStrictConf
       body: JSON.stringify(body),
     });
 
-    hasVerbose(config) &&
+    hasVerbose(config.flags) &&
       console.debug('\nSent %O metric to events service (status: %O)', data.name, response.status, '\n');
 
     if (response.status !== 204) {
-      hasVerbose(config) &&
+      hasVerbose(config.flags) &&
         console.debug('\nBad response from events service. Request body: %O', response.body.toString(), '\n');
     }
   } catch (e) {
-    hasVerbose(config) && console.debug('Telemetry request failed:', e);
+    hasVerbose(config.flags) && console.debug('Telemetry request failed:', e);
   }
 }
 

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -16,7 +16,7 @@ import { isOutputTargetHydrate, WWW } from '../../compiler/output-targets/output
  */
 export async function telemetryBuildFinishedAction(
   sys: d.CompilerSystem,
-  config: d.Config,
+  config: d.InternalStrictConfig,
   logger: d.Logger,
   coreCompiler: CoreCompiler,
   result: d.CompilerBuildResults
@@ -47,12 +47,12 @@ export async function telemetryBuildFinishedAction(
  */
 export async function telemetryAction(
   sys: d.CompilerSystem,
-  config: d.Config,
+  config: d.InternalStrictConfig,
   logger: d.Logger,
   coreCompiler: CoreCompiler,
   action?: d.TelemetryCallback
 ) {
-  const tracking = await shouldTrack(config, sys, !!config?.flags?.ci);
+  const tracking = await shouldTrack(config, sys, !!config.flags.ci);
 
   let duration = undefined;
   let error: any;
@@ -112,7 +112,7 @@ export async function getActiveTargets(config: d.Config): Promise<string[]> {
  */
 export const prepareData = async (
   coreCompiler: CoreCompiler,
-  config: d.Config,
+  config: d.InternalStrictConfig,
   sys: d.CompilerSystem,
   duration_ms: number,
   component_count: number = undefined
@@ -250,7 +250,7 @@ export const anonymizeConfigForTelemetry = (config: d.Config): d.Config => {
  */
 async function getInstalledPackages(
   sys: d.CompilerSystem,
-  config: d.Config
+  config: d.InternalStrictConfig
 ): Promise<{ packages: string[]; packagesNoVersions: string[] }> {
   let packages: string[] = [];
   let packagesNoVersions: string[] = [];
@@ -350,7 +350,7 @@ function sanitizeDeclaredVersion(version: string): string {
  */
 export async function sendMetric(
   sys: d.CompilerSystem,
-  config: d.Config,
+  config: d.InternalStrictConfig,
   name: string,
   value: d.TrackableData
 ): Promise<void> {
@@ -388,7 +388,7 @@ async function getTelemetryToken(sys: d.CompilerSystem) {
  * @param config The config passed into the Stencil command
  * @param data Data to be tracked
  */
-async function sendTelemetry(sys: d.CompilerSystem, config: d.Config, data: d.Metric): Promise<void> {
+async function sendTelemetry(sys: d.CompilerSystem, config: d.InternalStrictConfig, data: d.Metric): Promise<void> {
   try {
     const now = new Date().toISOString();
 

--- a/src/cli/telemetry/test/helpers.spec.ts
+++ b/src/cli/telemetry/test/helpers.spec.ts
@@ -3,60 +3,50 @@ import { createSystem } from '../../../compiler/sys/stencil-sys';
 
 describe('hasDebug', () => {
   it('Returns true when a flag is passed', () => {
-    const config = {
-      flags: {
-        debug: true,
-        verbose: false,
-      },
+    const flags = {
+      debug: true,
+      verbose: false,
     };
 
-    expect(hasDebug(config)).toBe(true);
+    expect(hasDebug(flags)).toBe(true);
   });
 
   it('Returns false when a flag is not passed', () => {
-    const config = {
-      flags: {
-        debug: false,
-        verbose: false,
-      },
+    const flags = {
+      debug: false,
+      verbose: false,
     };
 
-    expect(hasDebug(config)).toBe(false);
+    expect(hasDebug(flags)).toBe(false);
   });
 });
 
 describe('hasVerbose', () => {
   it('Returns true when both flags are passed', () => {
-    const config = {
-      flags: {
-        debug: true,
-        verbose: true,
-      },
+    const flags = {
+      debug: true,
+      verbose: true,
     };
 
-    expect(hasVerbose(config)).toBe(true);
+    expect(hasVerbose(flags)).toBe(true);
   });
 
   it('Returns false when the verbose flag is passed, and debug is not', () => {
-    const config = {
-      flags: {
-        debug: false,
-        verbose: true,
-      },
+    const flags = {
+      debug: false,
+      verbose: true,
     };
 
-    expect(hasVerbose(config)).toBe(false);
+    expect(hasVerbose(flags)).toBe(false);
   });
 
   it('Returns false when the flag is not passed', () => {
-    const config = {
-      flags: {
-        debug: false,
-        verbose: false,
-      },
+    const flags = {
+      debug: false,
+      verbose: false,
     };
 
-    expect(hasVerbose(config)).toBe(false);
+    expect(hasVerbose(flags)).toBe(false);
   });
 });
 
@@ -72,22 +62,22 @@ describe('isInteractive', () => {
   const sys = createSystem();
 
   it('returns false by default', () => {
-    const result = isInteractive(sys, { flags: { ci: false } }, { ci: false, tty: false });
+    const result = isInteractive(sys, { ci: false }, { ci: false, tty: false });
     expect(result).toBe(false);
   });
 
   it('returns false when tty is false', () => {
-    const result = isInteractive(sys, { flags: { ci: true } }, { ci: true, tty: false });
+    const result = isInteractive(sys, { ci: true }, { ci: true, tty: false });
     expect(result).toBe(false);
   });
 
   it('returns false when ci is true', () => {
-    const result = isInteractive(sys, { flags: { ci: true } }, { ci: true, tty: true });
+    const result = isInteractive(sys, { ci: true }, { ci: true, tty: true });
     expect(result).toBe(false);
   });
 
   it('returns true when tty is true and ci is false', () => {
-    const result = isInteractive(sys, { flags: { ci: false } }, { ci: false, tty: true });
+    const result = isInteractive(sys, { ci: false }, { ci: false, tty: true });
     expect(result).toBe(true);
   });
 });

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -8,15 +8,21 @@ import { anonymizeConfigForTelemetry } from '../telemetry';
 import { DIST, DIST_CUSTOM_ELEMENTS, DIST_HYDRATE_SCRIPT, WWW } from '../../../compiler/output-targets/output-utils';
 
 describe('telemetryBuildFinishedAction', () => {
-  const config: d.InternalStrictConfig = {
-    outputTargets: [],
-    flags: {
-      args: [],
-    },
-  };
+  let config: d.InternalStrictConfig;
+  let logger: d.Logger;
+  let sys: d.CompilerSystem;
 
-  const logger = mockLogger();
-  const sys = createSystem();
+  beforeEach(() => {
+    config = {
+      outputTargets: [],
+      flags: {
+        args: [],
+      },
+    };
+
+    logger = mockLogger();
+    sys = createSystem();
+  });
 
   it('issues a network request when complete', async () => {
     const spyShouldTrack = jest.spyOn(shouldTrack, 'shouldTrack');
@@ -39,14 +45,21 @@ describe('telemetryBuildFinishedAction', () => {
 });
 
 describe('telemetryAction', () => {
-  const config: d.InternalStrictConfig = {
-    outputTargets: [],
-    flags: {
-      args: [],
-    },
-  };
-  const logger = mockLogger();
-  const sys = createSystem();
+  let config: d.InternalStrictConfig;
+  let logger: d.Logger;
+  let sys: d.CompilerSystem;
+
+  beforeEach(() => {
+    config = {
+      outputTargets: [],
+      flags: {
+        args: [],
+      },
+    };
+
+    logger = mockLogger();
+    sys = createSystem();
+  });
 
   it('issues a network request when no async function is passed', async () => {
     const spyShouldTrack = jest.spyOn(shouldTrack, 'shouldTrack');
@@ -132,13 +145,19 @@ describe('hasAppTarget', () => {
 });
 
 describe('prepareData', () => {
-  const config: d.InternalStrictConfig = {
-    flags: {
-      args: [],
-    },
-    outputTargets: [],
-  };
-  const sys = createSystem();
+  let config: d.InternalStrictConfig;
+  let sys: d.CompilerSystem;
+
+  beforeEach(() => {
+    config = {
+      outputTargets: [],
+      flags: {
+        args: [],
+      },
+    };
+
+    sys = createSystem();
+  });
 
   it('provides an object', async () => {
     const data = await telemetry.prepareData(coreCompiler, config, sys, 1000);

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -8,7 +8,7 @@ import { anonymizeConfigForTelemetry } from '../telemetry';
 import { DIST, DIST_CUSTOM_ELEMENTS, DIST_HYDRATE_SCRIPT, WWW } from '../../../compiler/output-targets/output-utils';
 
 describe('telemetryBuildFinishedAction', () => {
-  const config: d.Config = {
+  const config: d.InternalStrictConfig = {
     outputTargets: [],
     flags: {
       args: [],
@@ -39,12 +39,12 @@ describe('telemetryBuildFinishedAction', () => {
 });
 
 describe('telemetryAction', () => {
-  const config = {
+  const config: d.InternalStrictConfig = {
     outputTargets: [],
     flags: {
       args: [],
     },
-  } as d.Config;
+  };
   const logger = mockLogger();
   const sys = createSystem();
 
@@ -132,12 +132,12 @@ describe('hasAppTarget', () => {
 });
 
 describe('prepareData', () => {
-  const config = {
+  const config: d.InternalStrictConfig = {
     flags: {
       args: [],
     },
     outputTargets: [],
-  } as d.Config;
+  };
   const sys = createSystem();
 
   it('provides an object', async () => {
@@ -171,12 +171,12 @@ describe('prepareData', () => {
   });
 
   it('updates when there is a PWA config', async () => {
-    const config = {
+    const config: d.InternalStrictConfig = {
       flags: {
         args: [],
       },
       outputTargets: [{ type: 'www', baseUrl: 'https://example.com', serviceWorker: { swDest: './tmp' } }],
-    } as d.Config;
+    };
 
     const data = await telemetry.prepareData(coreCompiler, config, sys, 1000);
 
@@ -217,12 +217,12 @@ describe('prepareData', () => {
   });
 
   it('updates when there is a component count passed in', async () => {
-    const config = {
+    const config: d.InternalStrictConfig = {
       flags: {
         args: [],
       },
       outputTargets: [{ type: 'www', baseUrl: 'https://example.com', serviceWorker: { swDest: './tmp' } }],
-    } as d.Config;
+    };
 
     const data = await telemetry.prepareData(coreCompiler, config, sys, 1000, 12);
 

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -2,18 +2,18 @@ import type * as d from '../../../declarations';
 import * as telemetry from '../telemetry';
 import * as shouldTrack from '../shouldTrack';
 import { createSystem } from '../../../compiler/sys/stencil-sys';
-import { mockInternalStrictConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
 import * as coreCompiler from '@stencil/core/compiler';
 import { anonymizeConfigForTelemetry } from '../telemetry';
 import { DIST, DIST_CUSTOM_ELEMENTS, DIST_HYDRATE_SCRIPT, WWW } from '../../../compiler/output-targets/output-utils';
 
 describe('telemetryBuildFinishedAction', () => {
-  let config: d.InternalStrictConfig;
+  let config: d.ValidatedConfig;
   let sys: d.CompilerSystem;
 
   beforeEach(() => {
     sys = createSystem();
-    config = mockInternalStrictConfig(sys);
+    config = mockValidatedConfig(sys);
     config.outputTargets = [];
     config.flags.args = [];
   });
@@ -39,12 +39,12 @@ describe('telemetryBuildFinishedAction', () => {
 });
 
 describe('telemetryAction', () => {
-  let config: d.InternalStrictConfig;
+  let config: d.ValidatedConfig;
   let sys: d.CompilerSystem;
 
   beforeEach(() => {
     sys = createSystem();
-    config = mockInternalStrictConfig(sys);
+    config = mockValidatedConfig(sys);
     config.outputTargets = [];
     config.flags.args = [];
   });
@@ -133,7 +133,7 @@ describe('hasAppTarget', () => {
 });
 
 describe('prepareData', () => {
-  let config: d.InternalStrictConfig;
+  let config: d.ValidatedConfig;
   let sys: d.CompilerSystem;
 
   beforeEach(() => {
@@ -178,7 +178,7 @@ describe('prepareData', () => {
   });
 
   it('updates when there is a PWA config', async () => {
-    const config: d.InternalStrictConfig = {
+    const config: d.ValidatedConfig = {
       flags: {
         args: [],
       },
@@ -224,7 +224,7 @@ describe('prepareData', () => {
   });
 
   it('updates when there is a component count passed in', async () => {
-    const config: d.InternalStrictConfig = {
+    const config: d.ValidatedConfig = {
       flags: {
         args: [],
       },

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -2,26 +2,20 @@ import type * as d from '../../../declarations';
 import * as telemetry from '../telemetry';
 import * as shouldTrack from '../shouldTrack';
 import { createSystem } from '../../../compiler/sys/stencil-sys';
-import { mockLogger } from '@stencil/core/testing';
+import { mockInternalStrictConfig } from '@stencil/core/testing';
 import * as coreCompiler from '@stencil/core/compiler';
 import { anonymizeConfigForTelemetry } from '../telemetry';
 import { DIST, DIST_CUSTOM_ELEMENTS, DIST_HYDRATE_SCRIPT, WWW } from '../../../compiler/output-targets/output-utils';
 
 describe('telemetryBuildFinishedAction', () => {
   let config: d.InternalStrictConfig;
-  let logger: d.Logger;
   let sys: d.CompilerSystem;
 
   beforeEach(() => {
-    config = {
-      outputTargets: [],
-      flags: {
-        args: [],
-      },
-    };
-
-    logger = mockLogger();
     sys = createSystem();
+    config = mockInternalStrictConfig(sys);
+    config.outputTargets = [];
+    config.flags.args = [];
   });
 
   it('issues a network request when complete', async () => {
@@ -37,7 +31,7 @@ describe('telemetryBuildFinishedAction', () => {
       duration: 100,
     } as d.CompilerBuildResults;
 
-    await telemetry.telemetryBuildFinishedAction(sys, config, logger, coreCompiler, results);
+    await telemetry.telemetryBuildFinishedAction(sys, config, config.logger, coreCompiler, results);
     expect(spyShouldTrack).toHaveBeenCalled();
 
     spyShouldTrack.mockRestore();
@@ -46,19 +40,13 @@ describe('telemetryBuildFinishedAction', () => {
 
 describe('telemetryAction', () => {
   let config: d.InternalStrictConfig;
-  let logger: d.Logger;
   let sys: d.CompilerSystem;
 
   beforeEach(() => {
-    config = {
-      outputTargets: [],
-      flags: {
-        args: [],
-      },
-    };
-
-    logger = mockLogger();
     sys = createSystem();
+    config = mockInternalStrictConfig(sys);
+    config.outputTargets = [];
+    config.flags.args = [];
   });
 
   it('issues a network request when no async function is passed', async () => {
@@ -69,7 +57,7 @@ describe('telemetryAction', () => {
       })
     );
 
-    await telemetry.telemetryAction(sys, config, logger, coreCompiler, () => {});
+    await telemetry.telemetryAction(sys, config, config.logger, coreCompiler, () => {});
     expect(spyShouldTrack).toHaveBeenCalled();
 
     spyShouldTrack.mockRestore();
@@ -83,7 +71,7 @@ describe('telemetryAction', () => {
       })
     );
 
-    await telemetry.telemetryAction(sys, config, logger, coreCompiler, async () => {
+    await telemetry.telemetryAction(sys, config, config.logger, coreCompiler, async () => {
       new Promise((resolve) => {
         setTimeout(() => {
           resolve(true);

--- a/src/cli/test/run.spec.ts
+++ b/src/cli/test/run.spec.ts
@@ -3,8 +3,14 @@ import * as coreCompiler from '@stencil/core/compiler';
 import { mockCompilerSystem, mockConfig, mockLogger as createMockLogger } from '@stencil/core/testing';
 import * as ParseFlags from '../parse-flags';
 import { run, runTask } from '../run';
+import * as BuildTask from '../task-build';
+import * as DocsTask from '../task-docs';
+import * as GenerateTask from '../task-generate';
 import * as HelpTask from '../task-help';
+import * as PrerenderTask from '../task-prerender';
+import * as ServeTask from '../task-serve';
 import * as TelemetryTask from '../task-telemetry';
+import * as TestTask from '../task-test';
 import { createTestingSystem } from '../../testing/testing-sys';
 
 describe('run', () => {
@@ -58,11 +64,8 @@ describe('run', () => {
         expect(taskHelpSpy).toHaveBeenCalledTimes(1);
         expect(taskHelpSpy).toHaveBeenCalledWith(
           {
-            flags: {
-              task: 'help',
-              args: [],
-            },
-            outputTargets: [],
+            task: 'help',
+            args: [],
           },
           mockLogger,
           mockSystem
@@ -81,11 +84,8 @@ describe('run', () => {
         expect(taskHelpSpy).toHaveBeenCalledTimes(1);
         expect(taskHelpSpy).toHaveBeenCalledWith(
           {
-            flags: {
-              task: 'help',
-              args: [],
-            },
-            outputTargets: [],
+            task: 'help',
+            args: [],
           },
           mockLogger,
           mockSystem
@@ -99,58 +99,161 @@ describe('run', () => {
   describe('runTask()', () => {
     let sys: d.CompilerSystem;
     let unvalidatedConfig: d.Config;
+    let validatedConfig: d.Config;
 
+    let taskBuildSpy: jest.SpyInstance<ReturnType<typeof BuildTask.taskBuild>, Parameters<typeof BuildTask.taskBuild>>;
+    let taskDocsSpy: jest.SpyInstance<ReturnType<typeof DocsTask.taskDocs>, Parameters<typeof DocsTask.taskDocs>>;
+    let taskGenerateSpy: jest.SpyInstance<
+      ReturnType<typeof GenerateTask.taskGenerate>,
+      Parameters<typeof GenerateTask.taskGenerate>
+    >;
     let taskHelpSpy: jest.SpyInstance<ReturnType<typeof HelpTask.taskHelp>, Parameters<typeof HelpTask.taskHelp>>;
+    let taskPrerenderSpy: jest.SpyInstance<
+      ReturnType<typeof PrerenderTask.taskPrerender>,
+      Parameters<typeof PrerenderTask.taskPrerender>
+    >;
+    let taskServeSpy: jest.SpyInstance<ReturnType<typeof ServeTask.taskServe>, Parameters<typeof ServeTask.taskServe>>;
     let taskTelemetrySpy: jest.SpyInstance<
       ReturnType<typeof TelemetryTask.taskTelemetry>,
       Parameters<typeof TelemetryTask.taskTelemetry>
     >;
+    let taskTestSpy: jest.SpyInstance<ReturnType<typeof TestTask.taskTest>, Parameters<typeof TestTask.taskTest>>;
 
     beforeEach(() => {
       sys = mockCompilerSystem();
       sys.exit = jest.fn();
 
       unvalidatedConfig = mockConfig(sys);
+      unvalidatedConfig.outputTargets = null;
+
+      validatedConfig = mockConfig(sys);
+      validatedConfig.outputTargets = [];
+
+      taskBuildSpy = jest.spyOn(BuildTask, 'taskBuild');
+      taskBuildSpy.mockResolvedValue();
+
+      taskDocsSpy = jest.spyOn(DocsTask, 'taskDocs');
+      taskDocsSpy.mockResolvedValue();
+
+      taskGenerateSpy = jest.spyOn(GenerateTask, 'taskGenerate');
+      taskGenerateSpy.mockResolvedValue();
 
       taskHelpSpy = jest.spyOn(HelpTask, 'taskHelp');
-      taskHelpSpy.mockReturnValue(Promise.resolve());
+      taskHelpSpy.mockResolvedValue();
+
+      taskPrerenderSpy = jest.spyOn(PrerenderTask, 'taskPrerender');
+      taskPrerenderSpy.mockResolvedValue();
+
+      taskServeSpy = jest.spyOn(ServeTask, 'taskServe');
+      taskServeSpy.mockResolvedValue();
+
       taskTelemetrySpy = jest.spyOn(TelemetryTask, 'taskTelemetry');
-      taskTelemetrySpy.mockReturnValue(Promise.resolve());
+      taskTelemetrySpy.mockResolvedValue();
+
+      taskTestSpy = jest.spyOn(TestTask, 'taskTest');
+      taskTestSpy.mockResolvedValue();
     });
 
     afterEach(() => {
+      taskBuildSpy.mockRestore();
+      taskDocsSpy.mockRestore();
+      taskGenerateSpy.mockRestore();
       taskHelpSpy.mockRestore();
+      taskPrerenderSpy.mockRestore();
+      taskServeSpy.mockRestore();
       taskTelemetrySpy.mockRestore();
+      taskTestSpy.mockRestore();
     });
 
-    it('calls the help task', () => {
-      runTask(coreCompiler, unvalidatedConfig, 'help', sys);
+    it('calls the build task', async () => {
+      await runTask(coreCompiler, unvalidatedConfig, 'build', sys);
+
+      expect(taskBuildSpy).toHaveBeenCalledTimes(1);
+      expect(taskBuildSpy).toHaveBeenCalledWith(coreCompiler, validatedConfig, sys);
+    });
+
+    it('calls the docs task', async () => {
+      await runTask(coreCompiler, unvalidatedConfig, 'docs', sys);
+
+      expect(taskDocsSpy).toHaveBeenCalledTimes(1);
+      expect(taskDocsSpy).toHaveBeenCalledWith(coreCompiler, validatedConfig);
+    });
+
+    describe('generate task', () => {
+      it("calls the generate task for the argument 'generate'", async () => {
+        await runTask(coreCompiler, unvalidatedConfig, 'generate', sys);
+
+        expect(taskGenerateSpy).toHaveBeenCalledTimes(1);
+        expect(taskGenerateSpy).toHaveBeenCalledWith(coreCompiler, validatedConfig);
+      });
+
+      it("calls the generate task for the argument 'g'", async () => {
+        await runTask(coreCompiler, unvalidatedConfig, 'g', sys);
+
+        expect(taskGenerateSpy).toHaveBeenCalledTimes(1);
+        expect(taskGenerateSpy).toHaveBeenCalledWith(coreCompiler, validatedConfig);
+      });
+    });
+
+    it('calls the help task', async () => {
+      await runTask(coreCompiler, unvalidatedConfig, 'help', sys);
 
       expect(taskHelpSpy).toHaveBeenCalledTimes(1);
-      expect(taskHelpSpy).toHaveBeenCalledWith(unvalidatedConfig, unvalidatedConfig.logger, sys);
+      expect(taskHelpSpy).toHaveBeenCalledWith(validatedConfig.flags, validatedConfig.logger, sys);
+    });
+
+    it('calls the prerender task', async () => {
+      await runTask(coreCompiler, unvalidatedConfig, 'prerender', sys);
+
+      expect(taskPrerenderSpy).toHaveBeenCalledTimes(1);
+      expect(taskPrerenderSpy).toHaveBeenCalledWith(coreCompiler, validatedConfig);
+    });
+
+    it('calls the serve task', async () => {
+      await runTask(coreCompiler, unvalidatedConfig, 'serve', sys);
+
+      expect(taskServeSpy).toHaveBeenCalledTimes(1);
+      expect(taskServeSpy).toHaveBeenCalledWith(validatedConfig);
     });
 
     describe('telemetry task', () => {
-      it('calls the telemetry task when a compiler system is present', () => {
-        runTask(coreCompiler, unvalidatedConfig, 'telemetry', sys);
+      it('calls the telemetry task when a compiler system is present', async () => {
+        await runTask(coreCompiler, unvalidatedConfig, 'telemetry', sys);
 
         expect(taskTelemetrySpy).toHaveBeenCalledTimes(1);
-        expect(taskTelemetrySpy).toHaveBeenCalledWith(unvalidatedConfig, sys, unvalidatedConfig.logger);
+        expect(taskTelemetrySpy).toHaveBeenCalledWith(validatedConfig.flags, sys, validatedConfig.logger);
       });
 
-      it("does not call the telemetry task when a compiler system isn't present", () => {
-        runTask(coreCompiler, unvalidatedConfig, 'telemetry');
+      it("does not call the telemetry task when a compiler system isn't present", async () => {
+        await runTask(coreCompiler, unvalidatedConfig, 'telemetry');
 
         expect(taskTelemetrySpy).not.toHaveBeenCalled();
       });
     });
 
-    it('defaults to the help task for an unaccounted for task name', () => {
+    it('calls the test task', async () => {
+      await runTask(coreCompiler, unvalidatedConfig, 'test', sys);
+
+      expect(taskTestSpy).toHaveBeenCalledTimes(1);
+      expect(taskTestSpy).toHaveBeenCalledWith(validatedConfig);
+    });
+
+    it('defaults to the help task for an unaccounted for task name', async () => {
       // info is a valid task name, but isn't used in the `switch` statement of `runTask`
-      runTask(coreCompiler, unvalidatedConfig, 'info', sys);
+      await runTask(coreCompiler, unvalidatedConfig, 'info', sys);
 
       expect(taskHelpSpy).toHaveBeenCalledTimes(1);
-      expect(taskHelpSpy).toHaveBeenCalledWith(unvalidatedConfig, unvalidatedConfig.logger, sys);
+      expect(taskHelpSpy).toHaveBeenCalledWith(validatedConfig.flags, validatedConfig.logger, sys);
+    });
+
+    it('defaults to the provided task if no flags exist on the provided config', async () => {
+      unvalidatedConfig = mockConfig(sys);
+      unvalidatedConfig.flags = undefined;
+
+      await runTask(coreCompiler, unvalidatedConfig, 'help', sys);
+
+      expect(taskHelpSpy).toHaveBeenCalledTimes(1);
+      expect(taskHelpSpy).toHaveBeenCalledWith(validatedConfig.flags, validatedConfig.logger, sys);
     });
   });
 });

--- a/src/cli/test/run.spec.ts
+++ b/src/cli/test/run.spec.ts
@@ -58,8 +58,8 @@ describe('run', () => {
         taskHelpSpy.mockRestore();
       });
 
-      it("calls the help task when the 'task' field is set to 'help'", () => {
-        run(cliInitOptions);
+      it("calls the help task when the 'task' field is set to 'help'", async () => {
+        await run(cliInitOptions);
 
         expect(taskHelpSpy).toHaveBeenCalledTimes(1);
         expect(taskHelpSpy).toHaveBeenCalledWith(
@@ -74,12 +74,12 @@ describe('run', () => {
         taskHelpSpy.mockRestore();
       });
 
-      it("calls the help task when the 'help' field is set on flags", () => {
+      it("calls the help task when the 'help' field is set on flags", async () => {
         parseFlagsSpy.mockReturnValue({
           help: true,
         });
 
-        run(cliInitOptions);
+        await run(cliInitOptions);
 
         expect(taskHelpSpy).toHaveBeenCalledTimes(1);
         expect(taskHelpSpy).toHaveBeenCalledWith(

--- a/src/cli/test/task-generate.spec.ts
+++ b/src/cli/test/task-generate.spec.ts
@@ -1,6 +1,6 @@
 import type * as d from '../../declarations';
 import { taskGenerate, getBoilerplateByExtension, BoilerplateFile } from '../task-generate';
-import { mockInternalStrictConfig, mockCompilerSystem } from '@stencil/core/testing';
+import { mockValidatedConfig, mockCompilerSystem } from '@stencil/core/testing';
 import * as utils from '../../utils/validation';
 
 import * as coreCompiler from '@stencil/core/compiler';
@@ -14,7 +14,7 @@ jest.mock('prompts', () => ({
 
 const setup = async () => {
   const sys = mockCompilerSystem();
-  const config: d.InternalStrictConfig = mockInternalStrictConfig(sys);
+  const config: d.ValidatedConfig = mockValidatedConfig(sys);
   config.configPath = '/testing-path';
   config.srcDir = '/src';
 
@@ -41,7 +41,7 @@ const setup = async () => {
  * @param coreCompiler the core compiler instance to forward to `taskGenerate`
  * @param config the user-supplied config to forward to `taskGenerate`
  */
-async function silentGenerate(coreCompiler: CoreCompiler, config: d.InternalStrictConfig): Promise<void> {
+async function silentGenerate(coreCompiler: CoreCompiler, config: d.ValidatedConfig): Promise<void> {
   const tmp = console.log;
   console.log = jest.fn();
   await taskGenerate(coreCompiler, config);

--- a/src/cli/test/task-generate.spec.ts
+++ b/src/cli/test/task-generate.spec.ts
@@ -1,6 +1,6 @@
 import type * as d from '../../declarations';
 import { taskGenerate, getBoilerplateByExtension, BoilerplateFile } from '../task-generate';
-import { mockConfig, mockCompilerSystem } from '@stencil/core/testing';
+import { mockInternalStrictConfig, mockCompilerSystem } from '@stencil/core/testing';
 import * as utils from '../../utils/validation';
 
 import * as coreCompiler from '@stencil/core/compiler';
@@ -14,7 +14,7 @@ jest.mock('prompts', () => ({
 
 const setup = async () => {
   const sys = mockCompilerSystem();
-  const config: d.Config = mockConfig(sys);
+  const config: d.InternalStrictConfig = mockInternalStrictConfig(sys);
   config.configPath = '/testing-path';
   config.srcDir = '/src';
 
@@ -41,7 +41,7 @@ const setup = async () => {
  * @param coreCompiler the core compiler instance to forward to `taskGenerate`
  * @param config the user-supplied config to forward to `taskGenerate`
  */
-async function silentGenerate(coreCompiler: CoreCompiler, config: d.Config): Promise<void> {
+async function silentGenerate(coreCompiler: CoreCompiler, config: d.InternalStrictConfig): Promise<void> {
   const tmp = console.log;
   console.log = jest.fn();
   await taskGenerate(coreCompiler, config);

--- a/src/compiler/build/build.ts
+++ b/src/compiler/build/build.ts
@@ -10,7 +10,7 @@ import { writeBuild } from './write-build';
 import ts from 'typescript';
 
 export const build = async (
-  config: d.InternalStrictConfig,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   tsBuilder: ts.BuilderProgram

--- a/src/compiler/build/build.ts
+++ b/src/compiler/build/build.ts
@@ -10,7 +10,7 @@ import { writeBuild } from './write-build';
 import ts from 'typescript';
 
 export const build = async (
-  config: d.Config,
+  config: d.InternalStrictConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   tsBuilder: ts.BuilderProgram

--- a/src/compiler/build/full-build.ts
+++ b/src/compiler/build/full-build.ts
@@ -11,7 +11,7 @@ import ts from 'typescript';
  * @returns the results of a full build of Stencil
  */
 export const createFullBuild = async (
-  config: d.InternalStrictConfig,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx
 ): Promise<d.CompilerBuildResults> => {
   return new Promise<d.CompilerBuildResults>((resolve) => {

--- a/src/compiler/build/full-build.ts
+++ b/src/compiler/build/full-build.ts
@@ -11,7 +11,7 @@ import ts from 'typescript';
  * @returns the results of a full build of Stencil
  */
 export const createFullBuild = async (
-  config: d.Config,
+  config: d.InternalStrictConfig,
   compilerCtx: d.CompilerCtx
 ): Promise<d.CompilerBuildResults> => {
   return new Promise<d.CompilerBuildResults>((resolve) => {

--- a/src/compiler/build/watch-build.ts
+++ b/src/compiler/build/watch-build.ts
@@ -18,7 +18,7 @@ import { isString } from '@utils';
 import type ts from 'typescript';
 
 export const createWatchBuild = async (
-  config: d.InternalStrictConfig,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx
 ): Promise<d.CompilerWatcher> => {
   let isRebuild = false;

--- a/src/compiler/build/watch-build.ts
+++ b/src/compiler/build/watch-build.ts
@@ -17,7 +17,10 @@ import { hasServiceWorkerChanges } from '../service-worker/generate-sw';
 import { isString } from '@utils';
 import type ts from 'typescript';
 
-export const createWatchBuild = async (config: d.Config, compilerCtx: d.CompilerCtx): Promise<d.CompilerWatcher> => {
+export const createWatchBuild = async (
+  config: d.InternalStrictConfig,
+  compilerCtx: d.CompilerCtx
+): Promise<d.CompilerWatcher> => {
   let isRebuild = false;
   let tsWatchProgram: {
     program: ts.WatchOfConfigFile<ts.EmitAndSemanticDiagnosticsBuilderProgram>;

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -14,14 +14,15 @@ import ts from 'typescript';
 
 /**
  * Generate a Stencil compiler instance
- * @param config a Stencil configuration to apply to the compiler instance
+ * @param userConfig a user-provided Stencil configuration to apply to the compiler instance
  * @returns a new instance of a Stencil compiler
+ * @public
  */
-export const createCompiler = async (config: Config): Promise<Compiler> => {
+export const createCompiler = async (userConfig: Config): Promise<Compiler> => {
   // actual compiler code
   // could be in a web worker on the browser
   // or the main thread in node
-  config = getConfig(config);
+  const config = getConfig(userConfig);
   const diagnostics: Diagnostic[] = [];
   const sys = config.sys;
   const compilerCtx = new CompilerContext();

--- a/src/compiler/config/load-config.ts
+++ b/src/compiler/config/load-config.ts
@@ -44,6 +44,8 @@ export const loadConfig = async (init: LoadConfigInit = {}): Promise<LoadConfigR
     },
   };
 
+  const unknownConfig: UnvalidatedConfig = {};
+
   try {
     const sys = init.sys || createSystem();
     const config = init.config || {};
@@ -54,23 +56,22 @@ export const loadConfig = async (init: LoadConfigInit = {}): Promise<LoadConfigR
       return results;
     }
 
-    if (loadedConfigFile != null) {
+    if (loadedConfigFile !== null) {
       // merge the user's config object into their loaded config file
       configPath = loadedConfigFile.configPath;
-      results.config = { ...loadedConfigFile, ...config };
-      results.config.configPath = configPath;
-      results.config.rootDir = normalizePath(dirname(configPath));
+      unknownConfig.config = { ...loadedConfigFile, ...config };
+      unknownConfig.config.configPath = configPath;
+      unknownConfig.config.rootDir = normalizePath(dirname(configPath));
     } else {
       // no stencil.config.ts or .js file, which is fine
-      // #0CJS ¯\_(ツ)_/¯
-      results.config = { ...config };
-      results.config.configPath = null;
-      results.config.rootDir = normalizePath(sys.getCurrentDirectory());
+      unknownConfig.config = { ...config };
+      unknownConfig.config.configPath = null;
+      unknownConfig.config.rootDir = normalizePath(sys.getCurrentDirectory());
     }
 
-    results.config.sys = sys;
+    unknownConfig.config.sys = sys;
 
-    const validated = validateConfig(results.config);
+    const validated = validateConfig(unknownConfig.config);
     results.diagnostics.push(...validated.diagnostics);
     if (hasError(results.diagnostics)) {
       return results;

--- a/src/compiler/config/outputs/index.ts
+++ b/src/compiler/config/outputs/index.ts
@@ -17,7 +17,7 @@ import { validateStats } from './validate-stats';
 import { validateWww } from './validate-www';
 import { validateCustomElementBundle } from './validate-custom-element-bundle';
 
-export const validateOutputTargets = (config: d.InternalStrictConfig, diagnostics: d.Diagnostic[]) => {
+export const validateOutputTargets = (config: d.ValidatedConfig, diagnostics: d.Diagnostic[]) => {
   const userOutputs = (config.outputTargets || []).slice();
 
   userOutputs.forEach((outputTarget) => {

--- a/src/compiler/config/outputs/index.ts
+++ b/src/compiler/config/outputs/index.ts
@@ -17,7 +17,7 @@ import { validateStats } from './validate-stats';
 import { validateWww } from './validate-www';
 import { validateCustomElementBundle } from './validate-custom-element-bundle';
 
-export const validateOutputTargets = (config: d.UnvalidatedConfig, diagnostics: d.Diagnostic[]) => {
+export const validateOutputTargets = (config: d.InternalStrictConfig, diagnostics: d.Diagnostic[]) => {
   const userOutputs = (config.outputTargets || []).slice();
 
   userOutputs.forEach((outputTarget) => {

--- a/src/compiler/config/outputs/validate-docs.ts
+++ b/src/compiler/config/outputs/validate-docs.ts
@@ -9,7 +9,11 @@ import {
 } from '../../output-targets/output-utils';
 import { NOTE } from '../../docs/constants';
 
-export const validateDocs = (config: d.Config, diagnostics: d.Diagnostic[], userOutputs: d.OutputTarget[]) => {
+export const validateDocs = (
+  config: d.InternalStrictConfig,
+  diagnostics: d.Diagnostic[],
+  userOutputs: d.OutputTarget[]
+) => {
   const docsOutputs: d.OutputTarget[] = [];
 
   // json docs flag

--- a/src/compiler/config/outputs/validate-docs.ts
+++ b/src/compiler/config/outputs/validate-docs.ts
@@ -9,11 +9,7 @@ import {
 } from '../../output-targets/output-utils';
 import { NOTE } from '../../docs/constants';
 
-export const validateDocs = (
-  config: d.InternalStrictConfig,
-  diagnostics: d.Diagnostic[],
-  userOutputs: d.OutputTarget[]
-) => {
+export const validateDocs = (config: d.ValidatedConfig, diagnostics: d.Diagnostic[], userOutputs: d.OutputTarget[]) => {
   const docsOutputs: d.OutputTarget[] = [];
 
   // json docs flag

--- a/src/compiler/config/outputs/validate-hydrate-script.ts
+++ b/src/compiler/config/outputs/validate-hydrate-script.ts
@@ -9,7 +9,7 @@ import { isBoolean, isString } from '@utils';
 import { isAbsolute, join } from 'path';
 import { NODE_BUILTINS } from '../../sys/modules';
 
-export const validateHydrateScript = (config: d.InternalStrictConfig, userOutputs: d.OutputTarget[]) => {
+export const validateHydrateScript = (config: d.ValidatedConfig, userOutputs: d.OutputTarget[]) => {
   const output: d.OutputTargetHydrate[] = [];
 
   const hasHydrateOutputTarget = userOutputs.some(isOutputTargetHydrate);

--- a/src/compiler/config/outputs/validate-hydrate-script.ts
+++ b/src/compiler/config/outputs/validate-hydrate-script.ts
@@ -9,7 +9,7 @@ import { isBoolean, isString } from '@utils';
 import { isAbsolute, join } from 'path';
 import { NODE_BUILTINS } from '../../sys/modules';
 
-export const validateHydrateScript = (config: d.Config, userOutputs: d.OutputTarget[]) => {
+export const validateHydrateScript = (config: d.InternalStrictConfig, userOutputs: d.OutputTarget[]) => {
   const output: d.OutputTargetHydrate[] = [];
 
   const hasHydrateOutputTarget = userOutputs.some(isOutputTargetHydrate);
@@ -19,7 +19,7 @@ export const validateHydrateScript = (config: d.Config, userOutputs: d.OutputTar
     // let's still see if we require one because of other output targets
 
     const hasWwwOutput = userOutputs.filter(isOutputTargetWww).some((o) => isString(o.indexHtml));
-    const shouldBuildHydrate = config?.flags.prerender || config?.flags.ssr;
+    const shouldBuildHydrate = config.flags.prerender || config.flags.ssr;
 
     if (hasWwwOutput && shouldBuildHydrate) {
       // we're prerendering a www output target, so we'll need a hydrate app

--- a/src/compiler/config/outputs/validate-stats.ts
+++ b/src/compiler/config/outputs/validate-stats.ts
@@ -2,7 +2,7 @@ import type * as d from '../../../declarations';
 import { isAbsolute, join } from 'path';
 import { STATS, isOutputTargetStats } from '../../output-targets/output-utils';
 
-export const validateStats = (userConfig: d.InternalStrictConfig, userOutputs: d.OutputTarget[]) => {
+export const validateStats = (userConfig: d.ValidatedConfig, userOutputs: d.OutputTarget[]) => {
   const outputTargets: d.OutputTargetStats[] = [];
 
   if (userConfig.flags.stats) {

--- a/src/compiler/config/outputs/validate-stats.ts
+++ b/src/compiler/config/outputs/validate-stats.ts
@@ -2,7 +2,7 @@ import type * as d from '../../../declarations';
 import { isAbsolute, join } from 'path';
 import { STATS, isOutputTargetStats } from '../../output-targets/output-utils';
 
-export const validateStats = (userConfig: d.Config, userOutputs: d.OutputTarget[]) => {
+export const validateStats = (userConfig: d.InternalStrictConfig, userOutputs: d.OutputTarget[]) => {
   const outputTargets: d.OutputTargetStats[] = [];
 
   if (userConfig.flags.stats) {

--- a/src/compiler/config/outputs/validate-www.ts
+++ b/src/compiler/config/outputs/validate-www.ts
@@ -14,9 +14,13 @@ import { validateCopy } from '../validate-copy';
 import { validatePrerender } from '../validate-prerender';
 import { validateServiceWorker } from '../validate-service-worker';
 
-export const validateWww = (config: d.Config, diagnostics: d.Diagnostic[], userOutputs: d.OutputTarget[]) => {
+export const validateWww = (
+  config: d.InternalStrictConfig,
+  diagnostics: d.Diagnostic[],
+  userOutputs: d.OutputTarget[]
+) => {
   const hasOutputTargets = userOutputs.length > 0;
-  const hasE2eTests = !!(config.flags && config.flags.e2e);
+  const hasE2eTests = !!config.flags.e2e;
   const userWwwOutputs = userOutputs.filter(isOutputTargetWww);
 
   if (
@@ -74,7 +78,11 @@ export const validateWww = (config: d.Config, diagnostics: d.Diagnostic[], userO
   }, []);
 };
 
-const validateWwwOutputTarget = (config: d.Config, outputTarget: d.OutputTargetWww, diagnostics: d.Diagnostic[]) => {
+const validateWwwOutputTarget = (
+  config: d.InternalStrictConfig,
+  outputTarget: d.OutputTargetWww,
+  diagnostics: d.Diagnostic[]
+) => {
   if (!isString(outputTarget.baseUrl)) {
     outputTarget.baseUrl = '/';
   }

--- a/src/compiler/config/outputs/validate-www.ts
+++ b/src/compiler/config/outputs/validate-www.ts
@@ -14,11 +14,7 @@ import { validateCopy } from '../validate-copy';
 import { validatePrerender } from '../validate-prerender';
 import { validateServiceWorker } from '../validate-service-worker';
 
-export const validateWww = (
-  config: d.InternalStrictConfig,
-  diagnostics: d.Diagnostic[],
-  userOutputs: d.OutputTarget[]
-) => {
+export const validateWww = (config: d.ValidatedConfig, diagnostics: d.Diagnostic[], userOutputs: d.OutputTarget[]) => {
   const hasOutputTargets = userOutputs.length > 0;
   const hasE2eTests = !!config.flags.e2e;
   const userWwwOutputs = userOutputs.filter(isOutputTargetWww);
@@ -79,7 +75,7 @@ export const validateWww = (
 };
 
 const validateWwwOutputTarget = (
-  config: d.InternalStrictConfig,
+  config: d.ValidatedConfig,
   outputTarget: d.OutputTargetWww,
   diagnostics: d.Diagnostic[]
 ) => {

--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -5,7 +5,7 @@ import { DOCS_JSON, DOCS_CUSTOM, DOCS_README, DOCS_VSCODE } from '../../output-t
 import { validateConfig } from '../validate-config';
 
 describe('validation', () => {
-  let userConfig: d.Config;
+  let userConfig: d.UnvalidatedConfig;
   const logger = mockLogger();
   const sys = mockCompilerSystem();
 

--- a/src/compiler/config/test/validate-dev-server.spec.ts
+++ b/src/compiler/config/test/validate-dev-server.spec.ts
@@ -4,7 +4,7 @@ import { validateConfig } from '../validate-config';
 import path from 'path';
 
 describe('validateDevServer', () => {
-  let inputConfig: d.Config;
+  let inputConfig: d.UnvalidatedConfig;
   const root = path.resolve('/');
 
   beforeEach(() => {
@@ -40,7 +40,7 @@ describe('validateDevServer', () => {
   });
 
   it('should set address from flags', () => {
-    inputConfig.flags.address = '123.123.123.123';
+    inputConfig.flags = { ...(inputConfig.flags ?? {}), address: '123.123.123.123' };
     const { config } = validateConfig(inputConfig);
     expect(config.devServer.address).toBe('123.123.123.123');
   });
@@ -143,7 +143,7 @@ describe('validateDevServer', () => {
   });
 
   it('should set port from flags', () => {
-    inputConfig.flags.port = 4444;
+    inputConfig.flags = { ...(inputConfig.flags ?? {}), port: 4444 };
     const { config } = validateConfig(inputConfig);
     expect(config.devServer.port).toBe(4444);
   });
@@ -219,7 +219,7 @@ describe('validateDevServer', () => {
   });
 
   it('should set ssr from flag', () => {
-    inputConfig.flags.ssr = true;
+    inputConfig.flags = { ...(inputConfig.flags ?? {}), ssr: true };
     const { config } = validateConfig(inputConfig);
     expect(config.devServer.ssr).toBe(true);
   });
@@ -240,7 +240,7 @@ describe('validateDevServer', () => {
       prerenderConfig: normalizePath(path.join(root, 'some', 'path', 'prerender.config.ts')),
     };
     inputConfig.outputTargets = [wwwOutputTarget];
-    inputConfig.flags.ssr = true;
+    inputConfig.flags = { ...(inputConfig.flags ?? {}), ssr: true };
     const { config } = validateConfig(inputConfig);
     expect(config.devServer.prerenderConfig).toBe(wwwOutputTarget.prerenderConfig);
   });

--- a/src/compiler/config/test/validate-dev-server.spec.ts
+++ b/src/compiler/config/test/validate-dev-server.spec.ts
@@ -2,19 +2,20 @@ import type * as d from '../../../declarations';
 import { normalizePath } from '../../../utils';
 import { validateConfig } from '../validate-config';
 import path from 'path';
+import { ConfigFlags } from '../../../cli/config-flags';
 
 describe('validateDevServer', () => {
-  let inputConfig: d.UnvalidatedConfig;
   const root = path.resolve('/');
+  let inputConfig: d.UnvalidatedConfig;
+  let flags: ConfigFlags;
 
   beforeEach(() => {
+    flags = { serve: true };
     inputConfig = {
       sys: {} as any,
       rootDir: normalizePath(path.join(root, 'some', 'path')),
       devServer: {},
-      flags: {
-        serve: true,
-      },
+      flags,
       namespace: 'Testing',
     };
   });
@@ -25,7 +26,7 @@ describe('validateDevServer', () => {
   });
 
   it.each(['https://localhost', 'http://localhost', 'https://localhost/', 'http://localhost/', 'localhost/'])(
-    'should remove extraneious stuff from addres %p',
+    'should remove extraneous stuff from address %p',
     (address) => {
       inputConfig.devServer.address = address;
       const { config } = validateConfig(inputConfig);
@@ -40,7 +41,7 @@ describe('validateDevServer', () => {
   });
 
   it('should set address from flags', () => {
-    inputConfig.flags = { ...(inputConfig.flags ?? {}), address: '123.123.123.123' };
+    inputConfig.flags = { ...flags, address: '123.123.123.123' };
     const { config } = validateConfig(inputConfig);
     expect(config.devServer.address).toBe('123.123.123.123');
   });
@@ -143,7 +144,7 @@ describe('validateDevServer', () => {
   });
 
   it('should set port from flags', () => {
-    inputConfig.flags = { ...(inputConfig.flags ?? {}), port: 4444 };
+    inputConfig.flags = { ...flags, port: 4444 };
     const { config } = validateConfig(inputConfig);
     expect(config.devServer.port).toBe(4444);
   });
@@ -219,7 +220,7 @@ describe('validateDevServer', () => {
   });
 
   it('should set ssr from flag', () => {
-    inputConfig.flags = { ...(inputConfig.flags ?? {}), ssr: true };
+    inputConfig.flags = { ...flags, ssr: true };
     const { config } = validateConfig(inputConfig);
     expect(config.devServer.ssr).toBe(true);
   });
@@ -240,7 +241,7 @@ describe('validateDevServer', () => {
       prerenderConfig: normalizePath(path.join(root, 'some', 'path', 'prerender.config.ts')),
     };
     inputConfig.outputTargets = [wwwOutputTarget];
-    inputConfig.flags = { ...(inputConfig.flags ?? {}), ssr: true };
+    inputConfig.flags = { ...flags, ssr: true };
     const { config } = validateConfig(inputConfig);
     expect(config.devServer.prerenderConfig).toBe(wwwOutputTarget.prerenderConfig);
   });

--- a/src/compiler/config/test/validate-docs.spec.ts
+++ b/src/compiler/config/test/validate-docs.spec.ts
@@ -10,7 +10,7 @@ describe('validateDocs', () => {
   });
 
   it('readme docs dir', () => {
-    userConfig.flags.docs = true;
+    userConfig.flags = { ...(userConfig.flags ?? {}), docs: true };
     userConfig.outputTargets = [
       {
         type: 'docs-readme',

--- a/src/compiler/config/test/validate-output-www.spec.ts
+++ b/src/compiler/config/test/validate-output-www.spec.ts
@@ -321,14 +321,14 @@ describe('validateOutputTargetWww', () => {
     });
 
     it('should add hydrate with --prerender flag', () => {
-      userConfig.flags.prerender = true;
+      userConfig.flags = { ...(userConfig.flags ?? {}), prerender: true };
       const { config } = validateConfig(userConfig);
       expect(config.outputTargets.some((o) => o.type === 'dist-hydrate-script')).toBe(true);
       expect(config.outputTargets.some((o) => o.type === 'www')).toBe(true);
     });
 
     it('should add hydrate with --ssr flag', () => {
-      userConfig.flags.ssr = true;
+      userConfig.flags = { ...(userConfig.flags ?? {}), ssr: true };
       const { config } = validateConfig(userConfig);
       expect(config.outputTargets.some((o) => o.type === 'dist-hydrate-script')).toBe(true);
       expect(config.outputTargets.some((o) => o.type === 'www')).toBe(true);
@@ -350,7 +350,8 @@ describe('validateOutputTargetWww', () => {
     });
 
     it('should add node builtins to external by default', () => {
-      userConfig.flags.prerender = true;
+      userConfig.flags = { ...(userConfig.flags ?? {}), prerender: true };
+
       const { config } = validateConfig(userConfig);
       const o = config.outputTargets.find(isOutputTargetHydrate);
       expect(o.external).toContain('fs');

--- a/src/compiler/config/test/validate-output-www.spec.ts
+++ b/src/compiler/config/test/validate-output-www.spec.ts
@@ -2,15 +2,19 @@ import type * as d from '@stencil/core/declarations';
 import { isOutputTargetCopy, isOutputTargetHydrate, isOutputTargetWww } from '../../output-targets/output-utils';
 import { validateConfig } from '../validate-config';
 import path from 'path';
+import { ConfigFlags } from '../../../cli/config-flags';
 
 describe('validateOutputTargetWww', () => {
   const rootDir = path.resolve('/');
   let userConfig: d.Config;
+  let flags: ConfigFlags;
+
   beforeEach(() => {
+    flags = {};
     userConfig = {
       rootDir: rootDir,
-      flags: {},
-    } as any;
+      flags,
+    };
   });
 
   it('should have default value', () => {
@@ -321,14 +325,14 @@ describe('validateOutputTargetWww', () => {
     });
 
     it('should add hydrate with --prerender flag', () => {
-      userConfig.flags = { ...(userConfig.flags ?? {}), prerender: true };
+      userConfig.flags = { ...flags, prerender: true };
       const { config } = validateConfig(userConfig);
       expect(config.outputTargets.some((o) => o.type === 'dist-hydrate-script')).toBe(true);
       expect(config.outputTargets.some((o) => o.type === 'www')).toBe(true);
     });
 
     it('should add hydrate with --ssr flag', () => {
-      userConfig.flags = { ...(userConfig.flags ?? {}), ssr: true };
+      userConfig.flags = { ...flags, ssr: true };
       const { config } = validateConfig(userConfig);
       expect(config.outputTargets.some((o) => o.type === 'dist-hydrate-script')).toBe(true);
       expect(config.outputTargets.some((o) => o.type === 'www')).toBe(true);
@@ -350,7 +354,7 @@ describe('validateOutputTargetWww', () => {
     });
 
     it('should add node builtins to external by default', () => {
-      userConfig.flags = { ...(userConfig.flags ?? {}), prerender: true };
+      userConfig.flags = { ...flags, prerender: true };
 
       const { config } = validateConfig(userConfig);
       const o = config.outputTargets.find(isOutputTargetHydrate);

--- a/src/compiler/config/test/validate-service-worker.spec.ts
+++ b/src/compiler/config/test/validate-service-worker.spec.ts
@@ -4,7 +4,7 @@ import { mockCompilerSystem } from '@stencil/core/testing';
 import { validateServiceWorker } from '../validate-service-worker';
 
 describe('validateServiceWorker', () => {
-  const config: d.InternalStrictConfig = {
+  const config: d.ValidatedConfig = {
     fsNamespace: 'app',
     sys: mockCompilerSystem(),
     devMode: false,

--- a/src/compiler/config/test/validate-service-worker.spec.ts
+++ b/src/compiler/config/test/validate-service-worker.spec.ts
@@ -4,7 +4,7 @@ import { mockCompilerSystem } from '@stencil/core/testing';
 import { validateServiceWorker } from '../validate-service-worker';
 
 describe('validateServiceWorker', () => {
-  const config: d.Config = {
+  const config: d.InternalStrictConfig = {
     fsNamespace: 'app',
     sys: mockCompilerSystem(),
     devMode: false,

--- a/src/compiler/config/test/validate-stats.spec.ts
+++ b/src/compiler/config/test/validate-stats.spec.ts
@@ -10,7 +10,7 @@ describe('validateStats', () => {
   });
 
   it('adds stats from flags, w/ no outputTargets', () => {
-    userConfig.flags.stats = true;
+    userConfig.flags = { ...(userConfig.flags ?? {}), stats: true };
 
     const { config } = validateConfig(userConfig);
     const o = config.outputTargets.find((o) => o.type === 'stats') as d.OutputTargetStats;

--- a/src/compiler/config/test/validate-testing.spec.ts
+++ b/src/compiler/config/test/validate-testing.spec.ts
@@ -2,20 +2,23 @@ import type * as d from '@stencil/core/declarations';
 import { mockLogger, mockCompilerSystem } from '@stencil/core/testing';
 import { validateConfig } from '../validate-config';
 import path from 'path';
+import { ConfigFlags } from '../../../cli/config-flags';
 
 describe('validateTesting', () => {
-  let userConfig: d.Config;
   const ROOT = path.resolve('/');
   const sys = mockCompilerSystem();
   const logger = mockLogger();
+  let userConfig: d.Config;
+  let flags: ConfigFlags;
 
   beforeEach(() => {
+    flags = {};
     userConfig = {
       sys: sys as any,
       logger: logger,
       rootDir: path.join(ROOT, 'User', 'some', 'path'),
       srcDir: path.join(ROOT, 'User', 'some', 'path', 'src'),
-      flags: {},
+      flags,
       namespace: 'Testing',
       configPath: path.join(ROOT, 'User', 'some', 'path', 'stencil.config.ts'),
     };
@@ -28,31 +31,31 @@ describe('validateTesting', () => {
   });
 
   it('set headless false w/ flag', () => {
-    userConfig.flags = { ...(userConfig.flags ?? {}), e2e: true, headless: false };
+    userConfig.flags = { ...flags, e2e: true, headless: false };
     const { config } = validateConfig(userConfig);
     expect(config.testing.browserHeadless).toBe(false);
   });
 
   it('set headless true w/ flag', () => {
-    userConfig.flags = { ...(userConfig.flags ?? {}), e2e: true, headless: true };
+    userConfig.flags = { ...flags, e2e: true, headless: true };
     const { config } = validateConfig(userConfig);
     expect(config.testing.browserHeadless).toBe(true);
   });
 
   it('default headless true', () => {
-    userConfig.flags = { ...(userConfig.flags ?? {}), e2e: true };
+    userConfig.flags = { ...flags, e2e: true };
     const { config } = validateConfig(userConfig);
     expect(config.testing.browserHeadless).toBe(true);
   });
 
   it('force headless with ci flag', () => {
-    userConfig.flags = { ...(userConfig.flags ?? {}), ci: true, e2e: true, headless: false };
+    userConfig.flags = { ...flags, ci: true, e2e: true, headless: false };
     const { config } = validateConfig(userConfig);
     expect(config.testing.browserHeadless).toBe(true);
   });
 
   it('default to no-sandbox browser args with ci flag', () => {
-    userConfig.flags = { ...(userConfig.flags ?? {}), ci: true, e2e: true };
+    userConfig.flags = { ...flags, ci: true, e2e: true };
     const { config } = validateConfig(userConfig);
     expect(config.testing.browserArgs).toEqual([
       '--font-render-hinting=medium',
@@ -64,13 +67,13 @@ describe('validateTesting', () => {
   });
 
   it('default browser args', () => {
-    userConfig.flags = { ...(userConfig.flags ?? {}), e2e: true };
+    userConfig.flags = { ...flags, e2e: true };
     const { config } = validateConfig(userConfig);
     expect(config.testing.browserArgs).toEqual(['--font-render-hinting=medium', '--incognito']);
   });
 
   it('set default testPathIgnorePatterns', () => {
-    userConfig.flags = { ...(userConfig.flags ?? {}), e2e: true };
+    userConfig.flags = { ...flags, e2e: true };
     const { config } = validateConfig(userConfig);
     expect(config.testing.testPathIgnorePatterns).toEqual([
       path.join(ROOT, 'User', 'some', 'path', '.vscode'),
@@ -81,7 +84,7 @@ describe('validateTesting', () => {
   });
 
   it('set default testPathIgnorePatterns with custom outputTargets', () => {
-    userConfig.flags = { ...(userConfig.flags ?? {}), e2e: true };
+    userConfig.flags = { ...flags, e2e: true };
     userConfig.outputTargets = [
       { type: 'dist', dir: 'dist-folder' },
       { type: 'www', dir: 'www-folder' },
@@ -98,7 +101,7 @@ describe('validateTesting', () => {
   });
 
   it('set relative testEnvironment to absolute', () => {
-    userConfig.flags = { ...(userConfig.flags ?? {}), e2e: true };
+    userConfig.flags = { ...flags, e2e: true };
     userConfig.testing = {
       testEnvironment: './rel-path.js',
     };
@@ -108,7 +111,7 @@ describe('validateTesting', () => {
   });
 
   it('set node module testEnvironment', () => {
-    userConfig.flags = { ...(userConfig.flags ?? {}), e2e: true };
+    userConfig.flags = { ...flags, e2e: true };
     userConfig.testing = {
       testEnvironment: 'jsdom',
     };
@@ -125,7 +128,7 @@ describe('validateTesting', () => {
     let testRegex: RegExp;
 
     beforeEach(() => {
-      userConfig.flags = { ...(userConfig.flags ?? {}), spec: true };
+      userConfig.flags = { ...flags, spec: true };
 
       const { testing: testConfig } = validateConfig(userConfig).config;
       const testRegexSetting = testConfig?.testRegex;

--- a/src/compiler/config/test/validate-testing.spec.ts
+++ b/src/compiler/config/test/validate-testing.spec.ts
@@ -28,36 +28,31 @@ describe('validateTesting', () => {
   });
 
   it('set headless false w/ flag', () => {
-    userConfig.flags.e2e = true;
-    userConfig.flags.headless = false;
+    userConfig.flags = { ...(userConfig.flags ?? {}), e2e: true, headless: false };
     const { config } = validateConfig(userConfig);
     expect(config.testing.browserHeadless).toBe(false);
   });
 
   it('set headless true w/ flag', () => {
-    userConfig.flags.e2e = true;
-    userConfig.flags.headless = true;
+    userConfig.flags = { ...(userConfig.flags ?? {}), e2e: true, headless: true };
     const { config } = validateConfig(userConfig);
     expect(config.testing.browserHeadless).toBe(true);
   });
 
   it('default headless true', () => {
-    userConfig.flags.e2e = true;
+    userConfig.flags = { ...(userConfig.flags ?? {}), e2e: true };
     const { config } = validateConfig(userConfig);
     expect(config.testing.browserHeadless).toBe(true);
   });
 
   it('force headless with ci flag', () => {
-    userConfig.flags.e2e = true;
-    userConfig.flags.headless = false;
-    userConfig.flags.ci = true;
+    userConfig.flags = { ...(userConfig.flags ?? {}), ci: true, e2e: true, headless: false };
     const { config } = validateConfig(userConfig);
     expect(config.testing.browserHeadless).toBe(true);
   });
 
   it('default to no-sandbox browser args with ci flag', () => {
-    userConfig.flags.e2e = true;
-    userConfig.flags.ci = true;
+    userConfig.flags = { ...(userConfig.flags ?? {}), ci: true, e2e: true };
     const { config } = validateConfig(userConfig);
     expect(config.testing.browserArgs).toEqual([
       '--font-render-hinting=medium',
@@ -69,13 +64,13 @@ describe('validateTesting', () => {
   });
 
   it('default browser args', () => {
-    userConfig.flags.e2e = true;
+    userConfig.flags = { ...(userConfig.flags ?? {}), e2e: true };
     const { config } = validateConfig(userConfig);
     expect(config.testing.browserArgs).toEqual(['--font-render-hinting=medium', '--incognito']);
   });
 
   it('set default testPathIgnorePatterns', () => {
-    userConfig.flags.e2e = true;
+    userConfig.flags = { ...(userConfig.flags ?? {}), e2e: true };
     const { config } = validateConfig(userConfig);
     expect(config.testing.testPathIgnorePatterns).toEqual([
       path.join(ROOT, 'User', 'some', 'path', '.vscode'),
@@ -86,7 +81,7 @@ describe('validateTesting', () => {
   });
 
   it('set default testPathIgnorePatterns with custom outputTargets', () => {
-    userConfig.flags.e2e = true;
+    userConfig.flags = { ...(userConfig.flags ?? {}), e2e: true };
     userConfig.outputTargets = [
       { type: 'dist', dir: 'dist-folder' },
       { type: 'www', dir: 'www-folder' },
@@ -103,7 +98,7 @@ describe('validateTesting', () => {
   });
 
   it('set relative testEnvironment to absolute', () => {
-    userConfig.flags.e2e = true;
+    userConfig.flags = { ...(userConfig.flags ?? {}), e2e: true };
     userConfig.testing = {
       testEnvironment: './rel-path.js',
     };
@@ -113,7 +108,7 @@ describe('validateTesting', () => {
   });
 
   it('set node module testEnvironment', () => {
-    userConfig.flags.e2e = true;
+    userConfig.flags = { ...(userConfig.flags ?? {}), e2e: true };
     userConfig.testing = {
       testEnvironment: 'jsdom',
     };
@@ -130,7 +125,7 @@ describe('validateTesting', () => {
     let testRegex: RegExp;
 
     beforeEach(() => {
-      userConfig.flags.spec = true;
+      userConfig.flags = { ...(userConfig.flags ?? {}), spec: true };
 
       const { testing: testConfig } = validateConfig(userConfig).config;
       const testRegexSetting = testConfig?.testRegex;

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -1,4 +1,4 @@
-import { ConfigBundle, Diagnostic, InternalStrictConfig, UnvalidatedConfig } from '../../declarations';
+import { ConfigBundle, Diagnostic, ValidatedConfig, UnvalidatedConfig } from '../../declarations';
 import { buildError, isBoolean, isNumber, isString, sortBy } from '@utils';
 import { setBooleanConfig } from './config-utils';
 import { validateDevServer } from './validate-dev-server';
@@ -19,7 +19,7 @@ type ConfigValidationResults = {
   /**
    * The validated configuration, with well-known default values set if they weren't previously provided
    */
-  config: InternalStrictConfig;
+  config: ValidatedConfig;
   /**
    * A collection of errors and warnings that occurred during the configuration validation process
    */
@@ -38,7 +38,7 @@ export const validateConfig = (userConfig: UnvalidatedConfig = {}): ConfigValida
   const config = Object.assign({}, userConfig || {}); // not positive it's json safe
   const diagnostics: Diagnostic[] = [];
 
-  const validatedConfig: InternalStrictConfig = {
+  const validatedConfig: ValidatedConfig = {
     ...config,
     // flags _should_ be JSON safe
     flags: JSON.parse(JSON.stringify(config.flags || {})),

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -1,4 +1,4 @@
-import { Config, ConfigBundle, Diagnostic, UnvalidatedConfig } from '../../declarations';
+import { ConfigBundle, Diagnostic, InternalStrictConfig, UnvalidatedConfig } from '../../declarations';
 import { buildError, isBoolean, isNumber, isString, sortBy } from '@utils';
 import { setBooleanConfig } from './config-utils';
 import { validateDevServer } from './validate-dev-server';
@@ -13,6 +13,20 @@ import { validateTesting } from './validate-testing';
 import { validateWorkers } from './validate-workers';
 
 /**
+ * Represents the results of validating a previously unvalidated configuration
+ */
+type ConfigValidationResults = {
+  /**
+   * The validated configuration, with well-known default values set if they weren't previously provided
+   */
+  config: InternalStrictConfig;
+  /**
+   * A collection of errors and warnings that occurred during the configuration validation process
+   */
+  diagnostics: Diagnostic[];
+};
+
+/**
  * Validate a Config object, ensuring that all its field are present and
  * consistent with our expectations. This function transforms an
  * `UnvalidatedConfig` to a `Config`.
@@ -20,125 +34,129 @@ import { validateWorkers } from './validate-workers';
  * @param userConfig an unvalidated config that we've gotten from a user
  * @returns an object with config and diagnostics props
  */
-export const validateConfig = (
-  userConfig: UnvalidatedConfig = {}
-): {
-  config: Config;
-  diagnostics: Diagnostic[];
-} => {
+export const validateConfig = (userConfig: UnvalidatedConfig = {}): ConfigValidationResults => {
   const config = Object.assign({}, userConfig || {}); // not positive it's json safe
   const diagnostics: Diagnostic[] = [];
 
-  // copy flags (we know it'll be json safe)
-  config.flags = JSON.parse(JSON.stringify(config.flags || {}));
+  // TODO: Not convinced this is the best thing to do
+  const validatedConfig: InternalStrictConfig = {
+    ...config,
+    flags: JSON.parse(JSON.stringify(config.flags || {})),
+  };
 
   // default devMode false
-  if (config.flags.prod) {
-    config.devMode = false;
-  } else if (config.flags.dev) {
-    config.devMode = true;
-  } else if (!isBoolean(config.devMode)) {
-    config.devMode = DEFAULT_DEV_MODE;
+  if (validatedConfig.flags.prod) {
+    validatedConfig.devMode = false;
+  } else if (validatedConfig.flags.dev) {
+    validatedConfig.devMode = true;
+  } else if (!isBoolean(validatedConfig.devMode)) {
+    validatedConfig.devMode = DEFAULT_DEV_MODE;
   }
 
-  config.extras = config.extras || {};
-  config.extras.appendChildSlotFix = !!config.extras.appendChildSlotFix;
-  config.extras.cloneNodeFix = !!config.extras.cloneNodeFix;
-  config.extras.cssVarsShim = !!config.extras.cssVarsShim;
-  config.extras.dynamicImportShim = !!config.extras.dynamicImportShim;
-  config.extras.lifecycleDOMEvents = !!config.extras.lifecycleDOMEvents;
-  config.extras.safari10 = !!config.extras.safari10;
-  config.extras.scriptDataOpts = !!config.extras.scriptDataOpts;
-  config.extras.shadowDomShim = !!config.extras.shadowDomShim;
-  config.extras.slotChildNodesFix = !!config.extras.slotChildNodesFix;
-  config.extras.initializeNextTick = !!config.extras.initializeNextTick;
-  config.extras.tagNameTransform = !!config.extras.tagNameTransform;
+  validatedConfig.extras = validatedConfig.extras || {};
+  validatedConfig.extras.appendChildSlotFix = !!validatedConfig.extras.appendChildSlotFix;
+  validatedConfig.extras.cloneNodeFix = !!validatedConfig.extras.cloneNodeFix;
+  validatedConfig.extras.cssVarsShim = !!validatedConfig.extras.cssVarsShim;
+  validatedConfig.extras.dynamicImportShim = !!validatedConfig.extras.dynamicImportShim;
+  validatedConfig.extras.lifecycleDOMEvents = !!validatedConfig.extras.lifecycleDOMEvents;
+  validatedConfig.extras.safari10 = !!validatedConfig.extras.safari10;
+  validatedConfig.extras.scriptDataOpts = !!validatedConfig.extras.scriptDataOpts;
+  validatedConfig.extras.shadowDomShim = !!validatedConfig.extras.shadowDomShim;
+  validatedConfig.extras.slotChildNodesFix = !!validatedConfig.extras.slotChildNodesFix;
+  validatedConfig.extras.initializeNextTick = !!validatedConfig.extras.initializeNextTick;
+  validatedConfig.extras.tagNameTransform = !!validatedConfig.extras.tagNameTransform;
 
-  config.buildEs5 = config.buildEs5 === true || (!config.devMode && config.buildEs5 === 'prod');
+  validatedConfig.buildEs5 =
+    validatedConfig.buildEs5 === true || (!validatedConfig.devMode && validatedConfig.buildEs5 === 'prod');
 
-  setBooleanConfig(config, 'minifyCss', null, !config.devMode);
-  setBooleanConfig(config, 'minifyJs', null, !config.devMode);
-  setBooleanConfig(config, 'sourceMap', null, typeof config.sourceMap === 'undefined' ? false : config.sourceMap);
-  setBooleanConfig(config, 'watch', 'watch', false);
-  setBooleanConfig(config, 'buildDocs', 'docs', !config.devMode);
-  setBooleanConfig(config, 'buildDist', 'esm', !config.devMode || config.buildEs5);
-  setBooleanConfig(config, 'profile', 'profile', config.devMode);
-  setBooleanConfig(config, 'writeLog', 'log', false);
-  setBooleanConfig(config, 'buildAppCore', null, true);
-  setBooleanConfig(config, 'autoprefixCss', null, config.buildEs5);
-  setBooleanConfig(config, 'validateTypes', null, !config._isTesting);
-  setBooleanConfig(config, 'allowInlineScripts', null, true);
+  setBooleanConfig(validatedConfig, 'minifyCss', null, !validatedConfig.devMode);
+  setBooleanConfig(validatedConfig, 'minifyJs', null, !validatedConfig.devMode);
+  setBooleanConfig(
+    validatedConfig,
+    'sourceMap',
+    null,
+    typeof validatedConfig.sourceMap === 'undefined' ? false : validatedConfig.sourceMap
+  );
+  setBooleanConfig(validatedConfig, 'watch', 'watch', false);
+  setBooleanConfig(validatedConfig, 'buildDocs', 'docs', !validatedConfig.devMode);
+  setBooleanConfig(validatedConfig, 'buildDist', 'esm', !validatedConfig.devMode || validatedConfig.buildEs5);
+  setBooleanConfig(validatedConfig, 'profile', 'profile', validatedConfig.devMode);
+  setBooleanConfig(validatedConfig, 'writeLog', 'log', false);
+  setBooleanConfig(validatedConfig, 'buildAppCore', null, true);
+  setBooleanConfig(validatedConfig, 'autoprefixCss', null, validatedConfig.buildEs5);
+  setBooleanConfig(validatedConfig, 'validateTypes', null, !validatedConfig._isTesting);
+  setBooleanConfig(validatedConfig, 'allowInlineScripts', null, true);
 
-  if (!isString(config.taskQueue)) {
-    config.taskQueue = 'async';
+  if (!isString(validatedConfig.taskQueue)) {
+    validatedConfig.taskQueue = 'async';
   }
 
   // hash file names
-  if (!isBoolean(config.hashFileNames)) {
-    config.hashFileNames = !config.devMode;
+  if (!isBoolean(validatedConfig.hashFileNames)) {
+    validatedConfig.hashFileNames = !validatedConfig.devMode;
   }
-  if (!isNumber(config.hashedFileNameLength)) {
-    config.hashedFileNameLength = DEFAULT_HASHED_FILENAME_LENTH;
+  if (!isNumber(validatedConfig.hashedFileNameLength)) {
+    validatedConfig.hashedFileNameLength = DEFAULT_HASHED_FILENAME_LENTH;
   }
-  if (config.hashedFileNameLength < MIN_HASHED_FILENAME_LENTH) {
+  if (validatedConfig.hashedFileNameLength < MIN_HASHED_FILENAME_LENTH) {
     const err = buildError(diagnostics);
-    err.messageText = `config.hashedFileNameLength must be at least ${MIN_HASHED_FILENAME_LENTH} characters`;
+    err.messageText = `validatedConfig.hashedFileNameLength must be at least ${MIN_HASHED_FILENAME_LENTH} characters`;
   }
-  if (config.hashedFileNameLength > MAX_HASHED_FILENAME_LENTH) {
+  if (validatedConfig.hashedFileNameLength > MAX_HASHED_FILENAME_LENTH) {
     const err = buildError(diagnostics);
-    err.messageText = `config.hashedFileNameLength cannot be more than ${MAX_HASHED_FILENAME_LENTH} characters`;
+    err.messageText = `validatedConfig.hashedFileNameLength cannot be more than ${MAX_HASHED_FILENAME_LENTH} characters`;
   }
-  if (!config.env) {
-    config.env = {};
+  if (!validatedConfig.env) {
+    validatedConfig.env = {};
   }
 
   // get a good namespace
-  validateNamespace(config, diagnostics);
+  validateNamespace(validatedConfig, diagnostics);
 
   // figure out all of the config paths and absolute paths
-  validatePaths(config);
+  validatePaths(validatedConfig);
 
   // outputTargets
-  validateOutputTargets(config, diagnostics);
+  validateOutputTargets(validatedConfig, diagnostics);
 
   // plugins
-  validatePlugins(config, diagnostics);
+  validatePlugins(validatedConfig, diagnostics);
 
   // rollup config
-  validateRollupConfig(config);
+  validateRollupConfig(validatedConfig);
 
   // dev server
-  config.devServer = validateDevServer(config, diagnostics);
+  validatedConfig.devServer = validateDevServer(validatedConfig, diagnostics);
 
   // testing
-  validateTesting(config, diagnostics);
+  validateTesting(validatedConfig, diagnostics);
 
   // hydrate flag
-  config.hydratedFlag = validateHydrated(config);
+  validatedConfig.hydratedFlag = validateHydrated(validatedConfig);
 
   // bundles
-  if (Array.isArray(config.bundles)) {
-    config.bundles = sortBy(config.bundles, (a: ConfigBundle) => a.components.length);
+  if (Array.isArray(validatedConfig.bundles)) {
+    validatedConfig.bundles = sortBy(validatedConfig.bundles, (a: ConfigBundle) => a.components.length);
   } else {
-    config.bundles = [];
+    validatedConfig.bundles = [];
   }
 
   // validate how many workers we can use
-  validateWorkers(config);
+  validateWorkers(validatedConfig);
 
   // default devInspector to whatever devMode is
-  setBooleanConfig(config, 'devInspector', null, config.devMode);
+  setBooleanConfig(validatedConfig, 'devInspector', null, validatedConfig.devMode);
 
-  if (!config._isTesting) {
-    validateDistNamespace(config, diagnostics);
+  if (!validatedConfig._isTesting) {
+    validateDistNamespace(validatedConfig, diagnostics);
   }
 
-  setBooleanConfig(config, 'enableCache', 'cache', true);
+  setBooleanConfig(validatedConfig, 'enableCache', 'cache', true);
 
-  if (!Array.isArray(config.watchIgnoredRegex) && config.watchIgnoredRegex != null) {
-    config.watchIgnoredRegex = [config.watchIgnoredRegex];
+  if (!Array.isArray(validatedConfig.watchIgnoredRegex) && validatedConfig.watchIgnoredRegex != null) {
+    validatedConfig.watchIgnoredRegex = [validatedConfig.watchIgnoredRegex];
   }
-  config.watchIgnoredRegex = ((config.watchIgnoredRegex as RegExp[]) || []).reduce((arr, reg) => {
+  validatedConfig.watchIgnoredRegex = ((validatedConfig.watchIgnoredRegex as RegExp[]) || []).reduce((arr, reg) => {
     if (reg instanceof RegExp) {
       arr.push(reg);
     }
@@ -146,7 +164,7 @@ export const validateConfig = (
   }, [] as RegExp[]);
 
   return {
-    config,
+    config: validatedConfig,
     diagnostics,
   };
 };

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -38,9 +38,9 @@ export const validateConfig = (userConfig: UnvalidatedConfig = {}): ConfigValida
   const config = Object.assign({}, userConfig || {}); // not positive it's json safe
   const diagnostics: Diagnostic[] = [];
 
-  // TODO: Not convinced this is the best thing to do
   const validatedConfig: InternalStrictConfig = {
     ...config,
+    // flags _should_ be JSON safe
     flags: JSON.parse(JSON.stringify(config.flags || {})),
   };
 

--- a/src/compiler/config/validate-dev-server.ts
+++ b/src/compiler/config/validate-dev-server.ts
@@ -4,7 +4,7 @@ import { isAbsolute, join } from 'path';
 import { isOutputTargetWww } from '../output-targets/output-utils';
 
 export const validateDevServer = (
-  config: d.InternalStrictConfig,
+  config: d.ValidatedConfig,
   diagnostics: d.Diagnostic[]
 ): d.DevServerConfig | undefined => {
   if ((config.devServer === null || (config.devServer as any)) === false) {

--- a/src/compiler/config/validate-dev-server.ts
+++ b/src/compiler/config/validate-dev-server.ts
@@ -4,14 +4,14 @@ import { isAbsolute, join } from 'path';
 import { isOutputTargetWww } from '../output-targets/output-utils';
 
 export const validateDevServer = (
-  config: d.UnvalidatedConfig,
+  config: d.InternalStrictConfig,
   diagnostics: d.Diagnostic[]
 ): d.DevServerConfig | undefined => {
   if ((config.devServer === null || (config.devServer as any)) === false) {
     return undefined;
   }
 
-  const flags = config.flags ?? {};
+  const { flags } = config;
   const devServer = { ...config.devServer };
 
   if (flags.address && isString(flags.address)) {
@@ -80,7 +80,7 @@ export const validateDevServer = (
     devServer.websocket = true;
   }
 
-  if (config?.flags?.ssr) {
+  if (flags.ssr) {
     devServer.ssr = true;
   } else {
     devServer.ssr = !!devServer.ssr;

--- a/src/compiler/config/validate-prerender.ts
+++ b/src/compiler/config/validate-prerender.ts
@@ -2,8 +2,12 @@ import type * as d from '../../declarations';
 import { buildError, isString, normalizePath } from '@utils';
 import { isAbsolute, join } from 'path';
 
-export const validatePrerender = (config: d.Config, diagnostics: d.Diagnostic[], outputTarget: d.OutputTargetWww) => {
-  if (!config.flags || (!config.flags.ssr && !config.flags.prerender && config.flags.task !== 'prerender')) {
+export const validatePrerender = (
+  config: d.InternalStrictConfig,
+  diagnostics: d.Diagnostic[],
+  outputTarget: d.OutputTargetWww
+) => {
+  if (!config.flags.ssr && !config.flags.prerender && config.flags.task !== 'prerender') {
     return;
   }
 

--- a/src/compiler/config/validate-prerender.ts
+++ b/src/compiler/config/validate-prerender.ts
@@ -3,7 +3,7 @@ import { buildError, isString, normalizePath } from '@utils';
 import { isAbsolute, join } from 'path';
 
 export const validatePrerender = (
-  config: d.InternalStrictConfig,
+  config: d.ValidatedConfig,
   diagnostics: d.Diagnostic[],
   outputTarget: d.OutputTargetWww
 ) => {

--- a/src/compiler/config/validate-service-worker.ts
+++ b/src/compiler/config/validate-service-worker.ts
@@ -3,7 +3,7 @@ import { HOST_CONFIG_FILENAME } from '../prerender/host-config';
 import { isAbsolute, join } from 'path';
 import { isString } from '@utils';
 
-export const validateServiceWorker = (config: d.InternalStrictConfig, outputTarget: d.OutputTargetWww) => {
+export const validateServiceWorker = (config: d.ValidatedConfig, outputTarget: d.OutputTargetWww) => {
   if (outputTarget.serviceWorker === false) {
     return;
   }

--- a/src/compiler/config/validate-service-worker.ts
+++ b/src/compiler/config/validate-service-worker.ts
@@ -3,7 +3,7 @@ import { HOST_CONFIG_FILENAME } from '../prerender/host-config';
 import { isAbsolute, join } from 'path';
 import { isString } from '@utils';
 
-export const validateServiceWorker = (config: d.Config, outputTarget: d.OutputTargetWww) => {
+export const validateServiceWorker = (config: d.InternalStrictConfig, outputTarget: d.OutputTargetWww) => {
   if (outputTarget.serviceWorker === false) {
     return;
   }

--- a/src/compiler/config/validate-testing.ts
+++ b/src/compiler/config/validate-testing.ts
@@ -4,10 +4,10 @@ import { isAbsolute, join, basename, dirname } from 'path';
 import { isLocalModule } from '../sys/resolve/resolve-utils';
 import { isOutputTargetDist, isOutputTargetWww } from '../output-targets/output-utils';
 
-export const validateTesting = (config: d.UnvalidatedConfig, diagnostics: d.Diagnostic[]) => {
+export const validateTesting = (config: d.InternalStrictConfig, diagnostics: d.Diagnostic[]) => {
   const testing = (config.testing = Object.assign({}, config.testing || {}));
 
-  if (!config.flags || (!config.flags.e2e && !config.flags.spec)) {
+  if (!config.flags.e2e && !config.flags.spec) {
     return;
   }
 
@@ -49,7 +49,7 @@ export const validateTesting = (config: d.UnvalidatedConfig, diagnostics: d.Diag
     testing.rootDir = config.rootDir;
   }
 
-  if (config.flags && typeof config.flags.screenshotConnector === 'string') {
+  if (typeof config.flags.screenshotConnector === 'string') {
     testing.screenshotConnector = config.flags.screenshotConnector;
   }
 

--- a/src/compiler/config/validate-testing.ts
+++ b/src/compiler/config/validate-testing.ts
@@ -4,7 +4,7 @@ import { isAbsolute, join, basename, dirname } from 'path';
 import { isLocalModule } from '../sys/resolve/resolve-utils';
 import { isOutputTargetDist, isOutputTargetWww } from '../output-targets/output-utils';
 
-export const validateTesting = (config: d.InternalStrictConfig, diagnostics: d.Diagnostic[]) => {
+export const validateTesting = (config: d.ValidatedConfig, diagnostics: d.Diagnostic[]) => {
   const testing = (config.testing = Object.assign({}, config.testing || {}));
 
   if (!config.flags.e2e && !config.flags.spec) {

--- a/src/compiler/config/validate-workers.ts
+++ b/src/compiler/config/validate-workers.ts
@@ -1,6 +1,6 @@
 import type * as d from '../../declarations';
 
-export const validateWorkers = (config: d.InternalStrictConfig) => {
+export const validateWorkers = (config: d.ValidatedConfig) => {
   if (typeof config.maxConcurrentWorkers !== 'number') {
     config.maxConcurrentWorkers = 8;
   }

--- a/src/compiler/config/validate-workers.ts
+++ b/src/compiler/config/validate-workers.ts
@@ -1,16 +1,14 @@
 import type * as d from '../../declarations';
 
-export const validateWorkers = (config: d.UnvalidatedConfig) => {
+export const validateWorkers = (config: d.InternalStrictConfig) => {
   if (typeof config.maxConcurrentWorkers !== 'number') {
     config.maxConcurrentWorkers = 8;
   }
 
-  if (config.flags) {
-    if (typeof config.flags.maxWorkers === 'number') {
-      config.maxConcurrentWorkers = config.flags.maxWorkers;
-    } else if (config.flags.ci) {
-      config.maxConcurrentWorkers = 4;
-    }
+  if (typeof config.flags.maxWorkers === 'number') {
+    config.maxConcurrentWorkers = config.flags.maxWorkers;
+  } else if (config.flags.ci) {
+    config.maxConcurrentWorkers = 4;
   }
 
   config.maxConcurrentWorkers = Math.max(Math.min(config.maxConcurrentWorkers, 16), 0);

--- a/src/compiler/output-targets/index.ts
+++ b/src/compiler/output-targets/index.ts
@@ -12,7 +12,11 @@ import { outputCollection } from './dist-collection';
 import { outputTypes } from './output-types';
 import type { RollupCache } from 'rollup';
 
-export const generateOutputTargets = async (config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
+export const generateOutputTargets = async (
+  config: d.InternalStrictConfig,
+  compilerCtx: d.CompilerCtx,
+  buildCtx: d.BuildCtx
+) => {
   const timeSpan = buildCtx.createTimeSpan('generate outputs started', true);
 
   const changedModuleFiles = Array.from(compilerCtx.changedModules)

--- a/src/compiler/output-targets/index.ts
+++ b/src/compiler/output-targets/index.ts
@@ -13,7 +13,7 @@ import { outputTypes } from './output-types';
 import type { RollupCache } from 'rollup';
 
 export const generateOutputTargets = async (
-  config: d.InternalStrictConfig,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx
 ) => {

--- a/src/compiler/output-targets/output-www.ts
+++ b/src/compiler/output-targets/output-www.ts
@@ -16,7 +16,7 @@ import { optimizeEsmImport } from '../html/inline-esm-import';
 import { updateGlobalStylesLink } from '../html/update-global-styles-link';
 import { updateIndexHtmlServiceWorker } from '../html/inject-sw-script';
 
-export const outputWww = async (config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
+export const outputWww = async (config: d.InternalStrictConfig, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
   const outputTargets = config.outputTargets.filter(isOutputTargetWww);
   if (outputTargets.length === 0) {
     return;
@@ -47,7 +47,7 @@ const getCriticalPath = (buildCtx: d.BuildCtx) => {
 };
 
 const generateWww = async (
-  config: d.Config,
+  config: d.InternalStrictConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   criticalPath: string[],
@@ -92,7 +92,7 @@ const generateHostConfig = (compilerCtx: d.CompilerCtx, outputTarget: d.OutputTa
 };
 
 const generateIndexHtml = async (
-  config: d.Config,
+  config: d.InternalStrictConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   criticalPath: string[],

--- a/src/compiler/output-targets/output-www.ts
+++ b/src/compiler/output-targets/output-www.ts
@@ -16,7 +16,7 @@ import { optimizeEsmImport } from '../html/inline-esm-import';
 import { updateGlobalStylesLink } from '../html/update-global-styles-link';
 import { updateIndexHtmlServiceWorker } from '../html/inject-sw-script';
 
-export const outputWww = async (config: d.InternalStrictConfig, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
+export const outputWww = async (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
   const outputTargets = config.outputTargets.filter(isOutputTargetWww);
   if (outputTargets.length === 0) {
     return;
@@ -47,7 +47,7 @@ const getCriticalPath = (buildCtx: d.BuildCtx) => {
 };
 
 const generateWww = async (
-  config: d.InternalStrictConfig,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   criticalPath: string[],
@@ -92,7 +92,7 @@ const generateHostConfig = (compilerCtx: d.CompilerCtx, outputTarget: d.OutputTa
 };
 
 const generateIndexHtml = async (
-  config: d.InternalStrictConfig,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   criticalPath: string[],

--- a/src/compiler/prerender/prerender-main.ts
+++ b/src/compiler/prerender/prerender-main.ts
@@ -13,7 +13,7 @@ import { getPrerenderConfig } from './prerender-config';
 import { isAbsolute, join } from 'path';
 import { isOutputTargetWww } from '../output-targets/output-utils';
 
-export const createPrerenderer = async (config: d.InternalStrictConfig) => {
+export const createPrerenderer = async (config: d.ValidatedConfig) => {
   const start = (opts: d.PrerenderStartOptions) => {
     return runPrerender(config, opts.hydrateAppFilePath, opts.componentGraph, opts.srcIndexHtmlPath, opts.buildId);
   };
@@ -23,7 +23,7 @@ export const createPrerenderer = async (config: d.InternalStrictConfig) => {
 };
 
 const runPrerender = async (
-  config: d.InternalStrictConfig,
+  config: d.ValidatedConfig,
   hydrateAppFilePath: string,
   componentGraph: d.BuildResultsComponentGraph,
   srcIndexHtmlPath: string,
@@ -126,7 +126,7 @@ const runPrerenderOutputTarget = async (
   workerCtx: d.CompilerWorkerContext,
   results: d.PrerenderResults,
   diagnostics: d.Diagnostic[],
-  config: d.InternalStrictConfig,
+  config: d.ValidatedConfig,
   devServer: d.DevServer,
   hydrateAppFilePath: string,
   componentGraph: d.BuildResultsComponentGraph,

--- a/src/compiler/prerender/prerender-main.ts
+++ b/src/compiler/prerender/prerender-main.ts
@@ -13,7 +13,7 @@ import { getPrerenderConfig } from './prerender-config';
 import { isAbsolute, join } from 'path';
 import { isOutputTargetWww } from '../output-targets/output-utils';
 
-export const createPrerenderer = async (config: d.Config) => {
+export const createPrerenderer = async (config: d.InternalStrictConfig) => {
   const start = (opts: d.PrerenderStartOptions) => {
     return runPrerender(config, opts.hydrateAppFilePath, opts.componentGraph, opts.srcIndexHtmlPath, opts.buildId);
   };
@@ -23,7 +23,7 @@ export const createPrerenderer = async (config: d.Config) => {
 };
 
 const runPrerender = async (
-  config: d.Config,
+  config: d.InternalStrictConfig,
   hydrateAppFilePath: string,
   componentGraph: d.BuildResultsComponentGraph,
   srcIndexHtmlPath: string,
@@ -126,7 +126,7 @@ const runPrerenderOutputTarget = async (
   workerCtx: d.CompilerWorkerContext,
   results: d.PrerenderResults,
   diagnostics: d.Diagnostic[],
-  config: d.Config,
+  config: d.InternalStrictConfig,
   devServer: d.DevServer,
   hydrateAppFilePath: string,
   componentGraph: d.BuildResultsComponentGraph,

--- a/src/compiler/prerender/test/prerendered-write-path.spec.ts
+++ b/src/compiler/prerender/test/prerendered-write-path.spec.ts
@@ -1,6 +1,6 @@
 import type * as d from '../../../declarations';
 import { getWriteFilePathFromUrlPath } from '../prerendered-write-path';
-import { mockConfig } from '@stencil/core/testing';
+import { mockInternalStrictConfig } from '@stencil/core/testing';
 import { validateWww } from '../../config/outputs/validate-www';
 import { join, resolve } from 'path';
 
@@ -9,10 +9,10 @@ describe('prerender-utils', () => {
 
   describe('getWriteFilePathFromUrlPath', () => {
     let manager: d.PrerenderManager;
-    let config: d.Config;
+    let config: d.InternalStrictConfig;
 
     beforeEach(() => {
-      config = mockConfig();
+      config = mockInternalStrictConfig();
       const outputTargets = validateWww(config, [], []);
 
       manager = {

--- a/src/compiler/prerender/test/prerendered-write-path.spec.ts
+++ b/src/compiler/prerender/test/prerendered-write-path.spec.ts
@@ -1,6 +1,6 @@
 import type * as d from '../../../declarations';
 import { getWriteFilePathFromUrlPath } from '../prerendered-write-path';
-import { mockInternalStrictConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
 import { validateWww } from '../../config/outputs/validate-www';
 import { join, resolve } from 'path';
 
@@ -9,10 +9,10 @@ describe('prerender-utils', () => {
 
   describe('getWriteFilePathFromUrlPath', () => {
     let manager: d.PrerenderManager;
-    let config: d.InternalStrictConfig;
+    let config: d.ValidatedConfig;
 
     beforeEach(() => {
-      config = mockInternalStrictConfig();
+      config = mockValidatedConfig();
       const outputTargets = validateWww(config, [], []);
 
       manager = {

--- a/src/compiler/service-worker/generate-sw.ts
+++ b/src/compiler/service-worker/generate-sw.ts
@@ -54,7 +54,7 @@ const injectManifest = async (buildCtx: d.BuildCtx, serviceWorker: d.ServiceWork
   }
 };
 
-export const hasServiceWorkerChanges = (config: d.Config, buildCtx: d.BuildCtx) => {
+export const hasServiceWorkerChanges = (config: d.InternalStrictConfig, buildCtx: d.BuildCtx) => {
   if (config.devMode && !config.flags.serviceWorker) {
     return false;
   }

--- a/src/compiler/service-worker/generate-sw.ts
+++ b/src/compiler/service-worker/generate-sw.ts
@@ -54,7 +54,7 @@ const injectManifest = async (buildCtx: d.BuildCtx, serviceWorker: d.ServiceWork
   }
 };
 
-export const hasServiceWorkerChanges = (config: d.InternalStrictConfig, buildCtx: d.BuildCtx) => {
+export const hasServiceWorkerChanges = (config: d.ValidatedConfig, buildCtx: d.BuildCtx) => {
   if (config.devMode && !config.flags.serviceWorker) {
     return false;
   }

--- a/src/compiler/sys/config.ts
+++ b/src/compiler/sys/config.ts
@@ -3,8 +3,8 @@ import { createLogger } from './logger/console-logger';
 import { createSystem } from './stencil-sys';
 import { setPlatformPath } from '../sys/modules/path';
 
-export const getConfig = (userConfig: d.Config): d.InternalStrictConfig => {
-  const config: d.InternalStrictConfig = { ...userConfig, flags: { ...(userConfig.flags ?? {}) } };
+export const getConfig = (userConfig: d.Config): d.ValidatedConfig => {
+  const config: d.ValidatedConfig = { ...userConfig, flags: { ...(userConfig.flags ?? {}) } };
 
   if (!config.logger) {
     config.logger = createLogger();

--- a/src/compiler/sys/config.ts
+++ b/src/compiler/sys/config.ts
@@ -3,8 +3,8 @@ import { createLogger } from './logger/console-logger';
 import { createSystem } from './stencil-sys';
 import { setPlatformPath } from '../sys/modules/path';
 
-export const getConfig = (userConfig: d.Config) => {
-  const config = { ...userConfig };
+export const getConfig = (userConfig: d.Config): d.InternalStrictConfig => {
+  const config: d.InternalStrictConfig = { ...userConfig, flags: { ...(userConfig.flags ?? {}) } };
 
   if (!config.logger) {
     config.logger = createLogger();
@@ -15,7 +15,6 @@ export const getConfig = (userConfig: d.Config) => {
 
   setPlatformPath(config.sys.platformPath);
 
-  config.flags = config.flags || {};
   if (config.flags.debug || config.flags.verbose) {
     config.logLevel = 'debug';
   } else if (config.flags.logLevel) {

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -395,6 +395,10 @@ type Loose<T extends Object> = Record<string, any> & Partial<T>;
  */
 export type UnvalidatedConfig = Loose<Config>;
 
+type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+type RequiredFields = 'flags';
+export type InternalStrictConfig = WithRequired<Config, RequiredFields>;
+
 export interface HydratedFlag {
   /**
    * Defaults to `hydrated`.
@@ -2167,7 +2171,7 @@ export interface LoadConfigInit {
  * operations around the codebase.
  */
 export interface LoadConfigResults {
-  config: UnvalidatedConfig;
+  config: InternalStrictConfig;
   diagnostics: Diagnostic[];
   tsconfig: {
     path: string;

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -407,7 +407,7 @@ export type UnvalidatedConfig = Loose<Config>;
 type RequireFields<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 
 /**
- * Fields in {@link Config} to make required for {@link InternalStrictConfig}
+ * Fields in {@link Config} to make required for {@link ValidatedConfig}
  */
 type StrictConfigFields = 'flags';
 
@@ -417,7 +417,7 @@ type StrictConfigFields = 'flags';
  * about the data from a type-safety perspective, this type is intended to be used throughout the codebase once
  * validations have occurred at runtime.
  */
-export type InternalStrictConfig = RequireFields<Config, StrictConfigFields>;
+export type ValidatedConfig = RequireFields<Config, StrictConfigFields>;
 
 export interface HydratedFlag {
   /**
@@ -2191,7 +2191,7 @@ export interface LoadConfigInit {
  * operations around the codebase.
  */
 export interface LoadConfigResults {
-  config: InternalStrictConfig;
+  config: ValidatedConfig;
   diagnostics: Diagnostic[];
   tsconfig: {
     path: string;

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -395,9 +395,29 @@ type Loose<T extends Object> = Record<string, any> & Partial<T>;
  */
 export type UnvalidatedConfig = Loose<Config>;
 
-type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
-type RequiredFields = 'flags';
-export type InternalStrictConfig = WithRequired<Config, RequiredFields>;
+/**
+ * Helper type to strip optional markers from keys in a type, while preserving other type information for the key.
+ * This type takes a union of keys, K, in type T to allow for the type T to be gradually updated.
+ *
+ * ```typescript
+ * type Foo { bar?: number, baz?: string }
+ * type ReqFieldFoo = RequireFields<Foo, 'bar'>; // { bar: number, baz?: string }
+ * ```
+ */
+type RequireFields<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+
+/**
+ * Fields in {@link Config} to make required for {@link InternalStrictConfig}
+ */
+type StrictConfigFields = 'flags';
+
+/**
+ * A version of {@link Config} that makes certain fields required. This type represents a valid configuration entity.
+ * When a configuration is received by the user, it is a bag of unverified data. In order to make stricter guarantees
+ * about the data from a type-safety perspective, this type is intended to be used throughout the codebase once
+ * validations have occurred at runtime.
+ */
+export type InternalStrictConfig = RequireFields<Config, StrictConfigFields>;
 
 export interface HydratedFlag {
   /**

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -8,6 +8,7 @@ export {
   mockConfig,
   mockCompilerCtx,
   mockDocument,
+  mockInternalStrictConfig,
   mockLogger,
   mockCompilerSystem,
   mockWindow,

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -8,7 +8,7 @@ export {
   mockConfig,
   mockCompilerCtx,
   mockDocument,
-  mockInternalStrictConfig,
+  mockValidatedConfig,
   mockLogger,
   mockCompilerSystem,
   mockWindow,

--- a/src/testing/jest/jest-config.ts
+++ b/src/testing/jest/jest-config.ts
@@ -43,7 +43,7 @@ function getLegacyJestOptions(): Record<string, boolean | number | string> {
  * @param config the Stencil config to use while generating Jest CLI arguments
  * @returns the arguments to pass to the Jest CLI, wrapped in an object
  */
-export function buildJestArgv(config: d.InternalStrictConfig): Config.Argv {
+export function buildJestArgv(config: d.ValidatedConfig): Config.Argv {
   const yargs = require('yargs');
 
   const args = [...config.flags.unknownArgs.slice(), ...config.flags.knownArgs.slice()];

--- a/src/testing/jest/jest-config.ts
+++ b/src/testing/jest/jest-config.ts
@@ -43,7 +43,7 @@ function getLegacyJestOptions(): Record<string, boolean | number | string> {
  * @param config the Stencil config to use while generating Jest CLI arguments
  * @returns the arguments to pass to the Jest CLI, wrapped in an object
  */
-export function buildJestArgv(config: d.Config): Config.Argv {
+export function buildJestArgv(config: d.InternalStrictConfig): Config.Argv {
   const yargs = require('yargs');
 
   const args = [...config.flags.unknownArgs.slice(), ...config.flags.knownArgs.slice()];

--- a/src/testing/jest/jest-runner.ts
+++ b/src/testing/jest/jest-runner.ts
@@ -4,7 +4,7 @@ import { setScreenshotEmulateData } from '../puppeteer/puppeteer-emulate';
 import type { AggregatedResult } from '@jest/test-result';
 import type { ConfigFlags } from '../../cli/config-flags';
 
-export async function runJest(config: d.Config, env: d.E2EProcessEnv) {
+export async function runJest(config: d.InternalStrictConfig, env: d.E2EProcessEnv) {
   let success = false;
 
   try {

--- a/src/testing/jest/jest-runner.ts
+++ b/src/testing/jest/jest-runner.ts
@@ -4,7 +4,7 @@ import { setScreenshotEmulateData } from '../puppeteer/puppeteer-emulate';
 import type { AggregatedResult } from '@jest/test-result';
 import type { ConfigFlags } from '../../cli/config-flags';
 
-export async function runJest(config: d.InternalStrictConfig, env: d.E2EProcessEnv) {
+export async function runJest(config: d.ValidatedConfig, env: d.E2EProcessEnv) {
   let success = false;
 
   try {

--- a/src/testing/jest/jest-screenshot.ts
+++ b/src/testing/jest/jest-screenshot.ts
@@ -2,7 +2,7 @@ import type * as d from '@stencil/core/internal';
 import { runJest } from './jest-runner';
 import { join } from 'path';
 
-export async function runJestScreenshot(config: d.InternalStrictConfig, env: d.E2EProcessEnv) {
+export async function runJestScreenshot(config: d.ValidatedConfig, env: d.E2EProcessEnv) {
   config.logger.debug(`screenshot connector: ${config.testing.screenshotConnector}`);
 
   const ScreenshotConnector = require(config.testing.screenshotConnector) as any;

--- a/src/testing/jest/jest-screenshot.ts
+++ b/src/testing/jest/jest-screenshot.ts
@@ -2,7 +2,7 @@ import type * as d from '@stencil/core/internal';
 import { runJest } from './jest-runner';
 import { join } from 'path';
 
-export async function runJestScreenshot(config: d.Config, env: d.E2EProcessEnv) {
+export async function runJestScreenshot(config: d.InternalStrictConfig, env: d.E2EProcessEnv) {
   config.logger.debug(`screenshot connector: ${config.testing.screenshotConnector}`);
 
   const ScreenshotConnector = require(config.testing.screenshotConnector) as any;

--- a/src/testing/jest/test/jest-config.spec.ts
+++ b/src/testing/jest/test/jest-config.spec.ts
@@ -1,13 +1,13 @@
 import type * as d from '@stencil/core/declarations';
 import { buildJestArgv } from '../jest-config';
-import { mockInternalStrictConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
 import { parseFlags } from '../../../cli/parse-flags';
 import path from 'path';
 
 describe('jest-config', () => {
   it('pass --maxWorkers=2 arg when --max-workers=2', () => {
     const args = ['test', '--ci', '--max-workers=2'];
-    const config = mockInternalStrictConfig();
+    const config = mockValidatedConfig();
     config.flags = parseFlags(args, config.sys);
     config.testing = {};
 
@@ -21,7 +21,7 @@ describe('jest-config', () => {
 
   it('pass --maxWorkers=2 arg when e2e test and --ci', () => {
     const args = ['test', '--ci', '--e2e', '--max-workers=2'];
-    const config = mockInternalStrictConfig();
+    const config = mockValidatedConfig();
     config.flags = parseFlags(args, config.sys);
     config.testing = {};
 
@@ -35,7 +35,7 @@ describe('jest-config', () => {
 
   it('forces --maxWorkers=4 arg when e2e test and --ci', () => {
     const args = ['test', '--ci', '--e2e'];
-    const config = mockInternalStrictConfig();
+    const config = mockValidatedConfig();
     config.flags = parseFlags(args, config.sys);
     config.testing = {};
 
@@ -49,7 +49,7 @@ describe('jest-config', () => {
 
   it('pass --maxWorkers=2 arg to jest', () => {
     const args = ['test', '--maxWorkers=2'];
-    const config = mockInternalStrictConfig();
+    const config = mockValidatedConfig();
     config.flags = parseFlags(args, config.sys);
     config.testing = {};
 
@@ -62,7 +62,7 @@ describe('jest-config', () => {
 
   it('pass --ci arg to jest', () => {
     const args = ['test', '--ci'];
-    const config = mockInternalStrictConfig();
+    const config = mockValidatedConfig();
     config.flags = parseFlags(args, config.sys);
     config.testing = {};
 
@@ -76,7 +76,7 @@ describe('jest-config', () => {
 
   it('sets legacy jest options', () => {
     const args = ['test'];
-    const config = mockInternalStrictConfig();
+    const config = mockValidatedConfig();
     config.flags = parseFlags(args, config.sys);
     config.testing = {};
 
@@ -106,7 +106,7 @@ describe('jest-config', () => {
 
   it('pass test spec arg to jest', () => {
     const args = ['test', 'hello.spec.ts'];
-    const config = mockInternalStrictConfig();
+    const config = mockValidatedConfig();
     config.flags = parseFlags(args, config.sys);
     config.testing = {};
 
@@ -119,7 +119,7 @@ describe('jest-config', () => {
 
   it('pass test config to jest', () => {
     const args = ['test'];
-    const config = mockInternalStrictConfig();
+    const config = mockValidatedConfig();
     config.flags = parseFlags(args, config.sys);
     config.testing = {
       testMatch: ['hello.spec.ts'],
@@ -135,7 +135,7 @@ describe('jest-config', () => {
   it('set jestArgv config reporters', () => {
     const rootDir = path.resolve('/');
     const args = ['test'];
-    const config = mockInternalStrictConfig();
+    const config = mockValidatedConfig();
     config.rootDir = rootDir;
     config.flags = parseFlags(args, config.sys);
     config.testing = {
@@ -153,7 +153,7 @@ describe('jest-config', () => {
   it('set jestArgv config rootDir', () => {
     const rootDir = path.resolve('/');
     const args = ['test'];
-    const config = mockInternalStrictConfig();
+    const config = mockValidatedConfig();
     config.rootDir = rootDir;
     config.flags = parseFlags(args, config.sys);
     config.testing = {};
@@ -166,7 +166,7 @@ describe('jest-config', () => {
   it('set jestArgv config collectCoverageFrom', () => {
     const rootDir = path.resolve('/');
     const args = ['test'];
-    const config = mockInternalStrictConfig();
+    const config = mockValidatedConfig();
     config.rootDir = rootDir;
     config.flags = parseFlags(args, config.sys);
     config.testing = {
@@ -181,7 +181,7 @@ describe('jest-config', () => {
 
   it('passed flags should be respected over defaults', () => {
     const args = ['test', '--spec', '--passWithNoTests'];
-    const config = mockInternalStrictConfig();
+    const config = mockValidatedConfig();
     config.flags = parseFlags(args, config.sys);
     config.testing = {};
 

--- a/src/testing/jest/test/jest-config.spec.ts
+++ b/src/testing/jest/test/jest-config.spec.ts
@@ -1,13 +1,13 @@
 import type * as d from '@stencil/core/declarations';
 import { buildJestArgv } from '../jest-config';
-import { mockConfig } from '@stencil/core/testing';
+import { mockInternalStrictConfig } from '@stencil/core/testing';
 import { parseFlags } from '../../../cli/parse-flags';
 import path from 'path';
 
 describe('jest-config', () => {
   it('pass --maxWorkers=2 arg when --max-workers=2', () => {
     const args = ['test', '--ci', '--max-workers=2'];
-    const config = mockConfig();
+    const config = mockInternalStrictConfig();
     config.flags = parseFlags(args, config.sys);
     config.testing = {};
 
@@ -21,7 +21,7 @@ describe('jest-config', () => {
 
   it('pass --maxWorkers=2 arg when e2e test and --ci', () => {
     const args = ['test', '--ci', '--e2e', '--max-workers=2'];
-    const config = mockConfig();
+    const config = mockInternalStrictConfig();
     config.flags = parseFlags(args, config.sys);
     config.testing = {};
 
@@ -35,7 +35,7 @@ describe('jest-config', () => {
 
   it('forces --maxWorkers=4 arg when e2e test and --ci', () => {
     const args = ['test', '--ci', '--e2e'];
-    const config = mockConfig();
+    const config = mockInternalStrictConfig();
     config.flags = parseFlags(args, config.sys);
     config.testing = {};
 
@@ -49,7 +49,7 @@ describe('jest-config', () => {
 
   it('pass --maxWorkers=2 arg to jest', () => {
     const args = ['test', '--maxWorkers=2'];
-    const config = mockConfig();
+    const config = mockInternalStrictConfig();
     config.flags = parseFlags(args, config.sys);
     config.testing = {};
 
@@ -62,7 +62,7 @@ describe('jest-config', () => {
 
   it('pass --ci arg to jest', () => {
     const args = ['test', '--ci'];
-    const config = mockConfig();
+    const config = mockInternalStrictConfig();
     config.flags = parseFlags(args, config.sys);
     config.testing = {};
 
@@ -76,7 +76,7 @@ describe('jest-config', () => {
 
   it('sets legacy jest options', () => {
     const args = ['test'];
-    const config = mockConfig();
+    const config = mockInternalStrictConfig();
     config.flags = parseFlags(args, config.sys);
     config.testing = {};
 
@@ -106,7 +106,7 @@ describe('jest-config', () => {
 
   it('pass test spec arg to jest', () => {
     const args = ['test', 'hello.spec.ts'];
-    const config = mockConfig();
+    const config = mockInternalStrictConfig();
     config.flags = parseFlags(args, config.sys);
     config.testing = {};
 
@@ -119,7 +119,7 @@ describe('jest-config', () => {
 
   it('pass test config to jest', () => {
     const args = ['test'];
-    const config = mockConfig();
+    const config = mockInternalStrictConfig();
     config.flags = parseFlags(args, config.sys);
     config.testing = {
       testMatch: ['hello.spec.ts'],
@@ -135,7 +135,7 @@ describe('jest-config', () => {
   it('set jestArgv config reporters', () => {
     const rootDir = path.resolve('/');
     const args = ['test'];
-    const config = mockConfig();
+    const config = mockInternalStrictConfig();
     config.rootDir = rootDir;
     config.flags = parseFlags(args, config.sys);
     config.testing = {
@@ -153,7 +153,7 @@ describe('jest-config', () => {
   it('set jestArgv config rootDir', () => {
     const rootDir = path.resolve('/');
     const args = ['test'];
-    const config = mockConfig();
+    const config = mockInternalStrictConfig();
     config.rootDir = rootDir;
     config.flags = parseFlags(args, config.sys);
     config.testing = {};
@@ -166,7 +166,7 @@ describe('jest-config', () => {
   it('set jestArgv config collectCoverageFrom', () => {
     const rootDir = path.resolve('/');
     const args = ['test'];
-    const config = mockConfig();
+    const config = mockInternalStrictConfig();
     config.rootDir = rootDir;
     config.flags = parseFlags(args, config.sys);
     config.testing = {
@@ -181,7 +181,7 @@ describe('jest-config', () => {
 
   it('passed flags should be respected over defaults', () => {
     const args = ['test', '--spec', '--passWithNoTests'];
-    const config = mockConfig();
+    const config = mockInternalStrictConfig();
     config.flags = parseFlags(args, config.sys);
     config.testing = {};
 

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -19,12 +19,27 @@ import path from 'path';
 import { noop } from '@utils';
 import { buildEvents } from '../compiler/events';
 
+// TODO(STENCIL-486): Update `mockInternalStrictConfig` to accept any property found on `InternalStrictConfig`
+/**
+ * Creates a mock instance of an internal, validated Stencil configuration object
+ * @param sys an optional compiler system to associate with the config. If one is not provided, one will be created for
+ * the caller
+ * @returns the mock Stencil configuration
+ */
 export function mockInternalStrictConfig(sys?: CompilerSystem): InternalStrictConfig {
   const baseConfig = mockConfig(sys);
 
   return { ...baseConfig, flags: {} };
 }
 
+// TODO(STENCIL-486): Update `mockInternalStrictConfig` to accept any property found on `InternalStrictConfig`
+/**
+ * Creates a mock instance of a Stencil configuration entity. The mocked configuration has no guarantees around the
+ * types/validity of its data.
+ * @param sys an optional compiler system to associate with the config. If one is not provided, one will be created for
+ * the caller
+ * @returns the mock Stencil configuration
+ */
 export function mockConfig(sys?: CompilerSystem): UnvalidatedConfig {
   const rootDir = path.resolve('/');
 

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -1,4 +1,13 @@
-import type { BuildCtx, Cache, CompilerCtx, CompilerSystem, Config, Module } from '@stencil/core/internal';
+import type {
+  BuildCtx,
+  Cache,
+  CompilerCtx,
+  CompilerSystem,
+  Config,
+  InternalStrictConfig,
+  Module,
+  UnvalidatedConfig,
+} from '@stencil/core/internal';
 import { BuildContext } from '../compiler/build/build-ctx';
 import { Cache as CompilerCache } from '../compiler/cache';
 import { createInMemoryFs } from '../compiler/sys/in-memory-fs';
@@ -10,7 +19,13 @@ import path from 'path';
 import { noop } from '@utils';
 import { buildEvents } from '../compiler/events';
 
-export function mockConfig(sys?: CompilerSystem) {
+export function mockInternalStrictConfig(sys?: CompilerSystem): InternalStrictConfig {
+  const baseConfig = mockConfig(sys);
+
+  return { ...baseConfig, flags: {} };
+}
+
+export function mockConfig(sys?: CompilerSystem): UnvalidatedConfig {
   const rootDir = path.resolve('/');
 
   if (!sys) {
@@ -18,7 +33,7 @@ export function mockConfig(sys?: CompilerSystem) {
   }
   sys.getCurrentDirectory = () => rootDir;
 
-  const config: Config = {
+  return {
     _isTesting: true,
 
     namespace: 'Testing',
@@ -50,8 +65,6 @@ export function mockConfig(sys?: CompilerSystem) {
       after: [],
     },
   };
-
-  return config;
 }
 
 export function mockCompilerCtx(config?: Config) {

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -4,7 +4,7 @@ import type {
   CompilerCtx,
   CompilerSystem,
   Config,
-  InternalStrictConfig,
+  ValidatedConfig,
   Module,
   UnvalidatedConfig,
 } from '@stencil/core/internal';
@@ -19,20 +19,20 @@ import path from 'path';
 import { noop } from '@utils';
 import { buildEvents } from '../compiler/events';
 
-// TODO(STENCIL-486): Update `mockInternalStrictConfig` to accept any property found on `InternalStrictConfig`
+// TODO(STENCIL-486): Update `mockValidatedConfig` to accept any property found on `ValidatedConfig`
 /**
  * Creates a mock instance of an internal, validated Stencil configuration object
  * @param sys an optional compiler system to associate with the config. If one is not provided, one will be created for
  * the caller
  * @returns the mock Stencil configuration
  */
-export function mockInternalStrictConfig(sys?: CompilerSystem): InternalStrictConfig {
+export function mockValidatedConfig(sys?: CompilerSystem): ValidatedConfig {
   const baseConfig = mockConfig(sys);
 
   return { ...baseConfig, flags: {} };
 }
 
-// TODO(STENCIL-486): Update `mockInternalStrictConfig` to accept any property found on `InternalStrictConfig`
+// TODO(STENCIL-486): Update `mockConfig` to accept any property found on `UnvalidatedConfig`
 /**
  * Creates a mock instance of a Stencil configuration entity. The mocked configuration has no guarantees around the
  * types/validity of its data.

--- a/src/testing/puppeteer/puppeteer-browser.ts
+++ b/src/testing/puppeteer/puppeteer-browser.ts
@@ -1,7 +1,7 @@
-import type { E2EProcessEnv, InternalStrictConfig } from '@stencil/core/internal';
+import type { E2EProcessEnv, ValidatedConfig } from '@stencil/core/internal';
 import type * as puppeteer from 'puppeteer';
 
-export async function startPuppeteerBrowser(config: InternalStrictConfig) {
+export async function startPuppeteerBrowser(config: ValidatedConfig) {
   if (!config.flags.e2e) {
     return null;
   }

--- a/src/testing/puppeteer/puppeteer-browser.ts
+++ b/src/testing/puppeteer/puppeteer-browser.ts
@@ -1,7 +1,7 @@
-import type { Config, E2EProcessEnv } from '@stencil/core/internal';
+import type { E2EProcessEnv, InternalStrictConfig } from '@stencil/core/internal';
 import type * as puppeteer from 'puppeteer';
 
-export async function startPuppeteerBrowser(config: Config) {
+export async function startPuppeteerBrowser(config: InternalStrictConfig) {
   if (!config.flags.e2e) {
     return null;
   }

--- a/src/testing/testing.ts
+++ b/src/testing/testing.ts
@@ -5,7 +5,7 @@ import type {
   Config,
   DevServer,
   E2EProcessEnv,
-  InternalStrictConfig,
+  ValidatedConfig,
   OutputTargetWww,
   Testing,
   TestingRunOptions,
@@ -18,7 +18,7 @@ import { startPuppeteerBrowser } from './puppeteer/puppeteer-browser';
 import { start } from '@stencil/core/dev-server';
 import type * as puppeteer from 'puppeteer';
 
-export const createTesting = async (config: InternalStrictConfig): Promise<Testing> => {
+export const createTesting = async (config: ValidatedConfig): Promise<Testing> => {
   config = setupTestingConfig(config);
 
   const { createCompiler } = require('../compiler/stencil.js');
@@ -184,8 +184,8 @@ export const createTesting = async (config: InternalStrictConfig): Promise<Testi
   };
 };
 
-function setupTestingConfig(config: Config): InternalStrictConfig {
-  const validatedConfig: InternalStrictConfig = { ...config, flags: { ...config.flags } };
+function setupTestingConfig(config: Config): ValidatedConfig {
+  const validatedConfig: ValidatedConfig = { ...config, flags: { ...config.flags } };
   validatedConfig.buildEs5 = false;
   validatedConfig.devMode = true;
   validatedConfig.minifyCss = false;

--- a/src/testing/testing.ts
+++ b/src/testing/testing.ts
@@ -5,6 +5,7 @@ import type {
   Config,
   DevServer,
   E2EProcessEnv,
+  InternalStrictConfig,
   OutputTargetWww,
   Testing,
   TestingRunOptions,
@@ -17,7 +18,7 @@ import { startPuppeteerBrowser } from './puppeteer/puppeteer-browser';
 import { start } from '@stencil/core/dev-server';
 import type * as puppeteer from 'puppeteer';
 
-export const createTesting = async (config: Config): Promise<Testing> => {
+export const createTesting = async (config: InternalStrictConfig): Promise<Testing> => {
   config = setupTestingConfig(config);
 
   const { createCompiler } = require('../compiler/stencil.js');
@@ -183,29 +184,29 @@ export const createTesting = async (config: Config): Promise<Testing> => {
   };
 };
 
-function setupTestingConfig(config: Config) {
-  config.buildEs5 = false;
-  config.devMode = true;
-  config.minifyCss = false;
-  config.minifyJs = false;
-  config.hashFileNames = false;
-  config.validateTypes = false;
-  config._isTesting = true;
-  config.buildDist = true;
+function setupTestingConfig(config: Config): InternalStrictConfig {
+  const validatedConfig: InternalStrictConfig = { flags: { ...(config.flags ?? {}) } };
+  validatedConfig.buildEs5 = false;
+  validatedConfig.devMode = true;
+  validatedConfig.minifyCss = false;
+  validatedConfig.minifyJs = false;
+  validatedConfig.hashFileNames = false;
+  validatedConfig.validateTypes = false;
+  validatedConfig._isTesting = true;
+  validatedConfig.buildDist = true;
 
-  config.flags = config.flags || {};
-  config.flags.serve = false;
-  config.flags.open = false;
+  validatedConfig.flags.serve = false;
+  validatedConfig.flags.open = false;
 
-  config.outputTargets.forEach((o) => {
+  validatedConfig.outputTargets.forEach((o) => {
     if (o.type === 'www') {
       o.serviceWorker = null;
     }
   });
 
-  if (config.flags.args.includes('--watchAll')) {
-    config.watch = true;
+  if (validatedConfig.flags.args.includes('--watchAll')) {
+    validatedConfig.watch = true;
   }
 
-  return config;
+  return validatedConfig;
 }

--- a/src/testing/testing.ts
+++ b/src/testing/testing.ts
@@ -185,7 +185,7 @@ export const createTesting = async (config: InternalStrictConfig): Promise<Testi
 };
 
 function setupTestingConfig(config: Config): InternalStrictConfig {
-  const validatedConfig: InternalStrictConfig = { flags: { ...(config.flags ?? {}) } };
+  const validatedConfig: InternalStrictConfig = { ...config, flags: { ...config.flags } };
   validatedConfig.buildEs5 = false;
   validatedConfig.devMode = true;
   validatedConfig.minifyCss = false;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

As written, Stencil uses a configuration object that is used throughout the codebase. Although the code is validated at runtime, it can be difficult to reason about the code at development time. At the same time, this leads to several `strictNullChecks` violations in the codebase.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR proposes a methodology where we could start to make `Config` entities stricter, by swapping them out with an internal, stricter version. It introduces a new `ValidatedConfig` type that can gradually introduce strictness on the `Config` entity. For this PR, the only field that is made required is the `flags` field.

The `ValidatedConfig` type is used throughout the codebase following the validating of a user-supplied configuration. Public APIs cannot use `ValidatedConfig` without introducing a breaking change. As a result, an instance of `ValidatedConfig` is created and backfilled with the contents of the user provided config and any now necessary fields (defaulting them if the field is not provided).

In making `flags` a required field, the signatures of any function that accessed the field was updated to accept an `ValidatedConfig`. Not every instance of `Config` in a function signature was updated in this PR as a result.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Unit tests were added, all tests pass

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
` git diff 27e9b27..81fce2a5b73d29b95669df2ba759d41426e2afff ` will allow you to see the changes since the original proposal (I've left that commit intact, although I broke my promise not to rebase this 😢) 