### PR TITLE
attempt setup-env

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -10,12 +10,6 @@ on:
       - 'main'
       - 'v3.0.0-dev'
 
-permissions: read-all
-
-env:
-  BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSER_STACK_ACCESS_KEY }}
-  BROWSERSTACK_USERNAME: ${{ secrets.BROWSER_STACK_USERNAME }}
-
 jobs:
   browser-tests:
     runs-on: ubuntu-latest
@@ -35,6 +29,12 @@ jobs:
 
       - name: Build
         run: npm run build -- --ci
+
+      - name: 'BrowserStack Env Setup'  # Invokes the setup-env action
+        uses: browserstack/github-actions/setup-env@master
+        with:
+          username:  ${{ secrets.BROWSERSTACK_USERNAME }}
+          access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
 
       - name: Start BrowserStack
         uses: browserstack/github-actions/setup-local@master

--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   browser-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_core:
     name: Core
-    runs-on: 'ubuntu-latest'
+    runs-on: macos-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0

--- a/.github/workflows/test-browserstack.yml
+++ b/.github/workflows/test-browserstack.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build -- --ci
+#      - name: Build
+#        run: npm run build -- --ci
 
       - name: 'BrowserStack Env Setup'  # Invokes the setup-env action
         uses: browserstack/github-actions/setup-env@master

--- a/.github/workflows/test-browserstack.yml
+++ b/.github/workflows/test-browserstack.yml
@@ -1,0 +1,44 @@
+name: BrowserStack Tests
+
+on: [push, pull_request]
+
+
+jobs:
+  browser-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.number) || '' }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@56337c425554a6be30cdef71bf441f15be286854 # v3.1.1
+        with:
+          node-version: '12'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build -- --ci
+
+      - name: 'BrowserStack Env Setup'  # Invokes the setup-env action
+        uses: browserstack/github-actions/setup-env@master
+        with:
+          username:  ${{ secrets.BROWSERSTACK_USERNAME }}
+          access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+
+      - name: Start BrowserStack
+        uses: browserstack/github-actions/setup-local@master
+        with:
+          local-testing: start
+          local-identifier: random
+
+      - name: Run karma tests
+        run: npm run test.karma.prod
+
+      - name: Stop BrowserStack
+        uses: browserstack/github-actions/setup-local@master
+        with:
+          local-testing: stop

--- a/.github/workflows/test-browserstack.yml
+++ b/.github/workflows/test-browserstack.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   browser-tests-2:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0

--- a/.github/workflows/test-browserstack.yml
+++ b/.github/workflows/test-browserstack.yml
@@ -7,6 +7,7 @@ permissions: read-all
 env:
   BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSER_STACK_ACCESS_KEY }}
   BROWSERSTACK_USERNAME: ${{ secrets.BROWSER_STACK_USERNAME }}
+
 jobs:
   browser-tests-2:
     runs-on: ubuntu-latest
@@ -30,8 +31,8 @@ jobs:
       - name: 'BrowserStack Env Setup'  # Invokes the setup-env action
         uses: browserstack/github-actions/setup-env@master
         with:
-          username:  ${{ secrets.BROWSERSTACK_USERNAME }}
-          access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          username:  ${{ secrets.BROWSER_STACK_USERNAME }}
+          access-key: ${{ secrets.BROWSER_STACK_ACCESS_KEY }}
 
       - name: Start BrowserStack
         uses: browserstack/github-actions/setup-local@master

--- a/.github/workflows/test-browserstack.yml
+++ b/.github/workflows/test-browserstack.yml
@@ -2,7 +2,11 @@ name: BrowserStack Tests
 
 on: [push, pull_request]
 
+permissions: read-all
 
+env:
+  BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSER_STACK_ACCESS_KEY }}
+  BROWSERSTACK_USERNAME: ${{ secrets.BROWSER_STACK_USERNAME }}
 jobs:
   browser-tests-2:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-browserstack.yml
+++ b/.github/workflows/test-browserstack.yml
@@ -31,8 +31,8 @@ jobs:
       - name: 'BrowserStack Env Setup'  # Invokes the setup-env action
         uses: browserstack/github-actions/setup-env@master
         with:
-          username:  ${{ secrets.BROWSER_STACK_USERNAME }}
-          access-key: ${{ secrets.BROWSER_STACK_ACCESS_KEY }}
+          username:  ${{ env.BROWSERSTACK_USERNAME }}
+          access-key: ${{ env.BROWSERSTACK_ACCESS_KEY }}
 
       - name: Start BrowserStack
         uses: browserstack/github-actions/setup-local@master

