### PR TITLE
chore(unused exports): remove unused export from validate-collection.ts

### DIFF
--- a/src/compiler/config/outputs/validate-collection.ts
+++ b/src/compiler/config/outputs/validate-collection.ts
@@ -1,22 +1,20 @@
 import type * as d from '../../../declarations';
 import { getAbsolutePath } from '../config-utils';
 import { isOutputTargetDistCollection } from '../../output-targets/output-utils';
-import { join } from 'path';
-import { normalizePath } from '@utils';
 
-export const validateCollection = (config: d.Config, userOutputs: d.OutputTarget[]) => {
-  return userOutputs.filter(isOutputTargetDistCollection).map((o) => {
+/**
+ * Validate and return DIST_COLLECTION output targets, ensuring that the `dir`
+ * property is set on them.
+ *
+ * @param config the user-supplied configuration object
+ * @param userOutputs an array of output targets
+ * @returns an array of validated DIST_COLLECTION output targets
+ */
+export const validateCollection = (config: d.Config, userOutputs: d.OutputTarget[]): d.OutputTargetDistCollection[] => {
+  return userOutputs.filter(isOutputTargetDistCollection).map((outputTarget) => {
     return {
-      ...o,
-      dir: getAbsolutePath(config, o.dir || 'dist/collection'),
+      ...outputTarget,
+      dir: getAbsolutePath(config, outputTarget.dir || 'dist/collection'),
     };
   });
-};
-
-export const getCollectionDistDir = (config: d.Config) => {
-  const collectionOutputTarget = config.outputTargets.find(isOutputTargetDistCollection);
-  if (collectionOutputTarget) {
-    return normalizePath(collectionOutputTarget.dir);
-  }
-  return normalizePath(join(config.rootDir, 'dist', 'collection'));
 };


### PR DESCRIPTION
We had a function called `getCollectionDistDir` defined in
`src/compiler/config/outputs/validate-collection.ts` which does not
appear to be used anywhere in the codebase.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

I removed a function that I couldn't find any uses of in the codebase, and added a JSDoc comment to the only other function remaining in the module.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
