### PR TITLE
chore(mocks): update mockConfig, mockValidatedConfig to accept any property

### DIFF
--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -14,7 +14,7 @@ describe('telemetryBuildFinishedAction', () => {
 
   beforeEach(() => {
     sys = createSystem();
-    config = mockValidatedConfig(sys);
+    config = mockValidatedConfig({ sys });
     config.outputTargets = [];
     config.flags.args = [];
   });
@@ -45,7 +45,7 @@ describe('telemetryAction', () => {
 
   beforeEach(() => {
     sys = createSystem();
-    config = mockValidatedConfig(sys);
+    config = mockValidatedConfig({ sys });
     config.outputTargets = [];
     config.flags.args = [];
   });

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -14,9 +14,11 @@ describe('telemetryBuildFinishedAction', () => {
 
   beforeEach(() => {
     sys = createSystem();
-    config = mockValidatedConfig({ sys });
-    config.outputTargets = [];
-    config.flags.args = [];
+    config = mockValidatedConfig({
+      flags: { args: [], knownArgs: [], task: 'build', unknownArgs: [] },
+      outputTargets: [],
+      sys,
+    });
   });
 
   it('issues a network request when complete', async () => {
@@ -45,9 +47,11 @@ describe('telemetryAction', () => {
 
   beforeEach(() => {
     sys = createSystem();
-    config = mockValidatedConfig({ sys });
-    config.outputTargets = [];
-    config.flags.args = [];
+    config = mockValidatedConfig({
+      flags: { args: [], knownArgs: [], task: 'build', unknownArgs: [] },
+      outputTargets: [],
+      sys,
+    });
   });
 
   it('issues a network request when no async function is passed', async () => {

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -15,7 +15,7 @@ describe('telemetryBuildFinishedAction', () => {
   beforeEach(() => {
     sys = createSystem();
     config = mockValidatedConfig({
-      flags: { args: [], knownArgs: [], task: 'build', unknownArgs: [] },
+      flags: createConfigFlags({ task: 'build' }),
       outputTargets: [],
       sys,
     });
@@ -48,7 +48,7 @@ describe('telemetryAction', () => {
   beforeEach(() => {
     sys = createSystem();
     config = mockValidatedConfig({
-      flags: { args: [], knownArgs: [], task: 'build', unknownArgs: [] },
+      flags: createConfigFlags({ task: 'build' }),
       outputTargets: [],
       sys,
     });

--- a/src/cli/test/run.spec.ts
+++ b/src/cli/test/run.spec.ts
@@ -137,8 +137,7 @@ describe('run', () => {
       sys = mockCompilerSystem();
       sys.exit = jest.fn();
 
-      unvalidatedConfig = mockConfig({ sys });
-      unvalidatedConfig.outputTargets = null;
+      unvalidatedConfig = mockConfig({ outputTargets: null, sys });
 
       validatedConfig = mockValidatedConfig({ sys });
 
@@ -260,8 +259,7 @@ describe('run', () => {
     });
 
     it('defaults to the provided task if no flags exist on the provided config', async () => {
-      unvalidatedConfig = mockConfig({ sys });
-      unvalidatedConfig.flags = undefined;
+      unvalidatedConfig = mockConfig({ flags: undefined, sys });
 
       await runTask(coreCompiler, unvalidatedConfig, 'help', sys);
 

--- a/src/cli/test/run.spec.ts
+++ b/src/cli/test/run.spec.ts
@@ -1,6 +1,11 @@
 import type * as d from '../../declarations';
 import * as coreCompiler from '@stencil/core/compiler';
-import { mockCompilerSystem, mockConfig, mockLogger as createMockLogger } from '@stencil/core/testing';
+import {
+  mockCompilerSystem,
+  mockConfig,
+  mockLogger as createMockLogger,
+  mockValidatedConfig,
+} from '@stencil/core/testing';
 import * as ParseFlags from '../parse-flags';
 import { run, runTask } from '../run';
 import * as BuildTask from '../task-build';
@@ -132,11 +137,10 @@ describe('run', () => {
       sys = mockCompilerSystem();
       sys.exit = jest.fn();
 
-      unvalidatedConfig = mockConfig(sys);
+      unvalidatedConfig = mockConfig({ sys });
       unvalidatedConfig.outputTargets = null;
 
-      validatedConfig = mockConfig(sys);
-      validatedConfig.outputTargets = [];
+      validatedConfig = mockValidatedConfig({ sys });
 
       taskBuildSpy = jest.spyOn(BuildTask, 'taskBuild');
       taskBuildSpy.mockResolvedValue();
@@ -256,7 +260,7 @@ describe('run', () => {
     });
 
     it('defaults to the provided task if no flags exist on the provided config', async () => {
-      unvalidatedConfig = mockConfig(sys);
+      unvalidatedConfig = mockConfig({ sys });
       unvalidatedConfig.flags = undefined;
 
       await runTask(coreCompiler, unvalidatedConfig, 'help', sys);

--- a/src/cli/test/task-generate.spec.ts
+++ b/src/cli/test/task-generate.spec.ts
@@ -14,7 +14,7 @@ jest.mock('prompts', () => ({
 
 const setup = async () => {
   const sys = mockCompilerSystem();
-  const config: d.ValidatedConfig = mockValidatedConfig(sys);
+  const config: d.ValidatedConfig = mockValidatedConfig({ sys });
   config.configPath = '/testing-path';
   config.srcDir = '/src';
 

--- a/src/cli/test/task-generate.spec.ts
+++ b/src/cli/test/task-generate.spec.ts
@@ -14,13 +14,15 @@ jest.mock('prompts', () => ({
 
 const setup = async () => {
   const sys = mockCompilerSystem();
-  const config: d.ValidatedConfig = mockValidatedConfig({ sys });
-  config.configPath = '/testing-path';
-  config.srcDir = '/src';
+  const config: d.ValidatedConfig = mockValidatedConfig({
+    configPath: '/testing-path',
+    flags: { args: [], knownArgs: [], task: 'generate', unknownArgs: [] },
+    srcDir: '/src',
+    sys,
+  });
 
   // set up some mocks / spies
   config.sys.exit = jest.fn();
-  config.flags.unknownArgs = [];
   const errorSpy = jest.spyOn(config.logger, 'error');
   const validateTagSpy = jest.spyOn(utils, 'validateComponentTag').mockReturnValue(undefined);
 

--- a/src/cli/test/task-generate.spec.ts
+++ b/src/cli/test/task-generate.spec.ts
@@ -5,6 +5,7 @@ import * as utils from '../../utils/validation';
 
 import * as coreCompiler from '@stencil/core/compiler';
 import { CoreCompiler } from '../load-compiler';
+import { createConfigFlags } from '../config-flags';
 
 const promptMock = jest.fn().mockResolvedValue('my-component');
 
@@ -16,7 +17,7 @@ const setup = async () => {
   const sys = mockCompilerSystem();
   const config: d.ValidatedConfig = mockValidatedConfig({
     configPath: '/testing-path',
-    flags: { args: [], knownArgs: [], task: 'generate', unknownArgs: [] },
+    flags: createConfigFlags({ task: 'generate' }),
     srcDir: '/src',
     sys,
   });

--- a/src/compiler/output-targets/test/custom-elements-types.spec.ts
+++ b/src/compiler/output-targets/test/custom-elements-types.spec.ts
@@ -15,18 +15,21 @@ import { join, relative } from 'path';
 
 const setup = () => {
   const sys = mockCompilerSystem();
-  const config: d.ValidatedConfig = mockValidatedConfig({ sys });
+  const config: d.ValidatedConfig = mockValidatedConfig({
+    configPath: '/testing-path',
+    buildAppCore: true,
+    buildEs5: true,
+    namespace: 'TestApp',
+    outputTargets: [{ type: DIST_CUSTOM_ELEMENTS, dir: 'my-best-dir' }],
+    srcDir: '/src',
+    sys,
+  });
   const compilerCtx = mockCompilerCtx(config);
   const buildCtx = mockBuildCtx(config, compilerCtx);
+
   const root = config.rootDir;
-  config.configPath = '/testing-path';
-  config.srcDir = '/src';
-  config.buildAppCore = true;
   config.rootDir = path.join(root, 'User', 'testing', '/');
-  config.namespace = 'TestApp';
-  config.buildEs5 = true;
   config.globalScript = path.join(root, 'User', 'testing', 'src', 'global.ts');
-  config.outputTargets = [{ type: DIST_CUSTOM_ELEMENTS, dir: 'my-best-dir' }];
 
   const bundleCustomElementsSpy = jest.spyOn(outputCustomElementsMod, 'bundleCustomElements');
 

--- a/src/compiler/output-targets/test/custom-elements-types.spec.ts
+++ b/src/compiler/output-targets/test/custom-elements-types.spec.ts
@@ -15,7 +15,7 @@ import { join, relative } from 'path';
 
 const setup = () => {
   const sys = mockCompilerSystem();
-  const config: d.ValidatedConfig = mockValidatedConfig(sys);
+  const config: d.ValidatedConfig = mockValidatedConfig({ sys });
   const compilerCtx = mockCompilerCtx(config);
   const buildCtx = mockBuildCtx(config, compilerCtx);
   const root = config.rootDir;

--- a/src/compiler/output-targets/test/output-targets-dist-custom-elements.spec.ts
+++ b/src/compiler/output-targets/test/output-targets-dist-custom-elements.spec.ts
@@ -22,7 +22,7 @@ import { DIST_CUSTOM_ELEMENTS, DIST_CUSTOM_ELEMENTS_BUNDLE } from '../output-uti
 
 const setup = () => {
   const sys = mockCompilerSystem();
-  const config: d.ValidatedConfig = mockValidatedConfig(sys);
+  const config: d.ValidatedConfig = mockValidatedConfig({ sys });
   const compilerCtx = mockCompilerCtx(config);
   const buildCtx = mockBuildCtx(config, compilerCtx);
   const root = config.rootDir;

--- a/src/compiler/output-targets/test/output-targets-dist-custom-elements.spec.ts
+++ b/src/compiler/output-targets/test/output-targets-dist-custom-elements.spec.ts
@@ -22,18 +22,21 @@ import { DIST_CUSTOM_ELEMENTS, DIST_CUSTOM_ELEMENTS_BUNDLE } from '../output-uti
 
 const setup = () => {
   const sys = mockCompilerSystem();
-  const config: d.ValidatedConfig = mockValidatedConfig({ sys });
+  const config: d.ValidatedConfig = mockValidatedConfig({
+    buildAppCore: true,
+    buildEs5: true,
+    configPath: '/testing-path',
+    namespace: 'TestApp',
+    outputTargets: [{ type: DIST_CUSTOM_ELEMENTS }],
+    srcDir: '/src',
+    sys,
+  });
   const compilerCtx = mockCompilerCtx(config);
   const buildCtx = mockBuildCtx(config, compilerCtx);
+
   const root = config.rootDir;
-  config.configPath = '/testing-path';
-  config.srcDir = '/src';
-  config.buildAppCore = true;
   config.rootDir = path.join(root, 'User', 'testing', '/');
-  config.namespace = 'TestApp';
-  config.buildEs5 = true;
   config.globalScript = path.join(root, 'User', 'testing', 'src', 'global.ts');
-  config.outputTargets = [{ type: DIST_CUSTOM_ELEMENTS }];
 
   const bundleCustomElementsSpy = jest.spyOn(outputCustomElementsMod, 'bundleCustomElements');
 

--- a/src/compiler/output-targets/test/output-targets-dist.spec.ts
+++ b/src/compiler/output-targets/test/output-targets-dist.spec.ts
@@ -11,13 +11,14 @@ describe.skip('outputTarget, dist', () => {
   const root = path.resolve('/');
 
   it('default dist files', async () => {
-    config = mockConfig();
-    config.buildAppCore = true;
-    config.rootDir = path.join(root, 'User', 'testing', '/');
-    config.namespace = 'TestApp';
-    config.buildEs5 = true;
-    config.globalScript = path.join(root, 'User', 'testing', 'src', 'global.ts');
-    config.outputTargets = [{ type: 'dist' }];
+    config = mockConfig({
+      buildAppCore: true,
+      buildEs5: true,
+      globalScript: path.join(root, 'User', 'testing', 'src', 'global.ts'),
+      namespace: 'TestApp',
+      outputTargets: [{ type: 'dist' }],
+      rootDir: path.join(root, 'User', 'testing', '/'),
+    });
 
     compiler = new Compiler(config);
 

--- a/src/compiler/output-targets/test/output-targets-www-dist.spec.ts
+++ b/src/compiler/output-targets/test/output-targets-www-dist.spec.ts
@@ -12,29 +12,30 @@ describe.skip('outputTarget, www / dist / docs', () => {
   const root = path.resolve('/');
 
   it('dist, www and readme files w/ custom paths', async () => {
-    config = mockConfig();
-    config.flags.docs = true;
-    config.buildAppCore = true;
-    config.rootDir = path.join(root, 'User', 'testing', '/');
-    config.namespace = 'TestApp';
-    config.outputTargets = [
-      {
-        type: 'www',
-        dir: 'custom-www',
-        buildDir: 'www-build',
-        indexHtml: 'custom-index.htm',
-      } as any as d.OutputTargetDist,
-      {
-        type: 'dist',
-        dir: 'custom-dist',
-        buildDir: 'dist-build',
-        collectionDir: 'dist-collection',
-        typesDir: 'custom-types',
-      },
-      {
-        type: 'docs',
-      } as d.OutputTargetDocsReadme,
-    ];
+    config = mockConfig({
+      buildAppCore: true,
+      flags: { docs: true },
+      namespace: 'TestApp',
+      outputTargets: [
+        {
+          type: 'www',
+          dir: 'custom-www',
+          buildDir: 'www-build',
+          indexHtml: 'custom-index.htm',
+        } as any as d.OutputTargetDist,
+        {
+          type: 'dist',
+          dir: 'custom-dist',
+          buildDir: 'dist-build',
+          collectionDir: 'dist-collection',
+          typesDir: 'custom-types',
+        },
+        {
+          type: 'docs',
+        } as d.OutputTargetDocsReadme,
+      ],
+      rootDir: path.join(root, 'User', 'testing', '/'),
+    });
 
     compiler = new Compiler(config);
 

--- a/src/compiler/output-targets/test/output-targets-www.spec.ts
+++ b/src/compiler/output-targets/test/output-targets-www.spec.ts
@@ -11,10 +11,11 @@ describe.skip('outputTarget, www', () => {
   const root = path.resolve('/');
 
   it('default www files', async () => {
-    config = mockConfig();
-    config.namespace = 'App';
-    config.buildAppCore = true;
-    config.rootDir = path.join(root, 'User', 'testing', '/');
+    config = mockConfig({
+      buildAppCore: true,
+      namespace: 'App',
+      rootDir: path.join(root, 'User', 'testing', '/'),
+    });
 
     compiler = new Compiler(config);
 

--- a/src/compiler/service-worker/test/service-worker-util.spec.ts
+++ b/src/compiler/service-worker/test/service-worker-util.spec.ts
@@ -8,14 +8,15 @@ describe('generateServiceWorkerUrl', () => {
   let outputTarget: d.OutputTargetWww;
 
   it('sw url w/ baseUrl', () => {
-    userConfig = mockConfig();
-    userConfig.devMode = false;
-    userConfig.outputTargets = [
-      {
-        type: 'www',
-        baseUrl: '/docs',
-      } as d.OutputTargetWww,
-    ];
+    userConfig = mockConfig({
+      devMode: false,
+      outputTargets: [
+        {
+          type: 'www',
+          baseUrl: '/docs',
+        } as d.OutputTargetWww,
+      ],
+    });
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
     outputTarget = config.outputTargets[0] as d.OutputTargetWww;
     const swUrl = generateServiceWorkerUrl(outputTarget, outputTarget.serviceWorker as d.ServiceWorkerConfig);
@@ -23,8 +24,7 @@ describe('generateServiceWorkerUrl', () => {
   });
 
   it('default sw url', () => {
-    userConfig = mockConfig();
-    userConfig.devMode = false;
+    userConfig = mockConfig({ devMode: false });
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
     outputTarget = config.outputTargets[0] as d.OutputTargetWww;
     const swUrl = generateServiceWorkerUrl(outputTarget, outputTarget.serviceWorker as d.ServiceWorkerConfig);

--- a/src/compiler/service-worker/test/service-worker.spec.ts
+++ b/src/compiler/service-worker/test/service-worker.spec.ts
@@ -13,17 +13,18 @@ describe.skip('service worker', () => {
   const root = path.resolve('/');
 
   it('dev service worker', async () => {
-    config = mockConfig();
-    config.devMode = true;
-    config.outputTargets = [
-      {
-        type: 'www',
-        serviceWorker: {
-          swSrc: path.join('src', 'sw.js'),
-          globPatterns: ['**/*.{html,js,css,json,ico,png}'],
-        },
-      } as d.OutputTargetWww,
-    ];
+    config = mockConfig({
+      devMode: true,
+      outputTargets: [
+        {
+          type: 'www',
+          serviceWorker: {
+            swSrc: path.join('src', 'sw.js'),
+            globPatterns: ['**/*.{html,js,css,json,ico,png}'],
+          },
+        } as d.OutputTargetWww,
+      ],
+    });
 
     compiler = new Compiler(config);
     await compiler.fs.writeFile(path.join(root, 'www', 'script.js'), `/**/`);

--- a/src/compiler/style/test/optimize-css.spec.ts
+++ b/src/compiler/style/test/optimize-css.spec.ts
@@ -14,15 +14,13 @@ describe('optimizeCss', () => {
   jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
 
   beforeEach(() => {
-    config = mockConfig();
-    config.maxConcurrentWorkers = 0;
+    config = mockConfig({ maxConcurrentWorkers: 0, minifyCss: true });
     compilerCtx = mockCompilerCtx(config);
     diagnostics = [];
   });
 
   it('handles error', async () => {
     const filePath = path.join(os.tmpdir(), 'my.css');
-    config.minifyCss = true;
     const styleText = `/* css */ body color: #ff0000; }`;
     await optimizeCss(config, compilerCtx, diagnostics, styleText, filePath);
 
@@ -30,7 +28,6 @@ describe('optimizeCss', () => {
   });
 
   it('discard-comments', async () => {
-    config.minifyCss = true;
     const styleText = `/* css */ body { color: #ff0000; }`;
     const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
 
@@ -40,7 +37,6 @@ describe('optimizeCss', () => {
 
   it('minify-gradients', async () => {
     config.autoprefixCss = false;
-    config.minifyCss = true;
     const styleText = `
       h1 {
         background: linear-gradient(to bottom, #ffe500 0%, #ffe500 50%, #121 50%, #121 100%);
@@ -53,7 +49,6 @@ describe('optimizeCss', () => {
   });
 
   it('reduce-initial', async () => {
-    config.minifyCss = true;
     const styleText = `
       h1 {
         min-width: initial;
@@ -66,7 +61,6 @@ describe('optimizeCss', () => {
   });
 
   it('normalize-display-values', async () => {
-    config.minifyCss = true;
     const styleText = `
       h1 {
         display: inline flow-root;
@@ -80,7 +74,6 @@ describe('optimizeCss', () => {
 
   it('reduce-transforms', async () => {
     config.autoprefixCss = false;
-    config.minifyCss = true;
     const styleText = `
       h1 {
         transform: rotate3d(0, 0, 1, 20deg);
@@ -93,7 +86,6 @@ describe('optimizeCss', () => {
   });
 
   it('colormin', async () => {
-    config.minifyCss = true;
     const styleText = `body { color: #ff0000; }`;
     const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
 
@@ -102,7 +94,6 @@ describe('optimizeCss', () => {
   });
 
   it('convert-values', async () => {
-    config.minifyCss = true;
     const styleText = `
       h1 {
         width: 0em;
@@ -115,7 +106,6 @@ describe('optimizeCss', () => {
   });
 
   it('ordered-values', async () => {
-    config.minifyCss = true;
     const styleText = `
       h1 {
         border: red solid .5em;
@@ -128,7 +118,6 @@ describe('optimizeCss', () => {
   });
 
   it('minify-selectors', async () => {
-    config.minifyCss = true;
     const styleText = `
       h1 + p, h2, h3, h2{color:red}
     `;
@@ -139,7 +128,6 @@ describe('optimizeCss', () => {
   });
 
   it('minify-params', async () => {
-    config.minifyCss = true;
     const styleText = `
       @media only screen   and ( min-width: 400px, min-height: 500px ) {
         h2 {
@@ -154,7 +142,6 @@ describe('optimizeCss', () => {
   });
 
   it('normalize-string', async () => {
-    config.minifyCss = true;
     const styleText = `
       p:after {
         content: '\\'string\\' is intact';
@@ -167,7 +154,6 @@ describe('optimizeCss', () => {
   });
 
   it('minify-font-values', async () => {
-    config.minifyCss = true;
     const styleText = `
       p {
         font-family: "Helvetica Neue", Arial, sans-serif, Helvetica;
@@ -181,7 +167,6 @@ describe('optimizeCss', () => {
   });
 
   it('normalize-repeat-style', async () => {
-    config.minifyCss = true;
     const styleText = `
       h1 {
         background: url(image.jpg) repeat no-repeat;
@@ -194,7 +179,6 @@ describe('optimizeCss', () => {
   });
 
   it('normalize-positions', async () => {
-    config.minifyCss = true;
     const styleText = `
       h1 {
         background-position: bottom left;
@@ -207,7 +191,6 @@ describe('optimizeCss', () => {
   });
 
   it('normalize-whitespace', async () => {
-    config.minifyCss = true;
     const styleText = `
       h1 {
         width: calc(10px -  ( 100px / var(--test)  )) ;
@@ -220,7 +203,6 @@ describe('optimizeCss', () => {
   });
 
   it('unique-selectors', async () => {
-    config.minifyCss = true;
     const styleText = `
       h1, h3, h2, h1 {
         color: red;
@@ -234,7 +216,6 @@ describe('optimizeCss', () => {
 
   it('prevent autoprefix with null', async () => {
     config.autoprefixCss = null;
-    config.minifyCss = true;
     const styleText = `
       h1 {
         box-shadow: 1px;
@@ -248,7 +229,6 @@ describe('optimizeCss', () => {
 
   it('prevent autoprefix with false', async () => {
     config.autoprefixCss = false;
-    config.minifyCss = true;
     const styleText = `
       h1 {
         box-shadow: 1px;
@@ -261,7 +241,6 @@ describe('optimizeCss', () => {
   });
 
   it('autoprefix by default', async () => {
-    config.minifyCss = true;
     const styleText = `
       h1 {
         box-shadow: 1px;
@@ -275,7 +254,6 @@ describe('optimizeCss', () => {
 
   it('runs autoprefixerCss true config', async () => {
     config.autoprefixCss = true;
-    config.minifyCss = true;
     const styleText = `
       h1 {
         box-shadow: 1px;

--- a/src/compiler/style/test/style.spec.ts
+++ b/src/compiler/style/test/style.spec.ts
@@ -13,16 +13,17 @@ xdescribe('component-styles', () => {
   const root = path.resolve('/');
 
   beforeEach(async () => {
-    config = mockConfig();
+    config = mockConfig({
+      minifyCss: true,
+      minifyJs: true,
+      hashFileNames: true,
+    });
     compiler = new Compiler(config);
     await compiler.fs.writeFile(path.join(root, 'src', 'index.html'), `<cmp-a></cmp-a>`);
     await compiler.fs.commit();
   });
 
   it('should add mode styles to hashed filename/minified builds', async () => {
-    compiler.config.minifyJs = true;
-    compiler.config.minifyCss = true;
-    compiler.config.hashFileNames = true;
     compiler.config.hashedFileNameLength = 2;
     await compiler.fs.writeFiles({
       [path.join(root, 'src', 'cmp-a.tsx')]: `@Component({
@@ -59,9 +60,6 @@ xdescribe('component-styles', () => {
   });
 
   it('should add default styles to hashed filename/minified builds', async () => {
-    compiler.config.minifyJs = true;
-    compiler.config.minifyCss = true;
-    compiler.config.hashFileNames = true;
     compiler.config.sys.generateContentHash = function () {
       return 'hashed';
     };

--- a/src/compiler/types/tests/validate-package-json.spec.ts
+++ b/src/compiler/types/tests/validate-package-json.spec.ts
@@ -24,14 +24,17 @@ describe('validate-package-json', () => {
       dir: '/dist',
       typesDir: '/dist/types',
     };
-    config = mockConfig();
-    config.devMode = false;
-    config.namespace = 'SomeNamespace';
-    config.fsNamespace = config.namespace.toLowerCase();
+
+    const namespace = 'SomeNamespace';
+    config = mockConfig({
+      devMode: false,
+      fsNamespace: namespace.toLowerCase(),
+      namespace,
+      packageJsonFilePath: path.join(root, 'package.json'),
+    });
     compilerCtx = mockCompilerCtx(config);
     buildCtx = mockBuildCtx(config, compilerCtx);
     buildCtx.packageJson = {};
-    config.packageJsonFilePath = path.join(root, 'package.json');
     await compilerCtx.fs.writeFile(config.packageJsonFilePath, JSON.stringify(buildCtx.packageJson));
   });
 

--- a/src/testing/jest/test/jest-config.spec.ts
+++ b/src/testing/jest/test/jest-config.spec.ts
@@ -7,9 +7,8 @@ import path from 'path';
 describe('jest-config', () => {
   it('pass --maxWorkers=2 arg when --max-workers=2', () => {
     const args = ['test', '--ci', '--max-workers=2'];
-    const config = mockValidatedConfig();
+    const config = mockValidatedConfig({ testing: {} });
     config.flags = parseFlags(args, config.sys);
-    config.testing = {};
 
     expect(config.flags.args).toEqual(['--ci', '--max-workers=2']);
     expect(config.flags.unknownArgs).toEqual([]);
@@ -21,8 +20,7 @@ describe('jest-config', () => {
 
   it('marks outputFile as a Jest argument', () => {
     const args = ['test', '--ci', '--outputFile=path/to/my-file'];
-    const config = mockValidatedConfig();
-    config.testing = {};
+    const config = mockValidatedConfig({ testing: {} });
     config.flags = parseFlags(args, config.sys);
     expect(config.flags.args).toEqual(['--ci', '--outputFile=path/to/my-file']);
     expect(config.flags.unknownArgs).toEqual([]);
@@ -32,9 +30,8 @@ describe('jest-config', () => {
 
   it('pass --maxWorkers=2 arg when e2e test and --ci', () => {
     const args = ['test', '--ci', '--e2e', '--max-workers=2'];
-    const config = mockValidatedConfig();
+    const config = mockValidatedConfig({ testing: {} });
     config.flags = parseFlags(args, config.sys);
-    config.testing = {};
 
     expect(config.flags.args).toEqual(['--ci', '--e2e', '--max-workers=2']);
     expect(config.flags.unknownArgs).toEqual([]);
@@ -46,9 +43,8 @@ describe('jest-config', () => {
 
   it('forces --maxWorkers=4 arg when e2e test and --ci', () => {
     const args = ['test', '--ci', '--e2e'];
-    const config = mockValidatedConfig();
+    const config = mockValidatedConfig({ testing: {} });
     config.flags = parseFlags(args, config.sys);
-    config.testing = {};
 
     expect(config.flags.args).toEqual(['--ci', '--e2e']);
     expect(config.flags.unknownArgs).toEqual([]);
@@ -60,9 +56,8 @@ describe('jest-config', () => {
 
   it('pass --maxWorkers=2 arg to jest', () => {
     const args = ['test', '--maxWorkers=2'];
-    const config = mockValidatedConfig();
+    const config = mockValidatedConfig({ testing: {} });
     config.flags = parseFlags(args, config.sys);
-    config.testing = {};
 
     expect(config.flags.args).toEqual(['--maxWorkers=2']);
     expect(config.flags.unknownArgs).toEqual([]);
@@ -73,9 +68,8 @@ describe('jest-config', () => {
 
   it('pass --ci arg to jest', () => {
     const args = ['test', '--ci'];
-    const config = mockValidatedConfig();
+    const config = mockValidatedConfig({ testing: {} });
     config.flags = parseFlags(args, config.sys);
-    config.testing = {};
 
     expect(config.flags.args).toEqual(['--ci']);
     expect(config.flags.unknownArgs).toEqual([]);
@@ -87,9 +81,8 @@ describe('jest-config', () => {
 
   it('sets legacy jest options', () => {
     const args = ['test'];
-    const config = mockValidatedConfig();
+    const config = mockValidatedConfig({ testing: {} });
     config.flags = parseFlags(args, config.sys);
-    config.testing = {};
 
     const jestArgv = buildJestArgv(config);
 
@@ -117,9 +110,8 @@ describe('jest-config', () => {
 
   it('pass test spec arg to jest', () => {
     const args = ['test', 'hello.spec.ts'];
-    const config = mockValidatedConfig();
+    const config = mockValidatedConfig({ testing: {} });
     config.flags = parseFlags(args, config.sys);
-    config.testing = {};
 
     expect(config.flags.args).toEqual(['hello.spec.ts']);
     expect(config.flags.unknownArgs).toEqual(['hello.spec.ts']);
@@ -130,11 +122,12 @@ describe('jest-config', () => {
 
   it('pass test config to jest', () => {
     const args = ['test'];
-    const config = mockValidatedConfig();
+    const config = mockValidatedConfig({
+      testing: {
+        testMatch: ['hello.spec.ts'],
+      },
+    });
     config.flags = parseFlags(args, config.sys);
-    config.testing = {
-      testMatch: ['hello.spec.ts'],
-    };
 
     expect(config.flags.task).toBe('test');
 
@@ -146,12 +139,11 @@ describe('jest-config', () => {
   it('set jestArgv config reporters', () => {
     const rootDir = path.resolve('/');
     const args = ['test'];
-    const config = mockValidatedConfig();
-    config.rootDir = rootDir;
+    const config = mockValidatedConfig({
+      rootDir,
+      testing: { reporters: ['default', ['jest-junit', { suiteName: 'jest tests' }]] },
+    });
     config.flags = parseFlags(args, config.sys);
-    config.testing = {
-      reporters: ['default', ['jest-junit', { suiteName: 'jest tests' }]],
-    };
 
     const jestArgv = buildJestArgv(config);
     const parsedConfig = JSON.parse(jestArgv.config) as d.JestConfig;
@@ -164,10 +156,8 @@ describe('jest-config', () => {
   it('set jestArgv config rootDir', () => {
     const rootDir = path.resolve('/');
     const args = ['test'];
-    const config = mockValidatedConfig();
-    config.rootDir = rootDir;
+    const config = mockValidatedConfig({ rootDir, testing: {} });
     config.flags = parseFlags(args, config.sys);
-    config.testing = {};
 
     const jestArgv = buildJestArgv(config);
     const parsedConfig = JSON.parse(jestArgv.config) as d.JestConfig;
@@ -177,12 +167,8 @@ describe('jest-config', () => {
   it('set jestArgv config collectCoverageFrom', () => {
     const rootDir = path.resolve('/');
     const args = ['test'];
-    const config = mockValidatedConfig();
-    config.rootDir = rootDir;
+    const config = mockValidatedConfig({ rootDir, testing: { collectCoverageFrom: ['**/*.+(ts|tsx)'] } });
     config.flags = parseFlags(args, config.sys);
-    config.testing = {
-      collectCoverageFrom: ['**/*.+(ts|tsx)'],
-    };
 
     const jestArgv = buildJestArgv(config);
     const parsedConfig = JSON.parse(jestArgv.config) as d.JestConfig;
@@ -192,9 +178,8 @@ describe('jest-config', () => {
 
   it('passed flags should be respected over defaults', () => {
     const args = ['test', '--spec', '--passWithNoTests'];
-    const config = mockValidatedConfig();
+    const config = mockValidatedConfig({ testing: {} });
     config.flags = parseFlags(args, config.sys);
-    config.testing = {};
 
     expect(config.flags.args).toEqual(['--spec', '--passWithNoTests']);
     expect(config.flags.unknownArgs).toEqual([]);

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -26,9 +26,11 @@ import { createConfigFlags } from '../cli/config-flags';
  * Creates a mock instance of an internal, validated Stencil configuration object
  * @param sys an optional compiler system to associate with the config. If one is not provided, one will be created for
  * the caller
+ * @param overrides a partial implementation of `ValidatedConfig`. Any provided fields will override the defaults
+ * provided by this function.
  * @returns the mock Stencil configuration
  */
-export function mockValidatedConfig(sys?: CompilerSystem): ValidatedConfig {
+export function mockValidatedConfig(sys?: CompilerSystem, overrides: Partial<ValidatedConfig> = {}): ValidatedConfig {
   const baseConfig = mockConfig(sys);
 
   return {
@@ -36,6 +38,7 @@ export function mockValidatedConfig(sys?: CompilerSystem): ValidatedConfig {
     flags: createConfigFlags(),
     logger: mockLogger(),
     outputTargets: baseConfig.outputTargets ?? [],
+    ...overrides,
   };
 }
 

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -2,7 +2,6 @@ import type {
   BuildCtx,
   Cache,
   CompilerCtx,
-  CompilerSystem,
   Config,
   LoadConfigInit,
   ValidatedConfig,
@@ -30,7 +29,7 @@ import { createConfigFlags } from '../cli/config-flags';
  * @returns the mock Stencil configuration
  */
 export function mockValidatedConfig(overrides: Partial<ValidatedConfig> = {}): ValidatedConfig {
-  const baseConfig = mockConfig(overrides.sys);
+  const baseConfig = mockConfig(overrides);
 
   return {
     ...baseConfig,
@@ -45,15 +44,14 @@ export function mockValidatedConfig(overrides: Partial<ValidatedConfig> = {}): V
 /**
  * Creates a mock instance of a Stencil configuration entity. The mocked configuration has no guarantees around the
  * types/validity of its data.
- * @param sys an optional compiler system to associate with the config. If one is not provided, one will be created for
- * the caller
  * @param overrides a partial implementation of `UnvalidatedConfig`. Any provided fields will override the defaults
  * provided by this function.
  * @returns the mock Stencil configuration
  */
-export function mockConfig(sys?: CompilerSystem, overrides: Partial<UnvalidatedConfig> = {}): UnvalidatedConfig {
+export function mockConfig(overrides: Partial<UnvalidatedConfig> = {}): UnvalidatedConfig {
   const rootDir = path.resolve('/');
 
+  let { sys } = overrides;
   if (!sys) {
     sys = createTestingSystem();
   }

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -47,9 +47,11 @@ export function mockValidatedConfig(overrides: Partial<ValidatedConfig> = {}): V
  * types/validity of its data.
  * @param sys an optional compiler system to associate with the config. If one is not provided, one will be created for
  * the caller
+ * @param overrides a partial implementation of `UnvalidatedConfig`. Any provided fields will override the defaults
+ * provided by this function.
  * @returns the mock Stencil configuration
  */
-export function mockConfig(sys?: CompilerSystem): UnvalidatedConfig {
+export function mockConfig(sys?: CompilerSystem, overrides: Partial<UnvalidatedConfig> = {}): UnvalidatedConfig {
   const rootDir = path.resolve('/');
 
   if (!sys) {
@@ -87,6 +89,7 @@ export function mockConfig(sys?: CompilerSystem): UnvalidatedConfig {
     sys,
     testing: null,
     validateTypes: false,
+    ...overrides,
   };
 }
 

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -57,35 +57,34 @@ export function mockConfig(sys?: CompilerSystem): UnvalidatedConfig {
 
   return {
     _isTesting: true,
-
-    namespace: 'Testing',
-    rootDir: rootDir,
-    globalScript: null,
-    devMode: true,
-    enableCache: false,
     buildAppCore: false,
     buildDist: true,
-    flags: createConfigFlags(),
-    bundles: null,
-    outputTargets: null,
     buildEs5: false,
+    bundles: null,
+    devMode: true,
+    enableCache: false,
+    extras: {},
+    flags: createConfigFlags(),
+    globalScript: null,
     hashFileNames: false,
     logger: new TestingLogger(),
     maxConcurrentWorkers: 0,
     minifyCss: false,
     minifyJs: false,
-    sys,
-    testing: null,
-    validateTypes: false,
-    extras: {},
+    namespace: 'Testing',
     nodeResolve: {
       customResolveOptions: {},
     },
-    sourceMap: true,
+    outputTargets: null,
     rollupPlugins: {
       before: [],
       after: [],
     },
+    rootDir,
+    sourceMap: true,
+    sys,
+    testing: null,
+    validateTypes: false,
   };
 }
 

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -24,14 +24,13 @@ import { createConfigFlags } from '../cli/config-flags';
 // TODO(STENCIL-486): Update `mockValidatedConfig` to accept any property found on `ValidatedConfig`
 /**
  * Creates a mock instance of an internal, validated Stencil configuration object
- * @param sys an optional compiler system to associate with the config. If one is not provided, one will be created for
  * the caller
  * @param overrides a partial implementation of `ValidatedConfig`. Any provided fields will override the defaults
  * provided by this function.
  * @returns the mock Stencil configuration
  */
-export function mockValidatedConfig(sys?: CompilerSystem, overrides: Partial<ValidatedConfig> = {}): ValidatedConfig {
-  const baseConfig = mockConfig(sys);
+export function mockValidatedConfig(overrides: Partial<ValidatedConfig> = {}): ValidatedConfig {
+  const baseConfig = mockConfig(overrides.sys);
 
   return {
     ...baseConfig,

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -20,7 +20,6 @@ import { noop } from '@utils';
 import { buildEvents } from '../compiler/events';
 import { createConfigFlags } from '../cli/config-flags';
 
-// TODO(STENCIL-486): Update `mockValidatedConfig` to accept any property found on `ValidatedConfig`
 /**
  * Creates a mock instance of an internal, validated Stencil configuration object
  * the caller
@@ -40,7 +39,6 @@ export function mockValidatedConfig(overrides: Partial<ValidatedConfig> = {}): V
   };
 }
 
-// TODO(STENCIL-486): Update `mockConfig` to accept any property found on `UnvalidatedConfig`
 /**
  * Creates a mock instance of a Stencil configuration entity. The mocked configuration has no guarantees around the
  * types/validity of its data.

--- a/src/utils/test/util.spec.ts
+++ b/src/utils/test/util.spec.ts
@@ -6,8 +6,7 @@ import { stubDiagnostic } from '../../dev-server/test/Diagnostic.stub';
 describe('util', () => {
   describe('generatePreamble', () => {
     it('generates a comment with a single line preamble', () => {
-      const testConfig = mockConfig();
-      testConfig.preamble = 'I am Stencil';
+      const testConfig = mockConfig({ preamble: 'I am Stencil' });
 
       const result = util.generatePreamble(testConfig);
 
@@ -17,8 +16,7 @@ describe('util', () => {
     });
 
     it('generates a comment with a multi-line preamble', () => {
-      const testConfig = mockConfig();
-      testConfig.preamble = 'I am Stencil\nHear me roar';
+      const testConfig = mockConfig({ preamble: 'I am Stencil\nHear me roar' });
 
       const result = util.generatePreamble(testConfig);
 
@@ -37,8 +35,7 @@ describe('util', () => {
     });
 
     it('returns an empty string a null preamble is provided', () => {
-      const testConfig = mockConfig();
-      testConfig.preamble = null;
+      const testConfig = mockConfig({ preamble: null });
 
       const result = util.generatePreamble(testConfig);
 
@@ -46,8 +43,7 @@ describe('util', () => {
     });
 
     it('returns an empty string if an empty preamble is provided', () => {
-      const testConfig = mockConfig();
-      testConfig.preamble = '';
+      const testConfig = mockConfig({ preamble: '' });
 
       const result = util.generatePreamble(testConfig);
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Our mocks for configuration entities, both unvalidated and validated, are cumbersome
to override.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit adds a new parameter to `mockValidatedConfig`, `overrides`.
the argument is optional, and defaults to an empty object literal. it is
spread over the returned object to override and defaults put in place by
this method. the `sys` argument is also removed, as it now can be safely
derived from the `overrides` argument (and still falls back to a new
`TestingSystem` if `overrides.sys` is falsy

this commit adds an `overrides` parameter to `mockConfig`. `overrides`
is a partial instance of `UnvalidatedConfig`, which defaults to an empty
object literal. its contents are spread over the returned object,
overriding the values put in place by default. it also removes the `sys` arg.
' this value is now derived from the provided `overrides`, falling back to a
`TestingSystem` otherwise.

STENCIL-486: Update mockConfig, mockValidatedConfig to accept any property

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Unit tests continue to pass
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
