### PR TITLE
fix(styles): ensure styles are applied before paint

### DIFF
--- a/src/client/client-window.ts
+++ b/src/client/client-window.ts
@@ -52,11 +52,11 @@ export const supportsListenerOptions = /*@__PURE__*/ (() => {
 
 export const promiseResolve = (v?: any) => Promise.resolve(v);
 
-export const supportsConstructibleStylesheets = BUILD.constructableCSS
+export const supportsConstructableStylesheets = BUILD.constructableCSS
   ? /*@__PURE__*/ (() => {
       try {
         new CSSStyleSheet();
-        return typeof new CSSStyleSheet().replace === 'function';
+        return typeof new CSSStyleSheet().replaceSync === 'function';
       } catch (e) {}
       return false;
     })()

--- a/src/hydrate/platform/index.ts
+++ b/src/hydrate/platform/index.ts
@@ -121,7 +121,7 @@ export const supportsShadow = false;
 
 export const supportsListenerOptions = false;
 
-export const supportsConstructibleStylesheets = false;
+export const supportsConstructableStylesheets = false;
 
 const hostRefs: WeakMap<d.RuntimeRef, d.HostRef> = new WeakMap();
 

--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -1,7 +1,7 @@
 import type * as d from '../declarations';
 import { BUILD } from '@app-data';
 import { CMP_FLAGS } from '@utils';
-import { doc, plt, styles, supportsConstructibleStylesheets, supportsShadow } from '@platform';
+import { doc, plt, styles, supportsConstructableStylesheets, supportsShadow } from '@platform';
 import { HYDRATED_STYLE_ID, NODE_TYPE } from './runtime-constants';
 import { createTime } from './profile';
 
@@ -9,9 +9,13 @@ const rootAppliedStyles: d.RootAppliedStyleMap = /*@__PURE__*/ new WeakMap();
 
 export const registerStyle = (scopeId: string, cssText: string, allowCS: boolean) => {
   let style = styles.get(scopeId);
-  if (supportsConstructibleStylesheets && allowCS) {
+  if (supportsConstructableStylesheets && allowCS) {
     style = (style || new CSSStyleSheet()) as CSSStyleSheet;
-    style.replace(cssText);
+    if (typeof style === 'string') {
+      style = cssText;
+    } else {
+      style.replaceSync(cssText);
+    }
   } else {
     style = cssText;
   }

--- a/src/testing/platform/index.ts
+++ b/src/testing/platform/index.ts
@@ -13,7 +13,7 @@ export {
   resetPlatform,
   startAutoApplyChanges,
   stopAutoApplyChanges,
-  supportsConstructibleStylesheets,
+  supportsConstructableStylesheets,
   supportsListenerOptions,
   setSupportsShadowDom,
 } from './testing-platform';

--- a/src/testing/platform/testing-platform.ts
+++ b/src/testing/platform/testing-platform.ts
@@ -27,7 +27,7 @@ export const setPlatformHelpers = (helpers: {
 
 export const cssVarShim: d.CssVarShim = false as any;
 export const supportsListenerOptions = true;
-export const supportsConstructibleStylesheets = false;
+export const supportsConstructableStylesheets = false;
 export const Context: any = {};
 
 export const setSupportsShadowDom = (supports: boolean) => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit fixes a bug where styles from a stencil component would not
be applied prior to render. the issue involved stylesheet construction &
application not blocking render, causing the component to be created
without styles applied.

this commit moves from the `replace` function to the `replaceSync`
function to properly await the call


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

This was one of the primary culprits for our flaky Browserstack tests. Roughly 75% of all failures were from tests run against Firefox (v101, 102) with an error something to the effect of:
```
Expected 'rgba(0, 0, 0, 0)' to be 'rgb(0, 0, 0)'
```

We should see stabilization of these tests as a result of this PR

## Other information

### JIRA Ticket
This is being done as a part of STENCIL-433: Stabilize Browserstack CI Tests

### Debugging
All tests that would sporadically fail with an error message similar to '`Expected 'rgba(0, 0, 0, 0)' to be 'rgb(0, 0, 0)'`' had one commonality - the usage of `getComputedStyle`. I debugged this issue by adding a combination of `console.log` and pseudo-sleep statements in the test code to verify the issue:
```diff
app = await setupDom('/prerender/index.html', 1000);

const scoped = app.querySelector('cmp-client-scoped');

+ console.log(`Initial result of getComputedStyle() ${getComputedStyle(scoped.querySelector('section'))}`);
+ new Promise(resolve => setTimeout(resolve, 1000));
+ console.log(`After result of getComputedStyle() ${getComputedStyle(scoped.querySelector('section'))}`);

const scopedStyle = getComputedStyle(scoped.querySelector('section'));
expect(scopedStyle.color).toBe('rgb(255, 0, 0)');
```

And would observe the number of applied styles change between the two `console.log` statements - the applied CSS just _happened_ to be the styles for the component (found in the components stylesheet).

### Stabilization

This does not completely stabilize CI. There are additional issues not addressed in this PR (and it is possible that by now awaiting styles to be applied, we exacerbate other issues).
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
