### PR TITLE
chore(run): remove unneeded CompilerSystem checks

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -138,7 +138,7 @@ export const runTask = async (
 
   switch (task) {
     case 'build':
-      await taskBuild(coreCompiler, strictConfig, sys);
+      await taskBuild(coreCompiler, strictConfig);
       break;
 
     case 'docs':

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -163,10 +163,7 @@ export const runTask = async (
       break;
 
     case 'telemetry':
-      // TODO(STENCIL-148) make this parameter no longer optional, remove the surrounding if statement
-      if (sys) {
-        await taskTelemetry(strictConfig.flags, sys, strictConfig.logger);
-      }
+      await taskTelemetry(strictConfig.flags, sys, strictConfig.logger);
       break;
 
     case 'test':

--- a/src/cli/task-build.ts
+++ b/src/cli/task-build.ts
@@ -6,7 +6,7 @@ import { startupCompilerLog } from './logs';
 import { taskWatch } from './task-watch';
 import { telemetryBuildFinishedAction } from './telemetry/telemetry';
 
-export const taskBuild = async (coreCompiler: CoreCompiler, config: d.ValidatedConfig, sys?: d.CompilerSystem) => {
+export const taskBuild = async (coreCompiler: CoreCompiler, config: d.ValidatedConfig) => {
   if (config.flags.watch) {
     // watch build
     await taskWatch(coreCompiler, config);
@@ -24,10 +24,7 @@ export const taskBuild = async (coreCompiler: CoreCompiler, config: d.ValidatedC
     const compiler = await coreCompiler.createCompiler(config);
     const results = await compiler.build();
 
-    // TODO(STENCIL-148) make this parameter no longer optional, remove the surrounding if statement
-    if (sys) {
-      await telemetryBuildFinishedAction(sys, config, coreCompiler, results);
-    }
+    await telemetryBuildFinishedAction(config.sys, config, coreCompiler, results);
 
     await compiler.destroy();
 

--- a/src/cli/task-help.ts
+++ b/src/cli/task-help.ts
@@ -9,7 +9,7 @@ import { taskTelemetry } from './task-telemetry';
  * @param logger a logging implementation to log the results out to the user
  * @param sys the abstraction for interfacing with the operating system
  */
-export const taskHelp = async (flags: ConfigFlags, logger: d.Logger, sys?: d.CompilerSystem): Promise<void> => {
+export const taskHelp = async (flags: ConfigFlags, logger: d.Logger, sys: d.CompilerSystem): Promise<void> => {
   const prompt = logger.dim(sys.details.platform === 'windows' ? '>' : '$');
 
   console.log(`
@@ -42,10 +42,7 @@ export const taskHelp = async (flags: ConfigFlags, logger: d.Logger, sys?: d.Com
 
 `);
 
-  // TODO(STENCIL-148) make this parameter no longer optional, remove the surrounding if statement
-  if (sys) {
-    await taskTelemetry(flags, sys, logger);
-  }
+  await taskTelemetry(flags, sys, logger);
 
   console.log(`
   ${logger.bold('Examples:')}

--- a/src/cli/test/run.spec.ts
+++ b/src/cli/test/run.spec.ts
@@ -181,7 +181,7 @@ describe('run', () => {
       await runTask(coreCompiler, unvalidatedConfig, 'build', sys);
 
       expect(taskBuildSpy).toHaveBeenCalledTimes(1);
-      expect(taskBuildSpy).toHaveBeenCalledWith(coreCompiler, validatedConfig, sys);
+      expect(taskBuildSpy).toHaveBeenCalledWith(coreCompiler, validatedConfig);
     });
 
     it('calls the docs task', async () => {
@@ -234,12 +234,6 @@ describe('run', () => {
 
         expect(taskTelemetrySpy).toHaveBeenCalledTimes(1);
         expect(taskTelemetrySpy).toHaveBeenCalledWith(validatedConfig.flags, sys, validatedConfig.logger);
-      });
-
-      it("does not call the telemetry task when a compiler system isn't present", async () => {
-        await runTask(coreCompiler, unvalidatedConfig, 'telemetry');
-
-        expect(taskTelemetrySpy).not.toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In 66d0476b (#3079), we added a truthy check for `CompilerSystem` entities.
With the recent move to making that entity required on a `ValidatedConfig` entity
(a6a9171 - #3491), these checks can be safely removed.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
This PR removes cases throughout the code base where a truthy check is
required in order to call a function that requires it. In every case, we are able to
utilize the fact that the calling function has an instance of `ValidatedConfig`, which
now has a `sys` on it. 

The original belief was that this would need to be a breaking change (this was
months ago when the ticket was originally written). However, the foundation of this
PR  (a6a9171) does not require this to be a breaking change anymore. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Unit tests updated

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
