### PR TITLE
chore(types): remove optional types on ConfigFlags interface

### DIFF
--- a/src/cli/config-flags.ts
+++ b/src/cli/config-flags.ts
@@ -269,8 +269,27 @@ export interface ConfigFlags
     NumberConfigFlags,
     StringNumberConfigFlags,
     LogLevelFlags {
-  task?: TaskCommand | null;
-  args?: string[];
-  knownArgs?: string[];
-  unknownArgs?: string[];
+  task: TaskCommand | null;
+  args: string[];
+  knownArgs: string[];
+  unknownArgs: string[];
 }
+
+/**
+ * Helper function for initializing a `ConfigFlags` object. Provide any overrides
+ * for default values and off you go!
+ *
+ * @param init an object with any overrides for default values
+ * @returns a complete CLI flag object
+ */
+export const createConfigFlags = (init: Partial<ConfigFlags> = {}): ConfigFlags => {
+  const flags: ConfigFlags = {
+    task: null,
+    args: [],
+    knownArgs: [],
+    unknownArgs: [],
+    ...init,
+  };
+
+  return flags;
+};

--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -13,6 +13,7 @@ import {
   STRING_NUMBER_CLI_ARGS,
   StringCLIArg,
   StringNumberCLIArg,
+  createConfigFlags,
 } from './config-flags';
 
 /**
@@ -23,12 +24,7 @@ import {
  * @returns a structured ConfigFlags object
  */
 export const parseFlags = (args: string[], sys?: CompilerSystem): ConfigFlags => {
-  const flags: ConfigFlags = {
-    task: null,
-    args: [],
-    knownArgs: [],
-    unknownArgs: [],
-  };
+  const flags: ConfigFlags = createConfigFlags();
 
   // cmd line has more priority over npm scripts cmd
   flags.args = Array.isArray(args) ? args.slice() : [];
@@ -42,8 +38,8 @@ export const parseFlags = (args: string[], sys?: CompilerSystem): ConfigFlags =>
     parseArgs(flags, envArgs);
 
     envArgs.forEach((envArg) => {
-      if (!flags.args!.includes(envArg)) {
-        flags.args!.push(envArg);
+      if (!flags.args.includes(envArg)) {
+        flags.args.push(envArg);
       }
     });
   }
@@ -56,7 +52,7 @@ export const parseFlags = (args: string[], sys?: CompilerSystem): ConfigFlags =>
   }
 
   flags.unknownArgs = flags.args.filter((arg: string) => {
-    return !flags.knownArgs!.includes(arg);
+    return !flags.knownArgs.includes(arg);
   });
 
   return flags;
@@ -117,7 +113,7 @@ const parseBooleanArg = (flags: ConfigFlags, args: string[], configCaseName: Boo
 
     if (value !== undefined && cmdArg !== undefined) {
       flags[configCaseName] = value;
-      flags.knownArgs!.push(cmdArg);
+      flags.knownArgs.push(cmdArg);
     }
   });
 };
@@ -138,8 +134,8 @@ const parseStringArg = (flags: ConfigFlags, args: string[], configCaseName: Stri
 
   if (value !== undefined && matchingArg !== undefined) {
     flags[configCaseName] = value;
-    flags.knownArgs!.push(matchingArg);
-    flags.knownArgs!.push(value);
+    flags.knownArgs.push(matchingArg);
+    flags.knownArgs.push(value);
   }
 };
 
@@ -159,8 +155,8 @@ const parseNumberArg = (flags: ConfigFlags, args: string[], configCaseName: Numb
 
   if (value !== undefined && matchingArg !== undefined) {
     flags[configCaseName] = parseInt(value, 10);
-    flags.knownArgs!.push(matchingArg);
-    flags.knownArgs!.push(value);
+    flags.knownArgs.push(matchingArg);
+    flags.knownArgs.push(value);
   }
 };
 
@@ -186,8 +182,8 @@ const parseStringNumberArg = (flags: ConfigFlags, args: string[], configCaseName
       // it was a number, great!
       flags[configCaseName] = Number(value);
     }
