### PR TITLE
fix(compiler): don't break HMR by mangling CSS

### DIFF
--- a/src/compiler/bundle/bundle-interface.ts
+++ b/src/compiler/bundle/bundle-interface.ts
@@ -2,6 +2,12 @@ import type { BuildConditionals } from '../../declarations';
 import type { SourceFile, TransformerFactory } from 'typescript';
 import type { PreserveEntrySignaturesOption } from 'rollup';
 
+/**
+ * Options for bundled output passed on Rollup
+ *
+ * This covers the ID for the bundle, the platform it runs on, input modules,
+ * and more
+ */
 export interface BundleOptions {
   id: string;
   conditionals?: BuildConditionals;

--- a/src/compiler/bundle/bundle-output.ts
+++ b/src/compiler/bundle/bundle-output.ts
@@ -19,7 +19,7 @@ import { userIndexPlugin } from './user-index-plugin';
 import { workerPlugin } from './worker-plugin';
 
 export const bundleOutput = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   bundleOpts: BundleOptions
@@ -49,7 +49,7 @@ export const bundleOutput = async (
  * @returns the rollup options to be used
  */
 export const getRollupOptions = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   bundleOpts: BundleOptions

--- a/src/compiler/bundle/dev-module.ts
+++ b/src/compiler/bundle/dev-module.ts
@@ -56,7 +56,11 @@ const getPackageJsonPath = (resolvedPath: string, importee: string): string => {
   return null;
 };
 
-export const compilerRequest = async (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx, data: d.CompilerRequest) => {
+export const compilerRequest = async (
+  config: d.ValidatedConfig,
+  compilerCtx: d.CompilerCtx,
+  data: d.CompilerRequest
+) => {
   const results: d.CompilerRequestResponse = {
     path: data.path,
     nodeModuleId: null,

--- a/src/compiler/bundle/dev-module.ts
+++ b/src/compiler/bundle/dev-module.ts
@@ -56,7 +56,7 @@ const getPackageJsonPath = (resolvedPath: string, importee: string): string => {
   return null;
 };
 
-export const compilerRequest = async (config: d.Config, compilerCtx: d.CompilerCtx, data: d.CompilerRequest) => {
+export const compilerRequest = async (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx, data: d.CompilerRequest) => {
   const results: d.CompilerRequestResponse = {
     path: data.path,
     nodeModuleId: null,
@@ -126,7 +126,7 @@ export const compilerRequest = async (config: d.Config, compilerCtx: d.CompilerC
 };
 
 const bundleDevModule = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   parsedUrl: ParsedDevModuleUrl,
   results: d.CompilerRequestResponse

--- a/src/compiler/bundle/ext-transforms-plugin.ts
+++ b/src/compiler/bundle/ext-transforms-plugin.ts
@@ -9,8 +9,7 @@ import { runPluginTransformsEsmImports } from '../plugin/plugin';
 
 /**
  * A Rollup plugin which bundles up some transformation of CSS imports as well
- * as writing CSS files for components to disk for the `DIST_COLLECTION` output
- * target.
+* as writing some files to disk for the `DIST_COLLECTION` output target.
  *
  * @param config a user-supplied configuration
  * @param compilerCtx the current compiler context

--- a/src/compiler/bundle/ext-transforms-plugin.ts
+++ b/src/compiler/bundle/ext-transforms-plugin.ts
@@ -62,10 +62,10 @@ export const extTransformsPlugin = (
         // We need to check whether the current build is a dev-mode watch build w/ HMR enabled in
         // order to know how we'll want to set `commentOriginalSelector` (below). If we are doing
         // a hydrate build we need to set this to `true` because commenting-out selectors is what
-        // gives us support for scoped CSS w/ hydrated components (we don't support shadow DOM and 
-        // styling via that route for them). However, we don't want to comment selectors in dev 
+        // gives us support for scoped CSS w/ hydrated components (we don't support shadow DOM and
+        // styling via that route for them). However, we don't want to comment selectors in dev
         // mode when using HMR in the browser, since there we _do_ support putting stylesheets into
-        // the shadow DOM and commenting out e.g. the `:host` selector in those stylesheets will 
+        // the shadow DOM and commenting out e.g. the `:host` selector in those stylesheets will
         // break components' CSS when an HMR update is sent to the browser.
         //
         // See https://github.com/ionic-team/stencil/issues/3461 for details

--- a/src/compiler/bundle/ext-transforms-plugin.ts
+++ b/src/compiler/bundle/ext-transforms-plugin.ts
@@ -19,7 +19,7 @@ import { runPluginTransformsEsmImports } from '../plugin/plugin';
  * @returns a Rollup plugin which carries out the necessary work
  */
 export const extTransformsPlugin = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   bundleOpts: BundleOptions
@@ -67,7 +67,7 @@ export const extTransformsPlugin = (
       const { data } = parseImportPath(id);
 
       if (data != null) {
-        let cmp: d.ComponentCompilerMeta;
+        let cmp: d.ComponentCompilerMeta | undefined = undefined;
         const filePath = normalizeFsPath(id);
         const code = await compilerCtx.fs.readFile(filePath);
         if (typeof code !== 'string') {

--- a/src/compiler/bundle/ext-transforms-plugin.ts
+++ b/src/compiler/bundle/ext-transforms-plugin.ts
@@ -9,7 +9,7 @@ import { runPluginTransformsEsmImports } from '../plugin/plugin';
 
 /**
  * A Rollup plugin which bundles up some transformation of CSS imports as well
-* as writing some files to disk for the `DIST_COLLECTION` output target.
+ * as writing some files to disk for the `DIST_COLLECTION` output target.
  *
  * @param config a user-supplied configuration
  * @param compilerCtx the current compiler context

--- a/src/compiler/bundle/test/ext-transforms-plugin.spec.ts
+++ b/src/compiler/bundle/test/ext-transforms-plugin.spec.ts
@@ -1,0 +1,122 @@
+import { mockBuildCtx, mockCompilerCtx, mockModule, mockValidatedConfig } from '@stencil/core/testing';
+import { stubComponentCompilerMeta } from '../../types/tests/ComponentCompilerMeta.stub';
+import { BundleOptions } from '../bundle-interface';
+import { extTransformsPlugin } from '../ext-transforms-plugin';
+import * as importPathLib from '../../transformers/stencil-import-path';
+
+describe('extTransformsPlugin', () => {
+  function setup(bundleOptsOverrides: Partial<BundleOptions> = {}) {
+    const config = mockValidatedConfig({
+      plugins: [],
+      outputTargets: [
+        {
+          type: 'dist-collection',
+          dir: 'dist/',
+          collectionDir: 'dist/collectionDir',
+        },
+      ],
+      srcDir: '/some/stubbed/path',
+    });
+    const compilerCtx = mockCompilerCtx(config);
+    const buildCtx = mockBuildCtx(config, compilerCtx);
+
+    const compilerComponentMeta = stubComponentCompilerMeta({
+      tagName: 'my-component',
+      componentClassName: 'MyComponent',
+    });
+
+    buildCtx.components = [compilerComponentMeta];
+
+    compilerCtx.moduleMap.set(
+      compilerComponentMeta.sourceFilePath,
+      mockModule({
+        cmps: [compilerComponentMeta],
+      })
+    );
+
+    const bundleOpts: BundleOptions = {
+      id: 'test-bundle',
+      platform: 'client',
+      inputs: {},
+      ...bundleOptsOverrides,
+    };
+
+    const cssText = ':host { text: pink; }';
+
+    // mock out the read for our CSS
+    jest.spyOn(compilerCtx.fs, 'readFile').mockResolvedValue(cssText);
+
+    // mock out compilerCtx.worker.transformCssToEsm because 1) we want to
+    // test what arguments are passed to it and 2) calling it un-mocked causes
+    // the infamous autoprefixer-spew-issue :(
+    const transformCssToEsmSpy = jest.spyOn(compilerCtx.worker, 'transformCssToEsm').mockResolvedValue({
+      styleText: cssText,
+      output: cssText,
+      map: null,
+      diagnostics: [],
+      imports: [],
+      defaultVarName: 'foo',
+      styleDocs: [],
+    });
+
+    const writeFileSpy = jest.spyOn(compilerCtx.fs, 'writeFile');
+    return {
+      plugin: extTransformsPlugin(config, compilerCtx, buildCtx, bundleOpts),
+      config,
+      compilerCtx,
+      buildCtx,
+      bundleOpts,
+      writeFileSpy,
+      transformCssToEsmSpy,
+      cssText,
+    };
+  }
+
+  describe('transform function', () => {
+    it('should set name', () => {
+      expect(setup().plugin.name).toBe('extTransformsPlugin');
+    });
+
+    it('should return early if no data can be gleaned from the id', async () => {
+      const { plugin } = setup();
+      // @ts-ignore we're testing something which shouldn't normally happen,
+      // but might if an argument of the wrong type were passed as `id`
+      const parseSpy = jest.spyOn(importPathLib, 'parseImportPath').mockReturnValue({ data: null });
+      // @ts-ignore the Rollup plugins expect to be called in a Rollup context
+      expect(await plugin.transform('asdf', 'foo.css')).toBe(null);
+      parseSpy.mockRestore();
+    });
+
+    it('should write CSS files if associated with a tag', async () => {
+      const { plugin, writeFileSpy } = setup();
+
+      // @ts-ignore the Rollup plugins expect to be called in a Rollup context
+      await plugin.transform('asdf', '/some/stubbed/path/foo.css?tag=my-component');
+
+      expect(writeFileSpy).toBeCalledWith('dist/collectionDir/foo.css', ':host { text: pink; }');
+    });
+
+    describe('passing `commentOriginalSelector` to `transformCssToEsm`', () => {
+      it.each([
+        [true, 'tag=my-component&encapsulation=scoped'],
+        [false, 'tag=my-component&encapsulation=shadow'],
+        [false, 'tag=my-component'],
+      ])('should pass %p if %p and hydrate', async (expectation, queryParams) => {
+        const { plugin, transformCssToEsmSpy } = setup({ platform: 'hydrate' });
+        // @ts-ignore the Rollup plugins expect to be called in a Rollup context
+        await plugin.transform('asdf', `/some/stubbed/path/foo.css?${queryParams}`);
+        expect(transformCssToEsmSpy.mock.calls[0][0].commentOriginalSelector).toBe(expectation);
+      });
+
+      it.each(['tag=my-component&encapsulation=scoped', 'tag=my-component&encapsulation=shadow', 'tag=my-component'])(
+        'should pass false if %p without hydrate',
+        async (queryParams) => {
+          const { plugin, transformCssToEsmSpy } = setup();
+          // @ts-ignore the Rollup plugins expect to be called in a Rollup context
+          await plugin.transform('asdf', `/some/stubbed/path/foo.css?${queryParams}`);
+          expect(transformCssToEsmSpy.mock.calls[0][0].commentOriginalSelector).toBe(false);
+        }
+      );
+    });
+  });
+});

--- a/src/compiler/bundle/test/ext-transforms-plugin.spec.ts
+++ b/src/compiler/bundle/test/ext-transforms-plugin.spec.ts
@@ -116,16 +116,16 @@ describe('extTransformsPlugin', () => {
       it('should pass false if shadow, hydrate, but using HMR in dev watch mode', async () => {
         const { plugin, transformCssToEsmSpy, config } = setup({ platform: 'hydrate' });
 
-        config.flags.watch = true
-        config.flags.dev = true
-        config.flags.serve = true
-        config.devServer = { reloadStrategy: "hmr" };
+        config.flags.watch = true;
+        config.flags.dev = true;
+        config.flags.serve = true;
+        config.devServer = { reloadStrategy: 'hmr' };
 
         // @ts-ignore the Rollup plugins expect to be called in a Rollup context
-        await plugin.transform('asdf', '/some/stubbed/path/foo.css?tag=my-component&encapsulation=shadow')
+        await plugin.transform('asdf', '/some/stubbed/path/foo.css?tag=my-component&encapsulation=shadow');
         expect(transformCssToEsmSpy.mock.calls[0][0].commentOriginalSelector).toBe(false);
       });
-        
+
       it.each(['tag=my-component&encapsulation=scoped', 'tag=my-component&encapsulation=shadow', 'tag=my-component'])(
         'should pass false if %p without hydrate',
         async (queryParams) => {

--- a/src/compiler/bundle/test/ext-transforms-plugin.spec.ts
+++ b/src/compiler/bundle/test/ext-transforms-plugin.spec.ts
@@ -103,16 +103,29 @@ describe('extTransformsPlugin', () => {
 
     describe('passing `commentOriginalSelector` to `transformCssToEsm`', () => {
       it.each([
-        [true, 'tag=my-component&encapsulation=scoped'],
-        [false, 'tag=my-component&encapsulation=shadow'],
+        [false, 'tag=my-component&encapsulation=scoped'],
+        [true, 'tag=my-component&encapsulation=shadow'],
         [false, 'tag=my-component'],
-      ])('should pass %p if %p and hydrate', async (expectation, queryParams) => {
+      ])('should pass true if %p and hydrate', async (expectation, queryParams) => {
         const { plugin, transformCssToEsmSpy } = setup({ platform: 'hydrate' });
         // @ts-ignore the Rollup plugins expect to be called in a Rollup context
         await plugin.transform('asdf', `/some/stubbed/path/foo.css?${queryParams}`);
         expect(transformCssToEsmSpy.mock.calls[0][0].commentOriginalSelector).toBe(expectation);
       });
 
+      it('should pass false if shadow, hydrate, but using HMR in dev watch mode', async () => {
+        const { plugin, transformCssToEsmSpy, config } = setup({ platform: 'hydrate' });
+
+        config.flags.watch = true
+        config.flags.dev = true
+        config.flags.serve = true
+        config.devServer = { reloadStrategy: "hmr" };
+
+        // @ts-ignore the Rollup plugins expect to be called in a Rollup context
+        await plugin.transform('asdf', '/some/stubbed/path/foo.css?tag=my-component&encapsulation=shadow')
+        expect(transformCssToEsmSpy.mock.calls[0][0].commentOriginalSelector).toBe(false);
+      });
+        
       it.each(['tag=my-component&encapsulation=scoped', 'tag=my-component&encapsulation=shadow', 'tag=my-component'])(
         'should pass false if %p without hydrate',
         async (queryParams) => {

--- a/src/compiler/bundle/test/ext-transforms-plugin.spec.ts
+++ b/src/compiler/bundle/test/ext-transforms-plugin.spec.ts
@@ -3,6 +3,7 @@ import { stubComponentCompilerMeta } from '../../types/tests/ComponentCompilerMe
 import { BundleOptions } from '../bundle-interface';
 import { extTransformsPlugin } from '../ext-transforms-plugin';
 import * as importPathLib from '../../transformers/stencil-import-path';
+import { normalizePath } from '@utils';
 
 describe('extTransformsPlugin', () => {
   function setup(bundleOptsOverrides: Partial<BundleOptions> = {}) {
@@ -93,7 +94,11 @@ describe('extTransformsPlugin', () => {
       // @ts-ignore the Rollup plugins expect to be called in a Rollup context
       await plugin.transform('asdf', '/some/stubbed/path/foo.css?tag=my-component');
 
-      expect(writeFileSpy).toBeCalledWith('dist/collectionDir/foo.css', ':host { text: pink; }');
+      const [path, css] = writeFileSpy.mock.calls[0];
+
+      expect(normalizePath(path)).toBe('./dist/collectionDir/foo.css');
+
+      expect(css).toBe(':host { text: pink; }');
     });
 
     describe('passing `commentOriginalSelector` to `transformCssToEsm`', () => {

--- a/src/compiler/bundle/worker-plugin.ts
+++ b/src/compiler/bundle/worker-plugin.ts
@@ -6,7 +6,7 @@ import { optimizeModule } from '../optimize/optimize-module';
 import { STENCIL_INTERNAL_ID } from './entry-alias-ids';
 
 export const workerPlugin = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   platform: string,
@@ -138,7 +138,7 @@ interface WorkerMeta {
 }
 
 const getWorker = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   ctx: PluginContext,
@@ -160,7 +160,7 @@ const getWorkerName = (id: string) => {
 };
 
 const buildWorker = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   ctx: PluginContext,

--- a/src/compiler/transformers/stencil-import-path.ts
+++ b/src/compiler/transformers/stencil-import-path.ts
@@ -54,7 +54,7 @@ export const serializeImportPath = (data: SerializeImportData, styleImportData: 
  * Parse import paths (filepaths possibly annotated w/ component metadata,
  * formatted as URL queryparams) into a structured format.
  *
- * @param importPath an ann otated import path to examine
+ * @param importPath an annotated import path to examine
  * @returns formatted information about the import
  */
 export const parseImportPath = (importPath: string) => {

--- a/src/compiler/transformers/stencil-import-path.ts
+++ b/src/compiler/transformers/stencil-import-path.ts
@@ -2,7 +2,21 @@ import type { ImportData, ParsedImport, SerializeImportData } from '../../declar
 import { basename, dirname, isAbsolute, relative } from 'path';
 import { DEFAULT_STYLE_MODE, isString, normalizePath } from '@utils';
 
-export const serializeImportPath = (data: SerializeImportData, styleImportData: string) => {
+/**
+ * Serialize data about a style import to an annotated path, where
+ * the filename has a URL queryparams style string appended to it.
+ * This could look like:
+ *
+ * ```
+ * './some-file.CSS?tag=my-tag&mode=ios&encapsulation=scoped');
+ * ```
+ *
+ * @param data import data to be serialized
+ * @param styleImportData an argument which controls whether the import data
+ * will be added to the path (formatted as queryparams)
+ * @returns a formatted string
+ */
+export const serializeImportPath = (data: SerializeImportData, styleImportData: string | undefined | null): string => {
   let p = data.importeePath;
 
   if (isString(p)) {
@@ -36,6 +50,13 @@ export const serializeImportPath = (data: SerializeImportData, styleImportData: 
   return p;
 };
 
+/**
+ * Parse import paths (filepaths possibly annotated w/ component metadata,
+ * formatted as URL queryparams) into a structured format.
+ *
+ * @param importPath an ann otated import path to examine
+ * @returns formatted information about the import
+ */
 export const parseImportPath = (importPath: string) => {
   const parsedPath: ParsedImport = {
     importPath,


### PR DESCRIPTION
This fixes an issue (#3461) where CSS is being inappropriately mangled
when using the hot-reload dev server. The issue has details about
exactly what the problem is, but basically in short if you are using the
`dist-hydrate-script` output target and running the dev server then any
change to a CSS file will cause all styling to be wiped from the related
component in the browser, making for a pretty inadequate developer
experience.

This commit fixes the issue by changing the conditions under which
original CSS selectors are commented out and 'scoped' so that it is only
done when you are have `scoped: true` set on a component (I believe this
was the original intent but for some reason the code wasn't set up to do
this).

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?

The code change is to modify the conditions under which CSS selectors are rewritten to support [scoped CSS](https://stenciljs.com/docs/styling#scoped-css).

I also introduced a test file to provide (partial) coverage of the relevant file, and added some comments reflecting what I was able to learn about how this all works.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

You can confirm this fixes the issue by building the compiler with this change, running `npm pack`, and then installing it into the reproduction case on the linked issue. Then if you follow the reproduction steps you shouldn't be able to reproduce the problem any longer.

Alternatively, you could check out STENCIL-47 for info about how to reproduce this issue in Framework, build and install the compiler with this patch in Framework, and confirm that fixes the issue as reported there.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
