### PR TITLE
test(prerender): wait for load event

### DIFF
--- a/test/karma/test-app/prerender-test/karma.spec.ts
+++ b/test/karma/test-app/prerender-test/karma.spec.ts
@@ -1,4 +1,4 @@
-import { setupDomTests } from '../util';
+import { setupDomTests, waitForChanges } from '../util';
 
 describe('prerender', () => {
   const { setupDom, tearDownDom } = setupDomTests(document);
@@ -42,7 +42,8 @@ describe('prerender', () => {
   });
 
   it('root slots', async () => {
-    app = await setupDom('/prerender/index.html', 1000);
+    app = await setupDom('/prerender/index.html');
+    await waitForChanges(500);
 
     const scoped = app.querySelector('cmp-client-scoped');
     const scopedStyle = getComputedStyle(scoped.querySelector('section'));


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit fixes an issue where stencil's prerender tests that would begin to run before
the entire pre-render application would be loaded. this is accomplished by moving from
using the 'appload' event to the 'load' event to listen on by moving from the timeout
associated with `setupDom` to the `waitForChanges` API our testing utilities provides

STENCIL-433: Stabilize Browserstack CI Tests

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Tests are more stable. This doesn't solve the issue with disconnects, but that's outside the scope of this PR.
I've seen 2/11 fail, both for disconnect issues.

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