-    flags.knownArgs!.push(matchingArg);
-    flags.knownArgs!.push(value);
+    flags.knownArgs.push(matchingArg);
+    flags.knownArgs.push(value);
   }
 };
 
@@ -228,8 +224,8 @@ const parseLogLevelArg = (flags: ConfigFlags, args: string[], configCaseName: Lo
 
   if (value !== undefined && matchingArg !== undefined && isLogLevel(value)) {
     flags[configCaseName] = value;
-    flags.knownArgs!.push(matchingArg);
-    flags.knownArgs!.push(value);
+    flags.knownArgs.push(matchingArg);
+    flags.knownArgs.push(value);
   }
 };
 

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -16,6 +16,8 @@ import { taskTest } from './task-test';
 import { taskTelemetry } from './task-telemetry';
 import { telemetryAction } from './telemetry/telemetry';
 import { createLogger } from '../compiler/sys/logger/console-logger';
+import { ValidatedConfig } from '../declarations';
+import { createConfigFlags } from './config-flags';
 
 export const run = async (init: d.CliInitOptions) => {
   const { args, logger, sys } = init;
@@ -37,7 +39,8 @@ export const run = async (init: d.CliInitOptions) => {
     }
 
     if (task === 'help' || flags.help) {
-      await taskHelp({ task: 'help', args }, logger, sys);
+      await taskHelp(createConfigFlags({ task: 'help', args }), logger, sys);
+
       return;
     }
 
@@ -72,9 +75,14 @@ export const run = async (init: d.CliInitOptions) => {
     loadedCompilerLog(sys, logger, flags, coreCompiler);
 
     if (task === 'info') {
-      await telemetryAction(sys, { flags: { task: 'info' }, logger }, coreCompiler, async () => {
-        await taskInfo(coreCompiler, sys, logger);
-      });
+      await telemetryAction(
+        sys,
+        { flags: createConfigFlags({ task: 'info' }), logger },
+        coreCompiler,
+        async () => {
+          await taskInfo(coreCompiler, sys, logger);
+        }
+      );
       return;
     }
 
@@ -119,8 +127,8 @@ export const runTask = async (
   sys?: d.CompilerSystem
 ) => {
   const logger = config.logger ?? createLogger();
-  const strictConfig: d.ValidatedConfig = { ...config, flags: { ...config.flags } ?? { task }, logger };
 
+  const strictConfig: ValidatedConfig = { ...config, flags: createConfigFlags(config.flags ?? { task }), logger };
   strictConfig.outputTargets = strictConfig.outputTargets || [];
 
   switch (task) {

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -75,14 +75,9 @@ export const run = async (init: d.CliInitOptions) => {
     loadedCompilerLog(sys, logger, flags, coreCompiler);
 
     if (task === 'info') {
-      await telemetryAction(
-        sys,
-        { flags: createConfigFlags({ task: 'info' }), logger },
-        coreCompiler,
-        async () => {
-          await taskInfo(coreCompiler, sys, logger);
-        }
-      );
+      await telemetryAction(sys, { flags: createConfigFlags({ task: 'info' }), logger }, coreCompiler, async () => {
+        await taskInfo(coreCompiler, sys, logger);
+      });
       return;
     }
 
@@ -126,8 +121,6 @@ export const runTask = async (
   task: d.TaskCommand,
   sys?: d.CompilerSystem
 ) => {
-  const logger = config.logger ?? createLogger();
-
   const strictConfig: ValidatedConfig = { ...config, flags: createConfigFlags(config.flags ?? { task }), logger };
   strictConfig.outputTargets = strictConfig.outputTargets || [];
 

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -121,7 +121,9 @@ export const runTask = async (
   task: d.TaskCommand,
   sys?: d.CompilerSystem
 ) => {
+  const logger = config.logger ?? createLogger();
   const strictConfig: ValidatedConfig = { ...config, flags: createConfigFlags(config.flags ?? { task }), logger };
+
   strictConfig.outputTargets = strictConfig.outputTargets || [];
 
   switch (task) {

--- a/src/cli/telemetry/helpers.ts
+++ b/src/cli/telemetry/helpers.ts
@@ -53,7 +53,7 @@ export async function readJson(sys: d.CompilerSystem, path: string): Promise<any
  * @param flags The configuration flags passed into the Stencil command
  * @returns true if --debug has been passed, otherwise false
  */
-export function hasDebug(flags: ConfigFlags) {
+export function hasDebug(flags: ConfigFlags): boolean {
   return flags.debug;
 }
 
@@ -62,6 +62,6 @@ export function hasDebug(flags: ConfigFlags) {
  * @param flags The configuration flags passed into the Stencil command
  * @returns true if both --debug and --verbose have been passed, otherwise false
  */
-export function hasVerbose(flags: ConfigFlags) {
+export function hasVerbose(flags: ConfigFlags): boolean {
   return flags.verbose && hasDebug(flags);
 }

--- a/src/cli/telemetry/test/helpers.spec.ts
+++ b/src/cli/telemetry/test/helpers.spec.ts
@@ -1,21 +1,22 @@
 import { isInteractive, tryFn, uuidv4, hasDebug, hasVerbose } from '../helpers';
 import { createSystem } from '../../../compiler/sys/stencil-sys';
+import { createConfigFlags } from '../../config-flags';
 
 describe('hasDebug', () => {
   it('Returns true when a flag is passed', () => {
-    const flags = {
+    const flags = createConfigFlags({
       debug: true,
       verbose: false,
-    };
+    });
 
     expect(hasDebug(flags)).toBe(true);
   });
 
   it('Returns false when a flag is not passed', () => {
-    const flags = {
+    const flags = createConfigFlags({
       debug: false,
       verbose: false,
-    };
+    });
 
     expect(hasDebug(flags)).toBe(false);
   });
@@ -23,28 +24,28 @@ describe('hasDebug', () => {
 
 describe('hasVerbose', () => {
   it('Returns true when both flags are passed', () => {
-    const flags = {
+    const flags = createConfigFlags({
       debug: true,
       verbose: true,
-    };
+    });
 
     expect(hasVerbose(flags)).toBe(true);
   });
 
   it('Returns false when the verbose flag is passed, and debug is not', () => {
-    const flags = {
+    const flags = createConfigFlags({
       debug: false,
       verbose: true,
-    };
+    });
 
     expect(hasVerbose(flags)).toBe(false);
   });
 
   it('Returns false when the flag is not passed', () => {
-    const flags = {
+    const flags = createConfigFlags({
       debug: false,
       verbose: false,
-    };
+    });
 
     expect(hasVerbose(flags)).toBe(false);
   });
@@ -62,22 +63,22 @@ describe('isInteractive', () => {
   const sys = createSystem();
 
   it('returns false by default', () => {
-    const result = isInteractive(sys, { ci: false }, { ci: false, tty: false });
+    const result = isInteractive(sys, createConfigFlags({ ci: false }), { ci: false, tty: false });
     expect(result).toBe(false);
   });
 
   it('returns false when tty is false', () => {
-    const result = isInteractive(sys, { ci: true }, { ci: true, tty: false });
+    const result = isInteractive(sys, createConfigFlags({ ci: true }), { ci: true, tty: false });
     expect(result).toBe(false);
   });
 
   it('returns false when ci is true', () => {
-    const result = isInteractive(sys, { ci: true }, { ci: true, tty: true });
+    const result = isInteractive(sys, createConfigFlags({ ci: true }), { ci: true, tty: true });
     expect(result).toBe(false);
   });
 
   it('returns true when tty is true and ci is false', () => {
-    const result = isInteractive(sys, { ci: false }, { ci: false, tty: true });
+    const result = isInteractive(sys, createConfigFlags({ ci: false }), { ci: false, tty: true });
     expect(result).toBe(true);
   });
 });

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -6,6 +6,7 @@ import { mockLogger, mockValidatedConfig } from '@stencil/core/testing';
 import * as coreCompiler from '@stencil/core/compiler';
 import { anonymizeConfigForTelemetry } from '../telemetry';
 import { DIST, DIST_CUSTOM_ELEMENTS, DIST_HYDRATE_SCRIPT, WWW } from '../../../compiler/output-targets/output-utils';
+import { createConfigFlags } from '../../../cli/config-flags';
 
 describe('telemetryBuildFinishedAction', () => {
   let config: d.ValidatedConfig;
@@ -139,9 +140,7 @@ describe('prepareData', () => {
   beforeEach(() => {
     config = {
       outputTargets: [],
-      flags: {
-        args: [],
-      },
+      flags: createConfigFlags(),
       logger: mockLogger(),
     };
 
@@ -155,9 +154,7 @@ describe('prepareData', () => {
       build: coreCompiler.buildId,
       component_count: undefined,
       config: {
-        flags: {
-          args: [],
-        },
+        flags: createConfigFlags(),
         outputTargets: [],
       },
       cpu_model: '',
@@ -172,7 +169,7 @@ describe('prepareData', () => {
       system: 'in-memory __VERSION:STENCIL__',
       system_major: 'in-memory __VERSION:STENCIL__',
       targets: [],
-      task: undefined,
+      task: null,
       typescript: coreCompiler.versions.typescript,
       yarn: false,
     });
@@ -180,9 +177,7 @@ describe('prepareData', () => {
 
   it('updates when there is a PWA config', async () => {
     const config: d.ValidatedConfig = {
-      flags: {
-        args: [],
-      },
+      flags: createConfigFlags(),
       logger: mockLogger(),
       outputTargets: [{ type: 'www', baseUrl: 'https://example.com', serviceWorker: { swDest: './tmp' } }],
     };
@@ -196,6 +191,9 @@ describe('prepareData', () => {
       config: {
         flags: {
           args: [],
+          knownArgs: [],
+          task: null,
+          unknownArgs: [],
         },
         outputTargets: [
           {
@@ -219,7 +217,7 @@ describe('prepareData', () => {
       system: 'in-memory __VERSION:STENCIL__',
       system_major: 'in-memory __VERSION:STENCIL__',
       targets: ['www'],
-      task: undefined,
+      task: null,
       typescript: coreCompiler.versions.typescript,
       yarn: false,
     });
@@ -227,9 +225,7 @@ describe('prepareData', () => {
 
   it('updates when there is a component count passed in', async () => {
     const config: d.ValidatedConfig = {
-      flags: {
-        args: [],
-      },
+      flags: createConfigFlags(),
       logger: mockLogger(),
       outputTargets: [{ type: 'www', baseUrl: 'https://example.com', serviceWorker: { swDest: './tmp' } }],
     };
@@ -243,6 +239,9 @@ describe('prepareData', () => {
       config: {
         flags: {
           args: [],
+          knownArgs: [],
+          task: null,
+          unknownArgs: [],
         },
         outputTargets: [
           {
@@ -266,7 +265,7 @@ describe('prepareData', () => {
       system: 'in-memory __VERSION:STENCIL__',
       system_major: 'in-memory __VERSION:STENCIL__',
       targets: ['www'],
-      task: undefined,
+      task: null,
       typescript: coreCompiler.versions.typescript,
       yarn: false,
     });

--- a/src/cli/test/run.spec.ts
+++ b/src/cli/test/run.spec.ts
@@ -12,6 +12,7 @@ import * as ServeTask from '../task-serve';
 import * as TelemetryTask from '../task-telemetry';
 import * as TestTask from '../task-test';
 import { createTestingSystem } from '../../testing/testing-sys';
+import { createConfigFlags } from '../config-flags';
 
 describe('run', () => {
   describe('run()', () => {
@@ -35,11 +36,13 @@ describe('run', () => {
       };
 
       parseFlagsSpy = jest.spyOn(ParseFlags, 'parseFlags');
-      parseFlagsSpy.mockReturnValue({
-        // use the 'help' task as a reasonable default for all calls to this function.
-        // code paths that require a different task can always override this value as needed.
-        task: 'help',
-      });
+      parseFlagsSpy.mockReturnValue(
+        createConfigFlags({
+          // use the 'help' task as a reasonable default for all calls to this function.
+          // code paths that require a different task can always override this value as needed.
+          task: 'help',
+        })
+      );
     });
 
     afterEach(() => {
@@ -66,6 +69,8 @@ describe('run', () => {
           {
             task: 'help',
             args: [],
+            knownArgs: [],
+            unknownArgs: [],
           },
           mockLogger,
           mockSystem
@@ -75,9 +80,11 @@ describe('run', () => {
       });
 
       it("calls the help task when the 'help' field is set on flags", async () => {
-        parseFlagsSpy.mockReturnValue({
-          help: true,
-        });
+        parseFlagsSpy.mockReturnValue(
+          createConfigFlags({
+            help: true,
+          })
+        );
 
         await run(cliInitOptions);
 
@@ -86,6 +93,8 @@ describe('run', () => {
           {
             task: 'help',
             args: [],
+            unknownArgs: [],
+            knownArgs: [],
           },
           mockLogger,
           mockSystem
@@ -128,6 +137,9 @@ describe('run', () => {
 
       validatedConfig = mockConfig(sys);
       validatedConfig.outputTargets = [];
+
+      console.log('run.spec::beforeEach');
+      console.log(validatedConfig.flags);
 
       taskBuildSpy = jest.spyOn(BuildTask, 'taskBuild');
       taskBuildSpy.mockResolvedValue();
@@ -253,7 +265,7 @@ describe('run', () => {
       await runTask(coreCompiler, unvalidatedConfig, 'help', sys);
 
       expect(taskHelpSpy).toHaveBeenCalledTimes(1);
-      expect(taskHelpSpy).toHaveBeenCalledWith(validatedConfig.flags, validatedConfig.logger, sys);
+      expect(taskHelpSpy).toHaveBeenCalledWith(createConfigFlags({ task: 'help' }), validatedConfig.logger, sys);
     });
   });
 });

--- a/src/cli/test/run.spec.ts
+++ b/src/cli/test/run.spec.ts
@@ -138,9 +138,6 @@ describe('run', () => {
       validatedConfig = mockConfig(sys);
       validatedConfig.outputTargets = [];
 
-      console.log('run.spec::beforeEach');
-      console.log(validatedConfig.flags);
-
       taskBuildSpy = jest.spyOn(BuildTask, 'taskBuild');
       taskBuildSpy.mockResolvedValue();
 

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -1,4 +1,4 @@
-import type { Compiler, Config, Diagnostic } from '../declarations';
+import type { Compiler, Diagnostic, ValidatedConfig } from '../declarations';
 import { Cache } from './cache';
 import { CompilerContext } from './build/compiler-ctx';
 import { createFullBuild } from './build/full-build';
@@ -18,7 +18,7 @@ import ts from 'typescript';
  * @returns a new instance of a Stencil compiler
  * @public
  */
-export const createCompiler = async (userConfig: Config): Promise<Compiler> => {
+export const createCompiler = async (userConfig: ValidatedConfig): Promise<Compiler> => {
   // actual compiler code
   // could be in a web worker on the browser
   // or the main thread in node

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -1,4 +1,4 @@
-import type { Compiler, Diagnostic, ValidatedConfig } from '../declarations';
+import type { Compiler, Config, Diagnostic } from '../declarations';
 import { Cache } from './cache';
 import { CompilerContext } from './build/compiler-ctx';
 import { createFullBuild } from './build/full-build';
@@ -18,7 +18,7 @@ import ts from 'typescript';
  * @returns a new instance of a Stencil compiler
  * @public
  */
-export const createCompiler = async (userConfig: ValidatedConfig): Promise<Compiler> => {
+export const createCompiler = async (userConfig: Config): Promise<Compiler> => {
   // actual compiler code
   // could be in a web worker on the browser
   // or the main thread in node

--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -1,5 +1,6 @@
 import type * as d from '@stencil/core/declarations';
 import { mockLogger, mockCompilerSystem, mockLoadConfigInit } from '@stencil/core/testing';
+import { createConfigFlags } from '../../../cli/config-flags';
 import { isWatchIgnorePath } from '../../fs-watch/fs-watch-rebuild';
 import { DOCS_JSON, DOCS_CUSTOM, DOCS_README, DOCS_VSCODE } from '../../output-targets/output-utils';
 import { validateConfig } from '../validate-config';
@@ -28,26 +29,26 @@ describe('validation', () => {
     });
 
     it('serializes a provided "flags" object', () => {
-      userConfig.flags = { dev: false };
+      userConfig.flags = createConfigFlags({ dev: false });
       const { config } = validateConfig(userConfig, bootstrapConfig);
-      expect(config.flags).toEqual({ dev: false });
+      expect(config.flags).toEqual(createConfigFlags({ dev: false }));
     });
 
     describe('devMode', () => {
       it('defaults "devMode" to false when "flag.prod" is truthy', () => {
-        userConfig.flags = { prod: true };
+        userConfig.flags = createConfigFlags({ prod: true });
         const { config } = validateConfig(userConfig, bootstrapConfig);
         expect(config.devMode).toBe(false);
       });
 
       it('defaults "devMode" to true when "flag.dev" is truthy', () => {
-        userConfig.flags = { dev: true };
+        userConfig.flags = createConfigFlags({ dev: true });
         const { config } = validateConfig(userConfig, bootstrapConfig);
         expect(config.devMode).toBe(true);
       });
 
       it('defaults "devMode" to false when "flag.prod" & "flag.dev" are truthy', () => {
-        userConfig.flags = { dev: true, prod: true };
+        userConfig.flags = createConfigFlags({ dev: true, prod: true });
         const { config } = validateConfig(userConfig, bootstrapConfig);
         expect(config.devMode).toBe(false);
       });
@@ -436,7 +437,7 @@ describe('validation', () => {
 
   describe('buildDist', () => {
     it.each([true, false])('should set the field based on the config flag (%p)', (flag) => {
-      userConfig.flags = { esm: flag };
+      userConfig.flags = createConfigFlags({ esm: flag });
       const { config } = validateConfig(userConfig, bootstrapConfig);
       expect(config.buildDist).toBe(flag);
     });

--- a/src/compiler/config/test/validate-dev-server.spec.ts
+++ b/src/compiler/config/test/validate-dev-server.spec.ts
@@ -2,7 +2,7 @@ import type * as d from '../../../declarations';
 import { normalizePath } from '../../../utils';
 import { validateConfig } from '../validate-config';
 import path from 'path';
-import { ConfigFlags } from '../../../cli/config-flags';
+import { ConfigFlags, createConfigFlags } from '../../../cli/config-flags';
 import { mockLoadConfigInit } from '@stencil/core/testing';
 
 describe('validateDevServer', () => {
@@ -13,7 +13,7 @@ describe('validateDevServer', () => {
 
   beforeEach(() => {
     inputDevServerConfig = {};
-    flags = { serve: true };
+    flags = createConfigFlags({ serve: true });
     inputConfig = {
       sys: {} as any,
       rootDir: normalizePath(path.join(root, 'some', 'path')),
@@ -196,7 +196,7 @@ describe('validateDevServer', () => {
   });
 
   it('should set openBrowser from flag', () => {
-    inputConfig.flags = { open: false };
+    inputConfig.flags.open = false;
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.openBrowser).toBe(false);
   });

--- a/src/compiler/config/test/validate-docs.spec.ts
+++ b/src/compiler/config/test/validate-docs.spec.ts
@@ -10,7 +10,7 @@ describe('validateDocs', () => {
   });
 
   it('readme docs dir', () => {
-    userConfig.flags = { ...(userConfig.flags ?? {}), docs: true };
+    userConfig.flags.docs = true;
     userConfig.outputTargets = [
       {
         type: 'docs-readme',

--- a/src/compiler/config/test/validate-output-www.spec.ts
+++ b/src/compiler/config/test/validate-output-www.spec.ts
@@ -2,7 +2,7 @@ import type * as d from '@stencil/core/declarations';
 import { isOutputTargetCopy, isOutputTargetHydrate, isOutputTargetWww } from '../../output-targets/output-utils';
 import { validateConfig } from '../validate-config';
 import path from 'path';
-import { ConfigFlags } from '../../../cli/config-flags';
+import { ConfigFlags, createConfigFlags } from '../../../cli/config-flags';
 import { mockLoadConfigInit } from '@stencil/core/testing';
 
 describe('validateOutputTargetWww', () => {
@@ -11,7 +11,7 @@ describe('validateOutputTargetWww', () => {
   let flags: ConfigFlags;
 
   beforeEach(() => {
-    flags = {};
+    flags = createConfigFlags();
     userConfig = {
       rootDir: rootDir,
       flags,

--- a/src/compiler/config/test/validate-service-worker.spec.ts
+++ b/src/compiler/config/test/validate-service-worker.spec.ts
@@ -1,10 +1,12 @@
 import type * as d from '@stencil/core/declarations';
 import { OutputTargetWww } from '@stencil/core/declarations';
 import { mockCompilerSystem, mockLogger } from '@stencil/core/testing';
+import { createConfigFlags } from '../../../cli/config-flags';
 import { validateServiceWorker } from '../validate-service-worker';
 
 describe('validateServiceWorker', () => {
   let config: d.ValidatedConfig;
+
   let outputTarget: d.OutputTargetWww;
 
   beforeEach(() => {
@@ -12,7 +14,7 @@ describe('validateServiceWorker', () => {
       fsNamespace: 'app',
       sys: mockCompilerSystem(),
       devMode: false,
-      flags: {},
+      flags: createConfigFlags(),
       logger: mockLogger(),
     };
   });

--- a/src/compiler/config/test/validate-stats.spec.ts
+++ b/src/compiler/config/test/validate-stats.spec.ts
@@ -10,7 +10,7 @@ describe('validateStats', () => {
   });
 
   it('adds stats from flags, w/ no outputTargets', () => {
-    userConfig.flags = { ...(userConfig.flags ?? {}), stats: true };
+    userConfig.flags.stats = true;
 
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
     const o = config.outputTargets.find((o) => o.type === 'stats') as d.OutputTargetStats;

--- a/src/compiler/config/test/validate-testing.spec.ts
+++ b/src/compiler/config/test/validate-testing.spec.ts
@@ -2,7 +2,7 @@ import type * as d from '@stencil/core/declarations';
 import { mockLogger, mockCompilerSystem, mockLoadConfigInit } from '@stencil/core/testing';
 import { validateConfig } from '../validate-config';
 import path from 'path';
-import { ConfigFlags } from '../../../cli/config-flags';
+import { ConfigFlags, createConfigFlags } from '../../../cli/config-flags';
 
 describe('validateTesting', () => {
   const ROOT = path.resolve('/');
@@ -12,7 +12,7 @@ describe('validateTesting', () => {
   let flags: ConfigFlags;
 
   beforeEach(() => {
-    flags = {};
+    flags = createConfigFlags();
     userConfig = {
       sys: sys as any,
       logger: logger,

--- a/src/compiler/config/test/validate-workers.spec.ts
+++ b/src/compiler/config/test/validate-workers.spec.ts
@@ -2,6 +2,7 @@ import type * as d from '@stencil/core/declarations';
 import { validateConfig } from '../validate-config';
 import { mockLoadConfigInit, mockLogger } from '@stencil/core/testing';
 import path from 'path';
+import { createConfigFlags } from '../../../cli/config-flags';
 
 describe('validate-workers', () => {
   let userConfig: d.Config;
@@ -25,18 +26,18 @@ describe('validate-workers', () => {
   });
 
   it('set maxConcurrentWorkers from ci flags', () => {
-    userConfig.flags = {
+    userConfig.flags = createConfigFlags({
       ci: true,
-    };
+    });
     userConfig.maxConcurrentWorkers = 2;
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
     expect(config.maxConcurrentWorkers).toBe(4);
   });
 
   it('set maxConcurrentWorkers from flags', () => {
-    userConfig.flags = {
+    userConfig.flags = createConfigFlags({
       maxWorkers: 1,
-    };
+    });
     userConfig.maxConcurrentWorkers = 4;
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
     expect(config.maxConcurrentWorkers).toBe(1);

--- a/src/compiler/sys/config.ts
+++ b/src/compiler/sys/config.ts
@@ -2,11 +2,11 @@ import type * as d from '../../declarations';
 import { createLogger } from './logger/console-logger';
 import { createSystem } from './stencil-sys';
 import { setPlatformPath } from '../sys/modules/path';
+import { createConfigFlags } from '../../cli/config-flags';
 
 export const getConfig = (userConfig: d.Config): d.ValidatedConfig => {
-  const flags = userConfig.flags ?? {};
   const logger = userConfig.logger ?? createLogger();
-  const config: d.ValidatedConfig = { ...userConfig, flags, logger };
+  const config: d.ValidatedConfig = { ...userConfig, flags: createConfigFlags(userConfig.flags ?? {}), logger };
 
   if (!config.sys) {
     config.sys = createSystem({ logger: config.logger });

--- a/src/testing/jest/test/jest-runner.spec.ts
+++ b/src/testing/jest/test/jest-runner.spec.ts
@@ -1,5 +1,5 @@
 import type * as d from '@stencil/core/declarations';
-import { ConfigFlags } from '../../../cli/config-flags';
+import { ConfigFlags, createConfigFlags } from '../../../cli/config-flags';
 import { getEmulateConfigs, includeTestFile } from '../jest-runner';
 
 describe('jest-runner', () => {
@@ -75,9 +75,9 @@ describe('jest-runner', () => {
     const testing: d.TestingConfig = {
       emulate: [{ device: 'anDroiD' }, { device: 'iphone' }],
     };
-    const flags: ConfigFlags = {
+    const flags: ConfigFlags = createConfigFlags({
       emulate: 'Android',
-    };
+    });
     const emulateConfigs = getEmulateConfigs(testing, flags);
     expect(emulateConfigs).toHaveLength(1);
     expect(emulateConfigs[0].device).toBe('anDroiD');
@@ -87,9 +87,9 @@ describe('jest-runner', () => {
     const testing: d.TestingConfig = {
       emulate: [{ userAgent: 'Mozilla/Android' }, { userAgent: 'SomeUserAgent/iPhone X' }],
     };
-    const flags: ConfigFlags = {
+    const flags: ConfigFlags = createConfigFlags({
       emulate: 'android',
-    };
+    });
     const emulateConfigs = getEmulateConfigs(testing, flags);
     expect(emulateConfigs).toHaveLength(1);
     expect(emulateConfigs[0].userAgent).toBe('Mozilla/Android');
@@ -99,7 +99,7 @@ describe('jest-runner', () => {
     const testing: d.TestingConfig = {
       emulate: [{ device: 'android' }, { device: 'iphone' }],
     };
-    const flags: ConfigFlags = {};
+    const flags: ConfigFlags = createConfigFlags();
     const emulateConfigs = getEmulateConfigs(testing, flags);
     expect(emulateConfigs).toHaveLength(2);
   });

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -19,6 +19,7 @@ import { TestingLogger } from './testing-logger';
 import path from 'path';
 import { noop } from '@utils';
 import { buildEvents } from '../compiler/events';
+import { createConfigFlags } from '../cli/config-flags';
 
 // TODO(STENCIL-486): Update `mockValidatedConfig` to accept any property found on `ValidatedConfig`
 /**
@@ -30,7 +31,7 @@ import { buildEvents } from '../compiler/events';
 export function mockValidatedConfig(sys?: CompilerSystem): ValidatedConfig {
   const baseConfig = mockConfig(sys);
 
-  return { ...baseConfig, flags: {}, logger: mockLogger() };
+  return { ...baseConfig, flags: createConfigFlags(), logger: mockLogger() };
 }
 
 // TODO(STENCIL-486): Update `mockConfig` to accept any property found on `UnvalidatedConfig`
@@ -59,7 +60,7 @@ export function mockConfig(sys?: CompilerSystem): UnvalidatedConfig {
     enableCache: false,
     buildAppCore: false,
     buildDist: true,
-    flags: {},
+    flags: createConfigFlags(),
     bundles: null,
     outputTargets: null,
     buildEs5: false,


### PR DESCRIPTION
Removing the optional types on `ConfigFlags` lets us remove a few null
suppression errors here and there and removes some `strictNullChecks`
violations as well.

To make it easy to create a correctly-formed `ConfigFlags` object this
also introduces a `createConfigFlags` helper function which takes a
partial `ConfigFlags` object and returns one with default properties
set.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?

Basically this just cleans up the typing on the `ConfigFlags` object a little bit and introduced a helper function to make it easy to create correctly typed objects.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I just made sure everything is compiling and tests are passing.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
