### PR TITLE
chore(telemetry): remove info task telemetry call

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -75,14 +75,7 @@ export const run = async (init: d.CliInitOptions) => {
     loadedCompilerLog(sys, logger, flags, coreCompiler);
 
     if (task === 'info') {
-      await telemetryAction(
-        sys,
-        { flags: createConfigFlags({ task: 'info' }), logger, outputTargets: [] },
-        coreCompiler,
-        async () => {
-          await taskInfo(coreCompiler, sys, logger);
-        }
-      );
+      await taskInfo(coreCompiler, sys, logger);
       return;
     }
 

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -75,7 +75,7 @@ export const run = async (init: d.CliInitOptions) => {
     loadedCompilerLog(sys, logger, flags, coreCompiler);
 
     if (task === 'info') {
-      await taskInfo(coreCompiler, sys, logger);
+      taskInfo(coreCompiler, sys, logger);
       return;
     }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Remove dead functionality. It straddles the line of 'bugfix' and 'refactoring'


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

collecting telemetry on the `info` task has been broken for a bit now

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit removes a telemetry call from stencil for the info task.
this call has been broken for the debugging/verbose capabilities,
is seldom used, and is something that we don't feel we want or need
to collect.

it also has an additional positive side effect for making the stencil
configuration entity stricter - this call was placed before
loading/validating a configuration (because doing so is not required to
run the info task, making it faster). as `ValidatedConfig` grew in size,
additional fields were added to make a bespoke validated config.
removing this call removes the need to maintain the config used, making
the process of making `ValidatedConfig` stricter slightly easier


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Existing tests continue to pass.

I also tested this in a minimal component library:
```
npm init stencil@latest component ryan-test-info-change
```

By building this branch and tarballing it:
```
npm run build && npm pack
```

And subsequently installing it
```
npm i <PATH_TO_TARBALL>
```

I was able to run the `info` task and `build` task with no issue
```
npx stencil info
npx stencil build
```

## Other information

N/A
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
