### PR TITLE
fix(cli): fix bug with parsing --fooBar=baz type CLI flags 

### DIFF
--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -51,9 +51,13 @@ export const parseFlags = (args: string[], sys?: CompilerSystem): ConfigFlags =>
     }
   }
 
-  flags.unknownArgs = flags.args.filter((arg: string) => {
-    return !flags.knownArgs.includes(arg);
-  });
+  // to find unknown / unrecognized arguments we filter `args`, including only
+  // arguments whose normalized form is not found in `knownArgs`. `knownArgs`
+  // is populated during the call to `parseArgs` above. For arguments like
+  // `--foobar` the string `"--foobar"` will be added, while for more
+  // complicated arguments like `--bizBoz=bop` or `--bizBoz bop` just the
+  // string `"--bizBoz"` will be added.
+  flags.unknownArgs = flags.args.filter((arg: string) => !flags.knownArgs.includes(parseEqualsArg(arg)[0]));
 
   return flags;
 };
@@ -259,17 +263,18 @@ const getValue = (
 
   let value: string | undefined;
   let matchingArg: string | undefined;
+
   args.forEach((arg, i) => {
     if (arg.startsWith(`--${dashCaseName}=`) || arg.startsWith(`--${configCaseName}=`)) {
-      value = getEqualsValue(arg);
-      matchingArg = arg;
+      // our argument was passed at the command-line in the format --argName=arg-value
+      [matchingArg, value] = parseEqualsArg(arg);
     } else if (arg === `--${dashCaseName}` || arg === `--${configCaseName}`) {
+      // the next value in the array is assumed to be a value for this argument
       value = args[i + 1];
       matchingArg = arg;
     } else if (alias) {
       if (arg.startsWith(`-${alias}=`)) {
-        value = getEqualsValue(arg);
-        matchingArg = arg;
+        [matchingArg, value] = parseEqualsArg(arg);
       } else if (arg === `-${alias}`) {
         value = args[i + 1];
         matchingArg = arg;
@@ -287,13 +292,43 @@ interface CLIArgValue {
 }
 
 /**
- * When a parameter is set in the format `--foobar=12` at the CLI (as opposed to
- * `--foobar 12`) we want to get the value after the `=` sign
+ * Parse an 'equals' argument, which is a CLI argument-value pair in the
+ * format `--foobar=12` (as opposed to the space-separated format `--foobar
+ * 12`).
  *
- * @param commandArgument the arg in question
- * @returns the value after the `=`
+ * To parse this we split on the `=`, returning the first part as the argument
+ * name and the second part as the value. We join the value on `"="` in case
+ * there is another `"="` in the argument.
+ *
+ * This function is safe to call with any arg, and can therefore be used as
+ * an argument 'normalizer'. If CLI argument is not an 'equals' argument then
+ * the return value will be a tuple of the original argument and an empty
+ * string `""` for the value.
+ *
+ * In code terms, if you do:
+ *
+ * ```ts
+ * const [arg, value] = parseEqualsArg("--myArgument")
+ * ```
+ *
+ * Then `arg` will be `"--myArgument"` and `value` will be `""`, whereas if
+ * you do:
+ *
+ *
+ * ```ts
+ * const [arg, value] = parseEqualsArg("--myArgument=myValue")
+ * ```
+ *
+ * Then `arg` will be `"--myArgument"` and `value` will be `"myValue"`.
+ *
+ * @param arg the arg in question
+ * @returns a tuple containing the arg name and the value (if present)
  */
-const getEqualsValue = (commandArgument: string) => commandArgument.split('=').slice(1).join('=');
+export const parseEqualsArg = (arg: string): [string, string] => {
+  const [originalArg, ...value] = arg.split('=');
+
+  return [originalArg, value.join('=')];
+};
 
 /**
  * Small helper for getting type-system-level assurance that a `string` can be

--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -293,8 +293,8 @@ interface CLIArgValue {
 
 /**
  * Parse an 'equals' argument, which is a CLI argument-value pair in the
- * format `--foobar=12` (as opposed to the space-separated format `--foobar
- * 12`).
+ * format `--foobar=12` (as opposed to a space-separated format like
+ * `--foobar 12`).
  *
  * To parse this we split on the `=`, returning the first part as the argument
  * name and the second part as the value. We join the value on `"="` in case

--- a/src/cli/test/parse-flags.spec.ts
+++ b/src/cli/test/parse-flags.spec.ts
@@ -190,21 +190,21 @@ describe('parseFlags', () => {
   it.each(STRING_CLI_ARGS)('should parse string flag %s', (cliArg) => {
     const flags = parseFlags([`--${cliArg}`, 'test-value'], sys);
     expect(flags.knownArgs).toEqual([`--${cliArg}`, 'test-value']);
-    expect(flags.unknownArgs).toEqual([])
+    expect(flags.unknownArgs).toEqual([]);
     expect(flags[cliArg]).toBe('test-value');
   });
 
   it.each(STRING_CLI_ARGS)('should parse string flag --%s=value', (cliArg) => {
     const flags = parseFlags([`--${cliArg}=path/to/file.js`], sys);
     expect(flags.knownArgs).toEqual([`--${cliArg}`, 'path/to/file.js']);
-    expect(flags.unknownArgs).toEqual([])
+    expect(flags.unknownArgs).toEqual([]);
     expect(flags[cliArg]).toBe('path/to/file.js');
   });
 
   it.each(NUMBER_CLI_ARGS)('should parse number flag %s', (cliArg) => {
     const flags = parseFlags([`--${cliArg}`, '42'], sys);
     expect(flags.knownArgs).toEqual([`--${cliArg}`, '42']);
-    expect(flags.unknownArgs).toEqual([])
+    expect(flags.unknownArgs).toEqual([]);
     expect(flags[cliArg]).toBe(42);
   });
 
@@ -212,7 +212,7 @@ describe('parseFlags', () => {
     args[0] = '--compare';
     const flags = parseFlags(args, sys);
     expect(flags.knownArgs).toEqual(['--compare']);
-    expect(flags.unknownArgs).toEqual([])
+    expect(flags.unknownArgs).toEqual([]);
     expect(flags.compare).toBe(true);
   });
 

--- a/src/cli/test/parse-flags.spec.ts
+++ b/src/cli/test/parse-flags.spec.ts
@@ -1,7 +1,7 @@
 import type * as d from '../../declarations';
 import { LogLevel } from '../../declarations';
 import { BOOLEAN_CLI_ARGS, STRING_CLI_ARGS, NUMBER_CLI_ARGS } from '../config-flags';
-import { parseFlags } from '../parse-flags';
+import { parseEqualsArg, parseFlags } from '../parse-flags';
 
 describe('parseFlags', () => {
   let args: string[] = [];
@@ -190,12 +190,21 @@ describe('parseFlags', () => {
   it.each(STRING_CLI_ARGS)('should parse string flag %s', (cliArg) => {
     const flags = parseFlags([`--${cliArg}`, 'test-value'], sys);
     expect(flags.knownArgs).toEqual([`--${cliArg}`, 'test-value']);
+    expect(flags.unknownArgs).toEqual([])
     expect(flags[cliArg]).toBe('test-value');
+  });
+
+  it.each(STRING_CLI_ARGS)('should parse string flag --%s=value', (cliArg) => {
+    const flags = parseFlags([`--${cliArg}=path/to/file.js`], sys);
+    expect(flags.knownArgs).toEqual([`--${cliArg}`, 'path/to/file.js']);
+    expect(flags.unknownArgs).toEqual([])
+    expect(flags[cliArg]).toBe('path/to/file.js');
   });
 
   it.each(NUMBER_CLI_ARGS)('should parse number flag %s', (cliArg) => {
     const flags = parseFlags([`--${cliArg}`, '42'], sys);
     expect(flags.knownArgs).toEqual([`--${cliArg}`, '42']);
+    expect(flags.unknownArgs).toEqual([])
     expect(flags[cliArg]).toBe(42);
   });
 
@@ -203,6 +212,7 @@ describe('parseFlags', () => {
     args[0] = '--compare';
     const flags = parseFlags(args, sys);
     expect(flags.knownArgs).toEqual(['--compare']);
+    expect(flags.unknownArgs).toEqual([])
     expect(flags.compare).toBe(true);
   });
 
@@ -573,5 +583,19 @@ describe('parseFlags', () => {
     expect(flags.version).toBe(true);
     expect(flags.help).toBe(true);
     expect(flags.config).toBe('./myconfig.json');
+  });
+
+  describe('parseEqualsArg', () => {
+    it.each([
+      ['--fooBar=baz', '--fooBar', 'baz'],
+      ['--foo-bar=4', '--foo-bar', '4'],
+      ['--fooBar=twenty=3*4', '--fooBar', 'twenty=3*4'],
+      ['--fooBar', '--fooBar', ''],
+      ['--foo-bar', '--foo-bar', ''],
+    ])('should parse %s correctly', (testArg, expectedArg, expectedValue) => {
+      const [arg, value] = parseEqualsArg(testArg);
+      expect(arg).toBe(expectedArg);
+      expect(value).toBe(expectedValue);
+    });
   });
 });

--- a/src/testing/jest/test/jest-config.spec.ts
+++ b/src/testing/jest/test/jest-config.spec.ts
@@ -19,6 +19,17 @@ describe('jest-config', () => {
     expect(jestArgv.maxWorkers).toBe(2);
   });
 
+  it('should pass --outputFile=path/to/file', () => {
+    const args = ['test', '--ci', '--outputFile=path/to/my-file'];
+    const config = mockValidatedConfig();
+    config.flags = parseFlags(args, config.sys);
+    expect(config.flags.args).toEqual(['--ci', '--outputFile=path/to/my-file']);
+    expect(config.flags.unknownArgs).toEqual([]);
+    config.testing = {};
+    const jestArgv = buildJestArgv(config);
+    expect(jestArgv.outputFile).toBe('path/to/my-file');
+  });
+
   it('pass --maxWorkers=2 arg when e2e test and --ci', () => {
     const args = ['test', '--ci', '--e2e', '--max-workers=2'];
     const config = mockValidatedConfig();

--- a/src/testing/jest/test/jest-config.spec.ts
+++ b/src/testing/jest/test/jest-config.spec.ts
@@ -19,13 +19,13 @@ describe('jest-config', () => {
     expect(jestArgv.maxWorkers).toBe(2);
   });
 
-  it('should pass --outputFile=path/to/file', () => {
+  it('marks outputFile as a Jest argument', () => {
     const args = ['test', '--ci', '--outputFile=path/to/my-file'];
     const config = mockValidatedConfig();
+    config.testing = {};
     config.flags = parseFlags(args, config.sys);
     expect(config.flags.args).toEqual(['--ci', '--outputFile=path/to/my-file']);
     expect(config.flags.unknownArgs).toEqual([]);
-    config.testing = {};
     const jestArgv = buildJestArgv(config);
     expect(jestArgv.outputFile).toBe('path/to/my-file');
   });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

This fixes a bug with how these flags were being parsed which was
messing with Jest. Basically, the issue related to how the `knownArgs`
array on the `ConfigFlags` object was being populated. For CLI key-value
args of the format `--argName=value` the whole string
`"--argName=value"` was being added _as well as_ the value string
`"value"`, which had the effect of passing duplicate args to Jest.

This refactors how such arguments are handled to always parse apart the
argument name and the value, adding only the argument name and then the
argument value, so that if you pass, for instance,
`--outputFile=output.json`, the args passed to Jest will look like

```ts
['--outputFile', 'output.json']
```

See https://github.com/ionic-team/stencil/issues/3471 and https://github.com/ionic-team/stencil/issues/3481 for more details

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Previously CLI args of the format `--foo=bar` were not being passed to Jest correctly because of a bug in how they were being parsed.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Now they are handled correctly and should work well with jest.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Check out hte repro steps on the linked issues for some ideas of how to test this manually. Basically, in a simple stencil project (i.e. created w/ `npm init stencil`) if you try to do this w/ stencil installed from npm you should see an error:

```sh
npx stencil test --spec --e2e --json --outputFile=output.json
```

if you check out this branch, `npm run build`, `npm pack`, and then install the `.tgz` in that same project you should not see an error when running that same command.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
