### PR TITLE
chore(config): make testing property required field

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -134,6 +134,7 @@ export const runTask = async (
     logger,
     outputTargets: config.outputTargets ?? [],
     sys: sys ?? coreCompiler.createSystem({ logger }),
+    testing: config.testing ?? {},
   };
 
   switch (task) {

--- a/src/compiler/config/test/validate-service-worker.spec.ts
+++ b/src/compiler/config/test/validate-service-worker.spec.ts
@@ -17,6 +17,7 @@ describe('validateServiceWorker', () => {
       flags: createConfigFlags(),
       logger: mockLogger(),
       outputTargets: [],
+      testing: {},
     };
   });
 

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -54,6 +54,7 @@ export const validateConfig = (
     logger,
     outputTargets: config.outputTargets ?? [],
     sys: config.sys ?? bootstrapConfig.sys ?? createSystem({ logger }),
+    testing: config.testing ?? {},
   };
 
   // default devMode false

--- a/src/compiler/sys/config.ts
+++ b/src/compiler/sys/config.ts
@@ -12,6 +12,7 @@ export const getConfig = (userConfig: d.Config): d.ValidatedConfig => {
     logger,
     outputTargets: userConfig.outputTargets ?? [],
     sys: userConfig.sys ?? createSystem({ logger }),
+    testing: userConfig ?? {},
   };
 
   setPlatformPath(config.sys.platformPath);

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -409,7 +409,7 @@ type RequireFields<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 /**
  * Fields in {@link Config} to make required for {@link ValidatedConfig}
  */
-type StrictConfigFields = 'flags' | 'logger' | 'outputTargets' | 'sys';
+type StrictConfigFields = 'flags' | 'logger' | 'outputTargets' | 'sys' | 'testing';
 
 /**
  * A version of {@link Config} that makes certain fields required. This type represents a valid configuration entity.

--- a/src/testing/jest/jest-config.ts
+++ b/src/testing/jest/jest-config.ts
@@ -81,7 +81,7 @@ export function buildJestArgv(config: d.ValidatedConfig): Config.Argv {
  * @param config the Stencil config to use while generating Jest CLI arguments
  * @returns the Jest Config to attach to the `argv` argument
  */
-export function buildJestConfig(config: d.Config): string {
+export function buildJestConfig(config: d.ValidatedConfig): string {
   const stencilConfigTesting = config.testing;
   const jestDefaults: Config.DefaultOptions = require('jest-config').defaults;
 

--- a/src/testing/jest/test/jest-config.spec.ts
+++ b/src/testing/jest/test/jest-config.spec.ts
@@ -7,7 +7,7 @@ import path from 'path';
 describe('jest-config', () => {
   it('pass --maxWorkers=2 arg when --max-workers=2', () => {
     const args = ['test', '--ci', '--max-workers=2'];
-    const config = mockValidatedConfig({ testing: {} });
+    const config = mockValidatedConfig();
     config.flags = parseFlags(args);
 
     expect(config.flags.args).toEqual(['--ci', '--max-workers=2']);
@@ -20,7 +20,7 @@ describe('jest-config', () => {
 
   it('marks outputFile as a Jest argument', () => {
     const args = ['test', '--ci', '--outputFile=path/to/my-file'];
-    const config = mockValidatedConfig({ testing: {} });
+    const config = mockValidatedConfig();
     config.flags = parseFlags(args);
     expect(config.flags.args).toEqual(['--ci', '--outputFile=path/to/my-file']);
     expect(config.flags.unknownArgs).toEqual([]);
@@ -30,7 +30,7 @@ describe('jest-config', () => {
 
   it('pass --maxWorkers=2 arg when e2e test and --ci', () => {
     const args = ['test', '--ci', '--e2e', '--max-workers=2'];
-    const config = mockValidatedConfig({ testing: {} });
+    const config = mockValidatedConfig();
     config.flags = parseFlags(args);
 
     expect(config.flags.args).toEqual(['--ci', '--e2e', '--max-workers=2']);
@@ -43,7 +43,7 @@ describe('jest-config', () => {
 
   it('forces --maxWorkers=4 arg when e2e test and --ci', () => {
     const args = ['test', '--ci', '--e2e'];
-    const config = mockValidatedConfig({ testing: {} });
+    const config = mockValidatedConfig();
     config.flags = parseFlags(args);
 
     expect(config.flags.args).toEqual(['--ci', '--e2e']);
@@ -56,7 +56,7 @@ describe('jest-config', () => {
 
   it('pass --maxWorkers=2 arg to jest', () => {
     const args = ['test', '--maxWorkers=2'];
-    const config = mockValidatedConfig({ testing: {} });
+    const config = mockValidatedConfig();
     config.flags = parseFlags(args);
 
     expect(config.flags.args).toEqual(['--maxWorkers=2']);
@@ -68,7 +68,7 @@ describe('jest-config', () => {
 
   it('pass --ci arg to jest', () => {
     const args = ['test', '--ci'];
-    const config = mockValidatedConfig({ testing: {} });
+    const config = mockValidatedConfig();
     config.flags = parseFlags(args);
 
     expect(config.flags.args).toEqual(['--ci']);
@@ -81,7 +81,7 @@ describe('jest-config', () => {
 
   it('sets legacy jest options', () => {
     const args = ['test'];
-    const config = mockValidatedConfig({ testing: {} });
+    const config = mockValidatedConfig();
     config.flags = parseFlags(args);
 
     const jestArgv = buildJestArgv(config);
@@ -110,7 +110,7 @@ describe('jest-config', () => {
 
   it('pass test spec arg to jest', () => {
     const args = ['test', 'hello.spec.ts'];
-    const config = mockValidatedConfig({ testing: {} });
+    const config = mockValidatedConfig();
     config.flags = parseFlags(args);
 
     expect(config.flags.args).toEqual(['hello.spec.ts']);
@@ -156,7 +156,7 @@ describe('jest-config', () => {
   it('set jestArgv config rootDir', () => {
     const rootDir = path.resolve('/');
     const args = ['test'];
-    const config = mockValidatedConfig({ rootDir, testing: {} });
+    const config = mockValidatedConfig({ rootDir });
     config.flags = parseFlags(args);
 
     const jestArgv = buildJestArgv(config);
@@ -178,7 +178,7 @@ describe('jest-config', () => {
 
   it('passed flags should be respected over defaults', () => {
     const args = ['test', '--spec', '--passWithNoTests'];
-    const config = mockValidatedConfig({ testing: {} });
+    const config = mockValidatedConfig();
     config.flags = parseFlags(args);
 
     expect(config.flags.args).toEqual(['--spec', '--passWithNoTests']);

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -36,6 +36,7 @@ export function mockValidatedConfig(overrides: Partial<ValidatedConfig> = {}): V
     logger: mockLogger(),
     outputTargets: baseConfig.outputTargets ?? [],
     sys: createTestingSystem(),
+    testing: {},
     ...overrides,
   };
 }


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`testing` is responsible for several `strictNullChecks` violations in the code
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates `ValidatedConfig` in order to make the `testing`
field required. this is being done in pursuit of dropping the number of
`strictNullChecks` violations in the code, and was a side task of
stencil-501 (the author of this commit was actively in the testing code,
making it a good opportunity to knock this out).

this commit makes `testing` default to an empty object literal, rather
than `null` or prepopulating existing fields. choosing the former would
require additional optional checks throughout the code (which assumes
`testing` is a defined field, and choosing the latter would expand the
scope of this commit vastly. an empty object literal should incur
minimal runtime overhead, while keeping the size/scope of this commit to
a minimal


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing


All tests continue to pass
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
