### PR TITLE
feat: 🎸 add optional skipBuild flag for testing

### DIFF
--- a/src/cli/config-flags.ts
+++ b/src/cli/config-flags.ts
@@ -27,6 +27,7 @@ export const BOOLEAN_CLI_ARGS = [
   'serviceWorker',
   'screenshot',
   'serve',
+  'skipBuild',
   'skipNodeCheck',
   'spec',
   'ssr',

--- a/src/cli/task-help.ts
+++ b/src/cli/task-help.ts
@@ -34,6 +34,7 @@ export const taskHelp = async (flags: ConfigFlags, logger: d.Logger, sys: d.Comp
 
       ${logger.cyan('--spec')} ${logger.dim('............')} Run unit tests with Jest
       ${logger.cyan('--e2e')} ${logger.dim('.............')} Run e2e tests with Puppeteer
+      ${logger.cyan('--skipBuild')} ${logger.dim('.......')} Run tests without new build
 
 
   ${logger.bold('Generate:')} ${logger.dim('Bootstrap components.')}

--- a/src/cli/task-test.ts
+++ b/src/cli/task-test.ts
@@ -16,6 +16,7 @@ export const taskTest = async (config: ValidatedConfig): Promise<void> => {
     const testingRunOpts: TestingRunOptions = {
       e2e: !!config.flags.e2e,
       screenshot: !!config.flags.screenshot,
+      skipBuild: !!config.flags.skipBuild,
       spec: !!config.flags.spec,
       updateScreenshot: !!config.flags.updateScreenshot,
     };

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1502,6 +1502,7 @@ export interface Testing {
 export interface TestingRunOptions {
   e2e?: boolean;
   screenshot?: boolean;
+  skipBuild?: boolean;
   spec?: boolean;
   updateScreenshot?: boolean;
 }

--- a/src/testing/testing.ts
+++ b/src/testing/testing.ts
@@ -76,7 +76,7 @@ export const createTesting = async (config: ValidatedConfig): Promise<Testing> =
           outputTarget.empty = false;
         });
 
-        const doBuild = !(config.flags && config.flags.build === false);
+        const doBuild = !(config.flags && config.flags.build === false) && !(config.flags && config.flags.skipBuild === true);
         if (doBuild && config.watch) {
           compilerWatcher = await compiler.createWatcher();
         }
@@ -93,6 +93,8 @@ export const createTesting = async (config: ValidatedConfig): Promise<Testing> =
           } else {
             buildTask = compiler.build();
           }
+        } else {
+          config.logger.info(config.logger.magenta(`build step skipped`));
         }
 
         config.devServer.openBrowser = false;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type


Please check the type of change your PR introduces:
- [x] Feature
- [x] Documentation content changes


## What is the current behavior?
Currently `stencil test` always makes a build first. In some environments especially in a CI/CD-context it makes sense to be able to split the tasks.
Examples:
- Debugging tests is really painful when the build always run first. (I learned that the hard way regarding this problem: https://stackoverflow.com/questions/71833006/gitlab-pipeline-not-able-to-parse-double-dash-in-npm-script-property/73287469#73287469 – to debug faster I had to overwrite Stencil's test logic in the node_modules to skip the build step...)
- We sometimes had problems with Puppeteer timeouts (30s) because the builds of `stencil test` took to long – seperating the tasks could help us getting rid of this problem. 
- We're having a monorepo with different Stencil projects which can rely on each other. First step is to build all projects to be able to use their `dist`s in the tests. After that we're running `stencil test` which leads to unneeded double-builds.
- In this monorepo setup we're trying to get as much benefits as possible from `nx`'s caching system. We might even use `NX Cloud` to speed up development as well as our pipelines. Separating `test` and `build` helps us to get a lot more cache hits. 

GitHub Issue Number: N/A


## What is the new behavior?
`stencil test --skipBuild` makes it possible to skip the build process.

Of course an alternative would be to write our own Jest config etc. – but as the docs say:
> Jest can still be used, but configuring the presets, transpilation and setting up the correct commands must be done by the project.

Therefore I believe this solution might be more helpful regarding the before-mentioned problems.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

I tried to extend current tests but couldn't find a good place for them: `jest-config.spec.ts` focuses on Jest-args, `run.spec.ts` doesn't focus on args. If you could point me to a good place and an appropriate way I'm open to contribute the needed tests. Otherwise I'm happy about support on that.

## Other information:
I added a PR regarding docs, too: https://github.com/ionic-team/stencil-site/pull/903