### PR TITLE
fix(task): consider config sys in task runner

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -133,7 +133,7 @@ export const runTask = async (
     flags: createConfigFlags(config.flags ?? { task }),
     logger,
     outputTargets: config.outputTargets ?? [],
-    sys: sys ?? coreCompiler.createSystem({ logger }),
+    sys: sys ?? config.sys ?? coreCompiler.createSystem({ logger }),
     testing: config.testing ?? {},
   };
 

--- a/src/cli/test/run.spec.ts
+++ b/src/cli/test/run.spec.ts
@@ -177,6 +177,38 @@ describe('run', () => {
       taskTestSpy.mockRestore();
     });
 
+    describe('default configuration', () => {
+      describe('sys property', () => {
+        it('uses the sys argument if one is provided', async () => {
+          // remove the `CompilerSystem` on the config, just to be sure we don't accidentally use it
+          unvalidatedConfig.sys = undefined;
+
+          validatedConfig = mockValidatedConfig({ sys });
+
+          await runTask(coreCompiler, unvalidatedConfig, 'build', sys);
+
+          // first validate there was one call, and that call had two arguments
+          expect(taskBuildSpy).toHaveBeenCalledTimes(1);
+          expect(taskBuildSpy).toHaveBeenCalledWith(coreCompiler, validatedConfig);
+
+          const compilerSystemUsed: d.CompilerSystem = taskBuildSpy.mock.calls[0][1].sys;
+          expect(compilerSystemUsed).toBe(sys);
+        });
+
+        it('uses the sys field on the config if no sys argument is provided', async () => {
+          // if the optional `sys` argument isn't provided, attempt to default to the one on the config
+          await runTask(coreCompiler, unvalidatedConfig, 'build');
+
+          // first validate there was one call, and that call had two arguments
+          expect(taskBuildSpy).toHaveBeenCalledTimes(1);
+          expect(taskBuildSpy).toHaveBeenCalledWith(coreCompiler, validatedConfig);
+
+          const compilerSystemUsed: d.CompilerSystem = taskBuildSpy.mock.calls[0][1].sys;
+          expect(compilerSystemUsed).toBe(unvalidatedConfig.sys);
+        });
+      });
+    });
+
     it('calls the build task', async () => {
       await runTask(coreCompiler, unvalidatedConfig, 'build', sys);
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `sys` field on a configuration entity is not considered when
`runTask` is invoked directly. This causes us to configure the compiler
differently/incorrectly

GitHub Issue Number: https://github.com/ionic-team/stencil/issues/3510


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the generation of a `ValidatedConfig` entity to take
a `sys` property on a user provided `Config` in the context of
`runTask`.

when generating the validated configuration, the `sys` entity takes
precedence over all other configurations, with the belief that in the
event argument was provided, it is the intent of the user to use it. in
the event `sys` is not expressly provided, use the one on the provided
configuration entity. this is useful in the case that a user used
stencil's external facing apis in a flow that:
1. loads a configuration
2. validates that configuration
3. uses that configuration when calling `runTask` directly

this commit fixes a bug introduced making `sys` a required field on
`ValidatedConfig`, where `config.sys` was not properly accounted for.
the bug was initially introduced in
a6a9171a5e8aebd0070e3d6a89e41b1e9199de82 (#3491)


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
In addition to the new unit tests...

1. Checkout this branch, build a tarball of Stencil:
```
npm run clean && npm ci && npm run build && npm pack
```
which will generate a `stencil-core-2.17.3.tgz` file in your Stencil project's root directory

2. Clone the reproduction case at https://github.com/m4s7/failing-sample
3. Verify the reproduction (IE this should fail)
```
yarn install && yarn nx run sample:build
```
```
> nx run sample:build


[ WARN  ]  exit 1

YOUR_REPRO_LOCATION/node_modules/@stencil/core/compiler/stencil.js:41835
    results.fileNames = results.fileNames.filter((f) => {
```
4. Validate the changes work:
```
yarn remove @stencil/core --force && /
yarn cache clean && /
yarn add --dev PATH_TO_STENCIL/stencil/stencil-core-2.17.3.tgz --force --no-cache && /
nx run sample:build  --skip-nx-cache
```
## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
