### PR TITLE
feat(mock-doc): dispatch blur and focus events

### DIFF
--- a/src/mock-doc/event.ts
+++ b/src/mock-doc/event.ts
@@ -1,6 +1,7 @@
 import { MockDocument } from './document';
 import { MockElement } from './node';
 import { NODE_NAMES } from './constants';
+import { MockWindow } from './window';
 
 export class MockEvent {
   bubbles = false;
@@ -115,6 +116,15 @@ export class MockMouseEvent extends MockEvent {
 
 export class MockUIEvent extends MockEvent {
   detail: number | null = null;
+  view: MockWindow | null = null;
+
+  constructor(type: string, focusEventInitDic?: UIEventInit) {
+    super(type);
+
+    if (focusEventInitDic != null) {
+      Object.assign(this, focusEventInitDic);
+    }
+  }
 }
 
 export class MockFocusEvent extends MockUIEvent {

--- a/src/mock-doc/event.ts
+++ b/src/mock-doc/event.ts
@@ -113,6 +113,22 @@ export class MockMouseEvent extends MockEvent {
   }
 }
 
+export class MockUIEvent extends MockEvent {
+  detail: number | null = null;
+}
+
+export class MockFocusEvent extends MockUIEvent {
+  relatedTarget: EventTarget | null = null;
+
+  constructor(type: string, focusEventInitDic?: FocusEventInit) {
+    super(type);
+
+    if (focusEventInitDic != null) {
+      Object.assign(this, focusEventInitDic);
+    }
+  }
+}
+
 export class MockEventListener {
   type: string;
   handler: (ev?: any) => void;

--- a/src/mock-doc/global.ts
+++ b/src/mock-doc/global.ts
@@ -13,7 +13,7 @@ import {
   MockTemplateElement,
   MockTitleElement,
 } from './element';
-import { MockCustomEvent, MockEvent, MockKeyboardEvent, MockMouseEvent } from './event';
+import { MockCustomEvent, MockEvent, MockFocusEvent, MockKeyboardEvent, MockMouseEvent } from './event';
 import { MockHeaders } from './headers';
 import { MockRequest, MockResponse } from './request-response';
 import { MockDOMParser } from './parser';
@@ -148,6 +148,7 @@ const WINDOW_PROPS = [
   'HTMLElement',
   'Node',
   'NodeList',
+  'FocusEvent',
   'KeyboardEvent',
   'MouseEvent',
 ];
@@ -156,6 +157,7 @@ const GLOBAL_CONSTRUCTORS: [string, any][] = [
   ['CustomEvent', MockCustomEvent],
   ['Event', MockEvent],
   ['Headers', MockHeaders],
+  ['FocusEvent', MockFocusEvent],
   ['KeyboardEvent', MockKeyboardEvent],
   ['MouseEvent', MockMouseEvent],
   ['Request', MockRequest],

--- a/src/mock-doc/node.ts
+++ b/src/mock-doc/node.ts
@@ -4,7 +4,7 @@ import { matches, selectAll, selectOne } from './selector';
 import { MockAttr, MockAttributeMap, createAttributeProxy } from './attribute';
 import { MockClassList } from './class-list';
 import { MockCSSStyleDeclaration, createCSSStyleDeclaration } from './css-style-declaration';
-import { MockEvent, addEventListener, dispatchEvent, removeEventListener, resetEventListeners } from './event';
+import { MockEvent, addEventListener, dispatchEvent, removeEventListener, resetEventListeners, MockFocusEvent } from './event';
 import { NODE_NAMES, NODE_TYPES } from './constants';
 import { NON_ESCAPABLE_CONTENT, SerializeNodeToHtmlOptions, serializeNodeToHtml } from './serialize-node';
 import { parseFragmentUtil } from './parse-util';
@@ -236,7 +236,7 @@ export class MockElement extends MockNode {
   }
 
   blur() {
-    /**/
+    dispatchEvent(this, new MockFocusEvent('blur', { relatedTarget: null, bubbles: true, cancelable: true, composed: true }));
   }
 
   get shadowRoot() {
@@ -320,7 +320,9 @@ export class MockElement extends MockNode {
     return this.children[0] || null;
   }
 
-  focus(_options?: { preventScroll?: boolean }) {}
+  focus(_options?: { preventScroll?: boolean }) {
+    dispatchEvent(this, new MockFocusEvent('focus', { relatedTarget: null, bubbles: true, cancelable: true, composed: true }));
+  }
 
   getAttribute(attrName: string) {
     if (attrName === 'style') {

--- a/src/mock-doc/node.ts
+++ b/src/mock-doc/node.ts
@@ -4,7 +4,14 @@ import { matches, selectAll, selectOne } from './selector';
 import { MockAttr, MockAttributeMap, createAttributeProxy } from './attribute';
 import { MockClassList } from './class-list';
 import { MockCSSStyleDeclaration, createCSSStyleDeclaration } from './css-style-declaration';
-import { MockEvent, addEventListener, dispatchEvent, removeEventListener, resetEventListeners, MockFocusEvent } from './event';
+import {
+  MockEvent,
+  addEventListener,
+  dispatchEvent,
+  removeEventListener,
+  resetEventListeners,
+  MockFocusEvent,
+} from './event';
 import { NODE_NAMES, NODE_TYPES } from './constants';
 import { NON_ESCAPABLE_CONTENT, SerializeNodeToHtmlOptions, serializeNodeToHtml } from './serialize-node';
 import { parseFragmentUtil } from './parse-util';
@@ -236,7 +243,10 @@ export class MockElement extends MockNode {
   }
 
   blur() {
-    dispatchEvent(this, new MockFocusEvent('blur', { relatedTarget: null, bubbles: true, cancelable: true, composed: true }));
+    dispatchEvent(
+      this,
+      new MockFocusEvent('blur', { relatedTarget: null, bubbles: true, cancelable: true, composed: true })
+    );
   }
 
   get shadowRoot() {
@@ -321,7 +331,10 @@ export class MockElement extends MockNode {
   }
 
   focus(_options?: { preventScroll?: boolean }) {
-    dispatchEvent(this, new MockFocusEvent('focus', { relatedTarget: null, bubbles: true, cancelable: true, composed: true }));
+    dispatchEvent(
+      this,
+      new MockFocusEvent('focus', { relatedTarget: null, bubbles: true, cancelable: true, composed: true })
+    );
   }
 
   getAttribute(attrName: string) {

--- a/src/mock-doc/test/event.spec.ts
+++ b/src/mock-doc/test/event.spec.ts
@@ -90,6 +90,48 @@ describe('event', () => {
     expect(ev.detail).toBe(88);
   });
 
+  it('FocusEvent() requires type', () => {
+    expect(() => {
+      // @ts-ignore checking that it throws when not supplied required arguments
+      new win.FocusEvent();
+    }).toThrow();
+  });
+
+  it('FocusEvent(type)', () => {
+    const ev = new win.FocusEvent('focus');
+    expect(ev.bubbles).toBe(false);
+    expect(ev.cancelBubble).toBe(false);
+    expect(ev.cancelable).toBe(false);
+    expect(ev.composed).toBe(false);
+    expect(ev.currentTarget).toBe(null);
+    expect(ev.defaultPrevented).toBe(false);
+    expect(ev.srcElement).toBe(null);
+    expect(ev.target).toBe(null);
+    expect(typeof ev.timeStamp).toBe('number');
+    expect(ev.type).toBe('focus');
+    expect(ev.relatedTarget).toBe(null);
+  });
+
+  it('FocusEvent(type, eventInitDict)', () => {
+    const eventInitDict = {
+      bubbles: true,
+      composed: true,
+      relatedTarget: null as EventTarget | null,
+    };
+    const ev = new win.FocusEvent('blur', eventInitDict);
+    expect(ev.bubbles).toBe(true);
+    expect(ev.cancelBubble).toBe(false);
+    expect(ev.cancelable).toBe(false);
+    expect(ev.composed).toBe(true);
+    expect(ev.currentTarget).toBe(null);
+    expect(ev.defaultPrevented).toBe(false);
+    expect(ev.srcElement).toBe(null);
+    expect(ev.target).toBe(null);
+    expect(typeof ev.timeStamp).toBe('number');
+    expect(ev.type).toBe('blur');
+    expect(ev.relatedTarget).toBe(null);
+  });
+
   it('KeyboardEvent() requires type', () => {
     expect(() => {
       // @ts-ignore checking that it throws when not supplied required arguments

--- a/src/mock-doc/window.ts
+++ b/src/mock-doc/window.ts
@@ -10,6 +10,7 @@ import {
   MockMouseEvent,
   MockCustomEvent,
   MockKeyboardEvent,
+  MockFocusEvent,
 } from './event';
 import { MockDocument, resetDocument } from './document';
 import { MockDocumentFragment } from './document-fragment';
@@ -74,6 +75,7 @@ export class MockWindow {
   CustomEvent: typeof MockCustomEvent;
   Event: typeof MockEvent;
   Headers: typeof MockHeaders;
+  FocusEvent: typeof MockFocusEvent;
   KeyboardEvent: typeof MockKeyboardEvent;
   MouseEvent: typeof MockMouseEvent;
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

For mock-doc, `blur()` and `focus()` methods will now dispatch an event. Created `MockFocusEvent` which extends a new `MockUIEvent`, which extends the existing `MockEvent`.

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
The blur and focus methods are empty.


## What is the new behavior?
The methods now dispatch an event (similar to how `click()` works) via the`MockFocusEvent` class with a `type` property of `'blur'` or `'focus'` 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Added tests for verify new `MockFocusEvent` instantiation

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
