### PR TITLE
chore(compiler): make outputTargets required on the ValidatedConfig

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -75,7 +75,7 @@ export const run = async (init: d.CliInitOptions) => {
     loadedCompilerLog(sys, logger, flags, coreCompiler);
 
     if (task === 'info') {
-      await telemetryAction(sys, { flags: createConfigFlags({ task: 'info' }), logger }, coreCompiler, async () => {
+      await telemetryAction(sys, { flags: createConfigFlags({ task: 'info' }), logger, outputTargets: [] }, coreCompiler, async () => {
         await taskInfo(coreCompiler, sys, logger);
       });
       return;
@@ -122,9 +122,7 @@ export const runTask = async (
   sys?: d.CompilerSystem
 ) => {
   const logger = config.logger ?? createLogger();
-  const strictConfig: ValidatedConfig = { ...config, flags: createConfigFlags(config.flags ?? { task }), logger };
-
-  strictConfig.outputTargets = strictConfig.outputTargets || [];
+  const strictConfig: ValidatedConfig = { ...config, flags: createConfigFlags(config.flags ?? { task }), logger, outputTargets: config.outputTargets ?? [] };
 
   switch (task) {
     case 'build':

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -75,9 +75,14 @@ export const run = async (init: d.CliInitOptions) => {
     loadedCompilerLog(sys, logger, flags, coreCompiler);
 
     if (task === 'info') {
-      await telemetryAction(sys, { flags: createConfigFlags({ task: 'info' }), logger, outputTargets: [] }, coreCompiler, async () => {
-        await taskInfo(coreCompiler, sys, logger);
-      });
+      await telemetryAction(
+        sys,
+        { flags: createConfigFlags({ task: 'info' }), logger, outputTargets: [] },
+        coreCompiler,
+        async () => {
+          await taskInfo(coreCompiler, sys, logger);
+        }
+      );
       return;
     }
 
@@ -122,7 +127,12 @@ export const runTask = async (
   sys?: d.CompilerSystem
 ) => {
   const logger = config.logger ?? createLogger();
-  const strictConfig: ValidatedConfig = { ...config, flags: createConfigFlags(config.flags ?? { task }), logger, outputTargets: config.outputTargets ?? [] };
+  const strictConfig: ValidatedConfig = {
+    ...config,
+    flags: createConfigFlags(config.flags ?? { task }),
+    logger,
+    outputTargets: config.outputTargets ?? [],
+  };
 
   switch (task) {
     case 'build':

--- a/src/compiler/config/test/validate-service-worker.spec.ts
+++ b/src/compiler/config/test/validate-service-worker.spec.ts
@@ -16,6 +16,7 @@ describe('validateServiceWorker', () => {
       devMode: false,
       flags: createConfigFlags(),
       logger: mockLogger(),
+      outputTargets: []
     };
   });
 

--- a/src/compiler/config/test/validate-service-worker.spec.ts
+++ b/src/compiler/config/test/validate-service-worker.spec.ts
@@ -16,7 +16,7 @@ describe('validateServiceWorker', () => {
       devMode: false,
       flags: createConfigFlags(),
       logger: mockLogger(),
-      outputTargets: []
+      outputTargets: [],
     };
   });
 

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -51,7 +51,7 @@ export const validateConfig = (
     // flags _should_ be JSON safe
     flags: JSON.parse(JSON.stringify(config.flags || {})),
     logger,
-    outputTargets: config.outputTargets ?? []
+    outputTargets: config.outputTargets ?? [],
   };
 
   // default devMode false

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -51,6 +51,7 @@ export const validateConfig = (
     // flags _should_ be JSON safe
     flags: JSON.parse(JSON.stringify(config.flags || {})),
     logger,
+    outputTargets: config.outputTargets ?? []
   };
 
   // default devMode false

--- a/src/compiler/output-targets/dist-custom-elements/custom-elements-types.ts
+++ b/src/compiler/output-targets/dist-custom-elements/custom-elements-types.ts
@@ -12,12 +12,12 @@ import { normalizePath, dashToPascalCase } from '@utils';
  * @param typesDir the path to the directory where type declarations are saved
  */
 export const generateCustomElementsTypes = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   typesDir: string
 ): Promise<void> => {
-  const outputTargets = (config.outputTargets ?? []).filter(isOutputTargetDistCustomElements);
+  const outputTargets = config.outputTargets.filter(isOutputTargetDistCustomElements);
 
   await Promise.all(
     outputTargets.map((outputTarget) =>
@@ -36,7 +36,7 @@ export const generateCustomElementsTypes = async (
  * @param outputTarget the output target for which types are being currently generated
  */
 const generateCustomElementsTypesOutput = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   typesDir: string,

--- a/src/compiler/output-targets/dist-custom-elements/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements/index.ts
@@ -97,9 +97,9 @@ export const getBundleOptions = (
  * Get bundle options for rollup, run the rollup build, optionally minify the
  * output, and write files to disk.
  *
- * @param the validated Stencil configuration we're using
- * @param buildCtx the current build context
+ * @param config the validated Stencil configuration we're using
  * @param compilerCtx the current compiler context
+ * @param buildCtx the current build context
  * @param outputTarget the outputTarget we're currently dealing with
  * @returns an empty promise
  */

--- a/src/compiler/output-targets/dist-custom-elements/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements/index.ts
@@ -28,7 +28,7 @@ import ts from 'typescript';
  * which do actual work of generating the rollup configuration, creating an
  * entry chunk, running, the build, etc.
  *
- * @param config the user-supplied compiler configuration we're using
+ * @param config the validated compiler configuration we're using
  * @param compilerCtx the current compiler context
  * @param buildCtx the current build context
  * @returns an empty Promise which won't resolve until the work is done!
@@ -59,7 +59,7 @@ export const outputCustomElements = async (
  * Get bundle options for our current build and compiler context which we'll use
  * to generate a Rollup build and so on.
  *
- * @param config user-supplied Stencil configuration
+ * @param config a validated Stencil configuration object
  * @param buildCtx the current build context
  * @param compilerCtx the current compiler context
  * @param outputTarget the outputTarget we're currently dealing with
@@ -96,13 +96,13 @@ export const getBundleOptions = (
 /**
  * Get bundle options for rollup, run the rollup build, optionally minify the
  * output, and write files to disk.
- * @param config user-supplied Stencil configuration
+ *
+ * @param the validated Stencil configuration we're using
  * @param buildCtx the current build context
  * @param compilerCtx the current compiler context
  * @param outputTarget the outputTarget we're currently dealing with
  * @returns an empty promise
  */
-
 export const bundleCustomElements = async (
   config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,

--- a/src/compiler/output-targets/dist-custom-elements/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements/index.ts
@@ -34,7 +34,7 @@ import ts from 'typescript';
  * @returns an empty Promise which won't resolve until the work is done!
  */
 export const outputCustomElements = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx
 ): Promise<void> => {
@@ -42,7 +42,7 @@ export const outputCustomElements = async (
     return;
   }
 
-  const outputTargets = (config.outputTargets ?? []).filter(isOutputTargetDistCustomElements);
+  const outputTargets = config.outputTargets.filter(isOutputTargetDistCustomElements);
   if (outputTargets.length === 0) {
     return;
   }
@@ -66,7 +66,7 @@ export const outputCustomElements = async (
  * @returns bundle options suitable for generating a rollup configuration
  */
 export const getBundleOptions = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   buildCtx: d.BuildCtx,
   compilerCtx: d.CompilerCtx,
   outputTarget: d.OutputTargetDistCustomElements
@@ -104,7 +104,7 @@ export const getBundleOptions = (
  */
 
 export const bundleCustomElements = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   outputTarget: d.OutputTargetDistCustomElements

--- a/src/compiler/output-targets/output-types.ts
+++ b/src/compiler/output-targets/output-types.ts
@@ -9,7 +9,7 @@ import { isOutputTargetDistTypes } from './output-utils';
  * @param buildCtx the context associated with the current build
  */
 export const outputTypes = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx
 ): Promise<void> => {

--- a/src/compiler/output-targets/test/custom-elements-types.spec.ts
+++ b/src/compiler/output-targets/test/custom-elements-types.spec.ts
@@ -1,5 +1,5 @@
 import { path } from '@stencil/core/compiler';
-import { mockConfig, mockCompilerSystem, mockBuildCtx, mockCompilerCtx, mockModule } from '@stencil/core/testing';
+import { mockCompilerSystem, mockBuildCtx, mockCompilerCtx, mockModule, mockValidatedConfig } from '@stencil/core/testing';
 import type * as d from '../../../declarations';
 import * as outputCustomElementsMod from '../dist-custom-elements';
 import { stubComponentCompilerMeta } from '../../types/tests/ComponentCompilerMeta.stub';
@@ -9,7 +9,7 @@ import { join, relative } from 'path';
 
 const setup = () => {
   const sys = mockCompilerSystem();
-  const config: d.Config = mockConfig(sys);
+  const config: d.ValidatedConfig = mockValidatedConfig(sys);
   const compilerCtx = mockCompilerCtx(config);
   const buildCtx = mockBuildCtx(config, compilerCtx);
   const root = config.rootDir;

--- a/src/compiler/output-targets/test/custom-elements-types.spec.ts
+++ b/src/compiler/output-targets/test/custom-elements-types.spec.ts
@@ -1,5 +1,11 @@
 import { path } from '@stencil/core/compiler';
-import { mockCompilerSystem, mockBuildCtx, mockCompilerCtx, mockModule, mockValidatedConfig } from '@stencil/core/testing';
+import {
+  mockCompilerSystem,
+  mockBuildCtx,
+  mockCompilerCtx,
+  mockModule,
+  mockValidatedConfig,
+} from '@stencil/core/testing';
 import type * as d from '../../../declarations';
 import * as outputCustomElementsMod from '../dist-custom-elements';
 import { stubComponentCompilerMeta } from '../../types/tests/ComponentCompilerMeta.stub';

--- a/src/compiler/output-targets/test/output-targets-dist-custom-elements.spec.ts
+++ b/src/compiler/output-targets/test/output-targets-dist-custom-elements.spec.ts
@@ -1,5 +1,11 @@
 import { path } from '@stencil/core/compiler';
-import { mockCompilerSystem, mockBuildCtx, mockCompilerCtx, mockModule, mockValidatedConfig } from '@stencil/core/testing';
+import {
+  mockCompilerSystem,
+  mockBuildCtx,
+  mockCompilerCtx,
+  mockModule,
+  mockValidatedConfig,
+} from '@stencil/core/testing';
 import type * as d from '../../../declarations';
 import {
   addCustomElementInputs,

--- a/src/compiler/output-targets/test/output-targets-dist-custom-elements.spec.ts
+++ b/src/compiler/output-targets/test/output-targets-dist-custom-elements.spec.ts
@@ -1,5 +1,5 @@
 import { path } from '@stencil/core/compiler';
-import { mockConfig, mockCompilerSystem, mockBuildCtx, mockCompilerCtx, mockModule } from '@stencil/core/testing';
+import { mockCompilerSystem, mockBuildCtx, mockCompilerCtx, mockModule, mockValidatedConfig } from '@stencil/core/testing';
 import type * as d from '../../../declarations';
 import {
   addCustomElementInputs,
@@ -16,7 +16,7 @@ import { DIST_CUSTOM_ELEMENTS, DIST_CUSTOM_ELEMENTS_BUNDLE } from '../output-uti
 
 const setup = () => {
   const sys = mockCompilerSystem();
-  const config: d.Config = mockConfig(sys);
+  const config: d.ValidatedConfig = mockValidatedConfig(sys);
   const compilerCtx = mockCompilerCtx(config);
   const buildCtx = mockBuildCtx(config, compilerCtx);
   const root = config.rootDir;

--- a/src/compiler/sys/config.ts
+++ b/src/compiler/sys/config.ts
@@ -6,7 +6,12 @@ import { createConfigFlags } from '../../cli/config-flags';
 
 export const getConfig = (userConfig: d.Config): d.ValidatedConfig => {
   const logger = userConfig.logger ?? createLogger();
-  const config: d.ValidatedConfig = { ...userConfig, flags: createConfigFlags(userConfig.flags ?? {}), logger, outputTargets: userConfig.outputTargets ?? [] };
+  const config: d.ValidatedConfig = {
+    ...userConfig,
+    flags: createConfigFlags(userConfig.flags ?? {}),
+    logger,
+    outputTargets: userConfig.outputTargets ?? [],
+  };
 
   if (!config.sys) {
     config.sys = createSystem({ logger: config.logger });

--- a/src/compiler/sys/config.ts
+++ b/src/compiler/sys/config.ts
@@ -6,7 +6,7 @@ import { createConfigFlags } from '../../cli/config-flags';
 
 export const getConfig = (userConfig: d.Config): d.ValidatedConfig => {
   const logger = userConfig.logger ?? createLogger();
-  const config: d.ValidatedConfig = { ...userConfig, flags: createConfigFlags(userConfig.flags ?? {}), logger };
+  const config: d.ValidatedConfig = { ...userConfig, flags: createConfigFlags(userConfig.flags ?? {}), logger, outputTargets: userConfig.outputTargets ?? [] };
 
   if (!config.sys) {
     config.sys = createSystem({ logger: config.logger });

--- a/src/compiler/types/generate-types.ts
+++ b/src/compiler/types/generate-types.ts
@@ -14,7 +14,7 @@ import { isDtsFile } from '@utils';
  * @param outputTarget the output target to generate types for
  */
 export const generateTypes = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   outputTarget: d.OutputTargetDistTypes
@@ -33,7 +33,7 @@ export const generateTypes = async (
  * @param outputTarget the output target to generate types for
  */
 const generateTypesOutput = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   outputTarget: d.OutputTargetDistTypes

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -409,7 +409,7 @@ type RequireFields<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 /**
  * Fields in {@link Config} to make required for {@link ValidatedConfig}
  */
-type StrictConfigFields = 'flags' | 'logger';
+type StrictConfigFields = 'flags' | 'logger' | 'outputTargets';
 
 /**
  * A version of {@link Config} that makes certain fields required. This type represents a valid configuration entity.

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -31,7 +31,12 @@ import { createConfigFlags } from '../cli/config-flags';
 export function mockValidatedConfig(sys?: CompilerSystem): ValidatedConfig {
   const baseConfig = mockConfig(sys);
 
-  return { ...baseConfig, flags: createConfigFlags(), logger: mockLogger(), outputTargets: baseConfig.outputTargets ?? [] };
+  return {
+    ...baseConfig,
+    flags: createConfigFlags(),
+    logger: mockLogger(),
+    outputTargets: baseConfig.outputTargets ?? [],
+  };
 }
 
 // TODO(STENCIL-486): Update `mockConfig` to accept any property found on `UnvalidatedConfig`

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -31,7 +31,7 @@ import { createConfigFlags } from '../cli/config-flags';
 export function mockValidatedConfig(sys?: CompilerSystem): ValidatedConfig {
   const baseConfig = mockConfig(sys);
 
-  return { ...baseConfig, flags: createConfigFlags(), logger: mockLogger() };
+  return { ...baseConfig, flags: createConfigFlags(), logger: mockLogger(), outputTargets: baseConfig.outputTargets ?? [] };
 }
 
 // TODO(STENCIL-486): Update `mockConfig` to accept any property found on `UnvalidatedConfig`


### PR DESCRIPTION
This makes the `outputTargets` field required on the `ValidatedConfig`
type, allowing us to freely access `.outputTargets` on a validated
configuration object in the compiler code without having to use the `!`
operator, check `=== undefined`, etc.

This includes changes to the places where a `ValidatedConfig` object is
created to default `.outputTargets` to `[]` if no suitable value is
present.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

`.outputTargets` is currently not a required field on our `ValidatedConfig` type, which means that we get a null check error every place we access this (very commonly accessed!) property, unless we do `.outputTargets ?? []` or something of the sort everywhere.

We also have a few places where, due to the callstack, a `ValidatedConfig` is _actually_ what's being passed around, but we haven't updated type signatures to reflect that yet.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

`.outputTargets` is now a required field for `ValidatedConfig` and the type is changed from `d.Config` to `d.ValidatedConfig` in a few places. This does not eliminate every site where we could go from `d.Config` -> `d.ValidatedConfig` but just does to a few which are sort of relevant to the `.outputTargets` change.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
