### PR TITLE
fix(cli): remove usage of deprecated npm env var from arg parser

### DIFF
--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -1,4 +1,4 @@
-import { CompilerSystem, LogLevel, LOG_LEVELS, TaskCommand } from '../declarations';
+import { LogLevel, LOG_LEVELS, TaskCommand } from '../declarations';
 import { dashToPascalCase, toDashCase } from '@utils';
 import {
   BOOLEAN_CLI_ARGS,
@@ -19,11 +19,10 @@ import {
 /**
  * Parse command line arguments into a structured `ConfigFlags` object
  *
- * @param args an array of config flags
- * @param sys an optional compiler system
+ * @param args an array of CLI flags
  * @returns a structured ConfigFlags object
  */
-export const parseFlags = (args: string[], sys?: CompilerSystem): ConfigFlags => {
+export const parseFlags = (args: string[]): ConfigFlags => {
   const flags: ConfigFlags = createConfigFlags();
 
   // cmd line has more priority over npm scripts cmd
@@ -32,17 +31,6 @@ export const parseFlags = (args: string[], sys?: CompilerSystem): ConfigFlags =>
     flags.task = flags.args[0] as TaskCommand;
   }
   parseArgs(flags, flags.args);
-
-  if (sys && sys.name === 'node') {
-    const envArgs = getNpmConfigEnvArgs(sys);
-    parseArgs(flags, envArgs);
-
-    envArgs.forEach((envArg) => {
-      if (!flags.args.includes(envArg)) {
-        flags.args.push(envArg);
-      }
-    });
-  }
 
   if (flags.task != null) {
     const i = flags.args.indexOf(flags.task);
@@ -344,19 +332,3 @@ const isLogLevel = (maybeLogLevel: string): maybeLogLevel is LogLevel =>
   //
   // see microsoft/TypeScript#31018 for some discussion of this
   LOG_LEVELS.includes(maybeLogLevel as any);
-
-const getNpmConfigEnvArgs = (sys: CompilerSystem) => {
-  // process.env.npm_config_argv
-  // {"remain":["4444"],"cooked":["run","serve","--port","4444"],"original":["run","serve","--port","4444"]}
-  let args: string[] = [];
-  try {
-    const npmConfigArgs = sys.getEnvironmentVar('npm_config_argv');
-    if (npmConfigArgs) {
-      args = JSON.parse(npmConfigArgs).original as string[];
-      if (args[0] === 'run') {
-        args = args.slice(2);
-      }
-    }
-  } catch (e) {}
-  return args;
-};

--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -1,4 +1,4 @@
-import { LogLevel, LOG_LEVELS, TaskCommand } from '../declarations';
+import { CompilerSystem, LogLevel, LOG_LEVELS, TaskCommand } from '../declarations';
 import { dashToPascalCase, toDashCase } from '@utils';
 import {
   BOOLEAN_CLI_ARGS,
@@ -20,9 +20,11 @@ import {
  * Parse command line arguments into a structured `ConfigFlags` object
  *
  * @param args an array of CLI flags
+ * @param _sys an optional compiler system
  * @returns a structured ConfigFlags object
  */
-export const parseFlags = (args: string[]): ConfigFlags => {
+export const parseFlags = (args: string[], _sys?: CompilerSystem): ConfigFlags => {
+  // TODO(STENCIL-509): remove the _sys parameter here ^^ (for v3)
   const flags: ConfigFlags = createConfigFlags();
 
   // cmd line has more priority over npm scripts cmd

--- a/src/cli/public.ts
+++ b/src/cli/public.ts
@@ -15,6 +15,7 @@ export declare function run(init: CliInitOptions): Promise<void>;
  */
 export declare function runTask(coreCompiler: any, config: Config, task: TaskCommand): Promise<void>;
 
-export declare function parseFlags(args: string[], sys?: CompilerSystem): ConfigFlags;
+// TODO(STENCIL-509): remove the _sys parameter here (for v3)
+export declare function parseFlags(args: string[], _sys?: CompilerSystem): ConfigFlags;
 
 export { CompilerSystem, Config, ConfigFlags, Logger, TaskCommand };

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -23,7 +23,7 @@ export const run = async (init: d.CliInitOptions) => {
   const { args, logger, sys } = init;
 
   try {
-    const flags = parseFlags(args, sys);
+    const flags = parseFlags(args);
     const task = flags.task;
 
     if (flags.debug || flags.verbose) {

--- a/src/cli/test/parse-flags.spec.ts
+++ b/src/cli/test/parse-flags.spec.ts
@@ -1,23 +1,13 @@
-import type * as d from '../../declarations';
 import { LogLevel } from '../../declarations';
 import { BOOLEAN_CLI_ARGS, STRING_CLI_ARGS, NUMBER_CLI_ARGS } from '../config-flags';
 import { parseEqualsArg, parseFlags } from '../parse-flags';
+import { toDashCase } from '@utils';
 
 describe('parseFlags', () => {
-  let args: string[] = [];
-  let sys: d.CompilerSystem = {} as any;
-
-  beforeEach(() => {
-    args = [];
-    sys = {
-      name: 'node',
-    } as any;
-  });
-
   it('should get known and unknown args', () => {
-    args.push('serve', '--address', '127.0.0.1', '--potatoArgument', '--flimflammery', 'test.spec.ts');
+    const args = ['serve', '--address', '127.0.0.1', '--potatoArgument', '--flimflammery', 'test.spec.ts'];
 
-    const flags = parseFlags(args, sys);
+    const flags = parseFlags(args);
     expect(flags.task).toBe('serve');
     expect(flags.args[0]).toBe('--address');
     expect(flags.args[1]).toBe('127.0.0.1');
@@ -30,556 +20,221 @@ describe('parseFlags', () => {
     expect(flags.unknownArgs[2]).toBe('test.spec.ts');
   });
 
-  it('should use cli args, no npm cmds', () => {
+  it('should parse cli for dev server', () => {
     // user command line args
     // $ npm run serve --port 4444
 
     // args.slice(2)
     // [ 'serve', '--address', '127.0.0.1', '--port', '4444' ]
 
-    args.push('serve', '--address', '127.0.0.1', '--port', '4444');
+    const args = ['serve', '--address', '127.0.0.1', '--port', '4444'];
 
-    const flags = parseFlags(args, sys);
+    const flags = parseFlags(args);
     expect(flags.task).toBe('serve');
     expect(flags.address).toBe('127.0.0.1');
     expect(flags.port).toBe(4444);
     expect(flags.knownArgs).toEqual(['--address', '127.0.0.1', '--port', '4444']);
   });
 
-  it('should use cli args first, then npm cmds', () => {
-    // user command line args
-    // $ npm run serve --port 4444
-
-    // npm script
-    // "serve": "stencil serve --address 127.0.0.1 --port 8888"
-
-    // args.slice(2)
-    // [ 'serve', '--address', '127.0.0.1', '--port', '8888', '4444' ]
-
-    // process.env.npm_config_argv
-    // {"remain":["4444"],"cooked":["run","serve","--port","4444"],"original":["run","serve","--port","4444"]}
-
-    args.push('serve', '--address', '127.0.0.1', '--port', '8888', '4444');
-
-    sys.getEnvironmentVar = (key: string): string => {
-      if (key === 'npm_config_argv') {
-        return JSON.stringify({
-          original: ['run', 'serve', '--port', '4444'],
-        });
-      }
-      return '';
-    };
-
-    const flags = parseFlags(args, sys);
-    expect(flags.task).toBe('serve');
-    expect(flags.address).toBe('127.0.0.1');
-    expect(flags.port).toBe(4444);
-  });
-
-  it('run stencil cmd from npm scripts', () => {
-    // user command line args
-    // $ npm run dev
-
-    // npm script
-    // "dev": "stencil build --dev --watch --serve"
-
-    // args.slice(2)
-    // [ 'build', '--dev', '--watch', '--serve' ]
-
-    // process.env.npm_config_argv
-    // {"remain":[],"cooked":["run","dev"],"original":["run","dev"]}
-
-    args.push('build', '--dev', '--watch', '--serve');
-
-    process.env = {
-      npm_config_argv: JSON.stringify({
-        original: ['run', 'dev'],
-      }),
-    };
-
-    const flags = parseFlags(args, sys);
-    expect(flags.task).toBe('build');
-    expect(flags.dev).toBe(true);
-    expect(flags.watch).toBe(true);
-    expect(flags.serve).toBe(true);
-  });
-
   it('should parse task', () => {
-    args[0] = 'build';
-    const flags = parseFlags(args, sys);
+    const flags = parseFlags(['build']);
     expect(flags.task).toBe('build');
   });
 
   it('should parse no task', () => {
-    args[0] = '--flag';
-    const flags = parseFlags(args, sys);
+    const flags = parseFlags(['--flag']);
     expect(flags.task).toBe(null);
   });
 
-  it('should parse build flag to true', () => {
-    args[0] = 'test';
-    args[1] = '--build';
-    const flags = parseFlags(args, sys);
-    expect(flags.build).toBe(true);
-  });
-
-  it('should parse build flag to false', () => {
-    args[0] = 'test';
-    args[1] = '--no-build';
-    const flags = parseFlags(args, sys);
-    expect(flags.build).toBe(false);
-  });
-
-  it('should parse --no-prerender-external', () => {
-    const flags = parseFlags(['--no-prerender-external'], sys);
-    expect(flags.prerenderExternal).toBe(false);
-  });
-
-  it('should not parse build flag, default null', () => {
-    args[0] = 'test';
-    const flags = parseFlags(args, sys);
-    expect(flags.build).toBe(null);
-  });
-
-  it('should parse --cache', () => {
-    args[0] = '--cache';
-    const flags = parseFlags(args, sys);
-    expect(flags.cache).toBe(true);
-  });
-
-  it('should parse --no-cache', () => {
-    args[0] = '--no-cache';
-    const flags = parseFlags(args, sys);
-    expect(flags.cache).toBe(false);
-  });
-
-  it('should not parse --cache', () => {
-    const flags = parseFlags(args, sys);
-    expect(flags.cache).toBe(null);
-  });
-
-  it('should parse --ci', () => {
-    args[0] = '--ci';
-    const flags = parseFlags(args, sys);
-    expect(flags.knownArgs).toEqual(['--ci']);
-    expect(flags.ci).toBe(true);
-  });
-
   /**
-   * these comprehensive tests of all the supported args serve as regression
-   * tests against duplicating any of the arguments in the arrays. Because of
-   * the way that the arg parsing algorithm works having a dupe will result in a
-   * value like `[true, true]` being set on ConfigFlags, which will cause these
-   * tests to start failing.
+   * these comprehensive tests of all the supported boolean args serve as
+   * regression tests against duplicating any of the arguments in the arrays.
+   * Because of the way that the arg parsing algorithm works having a dupe
+   * will result in a value like `[true, true]` being set on ConfigFlags, which
+   * will cause these tests to start failing.
    */
   describe.each(BOOLEAN_CLI_ARGS)('should parse boolean flag %s', (cliArg) => {
     it('should parse arg', () => {
-      const flags = parseFlags([`--${cliArg}`], sys);
+      const flags = parseFlags([`--${cliArg}`]);
       expect(flags.knownArgs).toEqual([`--${cliArg}`]);
       expect(flags[cliArg]).toBe(true);
     });
 
     it(`should parse --no${cliArg}`, () => {
       const negativeFlag = '--no' + cliArg.charAt(0).toUpperCase() + cliArg.slice(1);
-      const flags = parseFlags([negativeFlag], sys);
+      const flags = parseFlags([negativeFlag]);
       expect(flags.knownArgs).toEqual([negativeFlag]);
       expect(flags[cliArg]).toBe(false);
     });
+
+    it(`should override --${cliArg} with --no${cliArg}`, () => {
+      const negativeFlag = '--no' + cliArg.charAt(0).toUpperCase() + cliArg.slice(1);
+      const flags = parseFlags([`--${cliArg}`, negativeFlag]);
+      expect(flags.knownArgs).toEqual([`--${cliArg}`, negativeFlag]);
+      expect(flags[cliArg]).toBe(false);
+    });
+
+    it('should set value to null if not present', () => {
+      const flags = parseFlags([]);
+      expect(flags.knownArgs).toEqual([]);
+      expect(flags[cliArg]).toBe(null);
+    });
   });
 
-  it.each(STRING_CLI_ARGS)('should parse string flag %s', (cliArg) => {
-    const flags = parseFlags([`--${cliArg}`, 'test-value'], sys);
-    expect(flags.knownArgs).toEqual([`--${cliArg}`, 'test-value']);
-    expect(flags.unknownArgs).toEqual([]);
-    expect(flags[cliArg]).toBe('test-value');
-  });
+  describe.each(STRING_CLI_ARGS)('should parse string flag %s', (cliArg) => {
+    it(`should parse "--${cliArg} value"`, () => {
+      const flags = parseFlags([`--${cliArg}`, 'test-value']);
+      expect(flags.knownArgs).toEqual([`--${cliArg}`, 'test-value']);
+      expect(flags.unknownArgs).toEqual([]);
+      expect(flags[cliArg]).toBe('test-value');
+    });
 
-  it.each(STRING_CLI_ARGS)('should parse string flag --%s=value', (cliArg) => {
-    const flags = parseFlags([`--${cliArg}=path/to/file.js`], sys);
-    expect(flags.knownArgs).toEqual([`--${cliArg}`, 'path/to/file.js']);
-    expect(flags.unknownArgs).toEqual([]);
-    expect(flags[cliArg]).toBe('path/to/file.js');
+    it(`should parse "--${cliArg}=value"`, () => {
+      const flags = parseFlags([`--${cliArg}=path/to/file.js`]);
+      expect(flags.knownArgs).toEqual([`--${cliArg}`, 'path/to/file.js']);
+      expect(flags.unknownArgs).toEqual([]);
+      expect(flags[cliArg]).toBe('path/to/file.js');
+    });
+
+    it(`should parse "--${toDashCase(cliArg)} value"`, () => {
+      const flags = parseFlags([`--${toDashCase(cliArg)}`, 'path/to/file.js']);
+      expect(flags.knownArgs).toEqual([`--${toDashCase(cliArg)}`, 'path/to/file.js']);
+      expect(flags.unknownArgs).toEqual([]);
+      expect(flags[cliArg]).toBe('path/to/file.js');
+    });
+
+    it(`should parse "--${toDashCase(cliArg)}=value"`, () => {
+      const flags = parseFlags([`--${toDashCase(cliArg)}=path/to/file.js`]);
+      expect(flags.knownArgs).toEqual([`--${toDashCase(cliArg)}`, 'path/to/file.js']);
+      expect(flags.unknownArgs).toEqual([]);
+      expect(flags[cliArg]).toBe('path/to/file.js');
+    });
   });
 
   it.each(NUMBER_CLI_ARGS)('should parse number flag %s', (cliArg) => {
-    const flags = parseFlags([`--${cliArg}`, '42'], sys);
+    const flags = parseFlags([`--${cliArg}`, '42']);
     expect(flags.knownArgs).toEqual([`--${cliArg}`, '42']);
     expect(flags.unknownArgs).toEqual([]);
     expect(flags[cliArg]).toBe(42);
   });
 
-  it('should parse --compare', () => {
-    args[0] = '--compare';
-    const flags = parseFlags(args, sys);
-    expect(flags.knownArgs).toEqual(['--compare']);
-    expect(flags.unknownArgs).toEqual([]);
-    expect(flags.compare).toBe(true);
-  });
-
-  it('should not parse --compare', () => {
-    const flags = parseFlags(args, sys);
-    expect(flags.compare).toBe(null);
-  });
-
   it('should override --config with second --config', () => {
-    args[0] = '--config';
-    args[1] = '/config-1.js';
-    args[2] = '--config';
-    args[3] = '/config-2.js';
-    const flags = parseFlags(args, sys);
+    const args = ['--config', '/config-1.js', '--config', '/config-2.js'];
+    const flags = parseFlags(args);
     expect(flags.config).toBe('/config-2.js');
   });
 
-  it('should parse --config', () => {
-    args[0] = '--config';
-    args[1] = '/my-config.js';
-    const flags = parseFlags(args, sys);
-    expect(flags.config).toBe('/my-config.js');
+  describe.each<LogLevel>(['info', 'warn', 'error', 'debug'])('logLevel %s', (level) => {
+    it("should parse '--logLevel %s'", () => {
+      const args = ['--logLevel', level];
+      const flags = parseFlags(args);
+      expect(flags.logLevel).toBe(level);
+    });
+
+    it('should parse --logLevel=%s', () => {
+      const args = [`--logLevel=${level}`];
+      const flags = parseFlags(args);
+      expect(flags.logLevel).toBe(level);
+    });
+
+    it("should parse '--log-level %s'", () => {
+      const flags = parseFlags(['--log-level', level]);
+      expect(flags.logLevel).toBe(level);
+    });
+
+    it('should parse --log-level=%s', () => {
+      const flags = parseFlags([`--log-level=${level}`]);
+      expect(flags.logLevel).toBe(level);
+    });
   });
 
-  it('should parse --config=/my-config.js', () => {
-    args[0] = '--config=/my-config.js';
-    const flags = parseFlags(args, sys);
-    expect(flags.config).toBe('/my-config.js');
+  /**
+   * maxWorkers is (as of this writing) our only StringNumberCLIArg, meaning it
+   * may be a string (like "50%") or a number (like 4). For this reason we have
+   * some tests just for it.
+   */
+  describe('maxWorkers', () => {
+    it.each([
+      ['--maxWorkers', '4'],
+      ['--maxWorkers=4'],
+      ['--max-workers', '4'],
+      ['--maxWorkers', '4e+0'],
+      ['--maxWorkers', '40e-1'],
+    ])('should parse %p, %p', (...args) => {
+      const flags = parseFlags(args);
+      expect(flags.maxWorkers).toBe(4);
+    });
+
+    it('should parse --maxWorkers 4', () => {
+      const flags = parseFlags(['--maxWorkers', '4']);
+      expect(flags.maxWorkers).toBe(4);
+    });
+
+    it('should parse --maxWorkers=4', () => {
+      const flags = parseFlags(['--maxWorkers=4']);
+      expect(flags.maxWorkers).toBe(4);
+    });
+
+    it('should parse --max-workers 4', () => {
+      const flags = parseFlags(['--max-workers', '4']);
+      expect(flags.maxWorkers).toBe(4);
+    });
+
+    it('should parse --maxWorkers=50%', function () {
+      // see https://jestjs.io/docs/27.x/cli#--maxworkersnumstring
+      const flags = parseFlags(['--maxWorkers=50%']);
+      expect(flags.maxWorkers).toBe('50%');
+    });
+
+    it('should parse --max-workers=1', () => {
+      const flags = parseFlags(['--max-workers=1']);
+      expect(flags.maxWorkers).toBe(1);
+    });
+
+    it('should not parse --max-workers', () => {
+      const flags = parseFlags([]);
+      expect(flags.maxWorkers).toBe(null);
+    });
   });
 
-  it('should parse -c', () => {
-    args[0] = '-c';
-    args[1] = '/my-config.js';
-    const flags = parseFlags(args, sys);
-    expect(flags.config).toBe('/my-config.js');
-  });
+  describe('aliases', () => {
+    describe('-p (alias for port)', () => {
+      it('should parse -p=4444', () => {
+        const flags = parseFlags(['-p=4444']);
+        expect(flags.port).toBe(4444);
+      });
+      it('should parse -p 4444', () => {
+        const flags = parseFlags(['-p', '4444']);
+        expect(flags.port).toBe(4444);
+      });
+    });
 
-  it('should parse -c=/my-config.js', () => {
-    args[0] = '-c=/my-config.js';
-    const flags = parseFlags(args, sys);
-    expect(flags.config).toBe('/my-config.js');
-  });
+    it('should parse -h (alias for help)', () => {
+      const flags = parseFlags(['-h']);
+      expect(flags.help).toBe(true);
+    });
 
-  it('should parse --debug', () => {
-    args[0] = '--debug';
-    const flags = parseFlags(args, sys);
-    expect(flags.debug).toBe(true);
-  });
+    it('should parse -v (alias for version)', () => {
+      const flags = parseFlags(['-v']);
+      expect(flags.version).toBe(true);
+    });
 
-  it('should parse --dev', () => {
-    args[0] = '--dev';
-    const flags = parseFlags(args, sys);
-    expect(flags.dev).toBe(true);
-  });
+    describe('-c alias for config', () => {
+      it('should parse -c /my-config.js', () => {
+        const flags = parseFlags(['-c', '/my-config.js']);
+        expect(flags.config).toBe('/my-config.js');
+      });
 
-  it('should override --no-docs flag with --docs', () => {
-    args[0] = '--no-docs';
-    args[1] = '--docs';
-    const flags = parseFlags(args, sys);
-    expect(flags.docs).toBe(true);
-  });
-
-  it('should override --docs flag with --no-docs', () => {
-    args[0] = '--docs';
-    args[1] = '--no-docs';
-    const flags = parseFlags(args, sys);
-    expect(flags.docs).toBe(false);
-  });
-
-  it('should parse --docs', () => {
-    args[0] = '--docs';
-    const flags = parseFlags(args, sys);
-    expect(flags.docs).toBe(true);
-  });
-
-  it('should parse --docs-json', () => {
-    args[0] = '--docs-json';
-    args[1] = 'some/path/docs.json';
-    const flags = parseFlags(args, sys);
-    expect(flags.docsJson).toBe('some/path/docs.json');
-  });
-
-  it('should parse --docs-json w/ =', () => {
-    args[0] = '--docs-json=some/path/docs.json';
-    const flags = parseFlags(args, sys);
-    expect(flags.docsJson).toBe('some/path/docs.json');
-  });
-
-  it('should parse --e2e', () => {
-    args[0] = '--e2e';
-    const flags = parseFlags(args, sys);
-    expect(flags.e2e).toBe(true);
-  });
-
-  it('should parse --emulate=android', () => {
-    args[0] = '--emulate=android';
-    const flags = parseFlags(args, sys);
-    expect(flags.emulate).toBe('android');
-  });
-
-  it('should parse --emulate android', () => {
-    args[0] = '--emulate';
-    args[1] = 'android';
-    const flags = parseFlags(args, sys);
-    expect(flags.emulate).toBe('android');
-  });
-
-  it('should not parse --emulate', () => {
-    const flags = parseFlags(args, sys);
-    expect(flags.emulate).toBe(null);
-  });
-
-  it('should parse --es5', () => {
-    args[0] = '--es5';
-    const flags = parseFlags(args, sys);
-    expect(flags.es5).toBe(true);
-  });
-
-  it('should parse --help', () => {
-    args[0] = '--help';
-    const flags = parseFlags(args, sys);
-    expect(flags.help).toBe(true);
-  });
-
-  it('should parse -h', () => {
-    args[0] = '-h';
-    const flags = parseFlags(args, sys);
-    expect(flags.help).toBe(true);
-  });
-
-  it('should parse --no-headless', () => {
-    args[0] = '--no-headless';
-    const flags = parseFlags(args, sys);
-    expect(flags.headless).toBe(false);
-  });
-
-  it('should parse --headless', () => {
-    args[0] = '--headless';
-    const flags = parseFlags(args, sys);
-    expect(flags.headless).toBe(true);
-  });
-
-  it.each<LogLevel>(['info', 'warn', 'error', 'debug'])("should parse '--logLevel %s'", (level) => {
-    const args = ['--logLevel', level];
-    const flags = parseFlags(args, sys);
-    expect(flags.logLevel).toBe(level);
-  });
-
-  it.each<LogLevel>(['info', 'warn', 'error', 'debug'])('should parse --logLevel=%s', (level) => {
-    const args = [`--logLevel=${level}`];
-    const flags = parseFlags(args, sys);
-    expect(flags.logLevel).toBe(level);
-  });
-
-  it.each<LogLevel>(['info', 'warn', 'error', 'debug'])("should parse '--log-level %s'", (level) => {
-    const flags = parseFlags(['--log-level', level], sys);
-    expect(flags.logLevel).toBe(level);
-  });
-
-  it.each<LogLevel>(['info', 'warn', 'error', 'debug'])('should parse --log-level=%s', (level) => {
-    const flags = parseFlags([`--log-level=${level}`], sys);
-    expect(flags.logLevel).toBe(level);
-  });
-
-  it('should parse --log', () => {
-    const flags = parseFlags(['--log'], sys);
-    expect(flags.log).toBe(true);
-  });
-
-  it.each([
-    ['--maxWorkers', '4'],
-    ['--maxWorkers=4'],
-    ['--max-workers', '4'],
-    ['--maxWorkers', '4e+0'],
-    ['--maxWorkers', '40e-1'],
-  ])('should parse %p, %p', (...args) => {
-    const flags = parseFlags(args, sys);
-    expect(flags.maxWorkers).toBe(4);
-  });
-
-  it('should parse --maxWorkers 4', () => {
-    args[0] = '--maxWorkers';
-    args[1] = '4';
-    const flags = parseFlags(args, sys);
-    expect(flags.maxWorkers).toBe(4);
-  });
-
-  it('should parse --maxWorkers=4', () => {
-    args[0] = '--maxWorkers=4';
-    const flags = parseFlags(args, sys);
-    expect(flags.maxWorkers).toBe(4);
-  });
-
-  it('should parse --max-workers 4', () => {
-    args[0] = '--max-workers';
-    args[1] = '4';
-    const flags = parseFlags(args, sys);
-    expect(flags.maxWorkers).toBe(4);
-  });
-
-  it('should parse --maxWorkers=50%', function () {
-    // see https://jestjs.io/docs/27.x/cli#--maxworkersnumstring
-    const flags = parseFlags(['--maxWorkers=50%']);
-    expect(flags.maxWorkers).toBe('50%');
-  });
-
-  it('should parse --max-workers=1', () => {
-    args[0] = '--max-workers=1';
-    const flags = parseFlags(args, sys);
-    expect(flags.maxWorkers).toBe(1);
-  });
-
-  it('should not parse --max-workers', () => {
-    const flags = parseFlags(args, sys);
-    expect(flags.maxWorkers).toBe(null);
-  });
-
-  it('should parse --no-open', () => {
-    args[0] = '--no-open';
-    const flags = parseFlags(args, sys);
-    expect(flags.open).toBe(false);
-  });
-
-  it('should parse --port', () => {
-    args[0] = '--port';
-    args[1] = '8888';
-    const flags = parseFlags(args, sys);
-    expect(flags.port).toBe(8888);
-  });
-
-  it('should parse -p', () => {
-    args[0] = '-p';
-    args[1] = '4444';
-    const flags = parseFlags(args, sys);
-    expect(flags.port).toBe(4444);
-  });
-
-  it('should parse --prod', () => {
-    args[0] = '--prod';
-    const flags = parseFlags(args, sys);
-    expect(flags.prod).toBe(true);
-  });
-
-  it('should parse --profile', () => {
-    args[0] = '--profile';
-    const flags = parseFlags(args, sys);
-    expect(flags.profile).toBe(true);
-  });
-
-  it('should parse --prerender', () => {
-    args[0] = '--prerender';
-    const flags = parseFlags(args, sys);
-    expect(flags.prerender).toBe(true);
-  });
-
-  it('should parse --root', () => {
-    args[0] = '--root';
-    args[1] = 'custom-www';
-    const flags = parseFlags(args, sys);
-    expect(flags.root).toBe('custom-www');
-  });
-
-  it('should parse --screenshot', () => {
-    args[0] = '--screenshot';
-    const flags = parseFlags(args, sys);
-    expect(flags.screenshot).toBe(true);
-  });
-
-  it('should parse --screenshot-connector scripts/connector.js', () => {
-    args[0] = '--screenshot-connector';
-    args[1] = 'scripts/connector.js';
-    const flags = parseFlags(args, sys);
-    expect(flags.screenshotConnector).toBe('scripts/connector.js');
-  });
-
-  it('should parse --screenshot-connector=scripts/connector.js', () => {
-    args[0] = '--screenshot-connector=scripts/connector.js';
-    const flags = parseFlags(args, sys);
-    expect(flags.screenshotConnector).toBe('scripts/connector.js');
-  });
-
-  it('should not parse --screenshot-connector', () => {
-    const flags = parseFlags(args, sys);
-    expect(flags.maxWorkers).toBe(null);
-  });
-
-  it('should parse --serve', () => {
-    args[0] = '--serve';
-    const flags = parseFlags(args, sys);
-    expect(flags.serve).toBe(true);
-  });
-
-  it('should parse --service-worker', () => {
-    args[0] = '--service-worker';
-    const flags = parseFlags(args, sys);
-    expect(flags.serviceWorker).toBe(true);
-  });
-
-  it('should parse --spec', () => {
-    args[0] = '--spec';
-    const flags = parseFlags(args, sys);
-    expect(flags.spec).toBe(true);
-  });
-
-  it('should parse --stats', () => {
-    args[0] = '--stats';
-    const flags = parseFlags(args, sys);
-    expect(flags.stats).toBe(true);
-  });
-
-  it('should parse --noUpdateScreenshot', () => {
-    args[0] = '--noUpdateScreenshot';
-    const flags = parseFlags(args, sys);
-    expect(flags.updateScreenshot).toBe(false);
-  });
-
-  it('should parse --updateScreenshot', () => {
-    args[0] = '--updateScreenshot';
-    const flags = parseFlags(args, sys);
-    expect(flags.updateScreenshot).toBe(true);
-  });
-
-  it('should parse --update-screenshot', () => {
-    args[0] = '--update-screenshot';
-    const flags = parseFlags(args, sys);
-    expect(flags.updateScreenshot).toBe(true);
-  });
-
-  it('should not parse --update-screenshot', () => {
-    const flags = parseFlags(args, sys);
-    expect(flags.updateScreenshot).toBe(null);
-  });
-
-  it('should parse --version', () => {
-    args[0] = '--version';
-    const flags = parseFlags(args, sys);
-    expect(flags.version).toBe(true);
-  });
-
-  it('should parse -v', () => {
-    args[0] = '-v';
-    const flags = parseFlags(args, sys);
-    expect(flags.version).toBe(true);
-  });
-
-  it('should set null version', () => {
-    const flags = parseFlags(args, sys);
-    expect(flags.version).toBe(null);
-  });
-
-  it('should parse --watch', () => {
-    args[0] = '--watch';
-    const flags = parseFlags(args, sys);
-    expect(flags.watch).toBe(true);
-  });
-
-  it('should parse --ssr', () => {
-    args[0] = '--ssr';
-    const flags = parseFlags(args, sys);
-    expect(flags.ssr).toBe(true);
+      it('should parse -c=/my-config.js', () => {
+        const flags = parseFlags(['-c=/my-config.js']);
+        expect(flags.config).toBe('/my-config.js');
+      });
+    });
   });
 
   it('should parse many', () => {
-    args[0] = '-v';
-    args[1] = '--help';
-    args[2] = '-c=./myconfig.json';
-    const flags = parseFlags(args, sys);
+    const args = ['-v', '--help', '-c=./myconfig.json'];
+    const flags = parseFlags(args);
     expect(flags.version).toBe(true);
     expect(flags.help).toBe(true);
     expect(flags.config).toBe('./myconfig.json');

--- a/src/testing/jest/test/jest-config.spec.ts
+++ b/src/testing/jest/test/jest-config.spec.ts
@@ -8,7 +8,7 @@ describe('jest-config', () => {
   it('pass --maxWorkers=2 arg when --max-workers=2', () => {
     const args = ['test', '--ci', '--max-workers=2'];
     const config = mockValidatedConfig({ testing: {} });
-    config.flags = parseFlags(args, config.sys);
+    config.flags = parseFlags(args);
 
     expect(config.flags.args).toEqual(['--ci', '--max-workers=2']);
     expect(config.flags.unknownArgs).toEqual([]);
@@ -21,7 +21,7 @@ describe('jest-config', () => {
   it('marks outputFile as a Jest argument', () => {
     const args = ['test', '--ci', '--outputFile=path/to/my-file'];
     const config = mockValidatedConfig({ testing: {} });
-    config.flags = parseFlags(args, config.sys);
+    config.flags = parseFlags(args);
     expect(config.flags.args).toEqual(['--ci', '--outputFile=path/to/my-file']);
     expect(config.flags.unknownArgs).toEqual([]);
     const jestArgv = buildJestArgv(config);
@@ -31,7 +31,7 @@ describe('jest-config', () => {
   it('pass --maxWorkers=2 arg when e2e test and --ci', () => {
     const args = ['test', '--ci', '--e2e', '--max-workers=2'];
     const config = mockValidatedConfig({ testing: {} });
-    config.flags = parseFlags(args, config.sys);
+    config.flags = parseFlags(args);
 
     expect(config.flags.args).toEqual(['--ci', '--e2e', '--max-workers=2']);
     expect(config.flags.unknownArgs).toEqual([]);
@@ -44,7 +44,7 @@ describe('jest-config', () => {
   it('forces --maxWorkers=4 arg when e2e test and --ci', () => {
     const args = ['test', '--ci', '--e2e'];
     const config = mockValidatedConfig({ testing: {} });
-    config.flags = parseFlags(args, config.sys);
+    config.flags = parseFlags(args);
 
     expect(config.flags.args).toEqual(['--ci', '--e2e']);
     expect(config.flags.unknownArgs).toEqual([]);
@@ -57,7 +57,7 @@ describe('jest-config', () => {
   it('pass --maxWorkers=2 arg to jest', () => {
     const args = ['test', '--maxWorkers=2'];
     const config = mockValidatedConfig({ testing: {} });
-    config.flags = parseFlags(args, config.sys);
+    config.flags = parseFlags(args);
 
     expect(config.flags.args).toEqual(['--maxWorkers=2']);
     expect(config.flags.unknownArgs).toEqual([]);
@@ -69,7 +69,7 @@ describe('jest-config', () => {
   it('pass --ci arg to jest', () => {
     const args = ['test', '--ci'];
     const config = mockValidatedConfig({ testing: {} });
-    config.flags = parseFlags(args, config.sys);
+    config.flags = parseFlags(args);
 
     expect(config.flags.args).toEqual(['--ci']);
     expect(config.flags.unknownArgs).toEqual([]);
@@ -82,7 +82,7 @@ describe('jest-config', () => {
   it('sets legacy jest options', () => {
     const args = ['test'];
     const config = mockValidatedConfig({ testing: {} });
-    config.flags = parseFlags(args, config.sys);
+    config.flags = parseFlags(args);
 
     const jestArgv = buildJestArgv(config);
 
@@ -111,7 +111,7 @@ describe('jest-config', () => {
   it('pass test spec arg to jest', () => {
     const args = ['test', 'hello.spec.ts'];
     const config = mockValidatedConfig({ testing: {} });
-    config.flags = parseFlags(args, config.sys);
+    config.flags = parseFlags(args);
 
     expect(config.flags.args).toEqual(['hello.spec.ts']);
     expect(config.flags.unknownArgs).toEqual(['hello.spec.ts']);
@@ -127,7 +127,7 @@ describe('jest-config', () => {
         testMatch: ['hello.spec.ts'],
       },
     });
-    config.flags = parseFlags(args, config.sys);
+    config.flags = parseFlags(args);
 
     expect(config.flags.task).toBe('test');
 
@@ -143,7 +143,7 @@ describe('jest-config', () => {
       rootDir,
       testing: { reporters: ['default', ['jest-junit', { suiteName: 'jest tests' }]] },
     });
-    config.flags = parseFlags(args, config.sys);
+    config.flags = parseFlags(args);
 
     const jestArgv = buildJestArgv(config);
     const parsedConfig = JSON.parse(jestArgv.config) as d.JestConfig;
@@ -157,7 +157,7 @@ describe('jest-config', () => {
     const rootDir = path.resolve('/');
     const args = ['test'];
     const config = mockValidatedConfig({ rootDir, testing: {} });
-    config.flags = parseFlags(args, config.sys);
+    config.flags = parseFlags(args);
 
     const jestArgv = buildJestArgv(config);
     const parsedConfig = JSON.parse(jestArgv.config) as d.JestConfig;
@@ -168,7 +168,7 @@ describe('jest-config', () => {
     const rootDir = path.resolve('/');
     const args = ['test'];
     const config = mockValidatedConfig({ rootDir, testing: { collectCoverageFrom: ['**/*.+(ts|tsx)'] } });
-    config.flags = parseFlags(args, config.sys);
+    config.flags = parseFlags(args);
 
     const jestArgv = buildJestArgv(config);
     const parsedConfig = JSON.parse(jestArgv.config) as d.JestConfig;
@@ -179,7 +179,7 @@ describe('jest-config', () => {
   it('passed flags should be respected over defaults', () => {
     const args = ['test', '--spec', '--passWithNoTests'];
     const config = mockValidatedConfig({ testing: {} });
-    config.flags = parseFlags(args, config.sys);
+    config.flags = parseFlags(args);
 
     expect(config.flags.args).toEqual(['--spec', '--passWithNoTests']);
     expect(config.flags.unknownArgs).toEqual([]);


### PR DESCRIPTION
This removes some code from our argument parsing implementation which
would look for an environment variable (`npm_config_argv`) set by npm
and, if present, merge CLI flags found their into the ones already
present on `process.argv`.

We want to remove this for two reasons:

- `npm_config_argv` is deprecated in `npm`, so in newer versions of the
  package manager it is no longer set and our code referencing it is
  effectively doing nothing
- `yarn` v1.x still sets it (presumably for compatibility with `npm`
  that hasn't been removed yet, which causes an inconsistency between
  `npm` and `yarn` where certain `package.json` scripts will run without
  issue in `npm` but fail in `yarn` (see #3482)

Accordingly, this commit deletes the offending function from
`src/cli/parse-flags.ts` and makes a few related changes at call sites,
etc which are necessary due to that change.

This commit also refactors the spec file for `parse-flags.ts` to remove
redundant tests. Because all of the supported CLI arguments (i.e. those
added to `knownArgs`) are defined in `ReadonlyArray<string>` variables
we can do a lot of exhaustive testing of all the arguments, set in the
various possible permutations, etc, so we don't need to define a bunch
of individual tests. Accordingly, the test file is refactored to remove
redundant tests, add a few more test cases for the exhaustive tests,
organize things a bit more with `describe` blocks, and ensure that we
have good tests around all off the 'edge-case-ey' things.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

When parsing CLI args (in `parse_flags.ts`) Stencil will look at `process.argv` and _also_ at an environment variable called `npm_config_argv`. This [was deprecated](https://github.com/npm/rfcs/blob/main/implemented/0021-reduce-lifecycle-script-environment.md) in `npm` but is still set by (at least) yarn v1.x. This causes a discrepancy between yarn and npm in what CLI arguments will be parsed by Stencil, and, in particular, this can lead to a situation where different arguments are passed to Jest (see #3482 for some details).


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This removes the code that accesses `npm_config_argv` in favor of just depending on `process.argv`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No\*

\* This does in a sense change the ways that CLI args can be passed to Stencil. It's possible that users of older versions of npm who depend on the (undocumented) behavior of passing through CLI arguments to npm will experience some disruption if they upgrade. However, given that this code _does nothing_ on newer versions of npm and that hasn't led to any disruption, any impact is likely to be minimal.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

There are some changes and enhancements to the unit tests for CLI argument parsing module. Additionally, I built and `npm pack`-ed these changes in a few example projects to make sure that various ways of running stencil are fully supported, e.g. `npx stencil test --e2e`, from a package.json script, etc.

Additionally, these things should all work the same between yarn and npm!

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
