### PR TITLE
fix(compiler): update package.json validation for the 'module' field

### DIFF
--- a/src/compiler/types/tests/validate-package-json.spec.ts
+++ b/src/compiler/types/tests/validate-package-json.spec.ts
@@ -123,7 +123,7 @@ describe('validate-package-json', () => {
       buildCtx.packageJson.module = 'dist/index.js';
       await v.validateModule(config, compilerCtx, buildCtx);
       expect(buildCtx.diagnostics).toHaveLength(1);
-      const [diagnostic] = buildCtx.diagnostics
+      const [diagnostic] = buildCtx.diagnostics;
       expect(diagnostic.level).toBe('warn');
       expect(diagnostic.messageText).toBe(
         `package.json "module" property is set to "dist/index.js". It's recommended to set the "module" property to: dist/components/index.js`
@@ -134,11 +134,9 @@ describe('validate-package-json', () => {
       config.outputTargets = [];
       await v.validateModule(config, compilerCtx, buildCtx);
       expect(buildCtx.diagnostics).toHaveLength(1);
-      const [diagnostic] = buildCtx.diagnostics
+      const [diagnostic] = buildCtx.diagnostics;
       expect(diagnostic.level).toBe('warn');
-      expect(diagnostic.messageText).toBe(
-        'package.json "module" property is required when generating a distribution.'
-      );      
+      expect(diagnostic.messageText).toBe('package.json "module" property is required when generating a distribution.');
     });
 
     it.each<{

--- a/src/compiler/types/tests/validate-package-json.spec.ts
+++ b/src/compiler/types/tests/validate-package-json.spec.ts
@@ -3,7 +3,7 @@ import { mockBuildCtx, mockCompilerCtx, mockConfig } from '@stencil/core/testing
 import * as v from '../validate-build-package-json';
 import path from 'path';
 import { DIST_COLLECTION, DIST_CUSTOM_ELEMENTS, DIST_CUSTOM_ELEMENTS_BUNDLE } from '../../output-targets/output-utils';
-import {normalizePath} from '../../../utils/normalize-path';
+import { normalizePath } from '../../../utils/normalize-path';
 
 describe('validate-package-json', () => {
   let config: d.Config;
@@ -174,7 +174,9 @@ describe('validate-package-json', () => {
       const [diagnostic] = buildCtx.diagnostics;
       expect(diagnostic.level).toBe('warn');
       expect(diagnostic.messageText).toBe(
-        `package.json "module" property is required when generating a distribution. It's recommended to set the "module" property to: ${normalizePath(path)}`
+        `package.json "module" property is required when generating a distribution. It's recommended to set the "module" property to: ${normalizePath(
+          path
+        )}`
       );
     });
   });

--- a/src/compiler/types/tests/validate-package-json.spec.ts
+++ b/src/compiler/types/tests/validate-package-json.spec.ts
@@ -123,12 +123,22 @@ describe('validate-package-json', () => {
       buildCtx.packageJson.module = 'dist/index.js';
       await v.validateModule(config, compilerCtx, buildCtx);
       expect(buildCtx.diagnostics).toHaveLength(1);
+      const [diagnostic] = buildCtx.diagnostics
+      expect(diagnostic.level).toBe('warn');
+      expect(diagnostic.messageText).toBe(
+        `package.json "module" property is set to "dist/index.js". It's recommended to set the "module" property to: dist/components/index.js`
+      );
     });
 
     it('missing dist module', async () => {
       config.outputTargets = [];
       await v.validateModule(config, compilerCtx, buildCtx);
       expect(buildCtx.diagnostics).toHaveLength(1);
+      const [diagnostic] = buildCtx.diagnostics
+      expect(diagnostic.level).toBe('warn');
+      expect(diagnostic.messageText).toBe(
+        'package.json "module" property is required when generating a distribution.'
+      );      
     });
 
     it.each<{

--- a/src/compiler/types/tests/validate-package-json.spec.ts
+++ b/src/compiler/types/tests/validate-package-json.spec.ts
@@ -3,6 +3,7 @@ import { mockBuildCtx, mockCompilerCtx, mockConfig } from '@stencil/core/testing
 import * as v from '../validate-build-package-json';
 import path from 'path';
 import { DIST_COLLECTION, DIST_CUSTOM_ELEMENTS, DIST_CUSTOM_ELEMENTS_BUNDLE } from '../../output-targets/output-utils';
+import {normalizePath} from '../../../utils/normalize-path';
 
 describe('validate-package-json', () => {
   let config: d.Config;
@@ -126,7 +127,7 @@ describe('validate-package-json', () => {
       const [diagnostic] = buildCtx.diagnostics;
       expect(diagnostic.level).toBe('warn');
       expect(diagnostic.messageText).toBe(
-        `package.json "module" property is set to "dist/index.js". It's recommended to set the "module" property to: dist/components/index.js`
+        `package.json "module" property is set to "dist/index.js". It's recommended to set the "module" property to: ./dist/components/index.js`
       );
     });
 
@@ -173,7 +174,7 @@ describe('validate-package-json', () => {
       const [diagnostic] = buildCtx.diagnostics;
       expect(diagnostic.level).toBe('warn');
       expect(diagnostic.messageText).toBe(
-        `package.json "module" property is required when generating a distribution. It's recommended to set the "module" property to: ${path}`
+        `package.json "module" property is required when generating a distribution. It's recommended to set the "module" property to: ${normalizePath(path)}`
       );
     });
   });

--- a/src/compiler/types/validate-build-package-json.ts
+++ b/src/compiler/types/validate-build-package-json.ts
@@ -164,7 +164,9 @@ export const validateModule = async (config: d.Config, compilerCtx: d.CompilerCt
   }
 
   if (recommendedRelPath !== null && normalizePath(recommendedRelPath) !== normalizePath(currentModule)) {
-    const msg = `package.json "module" property is set to "${currentModule}". It's recommended to set the "module" property to: ${normalizePath(recommendedRelPath)}`;
+    const msg = `package.json "module" property is set to "${currentModule}". It's recommended to set the "module" property to: ${normalizePath(
+      recommendedRelPath
+    )}`;
     packageJsonWarn(config, compilerCtx, buildCtx, msg, `"module"`);
   }
 };

--- a/src/compiler/types/validate-build-package-json.ts
+++ b/src/compiler/types/validate-build-package-json.ts
@@ -14,7 +14,7 @@ import {
  *
  * @param config the user-supplied Stencil config
  * @param compilerCtx the compiler context
- * @paran the build context
+ * @param buildCtx the build context
  * @returns an empty Promise
  */
 export const validateBuildPackageJson = async (config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
@@ -189,8 +189,6 @@ function recommendedModulePath(config: d.Config): string | null {
   }
 
   if (customElementsBundleOutput) {
-    const distAbs = join(customElementsBundleOutput.dir, 'index.js');
-    const distRel = relative(config.rootDir, distAbs);
     const customElementsAbs = join(customElementsBundleOutput.dir, 'index.js');
     return relative(config.rootDir, customElementsAbs);
   }
@@ -268,7 +266,6 @@ export const validateCollection = (
  * @param config the stencil config
  * @param compilerCtx the current compiler context
  * @param buildCtx the current build context
- * @param outputTarget a DIST_COLLECTION output target
  */
 export const validateBrowser = (config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
   if (isString(buildCtx.packageJson.browser)) {

--- a/src/compiler/types/validate-build-package-json.ts
+++ b/src/compiler/types/validate-build-package-json.ts
@@ -157,14 +157,14 @@ export const validateModule = async (config: d.Config, compilerCtx: d.CompilerCt
     let msg = 'package.json "module" property is required when generating a distribution.';
 
     if (recommendedRelPath !== null) {
-      msg += ` It's recommended to set the "module" property to: ${recommendedRelPath}`;
+      msg += ` It's recommended to set the "module" property to: ${normalizePath(recommendedRelPath)}`;
     }
     packageJsonWarn(config, compilerCtx, buildCtx, msg, `"module"`);
     return;
   }
 
   if (recommendedRelPath !== null && normalizePath(recommendedRelPath) !== normalizePath(currentModule)) {
-    const msg = `package.json "module" property is set to "${currentModule}". It's recommended to set the "module" property to: ${recommendedRelPath}`;
+    const msg = `package.json "module" property is set to "${currentModule}". It's recommended to set the "module" property to: ${normalizePath(recommendedRelPath)}`;
     packageJsonWarn(config, compilerCtx, buildCtx, msg, `"module"`);
   }
 };

--- a/src/compiler/types/validate-build-package-json.ts
+++ b/src/compiler/types/validate-build-package-json.ts
@@ -153,7 +153,6 @@ export const validateModule = async (config: d.Config, compilerCtx: d.CompilerCt
   const recommendedRelPath = recommendedModulePath(config);
 
   if (!isString(currentModule)) {
-    // TODO should this change?
     let msg = 'package.json "module" property is required when generating a distribution.';
 
     if (recommendedRelPath !== null) {

--- a/src/compiler/types/validate-build-package-json.ts
+++ b/src/compiler/types/validate-build-package-json.ts
@@ -152,7 +152,7 @@ export const validateModule = async (config: d.Config, compilerCtx: d.CompilerCt
     let msg = 'package.json "module" property is required when generating a distribution.';
 
     if (recommendedRelPath !== null) {
-      msg += `It's recommended to set the "module" property to: ${recommendedRelPath}`;
+      msg += ` It's recommended to set the "module" property to: ${recommendedRelPath}`;
     }
     packageJsonWarn(config, compilerCtx, buildCtx, msg, `"module"`);
     return;

--- a/src/compiler/types/validate-build-package-json.ts
+++ b/src/compiler/types/validate-build-package-json.ts
@@ -158,7 +158,7 @@ export const validateModule = async (config: d.Config, compilerCtx: d.CompilerCt
     return;
   }
 
-  if (recommendedRelPath !== null && recommendedRelPath !== currentModule) {
+  if (recommendedRelPath !== null && normalizePath(recommendedRelPath) !== normalizePath(currentModule)) {
     const msg = `package.json "module" property is set to "${currentModule}". It's recommended to set the "module" property to: ${recommendedRelPath}`;
     packageJsonWarn(config, compilerCtx, buildCtx, msg, `"module"`);
   }

--- a/src/utils/message-utils.ts
+++ b/src/utils/message-utils.ts
@@ -55,25 +55,38 @@ export const buildWarn = (diagnostics: d.Diagnostic[]): d.Diagnostic => {
   return diagnostic;
 };
 
+/**
+ * Create a diagnostic message suited for representing an error in a JSON
+ * file. This includes information about the exact lines in the JSON file which
+ * caused the error and the path to the file.
+ *
+ * @param compilerCtx the current compiler context
+ * @param diagnostics a list of diagnostics used as an return param
+ * @param jsonFilePath the path to the JSON file where the error occurred
+ * @param msg the error message
+ * @param jsonField the key for the field which caused the error, used for finding
+ * the error line in the original JSON file
+ * @returns a reference to the newly-created diagnostic
+ */
 export const buildJsonFileError = (
   compilerCtx: d.CompilerCtx,
   diagnostics: d.Diagnostic[],
   jsonFilePath: string,
   msg: string,
-  pkgKey: string
+  jsonField: string
 ) => {
   const err = buildError(diagnostics);
   err.messageText = msg;
   err.absFilePath = jsonFilePath;
 
-  if (typeof pkgKey === 'string') {
+  if (typeof jsonField === 'string') {
     try {
       const jsonStr = compilerCtx.fs.readFileSync(jsonFilePath);
       const lines = jsonStr.replace(/\r/g, '\n').split('\n');
 
       for (let i = 0; i < lines.length; i++) {
         const txtLine = lines[i];
-        const txtIndex = txtLine.indexOf(pkgKey);
+        const txtIndex = txtLine.indexOf(jsonField);
 
         if (txtIndex > -1) {
           const warnLine: d.PrintLine = {
@@ -81,7 +94,7 @@ export const buildJsonFileError = (
             lineNumber: i + 1,
             text: txtLine,
             errorCharStart: txtIndex,
-            errorLength: pkgKey.length,
+            errorLength: jsonField.length,
           };
           err.lineNumber = warnLine.lineNumber;
           err.columnNumber = txtIndex + 1;

--- a/src/utils/message-utils.ts
+++ b/src/utils/message-utils.ts
@@ -61,7 +61,7 @@ export const buildWarn = (diagnostics: d.Diagnostic[]): d.Diagnostic => {
  * caused the error and the path to the file.
  *
  * @param compilerCtx the current compiler context
- * @param diagnostics a list of diagnostics used as an return param
+ * @param diagnostics a list of diagnostics used as a return param
  * @param jsonFilePath the path to the JSON file where the error occurred
  * @param msg the error message
  * @param jsonField the key for the field which caused the error, used for finding


### PR DESCRIPTION
This updates the validation around the `module` field in `package.json`
to take the configured output targets into account. In particular, for
`DIST_CUSTOM_ELEMENTS_BUNDLE` it should be something like
`dist/index.js`, whereas for `DIST_CUSTOM_ELEMENTS` it should be
something like `dist/components/index.js`.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

Currently if you are using the `DIST_CUSTOM_ELEMENTS` output target we recommend setting the `module` field in the project's `package.json` field to `dist/components/index.js`, the path to the file where we re-export all of the components in the project.

This works great for importing these components in other projects, but, unfortunately, if you also have `DIST_CUSTOM_ELEMENTS_BUNDLE` configured you will get an inaccurate error message telling you to change the `module` field to something else (see #3438 for an example).


## What is the new behavior?

This changes our `package.json` validation to take the configured output targets into account. Basically:

- if the user has `DIST_CUSTOM_ELEMENTS` configured we don't raised issues related to the `DIST_CUSTOM_ELEMENTS_BUNDLE` OT. Since `DIST_CUSTOM_ELEMENTS` is the future we assume that this should define the rules for validation like this
- some of the logic for figuring out what the correct path should be is refactored a bit for clarity and so on
- comments and whatnot are added to the relevant files
- some changes to tests to reflect the change

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
