### PR TITLE
chore(cli): remove sys param from `parseFlags`

### DIFF
--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -1,4 +1,4 @@
-import { CompilerSystem, LogLevel, LOG_LEVELS, TaskCommand } from '../declarations';
+import { LogLevel, LOG_LEVELS, TaskCommand } from '../declarations';
 import { dashToPascalCase, toDashCase } from '@utils';
 import {
   BOOLEAN_CLI_ARGS,
@@ -20,11 +20,9 @@ import {
  * Parse command line arguments into a structured `ConfigFlags` object
  *
  * @param args an array of CLI flags
- * @param _sys an optional compiler system
  * @returns a structured ConfigFlags object
  */
-export const parseFlags = (args: string[], _sys?: CompilerSystem): ConfigFlags => {
-  // TODO(STENCIL-509): remove the _sys parameter here ^^ (for v3)
+export const parseFlags = (args: string[]): ConfigFlags => {
   const flags: ConfigFlags = createConfigFlags();
 
   // cmd line has more priority over npm scripts cmd

--- a/src/cli/public.ts
+++ b/src/cli/public.ts
@@ -1,4 +1,4 @@
-import type { CliInitOptions, CompilerSystem, Config, Logger, TaskCommand } from '@stencil/core/internal';
+import type { CliInitOptions, Config, Logger, TaskCommand } from '@stencil/core/internal';
 import type { ConfigFlags } from './config-flags';
 
 /**
@@ -15,7 +15,6 @@ export declare function run(init: CliInitOptions): Promise<void>;
  */
 export declare function runTask(coreCompiler: any, config: Config, task: TaskCommand): Promise<void>;
 
-// TODO(STENCIL-509): remove the _sys parameter here (for v3)
-export declare function parseFlags(args: string[], _sys?: CompilerSystem): ConfigFlags;
+export declare function parseFlags(args: string[]): ConfigFlags;
 
-export { CompilerSystem, Config, ConfigFlags, Logger, TaskCommand };
+export { Config, ConfigFlags, Logger, TaskCommand };


### PR DESCRIPTION
This removes the `sys` parameter from the `parseFlags` function in
`src/cli/parse-flags.ts`. This parameter was more or less deprecated
in #3486 but was not removed at the time because `parseFlags` is part of
Stencil's public API, so we need to wait for a major version change to
change the type signature of the function.

STENCIL-509: remove _sys param from cli/parse_flags.ts::parseFlags

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): cleanup, removing a 'deprecated' function parameter in a public API (the parameter is already unused and ignored with `_` on `main`)


## What is the current behavior, new behavior?

No code behavior change here, just removing a parameter on a public function.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

If anyone is using this function in a typescript environment they'll need to update their code to fix a type error (it will be real straightforward though).

## Testing

unit tests, and building and trying out a Stencil build with this change.
