### PR TITLE
fix(compiler): Re-enable build cache

### DIFF
--- a/src/compiler/build/write-build.ts
+++ b/src/compiler/build/write-build.ts
@@ -21,9 +21,9 @@ export const writeBuild = async (config: d.Config, compilerCtx: d.CompilerCtx, b
 
     // successful write
     // kick off writing the cached file stuff
-    // await compilerCtx.cache.commit();
+    await compilerCtx.cache.commit();
     buildCtx.debug(`in-memory-fs: ${compilerCtx.fs.getMemoryStats()}`);
-    // buildCtx.debug(`cache: ${compilerCtx.cache.getMemoryStats()}`);
+    buildCtx.debug(`cache: ${compilerCtx.cache.getMemoryStats()}`);
 
     await outputServiceWorkers(config, buildCtx), await validateBuildFiles(config, compilerCtx, buildCtx);
   } catch (e: any) {

--- a/src/compiler/config/validate-paths.ts
+++ b/src/compiler/config/validate-paths.ts
@@ -20,6 +20,10 @@ export const validatePaths = (config: d.UnvalidatedConfig) => {
     config.cacheDir = join(config.rootDir, config.cacheDir);
   }
 
+  if (typeof config.buildCacheDirName !== 'string') {
+    config.buildCacheDirName = DEFAULT_BUILD_CACHE_DIR_NAME;
+  }
+
   if (typeof config.srcIndexHtml !== 'string') {
     config.srcIndexHtml = join(config.srcDir, DEFAULT_INDEX_HTML);
   }
@@ -53,5 +57,6 @@ export const validatePaths = (config: d.UnvalidatedConfig) => {
 
 const DEFAULT_BUILD_LOG_FILE_NAME = 'stencil-build.log';
 const DEFAULT_CACHE_DIR = '.stencil';
+const DEFAULT_BUILD_CACHE_DIR_NAME = 'build';
 const DEFAULT_INDEX_HTML = 'index.html';
 const DEFAULT_SRC_DIR = 'src';

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -231,6 +231,7 @@ export interface StencilConfig {
   buildDist?: boolean;
   buildLogFilePath?: string;
   cacheDir?: string;
+  buildCacheDirName?: string;
   devInspector?: boolean;
   devServer?: StencilDevServerConfig;
   enableCacheStats?: boolean;


### PR DESCRIPTION
- uncomment cache write to disk
- add `buildCacheDirName` config option to prevent clash with `ScreenshotConnector`

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue 1:
Currently, the build cache is being populated, but not written to disk, so is not picked up in subsequent builds. 

The line of code here: 
https://github.com/ionic-team/stencil/blob/main/src/compiler/build/write-build.ts#L24

Was commented out in this commit: 
https://github.com/ionic-team/stencil/commit/63595bc540db9aa85295f5a8dc8738beb2a37611

Issue 2:

`ScreenshotConnector` also uses the cacheDir for it's cache, but a build clears out the cache here:
https://github.com/ionic-team/stencil/blob/c0aeac1176c474f4e0935e40f3944433f5c24860/src/compiler/cache.ts#L20


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

### Uncommenting the line that writes the cache to disk re-enables the cache.
This offers considerable speedup in large (~200 component) projects:

Before: ~71s (average of three runs [81.62s, 64.27s, 69.29s])
After: ~38s (average of three runs [39.37s, 38.11s, 37.98s]) (with cache populated)


### New config option `buildCacheDirName` with default `"build"` 

Places the cache in `\`${cacheDir}/${buildCacheDirName}`\` , matching the pattern of `ScreenshotConnector` (\`${cacheDir}/${screenshotCacheFileName}`\`. The means only `.stencil/build` is wiped when the cache is cleared, leaving the screenshot connector cache alone.


## Does this introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] Don't think so

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

See time measurements above

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Slack discussion: https://stencil-worldwide.slack.com/archives/C79EANFL7/p1657182204289689
