### PR TITLE
chore(config): propagate ValidatedConfig through telemetry directory

### DIFF
--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -109,7 +109,7 @@ export function isUsingYarn(sys: d.CompilerSystem) {
  * @param config the configuration used by the Stencil project
  * @returns a unique list of output target types found in the Stencil configuration
  */
-export async function getActiveTargets(config: d.ValidatedConfig): Promise<string[]> {
+export function getActiveTargets(config: d.ValidatedConfig): string[] {
   const result = config.outputTargets.map((t) => t.type);
   return Array.from(new Set(result));
 }
@@ -133,7 +133,7 @@ export const prepareData = async (
 ): Promise<d.TrackableData> => {
   const { typescript, rollup } = coreCompiler.versions || { typescript: 'unknown', rollup: 'unknown' };
   const { packages, packagesNoVersions } = await getInstalledPackages(sys, config);
-  const targets = await getActiveTargets(config);
+  const targets = getActiveTargets(config);
   const yarn = isUsingYarn(sys);
   const stencil = coreCompiler.version || 'unknown';
   const system = `${sys.name} ${sys.version}`;

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -207,8 +207,8 @@ const CONFIG_PROPS_TO_DELETE: ReadonlyArray<keyof d.Config> = ['sys', 'logger', 
  * @param config the config to anonymize
  * @returns an anonymized copy of the same config
  */
-export const anonymizeConfigForTelemetry = (config: d.Config): d.Config => {
-  const anonymizedConfig = { ...config };
+export const anonymizeConfigForTelemetry = (config: d.ValidatedConfig): d.Config => {
+  const anonymizedConfig: d.Config = { ...config };
 
   for (const prop of CONFIG_PROPS_TO_ANONYMIZE) {
     if (anonymizedConfig[prop] !== undefined) {
@@ -216,7 +216,7 @@ export const anonymizeConfigForTelemetry = (config: d.Config): d.Config => {
     }
   }
 
-  anonymizedConfig.outputTargets = (config.outputTargets ?? []).map((target) => {
+  anonymizedConfig.outputTargets = config.outputTargets.map((target) => {
     // Anonymize the outputTargets on our configuration, taking advantage of the
     // optional 2nd argument to `JSON.stringify`. If anything is not a string
     // we retain it so that any nested properties are handled, else we check

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -82,7 +82,16 @@ export async function telemetryAction(
   }
 }
 
-export function hasAppTarget(config: d.Config): boolean {
+/**
+ * Helper function to determine if a Stencil configuration builds an application.
+ *
+ * This function is a rough approximation whether an application is generated as a part of a Stencil build, based on
+ * contents of the project's `stencil.config.ts` file.
+ *
+ * @param config the configuration used by the Stencil project
+ * @returns true if we believe the project generates an application, false otherwise
+ */
+export function hasAppTarget(config: d.ValidatedConfig): boolean {
   return config.outputTargets.some(
     (target) => target.type === WWW && (!!target.serviceWorker || (!!target.baseUrl && target.baseUrl !== '/'))
   );

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -101,7 +101,15 @@ export function isUsingYarn(sys: d.CompilerSystem) {
   return sys.getEnvironmentVar('npm_execpath')?.includes('yarn') || false;
 }
 
-export async function getActiveTargets(config: d.Config): Promise<string[]> {
+/**
+ * Build a list of the different types of output targets used in a Stencil configuration.
+ *
+ * Duplicate entries will not be returned from the list
+ *
+ * @param config the configuration used by the Stencil project
+ * @returns a unique list of output target types found in the Stencil configuration
+ */
+export async function getActiveTargets(config: d.ValidatedConfig): Promise<string[]> {
   const result = config.outputTargets.map((t) => t.type);
   return Array.from(new Set(result));
 }

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -109,7 +109,7 @@ describe('hasAppTarget()', () => {
 
   beforeEach(() => {
     sys = createSystem();
-    config = mockValidatedConfig(sys);
+    config = mockValidatedConfig({ sys });
   });
 
   it("returns 'false' when `outputTargets` is empty", () => {
@@ -288,7 +288,7 @@ describe('anonymizeConfigForTelemetry', () => {
 
   beforeEach(() => {
     sys = createSystem();
-    config = mockValidatedConfig(sys);
+    config = mockValidatedConfig({ sys });
   });
 
   it.each([

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -99,36 +99,42 @@ describe('checkTelemetry', () => {
   });
 });
 
-describe('hasAppTarget', () => {
-  it('Result is correct when outputTargets are empty', () => {
-    const config = { outputTargets: [] } as d.Config;
+describe('hasAppTarget()', () => {
+  let config: d.ValidatedConfig;
+  let sys: d.CompilerSystem;
+
+  beforeEach(() => {
+    sys = createSystem();
+    config = mockValidatedConfig(sys);
+  });
+
+  it("returns 'false' when `outputTargets` is empty", () => {
+    config.outputTargets = [];
     expect(telemetry.hasAppTarget(config)).toBe(false);
   });
 
-  it('Result is correct when outputTargets contains www with no baseUrl or serviceWorker', () => {
-    const config = { outputTargets: [{ type: WWW }] } as d.Config;
+  it("returns 'false' when `outputTargets` contains `www` with no `baseUrl` and no service worker", () => {
+    config.outputTargets = [{ type: WWW }];
     expect(telemetry.hasAppTarget(config)).toBe(false);
   });
 
-  it('Result is correct when outputTargets contains www with default baseUrl value', () => {
-    const config = { outputTargets: [{ type: WWW, baseUrl: '/' }] } as d.Config;
+  it("returns 'false' when `outputTargets` contains `www` with '/' baseUrl value", () => {
+    config.outputTargets = [{ type: WWW, baseUrl: '/' }];
     expect(telemetry.hasAppTarget(config)).toBe(false);
   });
 
-  it('Result is correct when outputTargets contains www with serviceWorker', () => {
-    const config = { outputTargets: [{ type: WWW, serviceWorker: { swDest: './tmp' } }] } as d.Config;
+  it("returns 'true' when `outputTargets` contains `www` with a service worker", () => {
+    config.outputTargets = [{ type: WWW, serviceWorker: { swDest: './tmp' } }];
     expect(telemetry.hasAppTarget(config)).toBe(true);
   });
 
-  it('Result is correct when outputTargets contains www with baseUrl', () => {
-    const config = { outputTargets: [{ type: WWW, baseUrl: 'https://example.com' }] } as d.Config;
+  it("returns 'true' when `outputTargets` contains `www` with baseUrl", () => {
+    config.outputTargets = [{ type: WWW, baseUrl: 'https://example.com' }];
     expect(telemetry.hasAppTarget(config)).toBe(true);
   });
 
-  it('Result is correct when outputTargets contains www with serviceWorker and baseUrl', () => {
-    const config = {
-      outputTargets: [{ type: WWW, baseUrl: 'https://example.com', serviceWorker: { swDest: './tmp' } }],
-    } as d.Config;
+  it("returns 'true' when `outputTargets` contains `www` with serviceWorker and baseUrl", () => {
+    config.outputTargets = [{ type: WWW, baseUrl: 'https://example.com', serviceWorker: { swDest: './tmp' } }];
     expect(telemetry.hasAppTarget(config)).toBe(true);
   });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`Config` is used in a few remaining functions in the `cli/telemetry` directory. This leads to an
 inaccurate count of `strictNullChecks` violations
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

There are three functions that were updated as a part of this PR.

See each commit message for the details, although they're all largely the same, with https://github.com/ionic-team/stencil/pull/3484/commits/775aeee02f57e825b97dece5e3856ca1d7534104 probably being the more interesting of the three

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Unit tests continue to pass

## Other information

We move the needle forward by _2_ _whole_ violations here.  That's .07949125596% less than we had 🎉 🙃 

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
