### PR TITLE
fix(mock-doc): add missing methods to the element mock

### DIFF
--- a/src/mock-doc/node.ts
+++ b/src/mock-doc/node.ts
@@ -715,6 +715,9 @@ export class MockElement extends MockNode {
     this.setAttributeNS(null, 'title', value);
   }
 
+  animate() {
+    /**/
+  }
   onanimationstart() {
     /**/
   }
@@ -977,6 +980,18 @@ export class MockElement extends MockNode {
     /**/
   }
   onwheel() {
+    /**/
+  }
+  requestFullscreen() {
+    /**/
+  }
+  scrollBy() {
+    /**/
+  }
+  scrollTo() {
+    /**/
+  }
+  scrollIntoView() {
     /**/
   }
 


### PR DESCRIPTION
NOTE: I have previously created issues and example repositories but since this is a really small PR that does not impact any users directly, I feel that this can be done without an accompanied issue. If you feel differently about this, do say so.

Add missing methods to the mock-doc MockElement class.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
The methods that have been added were missing, causing errors.

GitHub Issue Number: N/A


## What is the new behavior?
No error is thrown when your component uses any of the methods while running unit tests.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

