### PR TITLE
chore(test): remove strictNullChecks from dev server validation

### DIFF
--- a/src/compiler/config/test/validate-dev-server.spec.ts
+++ b/src/compiler/config/test/validate-dev-server.spec.ts
@@ -8,14 +8,16 @@ import { mockLoadConfigInit } from '@stencil/core/testing';
 describe('validateDevServer', () => {
   const root = path.resolve('/');
   let inputConfig: d.UnvalidatedConfig;
+  let inputDevServerConfig: d.DevServerConfig;
   let flags: ConfigFlags;
 
   beforeEach(() => {
+    inputDevServerConfig = {};
     flags = { serve: true };
     inputConfig = {
       sys: {} as any,
       rootDir: normalizePath(path.join(root, 'some', 'path')),
-      devServer: {},
+      devServer: inputDevServerConfig,
       flags,
       namespace: 'Testing',
     };
@@ -29,14 +31,14 @@ describe('validateDevServer', () => {
   it.each(['https://localhost', 'http://localhost', 'https://localhost/', 'http://localhost/', 'localhost/'])(
     'should remove extraneous stuff from address %p',
     (address) => {
-      inputConfig.devServer.address = address;
+      inputConfig.devServer = { ...inputDevServerConfig, address };
       const { config } = validateConfig(inputConfig, mockLoadConfigInit());
       expect(config.devServer.address).toBe('localhost');
     }
   );
 
   it('should set address', () => {
-    inputConfig.devServer.address = '123.123.123.123';
+    inputConfig.devServer = { ...inputDevServerConfig, address: '123.123.123.123' };
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.address).toBe('123.123.123.123');
   });
@@ -80,13 +82,16 @@ describe('validateDevServer', () => {
   });
 
   it('should set relative root', () => {
-    inputConfig.devServer.root = 'my-rel-root';
+    inputConfig.devServer = { ...inputDevServerConfig, root: 'my-rel-root' };
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.root).toBe(normalizePath(path.join(root, 'some', 'path', 'my-rel-root')));
   });
 
   it('should set absolute root', () => {
-    inputConfig.devServer.root = normalizePath(path.join(root, 'some', 'path', 'my-abs-root'));
+    inputConfig.devServer = {
+      ...inputDevServerConfig,
+      root: normalizePath(path.join(root, 'some', 'path', 'my-abs-root')),
+    };
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.root).toBe(normalizePath(path.join(root, 'some', 'path', 'my-abs-root')));
   });
@@ -97,7 +102,7 @@ describe('validateDevServer', () => {
   });
 
   it('should set gzip', () => {
-    inputConfig.devServer.gzip = false;
+    inputConfig.devServer = { ...inputDevServerConfig, gzip: false };
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.gzip).toBe(false);
   });
@@ -110,28 +115,27 @@ describe('validateDevServer', () => {
   it.each(['https://subdomain.stenciljs.com:3000', 'localhost:3000/', 'localhost:3000'])(
     'should override port in address with port property',
     (address) => {
-      inputConfig.devServer.port = 1234;
-      inputConfig.devServer.address = address;
+      inputConfig.devServer = { ...inputDevServerConfig, address, port: 1234 };
       const { config } = validateConfig(inputConfig, mockLoadConfigInit());
       expect(config.devServer.port).toBe(1234);
     }
   );
 
   it('should not set default port if null', () => {
-    inputConfig.devServer.port = null;
+    inputConfig.devServer = { ...inputDevServerConfig, port: null };
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.port).toBe(null);
   });
 
   it.each(['localhost:20/', 'localhost:20'])('should set port from address %p if no port prop', (address) => {
-    inputConfig.devServer.address = address;
+    inputConfig.devServer = { ...inputDevServerConfig, address };
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.port).toBe(20);
     expect(config.devServer.address).toBe('localhost');
   });
 
   it('should set address, port null, protocol', () => {
-    inputConfig.devServer.address = 'https://subdomain.stenciljs.com/';
+    inputConfig.devServer = { ...inputDevServerConfig, address: 'https://subdomain.stenciljs.com/' };
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.port).toBe(undefined);
     expect(config.devServer.address).toBe('subdomain.stenciljs.com');
@@ -139,7 +143,7 @@ describe('validateDevServer', () => {
   });
 
   it('should set port', () => {
-    inputConfig.devServer.port = 4444;
+    inputConfig.devServer = { ...inputDevServerConfig, port: 4444 };
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.port).toBe(4444);
   });
@@ -157,14 +161,14 @@ describe('validateDevServer', () => {
   });
 
   it('should set historyApiFallback', () => {
-    inputConfig.devServer.historyApiFallback = {};
+    inputConfig.devServer = { ...inputDevServerConfig, historyApiFallback: {} };
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.historyApiFallback).toBeDefined();
     expect(config.devServer.historyApiFallback.index).toBe('index.html');
   });
 
   it('should disable historyApiFallback', () => {
-    inputConfig.devServer.historyApiFallback = null;
+    inputConfig.devServer = { ...inputDevServerConfig, historyApiFallback: null };
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.historyApiFallback).toBe(null);
   });
@@ -175,7 +179,7 @@ describe('validateDevServer', () => {
   });
 
   it('should set reloadStrategy pageReload', () => {
-    inputConfig.devServer.reloadStrategy = 'pageReload';
+    inputConfig.devServer = { ...inputDevServerConfig, reloadStrategy: 'pageReload' };
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.reloadStrategy).toBe('pageReload');
   });
@@ -186,7 +190,7 @@ describe('validateDevServer', () => {
   });
 
   it('should set openBrowser', () => {
-    inputConfig.devServer.openBrowser = false;
+    inputConfig.devServer = { ...inputDevServerConfig, openBrowser: false };
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.openBrowser).toBe(false);
   });
@@ -203,19 +207,19 @@ describe('validateDevServer', () => {
   });
 
   it('should set https protocol if credentials are set', () => {
-    inputConfig.devServer.https = { key: 'fake-key', cert: 'fake-cert' };
+    inputConfig.devServer = { ...inputDevServerConfig, https: { key: 'fake-key', cert: 'fake-cert' } };
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.protocol).toBe('https');
   });
 
   it('should set ssr true', () => {
-    inputConfig.devServer.ssr = true;
+    inputConfig.devServer = { ssr: true };
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.ssr).toBe(true);
   });
 
   it('should set ssr false', () => {
-    inputConfig.devServer.ssr = false;
+    inputConfig.devServer = { ssr: false };
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.ssr).toBe(false);
   });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

~20 or so over our `strictNullChecks` violations for validating the dev server are related to
configuration options that are unvalidated/won't have their type signature changed

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit removes the strictNullCheck violations from tests for
validating the dev server. it only removes those associated with an
unvalidated configuration. we have no intention at the moment to make
`devServer` or its subfields required on `Config`. regardless of what
happens on `ValidatedConfig#devServer`, we needed to handle these
unvalidated `devServer` instances

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Unit tests pass
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

I'm trying to break some of these larger efforts up into smaller, more manageable chunks. That's why this isn't in a larger PR for all of `devServer` fixes.

I know this PR will introduce a few type assignment issues ("property X is not assignable to 'null'"), those won't get fixed until we tackle `devServer` properly

finally, this PR is contingent on #3457 landing. I'll land that, then this. Until then, the `--strictNullChecks` error report is gonna look more impressive than it actually is 😆 
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
