### PR TITLE
chore(config): make sys required on ValidatedConfig

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -113,18 +113,27 @@ export const run = async (init: d.CliInitOptions) => {
   }
 };
 
+/**
+ * Run a specified task
+ * @param coreCompiler an instance of a minimal, bootstrap compiler for running the specified task
+ * @param config a configuration for the Stencil project to apply to the task run
+ * @param task the task to run
+ * @param sys the {@link CompilerSystem} for interacting with the operating system
+ * @public
+ */
 export const runTask = async (
   coreCompiler: CoreCompiler,
   config: d.Config,
   task: d.TaskCommand,
   sys?: d.CompilerSystem
-) => {
+): Promise<void> => {
   const logger = config.logger ?? createLogger();
   const strictConfig: ValidatedConfig = {
     ...config,
     flags: createConfigFlags(config.flags ?? { task }),
     logger,
     outputTargets: config.outputTargets ?? [],
+    sys: sys ?? coreCompiler.createSystem({ logger }),
   };
 
   switch (task) {

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -1,4 +1,4 @@
-import type { Compiler, Config, Diagnostic } from '../declarations';
+import type { Compiler, Config, Diagnostic, ValidatedConfig } from '../declarations';
 import { Cache } from './cache';
 import { CompilerContext } from './build/compiler-ctx';
 import { createFullBuild } from './build/full-build';
@@ -22,7 +22,7 @@ export const createCompiler = async (userConfig: Config): Promise<Compiler> => {
   // actual compiler code
   // could be in a web worker on the browser
   // or the main thread in node
-  const config = getConfig(userConfig);
+  const config: ValidatedConfig = getConfig(userConfig);
   const diagnostics: Diagnostic[] = [];
   const sys = config.sys;
   const compilerCtx = new CompilerContext();

--- a/src/compiler/config/load-config.ts
+++ b/src/compiler/config/load-config.ts
@@ -52,7 +52,7 @@ export const loadConfig = async (init: LoadConfigInit = {}): Promise<LoadConfigR
     // Pull the {@link CompilerSystem} out of the initialization object, or create one if it does not exist.
     // This entity is needed to load the project's configuration (and therefore needs to be created before it can be
     // attached to a configuration entity, validated or otherwise)
-    const sys = init.sys || createSystem();
+    const sys = init.sys ?? createSystem();
 
     const loadedConfigFile = await loadConfigFile(sys, results.diagnostics, configPath);
     if (hasError(results.diagnostics)) {

--- a/src/compiler/config/load-config.ts
+++ b/src/compiler/config/load-config.ts
@@ -46,9 +46,13 @@ export const loadConfig = async (init: LoadConfigInit = {}): Promise<LoadConfigR
   const unknownConfig: UnvalidatedConfig = {};
 
   try {
-    const sys = init.sys || createSystem();
     const config = init.config || {};
     let configPath = init.configPath || config.configPath;
+
+    // Pull the {@link CompilerSystem} out of the initialization object, or create one if it does not exist.
+    // This entity is needed to load the project's configuration (and therefore needs to be created before it can be
+    // attached to a configuration entity, validated or otherwise)
+    const sys = init.sys || createSystem();
 
     const loadedConfigFile = await loadConfigFile(sys, results.diagnostics, configPath);
     if (hasError(results.diagnostics)) {

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -12,6 +12,7 @@ import { validateRollupConfig } from './validate-rollup-config';
 import { validateTesting } from './validate-testing';
 import { validateWorkers } from './validate-workers';
 import { createLogger } from '../sys/logger/console-logger';
+import { createSystem } from '../sys/stencil-sys';
 
 /**
  * Represents the results of validating a previously unvalidated configuration
@@ -41,7 +42,7 @@ export const validateConfig = (
   userConfig: UnvalidatedConfig = {},
   bootstrapConfig: LoadConfigInit
 ): ConfigValidationResults => {
-  const config = Object.assign({}, userConfig || {}); // not positive it's json safe
+  const config = Object.assign({}, userConfig); // not positive it's json safe
   const diagnostics: Diagnostic[] = [];
 
   const logger = bootstrapConfig.logger || config.logger || createLogger();
@@ -52,6 +53,7 @@ export const validateConfig = (
     flags: JSON.parse(JSON.stringify(config.flags || {})),
     logger,
     outputTargets: config.outputTargets ?? [],
+    sys: config.sys ?? bootstrapConfig.sys ?? createSystem({ logger }),
   };
 
   // default devMode false

--- a/src/compiler/sys/config.ts
+++ b/src/compiler/sys/config.ts
@@ -11,11 +11,8 @@ export const getConfig = (userConfig: d.Config): d.ValidatedConfig => {
     flags: createConfigFlags(userConfig.flags ?? {}),
     logger,
     outputTargets: userConfig.outputTargets ?? [],
+    sys: userConfig.sys ?? createSystem({ logger }),
   };
-
-  if (!config.sys) {
-    config.sys = createSystem({ logger: config.logger });
-  }
 
   setPlatformPath(config.sys.platformPath);
 

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -409,7 +409,7 @@ type RequireFields<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 /**
  * Fields in {@link Config} to make required for {@link ValidatedConfig}
  */
-type StrictConfigFields = 'flags' | 'logger' | 'outputTargets';
+type StrictConfigFields = 'flags' | 'logger' | 'outputTargets' | 'sys';
 
 /**
  * A version of {@link Config} that makes certain fields required. This type represents a valid configuration entity.

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -35,6 +35,7 @@ export function mockValidatedConfig(overrides: Partial<ValidatedConfig> = {}): V
     flags: createConfigFlags(),
     logger: mockLogger(),
     outputTargets: baseConfig.outputTargets ?? [],
+    sys: createTestingSystem(),
     ...overrides,
   };
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`sys` is not a required property on `ValidatedConfig`, creating several
`strictNullCheck` violations in the codebase

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit makes the `sys` property required on `ValidatedConfig`. this
work decreases the number of `strictNullCheck` violations in the
codebase. it does not fix every violation pertaining to `config.sys`
usage - rather, it seeks to be the minimal work necessary to

1. make the `sys` property required on `ValidatedConfig`
2. prevent introducing breaking compilation errors

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Unit tests, e2e tests continue to pass (no function signature changes were made).

I tried hard here to replicate the existing behavior (otherwise saying 'tests pass boss 👍' wouldn't _really_ have any ground to stand on).  

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
