### PR TITLE
chore(config): use ValidatedConfig in output-targets/

### DIFF
--- a/src/compiler/docs/custom/index.ts
+++ b/src/compiler/docs/custom/index.ts
@@ -1,7 +1,11 @@
 import type * as d from '../../../declarations';
 import { isOutputTargetDocsCustom } from '../../output-targets/output-utils';
 
-export const generateCustomDocs = async (config: d.Config, docsData: d.JsonDocs, outputTargets: d.OutputTarget[]) => {
+export const generateCustomDocs = async (
+  config: d.ValidatedConfig,
+  docsData: d.JsonDocs,
+  outputTargets: d.OutputTarget[]
+) => {
   const customOutputTargets = outputTargets.filter(isOutputTargetDocsCustom);
   if (customOutputTargets.length === 0) {
     return;

--- a/src/compiler/docs/generate-doc-data.ts
+++ b/src/compiler/docs/generate-doc-data.ts
@@ -7,7 +7,7 @@ import { JsonDocsValue } from '../../declarations';
 import { typescriptVersion, version } from '../../version';
 
 export const generateDocData = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx
 ): Promise<d.JsonDocs> => {
@@ -23,7 +23,7 @@ export const generateDocData = async (
 };
 
 const getDocsComponents = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx
 ): Promise<d.JsonDocsComponent[]> => {

--- a/src/compiler/docs/json/index.ts
+++ b/src/compiler/docs/json/index.ts
@@ -3,7 +3,7 @@ import { isOutputTargetDocsJson } from '../../output-targets/output-utils';
 import { join } from 'path';
 
 export const generateJsonDocs = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   docsData: d.JsonDocs,
   outputTargets: d.OutputTarget[]

--- a/src/compiler/docs/readme/index.ts
+++ b/src/compiler/docs/readme/index.ts
@@ -3,7 +3,7 @@ import { generateReadme } from './output-docs';
 import { isOutputTargetDocsReadme } from '../../output-targets/output-utils';
 
 export const generateReadmeDocs = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   docsData: d.JsonDocs,
   outputTargets: d.OutputTarget[]
@@ -14,7 +14,7 @@ export const generateReadmeDocs = async (
   }
   const strictCheck = readmeOutputTargets.some((o) => o.strict);
   if (strictCheck) {
-    strickCheckDocs(config, docsData);
+    strictCheckDocs(config, docsData);
   }
 
   await Promise.all(
@@ -24,7 +24,7 @@ export const generateReadmeDocs = async (
   );
 };
 
-export const strickCheckDocs = (config: d.Config, docsData: d.JsonDocs) => {
+export const strictCheckDocs = (config: d.ValidatedConfig, docsData: d.JsonDocs) => {
   docsData.components.forEach((component) => {
     component.props.forEach((prop) => {
       if (!prop.docs && prop.deprecation === undefined) {

--- a/src/compiler/docs/readme/output-docs.ts
+++ b/src/compiler/docs/readme/output-docs.ts
@@ -11,7 +11,7 @@ import { depsToMarkdown } from './markdown-dependencies';
 import { AUTO_GENERATE_COMMENT } from '../constants';
 
 export const generateReadme = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   readmeOutputs: d.OutputTargetDocsReadme[],
   docsData: d.JsonDocsComponent,

--- a/src/compiler/entries/component-bundles.ts
+++ b/src/compiler/entries/component-bundles.ts
@@ -10,7 +10,7 @@ import { getDefaultBundles } from './default-bundles';
  * @returns a set of all component tags that are used
  */
 export function computeUsedComponents(
-  config: d.Config,
+  config: d.ValidatedConfig,
   defaultBundles: readonly d.ComponentCompilerMeta[][],
   allCmps: readonly d.ComponentCompilerMeta[]
 ): Set<string> {
@@ -47,7 +47,10 @@ export function computeUsedComponents(
  * @param buildCtx the current build context
  * @returns the bundles to be used during the bundling process
  */
-export function generateComponentBundles(config: d.Config, buildCtx: d.BuildCtx): readonly d.ComponentCompilerMeta[][] {
+export function generateComponentBundles(
+  config: d.ValidatedConfig,
+  buildCtx: d.BuildCtx
+): readonly d.ComponentCompilerMeta[][] {
   const cmps = sortBy(buildCtx.components, (cmp: d.ComponentCompilerMeta) => cmp.dependents.length);
 
   const defaultBundles = getDefaultBundles(config, buildCtx, cmps);

--- a/src/compiler/entries/default-bundles.ts
+++ b/src/compiler/entries/default-bundles.ts
@@ -10,7 +10,7 @@ import { getUsedComponents } from '../html/used-components';
  * @returns the component bundling data
  */
 export function getDefaultBundles(
-  config: d.Config,
+  config: d.ValidatedConfig,
   buildCtx: d.BuildCtx,
   cmps: d.ComponentCompilerMeta[]
 ): readonly d.ComponentCompilerMeta[][] {
@@ -50,7 +50,7 @@ export function getDefaultBundles(
  * @returns a three dimensional array with the compiler metadata for each component used
  */
 export function getUserConfigBundles(
-  config: d.Config,
+  config: d.ValidatedConfig,
   buildCtx: d.BuildCtx,
   cmps: d.ComponentCompilerMeta[]
 ): readonly d.ComponentCompilerMeta[][] {

--- a/src/compiler/output-targets/copy/assets-copy-tasks.ts
+++ b/src/compiler/output-targets/copy/assets-copy-tasks.ts
@@ -3,7 +3,7 @@ import { dirname, join, relative } from 'path';
 import { normalizePath } from '@utils';
 
 export const getComponentAssetsCopyTasks = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   buildCtx: d.BuildCtx,
   dest: string,
   collectionsPath: boolean

--- a/src/compiler/output-targets/copy/local-copy-tasks.ts
+++ b/src/compiler/output-targets/copy/local-copy-tasks.ts
@@ -1,7 +1,7 @@
 import type * as d from '../../../declarations';
 import { isAbsolute, join } from 'path';
 
-export const getSrcAbsPath = (config: d.Config, src: string) => {
+export const getSrcAbsPath = (config: d.ValidatedConfig, src: string) => {
   if (isAbsolute(src)) {
     return src;
   }

--- a/src/compiler/output-targets/copy/output-copy.ts
+++ b/src/compiler/output-targets/copy/output-copy.ts
@@ -6,7 +6,7 @@ import { isOutputTargetCopy } from '../output-utils';
 import { join } from 'path';
 import minimatch from 'minimatch';
 
-export const outputCopy = async (config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
+export const outputCopy = async (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
   const outputTargets = config.outputTargets.filter(isOutputTargetCopy);
   if (outputTargets.length === 0) {
     return;
@@ -43,7 +43,12 @@ export const outputCopy = async (config: d.Config, compilerCtx: d.CompilerCtx, b
   }
 };
 
-const getCopyTasks = (config: d.Config, buildCtx: d.BuildCtx, o: d.OutputTargetCopy, changedFiles: string[]) => {
+const getCopyTasks = (
+  config: d.ValidatedConfig,
+  buildCtx: d.BuildCtx,
+  o: d.OutputTargetCopy,
+  changedFiles: string[]
+) => {
   if (!Array.isArray(o.copy)) {
     return [];
   }
@@ -53,7 +58,7 @@ const getCopyTasks = (config: d.Config, buildCtx: d.BuildCtx, o: d.OutputTargetC
   return copyTasks.map((t) => transformToAbs(t, o.dir));
 };
 
-const filterCopyTasks = (config: d.Config, tasks: d.CopyTask[], changedFiles: string[]) => {
+const filterCopyTasks = (config: d.ValidatedConfig, tasks: d.CopyTask[], changedFiles: string[]) => {
   if (Array.isArray(tasks)) {
     return tasks.filter((copy) => {
       let copySrc = copy.src;

--- a/src/compiler/output-targets/dist-collection/index.ts
+++ b/src/compiler/output-targets/dist-collection/index.ts
@@ -5,7 +5,7 @@ import { join, relative } from 'path';
 import { typescriptVersion, version } from '../../../version';
 
 export const outputCollection = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   changedModuleFiles: d.Module[]
@@ -51,7 +51,7 @@ export const outputCollection = async (
 };
 
 const writeCollectionManifests = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   outputTargets: d.OutputTargetDistCollection[]
@@ -80,7 +80,7 @@ const writeCollectionManifest = async (
   await compilerCtx.fs.writeFile(collectionFilePath, collectionData);
 };
 
-const serializeCollectionManifest = (config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
+const serializeCollectionManifest = (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
   // create the single collection we're going to fill up with data
   const collectionManifest: d.CollectionManifest = {
     entries: buildCtx.moduleFiles

--- a/src/compiler/output-targets/dist-custom-elements-bundle/custom-elements-build-conditionals.ts
+++ b/src/compiler/output-targets/dist-custom-elements-bundle/custom-elements-build-conditionals.ts
@@ -1,7 +1,7 @@
 import type * as d from '../../../declarations';
 import { getBuildFeatures, updateBuildConditionals } from '../../app-core/app-data';
 
-export const getCustomElementsBuildConditionals = (config: d.Config, cmps: d.ComponentCompilerMeta[]) => {
+export const getCustomElementsBuildConditionals = (config: d.ValidatedConfig, cmps: d.ComponentCompilerMeta[]) => {
   // because custom elements bundling does not customize the build conditionals by default
   // then the default in "import { BUILD, NAMESPACE } from '@stencil/core/internal/app-data'"
   // needs to have the static build conditionals set for the custom elements build

--- a/src/compiler/output-targets/dist-custom-elements-bundle/custom-elements-bundle-types.ts
+++ b/src/compiler/output-targets/dist-custom-elements-bundle/custom-elements-bundle-types.ts
@@ -4,7 +4,7 @@ import { dirname, join, relative } from 'path';
 import { normalizePath, dashToPascalCase } from '@utils';
 
 export const generateCustomElementsBundleTypes = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   distDtsFilePath: string
@@ -19,7 +19,7 @@ export const generateCustomElementsBundleTypes = async (
 };
 
 const generateCustomElementsTypesOutput = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   distDtsFilePath: string,

--- a/src/compiler/output-targets/dist-custom-elements-bundle/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements-bundle/index.ts
@@ -21,7 +21,7 @@ import { STENCIL_INTERNAL_CLIENT_ID, USER_INDEX_ENTRY_ID, STENCIL_APP_GLOBALS_ID
 import { updateStencilCoreImports } from '../../transformers/update-stencil-core-import';
 
 export const outputCustomElementsBundle = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx
 ): Promise<void> => {
@@ -43,7 +43,7 @@ export const outputCustomElementsBundle = async (
 };
 
 const bundleCustomElements = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   outputTarget: d.OutputTargetDistCustomElementsBundle
@@ -162,7 +162,7 @@ const generateEntryPoint = (outputTarget: d.OutputTargetDistCustomElementsBundle
   return [...imp, ...exp].join('\n') + '\n';
 };
 
-const getCustomElementBundleCustomTransformer = (config: d.Config, compilerCtx: d.CompilerCtx) => {
+const getCustomElementBundleCustomTransformer = (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx) => {
   const transformOpts: d.TransformOptions = {
     coreImportPath: STENCIL_INTERNAL_CLIENT_ID,
     componentExport: null,

--- a/src/compiler/output-targets/dist-custom-elements/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements/index.ts
@@ -253,7 +253,7 @@ export const generateEntryPoint = (outputTarget: d.OutputTargetDistCustomElement
  * @returns a list of transformers to use in the transpilation process
  */
 const getCustomElementCustomTransformer = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   components: d.ComponentCompilerMeta[],
   outputTarget: d.OutputTargetDistCustomElements

--- a/src/compiler/output-targets/dist-hydrate-script/bundle-hydrate-factory.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/bundle-hydrate-factory.ts
@@ -9,7 +9,7 @@ import { STENCIL_INTERNAL_HYDRATE_ID } from '../../bundle/entry-alias-ids';
 import { updateStencilCoreImports } from '../../transformers/update-stencil-core-import';
 
 export const bundleHydrateFactory = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   _build: d.BuildConditionals,
@@ -42,7 +42,7 @@ export const bundleHydrateFactory = async (
   return undefined;
 };
 
-const getHydrateCustomTransformer = (config: d.Config, compilerCtx: d.CompilerCtx) => {
+const getHydrateCustomTransformer = (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx) => {
   const transformOpts: d.TransformOptions = {
     coreImportPath: STENCIL_INTERNAL_HYDRATE_ID,
     componentExport: null,

--- a/src/compiler/output-targets/dist-hydrate-script/generate-hydrate-app.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/generate-hydrate-app.ts
@@ -16,7 +16,7 @@ import { rollup } from 'rollup';
 import { join } from 'path';
 
 export const generateHydrateApp = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   outputTargets: d.OutputTargetHydrate[]
@@ -72,7 +72,7 @@ export const generateHydrateApp = async (
   }
 };
 
-const generateHydrateFactory = async (config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
+const generateHydrateFactory = async (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
   if (!buildCtx.hasError) {
     try {
       const cmps = buildCtx.components;
@@ -121,7 +121,7 @@ const generateHydrateFactoryEntry = async (buildCtx: d.BuildCtx) => {
   return s.toString();
 };
 
-const getHydrateBuildConditionals = (config: d.Config, cmps: d.ComponentCompilerMeta[]) => {
+const getHydrateBuildConditionals = (config: d.ValidatedConfig, cmps: d.ComponentCompilerMeta[]) => {
   const build = getBuildFeatures(cmps) as d.BuildConditionals;
 
   build.lazyLoad = true;

--- a/src/compiler/output-targets/dist-hydrate-script/index.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/index.ts
@@ -2,7 +2,11 @@ import type * as d from '../../../declarations';
 import { generateHydrateApp } from './generate-hydrate-app';
 import { isOutputTargetHydrate } from '../output-utils';
 
-export const outputHydrateScript = async (config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
+export const outputHydrateScript = async (
+  config: d.ValidatedConfig,
+  compilerCtx: d.CompilerCtx,
+  buildCtx: d.BuildCtx
+) => {
   const hydrateOutputTargets = config.outputTargets.filter(isOutputTargetHydrate);
   if (hydrateOutputTargets.length > 0) {
     const timespan = buildCtx.createTimeSpan(`generate hydrate app started`);

--- a/src/compiler/output-targets/dist-hydrate-script/write-hydrate-outputs.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/write-hydrate-outputs.ts
@@ -4,7 +4,7 @@ import { relocateHydrateContextConst } from './relocate-hydrate-context';
 import type { RollupOutput } from 'rollup';
 
 export const writeHydrateOutputs = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   outputTargets: d.OutputTargetHydrate[],
@@ -18,7 +18,7 @@ export const writeHydrateOutputs = (
 };
 
 const writeHydrateOutput = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   outputTarget: d.OutputTargetHydrate,
@@ -59,7 +59,7 @@ const writeHydrateOutput = async (
 };
 
 const getHydratePackageJson = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   hydrateAppFilePath: string,
   hydrateDtsFilePath: string,
   hydratePackageName: string
@@ -73,7 +73,7 @@ const getHydratePackageJson = (
   return JSON.stringify(pkg, null, 2);
 };
 
-const getHydratePackageName = async (config: d.Config, compilerCtx: d.CompilerCtx) => {
+const getHydratePackageName = async (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx) => {
   try {
     const rootPkgFilePath = join(config.rootDir, 'package.json');
     const pkgStr = await compilerCtx.fs.readFile(rootPkgFilePath);
@@ -84,7 +84,11 @@ const getHydratePackageName = async (config: d.Config, compilerCtx: d.CompilerCt
   return `${config.fsNamespace}/hydrate`;
 };
 
-const copyHydrateRunnerDts = async (config: d.Config, compilerCtx: d.CompilerCtx, hydrateAppDirPath: string) => {
+const copyHydrateRunnerDts = async (
+  config: d.ValidatedConfig,
+  compilerCtx: d.CompilerCtx,
+  hydrateAppDirPath: string
+) => {
   const packageDir = join(config.sys.getCompilerExecutingPath(), '..', '..');
   const srcHydrateDir = join(packageDir, 'internal', 'hydrate', 'runner.d.ts');
 

--- a/src/compiler/output-targets/dist-lazy/generate-cjs.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-cjs.ts
@@ -7,7 +7,7 @@ import { relativeImport } from '../output-utils';
 import { generatePreamble } from '@utils';
 
 export const generateCjs = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   rollupBuild: RollupBuild,

--- a/src/compiler/output-targets/dist-lazy/generate-esm-browser.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-esm-browser.ts
@@ -5,7 +5,7 @@ import type { OutputOptions, RollupBuild } from 'rollup';
 import { generatePreamble, getDynamicImportFunction } from '@utils';
 
 export const generateEsmBrowser = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   rollupBuild: RollupBuild,

--- a/src/compiler/output-targets/dist-lazy/generate-esm.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-esm.ts
@@ -8,7 +8,7 @@ import type { RollupResult } from '../../../declarations';
 import { generatePreamble } from '@utils';
 
 export const generateEsm = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   rollupBuild: RollupBuild,
@@ -64,7 +64,7 @@ export const generateEsm = async (
 };
 
 const copyPolyfills = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   outputTargets: d.OutputTargetDistLazy[]
 ): Promise<void> => {
@@ -88,7 +88,7 @@ const copyPolyfills = async (
 };
 
 const generateShortcuts = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   outputTargets: d.OutputTargetDistLazy[],
   rollupResult: RollupResult[]

--- a/src/compiler/output-targets/dist-lazy/generate-lazy-module.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-lazy-module.ts
@@ -12,7 +12,7 @@ import { join } from 'path';
 import type { SourceMap as RollupSourceMap } from 'rollup';
 
 export const generateLazyModules = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   outputTargetType: string,
@@ -180,7 +180,7 @@ const generateCaseClauseCjs = (bundleId: string): string => {
 };
 
 const generateLazyEntryModule = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   rollupResult: d.RollupChunkResult,
@@ -227,7 +227,7 @@ const generateLazyEntryModule = async (
 };
 
 const writeLazyChunk = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   rollupResult: d.RollupChunkResult,
@@ -263,7 +263,7 @@ const writeLazyChunk = async (
 };
 
 const writeLazyEntry = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   rollupResult: d.RollupChunkResult,
@@ -398,7 +398,7 @@ export const sortBundleComponents = (a: d.ComponentCompilerMeta, b: d.ComponentC
 };
 
 const convertChunk = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   sourceTarget: d.SourceTarget,

--- a/src/compiler/output-targets/dist-lazy/generate-system.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-system.ts
@@ -8,7 +8,7 @@ import { relativeImport } from '../output-utils';
 import { generatePreamble } from '@utils';
 
 export const generateSystem = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   rollupBuild: RollupBuild,
@@ -49,7 +49,7 @@ export const generateSystem = async (
 };
 
 const generateSystemLoaders = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   rollupResult: d.RollupResult[],
   systemOutputs: d.OutputTargetDistLazy[]
@@ -60,7 +60,7 @@ const generateSystemLoaders = (
 };
 
 const writeSystemLoader = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   loaderFilename: string,
   outputTarget: d.OutputTargetDistLazy
@@ -76,7 +76,7 @@ const writeSystemLoader = async (
 };
 
 const getSystemLoader = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   corePath: string,
   includePolyfills: boolean

--- a/src/compiler/output-targets/dist-lazy/lazy-build-conditionals.ts
+++ b/src/compiler/output-targets/dist-lazy/lazy-build-conditionals.ts
@@ -2,7 +2,10 @@ import type * as d from '../../../declarations';
 import { getBuildFeatures, updateBuildConditionals } from '../../app-core/app-data';
 import { isOutputTargetHydrate } from '../output-utils';
 
-export const getLazyBuildConditionals = (config: d.Config, cmps: d.ComponentCompilerMeta[]): d.BuildConditionals => {
+export const getLazyBuildConditionals = (
+  config: d.ValidatedConfig,
+  cmps: d.ComponentCompilerMeta[]
+): d.BuildConditionals => {
   const build = getBuildFeatures(cmps) as d.BuildConditionals;
 
   build.lazyLoad = true;

--- a/src/compiler/output-targets/dist-lazy/lazy-output.ts
+++ b/src/compiler/output-targets/dist-lazy/lazy-output.ts
@@ -24,7 +24,11 @@ import { updateStencilCoreImports } from '../../transformers/update-stencil-core
 import MagicString from 'magic-string';
 import { generateComponentBundles } from '../../entries/component-bundles';
 
-export const outputLazy = async (config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx): Promise<void> => {
+export const outputLazy = async (
+  config: d.ValidatedConfig,
+  compilerCtx: d.CompilerCtx,
+  buildCtx: d.BuildCtx
+): Promise<void> => {
   const outputTargets = config.outputTargets.filter(isOutputTargetDistLazy);
   if (outputTargets.length === 0) {
     return;
@@ -93,7 +97,7 @@ export const outputLazy = async (config: d.Config, compilerCtx: d.CompilerCtx, b
   timespan.finish(`${bundleEventMessage} finished`);
 };
 
-const getLazyCustomTransformer = (config: d.Config, compilerCtx: d.CompilerCtx) => {
+const getLazyCustomTransformer = (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx) => {
   const transformOpts: d.TransformOptions = {
     coreImportPath: STENCIL_CORE_ID,
     componentExport: 'lazy',
@@ -115,7 +119,7 @@ const getLazyCustomTransformer = (config: d.Config, compilerCtx: d.CompilerCtx) 
  * @param config the Stencil configuration file that was provided as a part of the build step
  * @param buildCtx the current build context
  */
-function generateEntryModules(config: d.Config, buildCtx: d.BuildCtx): void {
+function generateEntryModules(config: d.ValidatedConfig, buildCtx: d.BuildCtx): void {
   // figure out how modules and components connect
   try {
     const bundles = generateComponentBundles(config, buildCtx);

--- a/src/compiler/output-targets/dist-lazy/write-lazy-entry-module.ts
+++ b/src/compiler/output-targets/dist-lazy/write-lazy-entry-module.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 import { getSourceMappingUrlForEndOfFile } from '@utils';
 
 export const writeLazyModule = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   outputTargetType: string,
   destinations: string[],
@@ -39,7 +39,7 @@ export const writeLazyModule = async (
 };
 
 const getBundleId = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   entryKey: string,
   shouldHash: boolean,
   code: string,

--- a/src/compiler/output-targets/empty-dir.ts
+++ b/src/compiler/output-targets/empty-dir.ts
@@ -25,7 +25,11 @@ const isEmptable = (o: d.OutputTarget): o is OutputTargetEmptiable =>
   isOutputTargetDistLazyLoader(o) ||
   isOutputTargetHydrate(o);
 
-export const emptyOutputTargets = async (config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
+export const emptyOutputTargets = async (
+  config: d.ValidatedConfig,
+  compilerCtx: d.CompilerCtx,
+  buildCtx: d.BuildCtx
+) => {
   if (buildCtx.isRebuild) {
     return;
   }

--- a/src/compiler/output-targets/output-angular.ts
+++ b/src/compiler/output-targets/output-angular.ts
@@ -4,7 +4,7 @@ import { dirname, join } from 'path';
 import ts from 'typescript';
 import { isOutputTargetAngular, relativeImport } from './output-utils';
 
-export const outputAngular = async (config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
+export const outputAngular = async (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
   if (!config.buildDist) {
     return;
   }
@@ -22,7 +22,7 @@ export const outputAngular = async (config: d.Config, compilerCtx: d.CompilerCtx
 };
 
 export const angularDirectiveProxyOutput = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   outputTarget: d.OutputTargetAngular
@@ -41,7 +41,7 @@ const getFilteredComponents = (excludeComponents: string[] = [], cmps: d.Compone
 };
 
 const generateProxies = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   components: d.ComponentCompilerMeta[],

--- a/src/compiler/output-targets/output-custom.ts
+++ b/src/compiler/output-targets/output-custom.ts
@@ -3,7 +3,7 @@ import { catchError } from '@utils';
 import { isOutputTargetCustom } from './output-utils';
 
 export const outputCustom = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   docs: d.JsonDocs,

--- a/src/compiler/output-targets/output-docs.ts
+++ b/src/compiler/output-targets/output-docs.ts
@@ -13,7 +13,7 @@ import {
 } from './output-utils';
 import { outputCustom } from './output-custom';
 
-export const outputDocs = async (config: d.Config, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
+export const outputDocs = async (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
   if (!config.buildDocs) {
     return;
   }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There are ~two dozen `strctNullCheck` violations in the codebase related to using
`Config` over `ValidatedConfig`

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit propagates the usage of `ValidatedConfig` throughout the
`output-targets/` directory. This is being done following making `sys` a
required field on `ValidatedConfig` in 991843a747fcc165ff13cef9fc888cb4297df271
(#3491), where driving down the number of `sys`-related violations of the compile
time check is the primary driver.  however, this commit does also lay groundwork
for future fields being made required on the validated config, and require less
proliferation of the type in the future.

all output target types were updated in this commit. that includes the legacy angular
output target, and the custom elements bundle output target. both of the aforementioned
targets are intended to be deprecated/removed in stencil v3. however, the level of effort
required to proliferate the change provides us with a more accurate count of
`strictNullChecks` violations, and does not require waiting for a major version bump of
stencil to drive the violation count further

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Type checker, unit tests continue to pass
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

