### PR TITLE
 feat(ci): fail the browserstack tests if any files were changed or added 

### DIFF
--- a/.github/workflows/test-browserstack.yml
+++ b/.github/workflows/test-browserstack.yml
@@ -97,3 +97,9 @@ jobs:
           # local-testing must be one of two values: 'start' or 'stop' to start/stop Browserstack
           local-testing: stop
 
+      - name: Git status check
+        # here we check that there are no changed / new files from our test
+        # run. we use `git status`, grep out the build zip (downloaded above),
+        # and check if there are more than 0 lines in the output.
+        run: if [[ $(git status --short | grep -c -v stencil-core-build.zip) -ne 0 ]]; then exit 1; fi
+        shell: bash

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -37,3 +37,10 @@ jobs:
       - name: End-to-End Tests
         run: npm run test.end-to-end -- --ci
         shell: bash
+
+      - name: Git status check
+        # here we check that there are no changed / new files from our test
+        # run. we use `git status`, grep out the build zip (downloaded above),
+        # and check if there are more than 0 lines in the output.
+        run: if [[ $(git status --short | grep -v stencil-core-build.zip | wc -l) -ne 0 ]]; then exit 1; fi
+        shell: bash

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -37,10 +37,3 @@ jobs:
       - name: End-to-End Tests
         run: npm run test.end-to-end -- --ci
         shell: bash
-
-      - name: Git status check
-        # here we check that there are no changed / new files from our test
-        # run. we use `git status`, grep out the build zip (downloaded above),
-        # and check if there are more than 0 lines in the output.
-        run: if [[ $(git status --short | grep -v stencil-core-build.zip | wc -l) -ne 0 ]]; then exit 1; fi
-        shell: bash


### PR DESCRIPTION
This adds a small check to the end of our end-to-end CI tests which just
tries to ensure that no files were changed or added while the tests were
running.

STENCIL-451: Add CI Checks for a Dirty Git Context

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

Right now we have no automatic visibility into whether tests running on CI change files that should be committed.


## What is the new behavior?

This adds a simple check (implemented using `git`, `grep`, `wc`, and `-ne`) to make sure there aren't any uncommitted changes.

Note that we download a build zip file, so we have a little `grep -v` to ignore that.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I confirmed that this will fail if there is a file changed or added by the tests.