### PR TITLE
docs(karma): add running locally documentation

### DIFF
--- a/test/karma/README.md
+++ b/test/karma/README.md
@@ -18,6 +18,19 @@ The tests in this directory can be run three different ways:
 ### Running Entirely Locally
 
 Running the tests in a local environment is the quickest way to receive feedback as a part of daily development.
+Tests are run against pre-compiled applications in this directory, but the tests themselves are compiled when a test 
+command is invoked.
+This allows for developers to quickly iterate on tests, while still targeting applications built with Stencil. 
+
+To build all applications used for testing and to run all tests from this directory:
+```
+npm run karma.prod
+```
+Alternatively, if one does not need to rebuild the applications (e.g. only tests were modified), from this directory:
+```
+npm run karma
+```
+
 By default, locally running tests will start a headless Chrome instance and run the tests against that instance.
 For additional browsers to test against, please see the [Tunnelling into BrowserStack](#tunnelling-into-browserstack) section.
 
@@ -36,6 +49,15 @@ If you are a member of the Stencil team and do not have access to Browserstack, 
 
 Once an access key and username have been acquired, tunneling into Browserstack requires invoking the tests with the
 following environment variables:
+- `LOCAL_BROWSERSTACK=1` tells the test runner to tunnel into Browserstack from your local machine
+- `BROWSERSTACK_ACCESS_KEY=[KEY]` provides your personal access key to Browserstack for authentication purposes
+- `BROWSERSTACK_USERNAME=USERNAMEKEY]` provides your personal uesr name to Browserstack for authentication purposes
+
+To build all applications used for testing and to run all tests from this directory:
+```
+LOCAL_BROWSERSTACK=1 BROWSERSTACK_ACCESS_KEY=[KEY] BROWSERSTACK_USERNAME=[USERNAME] npm run karma.prod
+```
+Alternatively, if one does not need to rebuild the applications (e.g. only tests were modified), from this directory:
 ```
 LOCAL_BROWSERSTACK=1 BROWSERSTACK_ACCESS_KEY=[KEY] BROWSERSTACK_USERNAME=[USERNAME] npm run karma
 ```

--- a/test/karma/README.md
+++ b/test/karma/README.md
@@ -1,15 +1,57 @@
 # Karma Testing
 
-Karma can be used to test final rendered output on various browsers and operating systems. Use this process to recreate
-issues and test/fix them within browsers. Tests are then locked-in and re-validated with 
-[BrowserStack](https://www.browserstack.com/) on every Github commit against the browsers which Stencil supports
-(ie11+).
+Karma can be used to test final rendered output on various browsers and operating systems.
+Use this process to recreate issues and test/fix them within browsers.
+Tests are then locked-in and re-validated with [BrowserStack](https://www.browserstack.com/).
 
 To run any tests in this directory, minor setup is required:
 1. `cd` to `test/karma` (this directory)
 2. `npm install`
 
-### Sub-directories
+## Environments
+
+The tests in this directory can be run three different ways:
+1. Locally using Chrome
+2. Through a local tunnel to Browserstack
+3. In a continuous integration (CI) environment
+
+### Running Entirely Locally
+
+Running the tests in a local environment is the quickest way to receive feedback as a part of daily development.
+By default, locally running tests will start a headless Chrome instance and run the tests against that instance.
+For additional browsers to test against, please see the [Tunnelling into BrowserStack](#tunnelling-into-browserstack) section.
+
+### Tunnelling into Browserstack
+
+Stencil engineers can run the Karma tests by tunnelling into Browserstack.
+Doing so will allow one to target the same browsers that the project targets in CI.
+However, developers should note that tunnelling into Browserstack will count against the team's allotment of running no
+more than five parallel tests at once.
+This can delay Karma tests running in a CI environment, and affect the time it takes to land a pull request.
+
+To tunnel into Browserstack, an access key and username are required.
+These can be accessed through the [Browserstack Dashboard](https://automate.browserstack.com/dashboard/v2).
+At this time, only members of the Stencil core team are granted access keys/usernames.
+If you are a member of the Stencil team and do not have access to Browserstack, please see the team lead.
+
+Once an access key and username have been acquired, tunneling into Browserstack requires invoking the tests with the
+following environment variables:
+```
+LOCAL_BROWSERSTACK=1 BROWSERSTACK_ACCESS_KEY=[KEY] BROWSERSTACK_USERNAME=[USERNAME] npm run karma
+```
+
+*Note that the command above will save your credentials to your shell's history.*
+It is _highly_ recommended that developers look into alternatives to protect their access keys!
+
+### Continuous Integration (CI)
+
+These Karma tests run in a CI environment.
+In order for the CI job that runs the tests to communicate with Browserstack, environment-specific fields need to be set.
+This is controlled by the `CI` environment variable.
+This method of running the Karma tests is not designed to be run locally.
+If targeting multiple browsers, see the [Tunnelling into BrowserStack](#tunnelling-into-browserstack) section.
+
+## Sub-directories
 
 The Karma testing directory contains three child directories used in Stencil's Karma tests. Each of these directories
 have an associated build script in the `package.json` file that sits adjacent to this README, prefixed with `build.*`,

--- a/test/karma/karma.config.js
+++ b/test/karma/karma.config.js
@@ -105,7 +105,7 @@ module.exports = function (config) {
     browserStack: {
       // identifier for all browser runs in BrowserStack
       project: 'stencil_core',
-      ...(isCI ? ciBrowserstackConfig : localBrowserstackConfig)
+      ...(isCI ? ciBrowserstackConfig : localBrowserstackConfig),
     },
 
     preprocessors: {

--- a/test/karma/karma.config.js
+++ b/test/karma/karma.config.js
@@ -2,8 +2,12 @@ const path = require('path');
 
 const { WWW_OUT_DIR } = require('./constants');
 
-const browserStack = !!process.env.CI;
 process.env.CHROME_BIN = require('puppeteer').executablePath();
+
+// determine the environment to run in
+const isCI = !!process.env.CI;
+const localBrowserStackConnection = !isCI && !!process.env.LOCAL_BROWSERSTACK;
+const useBrowserStack = isCI || localBrowserStackConnection;
 
 const browserStackLaunchers = {
   bs_chrome: {
@@ -65,6 +69,19 @@ if (process.platform === 'win32') {
   // };
 }
 
+// this configuration shall be used in a CI environment (specifically, GitHub Actions)
+const ciBrowserstackConfig = {
+  startTunnel: false,
+  // set by browserstack/github-actions/setup-local
+  localIdentifier: process.env.BROWSERSTACK_LOCAL_IDENTIFIER,
+};
+
+// this configuration shall be used locally, creating a tunnel to Browserstack from your machine.
+// See the README for instructions to connect to Browserstack from your local environment
+const localBrowserstackConfig = {
+  startTunnel: true,
+};
+
 module.exports = function (config) {
   config.set({
     plugins: [
@@ -77,7 +94,7 @@ module.exports = function (config) {
       'karma-typescript',
       'karma-polyfill',
     ],
-    browsers: browserStack ? Object.keys(browserStackLaunchers) : Object.keys(localLaunchers),
+    browsers: useBrowserStack ? Object.keys(browserStackLaunchers) : Object.keys(localLaunchers),
 
     singleRun: true, // set this to false to leave the browser open
 
@@ -86,16 +103,16 @@ module.exports = function (config) {
     polyfill: ['Promise'],
 
     browserStack: {
+      // identifier for all browser runs in BrowserStack
       project: 'stencil_core',
-      startTunnel: false,
-      localIdentifier: process.env.BROWSERSTACK_LOCAL_IDENTIFIER, // set by browserstack/github-actions/setup-local
+      ...(isCI ? ciBrowserstackConfig : localBrowserstackConfig)
     },
 
     preprocessors: {
       '**/*.ts': 'karma-typescript',
     },
 
-    customLaunchers: browserStack ? browserStackLaunchers : {},
+    customLaunchers: useBrowserStack ? browserStackLaunchers : {},
     urlRoot: '/__karma__/',
     files: [
       // 'test-app/prerender-test/karma.spec.ts',
@@ -120,7 +137,7 @@ module.exports = function (config) {
 
     logLevel: config.LOG_INFO,
 
-    reporters: ['progress'].concat(browserStack ? ['BrowserStack'] : []),
+    reporters: ['progress'].concat(useBrowserStack ? ['BrowserStack'] : []),
 
     karmaTypescriptConfig: {
       tsconfig: './tsconfig.json',

--- a/test/karma/package.json
+++ b/test/karma/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "clean": "rm -rf test-output tmp-compiled-tests",
     "start": "node ../../bin/stencil build --dev --watch --serve --es5",
+    "build.all": "npm run clean && npm run build.sibling && npm run build.invisible-prehydration && npm run build.app && npm run build.custom-elements && npm run karma.webpack && npm run build.prerender",
     "build.app": "npm run compile.test-app && node ../../bin/stencil build --debug --es5",
     "compile.test-app": "node ../../node_modules/typescript/lib/tsc -p tsconfig.json",
     "build.custom-elements": "webpack-cli --config test-app/custom-elements-output-webpack/webpack.config.js && webpack-cli --config test-app/custom-elements-output-tag-class-different/webpack.config.js && webpack-cli --config test-app/custom-elements-delegates-focus/webpack.config.js",
@@ -17,7 +18,7 @@
     "build.prerender": "node ../../bin/stencil build --config test-prerender/stencil.config-prerender.ts --prerender --debug && node test-prerender/no-script-build.js",
     "build.sibling": "node ../../bin/stencil build --config test-sibling/stencil.config.ts --debug",
     "karma": "karma start karma.config.js",
-    "karma.prod": "npm run build.sibling && npm run build.invisible-prehydration && npm run build.app && npm run build.custom-elements && npm run karma.webpack && npm run build.prerender && npm run karma",
+    "karma.prod": "npm run build.all && npm run karma",
     "karma.webpack": "webpack-cli --config test-app/esm-webpack/webpack.config.js",
     "karma.chrome": "karma start karma.config.js --browsers=Chrome --single-run=false",
     "karma.edge": "karma start karma.config.js --browsers=Edge --single-run=false",


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

Previously, testing a change that affected our Karma/Browserstack tests involved one of two things:
- Creating a Draft PR and continuously pushing to a WIP branch to test changes (which wastes time waiting for builds to pass/complete)
- Hack at the Karma configuration to tunnel into Browserstack locally

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit documents the ability to run the karma tests locally. in
addition, it also removes hacks that developers once had to do in order
to connect to browserstack locally, by introducing a new environment
variable, LOCAL_BROWSERSTACK, that will allow the development team to
tunnel into browserstack for local testing purposes

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Run through the README changes, validated that the new env var works as expected

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This is being done as a part of STENCIL-433: Stabilize Browserstack CI Tests