--- a/.github/workflows/test-browserstack.yml
+++ b/.github/workflows/test-browserstack.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   browser-tests-2:
-    runs-on: ubuntu-18.04
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0

--- a/.github/workflows/test-browserstack.yml
+++ b/.github/workflows/test-browserstack.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 
 jobs:
-  browser-tests:
+  browser-tests-2:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This PR attempts to fix our current Browserstack setup.  Currently, the Browserstack step is unclear
as to whether it can establish a tunnel from GitHub to Browserstack, as it hangs with the following logs 
(taken from another run with GitHub's debug logging enabled):
```
Start BrowserStack

57m 16s
##[debug]Evaluating condition for step: 'Start BrowserStack'
##[debug]Evaluating: success()
##[debug]Evaluating success:
##[debug]=> true
##[debug]Result: true
##[debug]Starting: Start BrowserStack
##[debug]Loading inputs
##[debug]Loading env
Run browserstack/github-actions/setup-local@master
  
::group::Setting Environment Variables
Setting Environment Variables
##[debug]isExplicit: 1.0.0
##[debug]explicit? true
##[debug]checking cache: /opt/hostedtoolcache/BrowserStackLocal/1.0.0/x64
##[debug]not found
##[debug]BrowserStackLocal binary not found in cache. Deleting any stale/existing binary before downloading...
Downloading BrowserStackLocal binary...
##[debug]Downloading https://www.browserstack.com/browserstack-local/BrowserStackLocal-linux-x64.zip
##[debug]Destination /home/runner/_work/binary/LocalBinaryFolder/linux/binaryZip
##[debug]download complete
/usr/bin/unzip /home/runner/_work/binary/LocalBinaryFolder/linux/binaryZip
Archive:  /home/runner/_work/binary/LocalBinaryFolder/linux/binaryZip
  inflating: BrowserStackLocal       
BrowserStackLocal binary downloaded & extracted successfuly at: /home/runner/_work/binary/LocalBinaryFolder/linux
##[debug]Caching tool BrowserStackLocal 1.0.0 x64
##[debug]source dir: /home/runner/_work/binary/LocalBinaryFolder/linux
##[debug]destination /opt/hostedtoolcache/BrowserStackLocal/1.0.0/x64
##[debug]finished caching tool
Starting local tunnel with local-identifier=GitHubAction-bf632b19-a17d-4efe-8454-efb37e4adabf in daemon mode...
/opt/hostedtoolcache/BrowserStackLocal/1.0.0/x64/BrowserStackLocal --key *** --only-automate --ci-plugin GitHubAction --local-identifier GitHubAction-bf632b19-a17d-4efe-8454-efb37e4adabf --daemon start
```

Note the last line stating "Starting local tunnel...". At that point, the run hangs. In a successful run, we should see a connection status. Taken arbitrarily from [this successful run from 8 days ago](https://github.com/ionic-team/stencil/runs/7023169476?check_suite_focus=true)
```
 Starting local tunnel with local-identifier=GitHubAction-68ee876c-6974-4bd5-917a-42f882992ed5 in daemon mode...
/opt/hostedtoolcache/BrowserStackLocal/1.0.0/x64/BrowserStackLocal --key *** --only-automate --ci-plugin GitHubAction --local-identifier GitHubAction-68ee876c-6974-4bd5-917a-42f882992ed5 --daemon start
{"state":"connected","pid":2158,"message":{"message":"Connected"}}
Local tunnel status: {"message":"Connected"}
```

I've been digging into this for the last 24 hours (during the working day 😏).  Here is what I know:

- [Around 9:30 AM yesterday was the last run of Browserstack that succeeded](https://github.com/ionic-team/stencil/runs/7132142919?check_suite_focus=true)
  - The SHAs of the the GitHub actions used in the last successful run and runs of this PR's job are the same
  - The OS and Virtual Environments are the same between the two jobs
  - The Virtual Environment Provisioner is _not_  - successful run used   `1.0.0.0-main-20220531-1`, unsuccessful run used   `1.0.0.0-main-20220616-1`
    - It is possible that a new provisioner had an affect here? Unknown
- I have created a Service Account for our Browserstack runner, and replaced its access key/username in GH 
  - These are more ephemeral accounts, and seemed safer to debug with 
- I am able to tunnel into browserstack locally from Stencil (with minor tweaks to the Karma config) when running `npm run test.karma` using the service account creds
- I am _not_ able to tunnel into browserstack locally by running the local runner tarball (or I haven't gotten it to work yet) using the service account cred
- The tarball used in running Browserstack is not vendored/version controlled on our end
  - It is possible that it changed in some way, but I have no way to prove that 

**What's in this PR**