### PR TITLE
test(cli): add tests for run.ts

### DIFF
--- a/src/cli/test/run.spec.ts
+++ b/src/cli/test/run.spec.ts
@@ -1,0 +1,154 @@
+import type * as d from '../../declarations';
+import * as coreCompiler from '@stencil/core/compiler';
+import { mockCompilerSystem, mockConfig, mockLogger as createMockLogger } from '@stencil/core/testing';
+import * as ParseFlags from '../parse-flags';
+import { run, runTask } from '../run';
+import * as HelpTask from '../task-help';
+import * as TelemetryTask from '../task-telemetry';
+import { createTestingSystem } from '../../testing/testing-sys';
+
+describe('run', () => {
+  describe('run()', () => {
+    let cliInitOptions: d.CliInitOptions;
+    let mockLogger: d.Logger;
+    let mockSystem: d.CompilerSystem;
+
+    let parseFlagsSpy: jest.SpyInstance<
+      ReturnType<typeof ParseFlags.parseFlags>,
+      Parameters<typeof ParseFlags.parseFlags>
+    >;
+
+    beforeEach(() => {
+      mockLogger = createMockLogger();
+      mockSystem = createTestingSystem();
+
+      cliInitOptions = {
+        args: [],
+        logger: mockLogger,
+        sys: mockSystem,
+      };
+
+      parseFlagsSpy = jest.spyOn(ParseFlags, 'parseFlags');
+      parseFlagsSpy.mockReturnValue({
+        task: 'help',
+      });
+    });
+
+    afterEach(() => {
+      parseFlagsSpy.mockRestore();
+    });
+
+    describe('help task', () => {
+      let taskHelpSpy: jest.SpyInstance<ReturnType<typeof HelpTask.taskHelp>, Parameters<typeof HelpTask.taskHelp>>;
+
+      beforeEach(() => {
+        taskHelpSpy = jest.spyOn(HelpTask, 'taskHelp');
+        taskHelpSpy.mockReturnValue(Promise.resolve());
+      });
+
+      afterEach(() => {
+        taskHelpSpy.mockRestore();
+      });
+
+      it("calls the help task when the 'task' field is set to 'help'", () => {
+        run(cliInitOptions);
+
+        expect(taskHelpSpy).toHaveBeenCalledTimes(1);
+        expect(taskHelpSpy).toHaveBeenCalledWith(
+          {
+            flags: {
+              task: 'help',
+              args: [],
+            },
+            outputTargets: [],
+          },
+          mockLogger,
+          mockSystem
+        );
+
+        taskHelpSpy.mockRestore();
+      });
+
+      it("calls the help task when the 'help' field is set on flags", () => {
+        parseFlagsSpy.mockReturnValue({
+          help: true,
+        });
+
+        run(cliInitOptions);
+
+        expect(taskHelpSpy).toHaveBeenCalledTimes(1);
+        expect(taskHelpSpy).toHaveBeenCalledWith(
+          {
+            flags: {
+              task: 'help',
+              args: [],
+            },
+            outputTargets: [],
+          },
+          mockLogger,
+          mockSystem
+        );
+
+        taskHelpSpy.mockRestore();
+      });
+    });
+  });
+
+  describe('runTask()', () => {
+    let sys: d.CompilerSystem;
+    let unvalidatedConfig: d.Config;
+
+    let taskHelpSpy: jest.SpyInstance<ReturnType<typeof HelpTask.taskHelp>, Parameters<typeof HelpTask.taskHelp>>;
+    let taskTelemetrySpy: jest.SpyInstance<
+      ReturnType<typeof TelemetryTask.taskTelemetry>,
+      Parameters<typeof TelemetryTask.taskTelemetry>
+    >;
+
+    beforeEach(() => {
+      sys = mockCompilerSystem();
+      sys.exit = jest.fn();
+
+      unvalidatedConfig = mockConfig(sys);
+
+      taskHelpSpy = jest.spyOn(HelpTask, 'taskHelp');
+      taskHelpSpy.mockReturnValue(Promise.resolve());
+      taskTelemetrySpy = jest.spyOn(TelemetryTask, 'taskTelemetry');
+      taskTelemetrySpy.mockReturnValue(Promise.resolve());
+    });
+
+    afterEach(() => {
+      taskHelpSpy.mockRestore();
+      taskTelemetrySpy.mockRestore();
+    });
+
+    it('calls the help task', () => {
+      runTask(coreCompiler, unvalidatedConfig, 'help', sys);
+
+      expect(taskHelpSpy).toHaveBeenCalledTimes(1);
+      expect(taskHelpSpy).toHaveBeenCalledWith(unvalidatedConfig, unvalidatedConfig.logger, sys);
+    });
+
+    describe('telemetry task', () => {
+      it('calls the telemetry task when a compiler system is present', () => {
+        runTask(coreCompiler, unvalidatedConfig, 'telemetry', sys);
+
+        expect(taskTelemetrySpy).toHaveBeenCalledTimes(1);
+        expect(taskTelemetrySpy).toHaveBeenCalledWith(unvalidatedConfig, sys, unvalidatedConfig.logger);
+      });
+
+      it("does not call the telemetry task when a compiler system isn't present", () => {
+        runTask(coreCompiler, unvalidatedConfig, 'telemetry');
+
+        expect(taskTelemetrySpy).not.toHaveBeenCalled();
+      });
+    });
+
+    it('defaults to the help task for an unaccounted for task name', () => {
+      // info is a valid task name, but isn't used in the `switch` statement of `runTask`
+      runTask(coreCompiler, unvalidatedConfig, 'info', sys);
+
+      expect(taskHelpSpy).toHaveBeenCalledTimes(1);
+      expect(taskHelpSpy).toHaveBeenCalledWith(unvalidatedConfig, unvalidatedConfig.logger, sys);
+    });
+  });
+});

--- a/src/cli/test/run.spec.ts
+++ b/src/cli/test/run.spec.ts
@@ -30,6 +30,8 @@ describe('run', () => {
 
       parseFlagsSpy = jest.spyOn(ParseFlags, 'parseFlags');
       parseFlagsSpy.mockReturnValue({
+        // use the 'help' task as a reasonable default for all calls to this function.
+        // code paths that require a different task can always override this value as needed.
         task: 'help',
       });
     });


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`run.ts` is not under test.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit adds initial unit tests for `run.ts`. the goal of these
tests are to get the minimal amount of coverage under the `run` and
`runTask` functions so that we can (eventually) begin to change the
function signatures on the functions they invoke.

specifcially, the stencil team is looking to make the configuration
object that is used throughout the compiler stricter by making fields
no longer optional on the type. as a part of that effort, we are
reassessing what data fields functions need. we know that we will be
changing the signatures of the tasks for 'help' and 'telemetry'. by
adding tests around the invocation of these tasks, we can have greater
trust in the changes that we're making

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Unit tests pass

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

#3436 is the driving force behind this PR. I'd like to land this PR first, then I'll update #3436 to include the test suite, and update the tests accordingly
