### PR TITLE
fix(validation): update module location suggestion

### DIFF
--- a/src/compiler/types/tests/validate-package-json.spec.ts
+++ b/src/compiler/types/tests/validate-package-json.spec.ts
@@ -109,7 +109,7 @@ describe('validate-package-json', () => {
       config.outputTargets = [
         {
           type: DIST_CUSTOM_ELEMENTS,
-          dir: path.join(root, 'dist'),
+          dir: path.join(root, 'dist', 'components'),
         },
       ];
       buildCtx.packageJson.module = 'dist/components/index.js';
@@ -121,7 +121,7 @@ describe('validate-package-json', () => {
       config.outputTargets = [
         {
           type: DIST_CUSTOM_ELEMENTS,
-          dir: path.join(root, 'dist'),
+          dir: path.join(root, 'dist', 'components'),
         },
       ];
       buildCtx.packageJson.module = 'dist/index.js';
@@ -157,7 +157,7 @@ describe('validate-package-json', () => {
       {
         ot: {
           type: DIST_CUSTOM_ELEMENTS,
-          dir: path.join(root, 'dist'),
+          dir: path.join(root, 'dist', 'components'),
         },
         path: 'dist/components/index.js',
       },

--- a/src/compiler/types/validate-build-package-json.ts
+++ b/src/compiler/types/validate-build-package-json.ts
@@ -170,6 +170,7 @@ export const validateModule = async (config: d.Config, compilerCtx: d.CompilerCt
   }
 };
 
+// TODO(STENCIL-516): Investigate the hierarchy of these output targets
 /**
  * Get the recommended `"module"` path for `package.json` given the output
  * targets that a user has set on their config.
@@ -183,6 +184,10 @@ function recommendedModulePath(config: d.Config): string | null {
   const customElementsOT = config.outputTargets.find(isOutputTargetDistCustomElements);
   const distCollectionOT = config.outputTargets.find(isOutputTargetDistCollection);
 
+  if (distCollectionOT) {
+    return relative(config.rootDir, join(distCollectionOT.dir, 'index.js'));
+  }
+
   if (customElementsOT) {
     const componentsIndexAbs = join(customElementsOT.dir, 'index.js');
     return relative(config.rootDir, componentsIndexAbs);
@@ -191,10 +196,6 @@ function recommendedModulePath(config: d.Config): string | null {
   if (customElementsBundleOT) {
     const customElementsAbs = join(customElementsBundleOT.dir, 'index.js');
     return relative(config.rootDir, customElementsAbs);
-  }
-
-  if (distCollectionOT) {
-    return relative(config.rootDir, join(distCollectionOT.dir, 'index.js'));
   }
 
   // if no output target for which we define a recommended output target is set

--- a/src/compiler/types/validate-build-package-json.ts
+++ b/src/compiler/types/validate-build-package-json.ts
@@ -183,14 +183,8 @@ function recommendedModulePath(config: d.Config): string | null {
   const customElementsOT = config.outputTargets.find(isOutputTargetDistCustomElements);
   const distCollectionOT = config.outputTargets.find(isOutputTargetDistCollection);
 
-  // If we're using `dist-custom-elements` then the preferred "module" field
-  // value is `$OUTPUT_DIR/components/index.js`
-  //
-  // Additionally, the `DIST_CUSTOM_ELEMENTS` output target should override
-  // `DIST_CUSTOM_ELEMENTS_BUNDLE` and `DIST_COLLECTION` output targets if
-  // they're also set, so we return first with this one.
   if (customElementsOT) {
-    const componentsIndexAbs = join(customElementsOT.dir, 'components', 'index.js');
+    const componentsIndexAbs = join(customElementsOT.dir, 'index.js');
     return relative(config.rootDir, componentsIndexAbs);
   }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See the GitHub Issue referenced below

GitHub Issue Number: Fixes #3507 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit fixes the module directory suggestion for the
`dist-custom-elements` output target. in 47c4ccb, we introduced a bug
where we assumed that the output target's `dir` field did not include a
'components' subdirectory. however, this is not the case, as we add
'components' to the `dir` field at the time of validating the output
target. by removing 'components' from the directory in this commit, we
use the value that is stored in `dir` as the source of truth

this commit moves the check for the `dist-custom-elements` output target
to occur after the `dist` output target check. this results in the
validation for the `module` field in `package.json` giving higher
precedence to the `dist` output target. this change was made for two
reasons:

1. it aligns with the current output of the stencil-component-starter,
   which includes both output targets in its stencil config file
    - [the current module field is set for `dist`](https://github.com/ionic-team/stencil-component-starter/blob/ac43cfcaa46e79e7ad125a13dfbf58a2fd4b3350/package.json#L6)
    - [both `dist` and `dist-custom-elements` are set](https://github.com/ionic-team/stencil-component-starter/blob/ac43cfcaa46e79e7ad125a13dfbf58a2fd4b3350/stencil.config.ts#L6-L12)
2. it (temporarily) avoids complicating the logic of validating the
   `module` filed when there is more than one output target (by
   restoring the original behavior)

the latter point will be covered in a future task to be completed by the
stencil team. that work was deferred for now in an attempt to avoid
rushing through a design in order to get this bug fix out the door

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Unit tests continue to pass

When applying this change to the reproduction case in the issue mentioned above, the issue is resolved
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
