### PR TITLE
chore(browserstack): add concurrency field

### DIFF
--- a/.github/workflows/test-browserstack.yml
+++ b/.github/workflows/test-browserstack.yml
@@ -41,6 +41,8 @@ jobs:
     name: Run Browserstack
     runs-on: ubuntu-latest
     needs: [ build_core ]
+
+    concurrency: run_browserstack_queue
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
         with:

--- a/.github/workflows/test-browserstack.yml
+++ b/.github/workflows/test-browserstack.yml
@@ -1,7 +1,7 @@
 name: BrowserStack Tests
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - 'main'
       - 'v3.0.0-dev'

--- a/.github/workflows/test-browserstack.yml
+++ b/.github/workflows/test-browserstack.yml
@@ -1,7 +1,7 @@
 name: BrowserStack Tests
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - 'main'
       - 'v3.0.0-dev'

--- a/.github/workflows/test-browserstack.yml
+++ b/.github/workflows/test-browserstack.yml
@@ -42,6 +42,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ build_core ]
 
+    # The concurrency field allows us to block multiple invocations of this job across multiple workflow runs.
+    # Stencil is only able to run 5 parallel tests in Browserstack, which is exceeded when more than one run of this
+    # workflow occurs - e.g. more than one pull request is submitted in proximity, a pull request and a merge to a
+    # branch that runs this workflow, etc.
+    #
+    # At this time, Karma is unable to properly wait for the queued Browserstack tests to finish. Instead, use the
+    # GitHub Actions 'concurrency' field as means to block the job until no other tests are running.
     concurrency: run_browserstack_queue
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See 'new behavior' section below

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit adds a concurrency string, 'run_browserstack_queue' to the
'run_browserstack' job in ci.

the name for the concurrency field was chosen to:
- make it easily identifiable as a part of running browswerstack
- not overlap with the name of the run_browserstack job completely to
   avoid any confusion when debugging in the future
    
this change prevents a condition in ci where two simultaneous browserstack 
runs are attempted at the same time. stencil's browserstack license only
allows for five parallel runs at a given time. as of the time of this
writing, stencil uses three browsers per run of browserstack. as a
result, two runs of the job will result in requesting more browsers than
our license permits. on the browserstack side, the extra run (number six
of the five) is queued to run once one of the five completes. however,
on the karma side things, we don't have a great way to check for these
queued jobs and poll until one is done. as a result, we experience
timeouts/disconnects with browserstack as a result of waiting for a
browser instance (that's queued) to start up. oftentimes, we hit a
jasmine/karma timeout of ~30_000 milliseconds.
    
with this change, we are able to continue to have the flexibility to
re-run just the browserstack tests, while blocking them from running
when we aren't sure that we can acquire all the necessary instances. it
should be noted that this does not handle cases where a developer is
tunneling into browserstack from their local machine



## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

First, I changed `pull_request_target` to `pull_request` to test this in CI.

Next, I pushed two PRs up - this one and https://github.com/ionic-team/stencil/pull/3467. I made sure they didn't have the same commit history, but did have the same contents (I think GH is smart enough to know that it's testing the same SHA otherwise and will only do one run of the various workflows).  I let the workflows run all the way through - the reason being is that the Browserstack workflows for `pull_request_target` were still going to run, and cause Browserstack resource contention otherwise (which will not exist once this PR is merged).

Then, I kicked off a Run of Browserstack in both PRs, to ensure that one awaited the other:
<img width="1426" alt="Screen Shot 2022-07-13 at 4 11 39 PM" src="https://user-images.githubusercontent.com/1930213/178827255-cf8d14d8-7937-48b9-9abf-bc97e8c7a824.png">

Once the first once completed, I observed the second one start. Once the second one had started, I kicked the first one back off to observe that one waiting. We did see the first one fail due to disconnects, but it's hard to get a good run in with other PRs not having the same blocking behavior 😆 I was able to get both to pass earlier in the day just fine, just the luck of the draw I suppose

## Other information

I have to revert the change of `pull_request_target` to `pull_request` before we land this
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
