### PR TITLE
feat(formAssociated): enables formAssociated components (using ElementInternals) 

### DIFF
--- a/src/compiler/transformers/static-to-meta/component.ts
+++ b/src/compiler/transformers/static-to-meta/component.ts
@@ -44,7 +44,7 @@ export const parseStaticComponentMeta = (
   if (!srcNode.statements) {
     return srcNode;
   }
-  let cmpNode = srcNode.statements.find(st => ts.isClassDeclaration(st)) as ts.ClassDeclaration;
+  let cmpNode = srcNode.statements.find((st) => ts.isClassDeclaration(st)) as ts.ClassDeclaration;
 
   if (!cmpNode || cmpNode.members == null) {
     return srcNode;
@@ -165,12 +165,15 @@ export const parseStaticComponentMeta = (
 
   if (transformOpts && transformOpts.componentMetadata === 'compilerstatic') {
     cmpNode = addComponentMetaStatic(cmpNode, cmp);
-    srcNode = ts.factory.updateSourceFile(srcNode, ts.factory.createNodeArray([
-      ...srcNode.statements.map(st => {
-        if (ts.isClassDeclaration(st)) return cmpNode;
-        return st;
-      })
-    ]))
+    srcNode = ts.factory.updateSourceFile(
+      srcNode,
+      ts.factory.createNodeArray([
+        ...srcNode.statements.map((st) => {
+          if (ts.isClassDeclaration(st)) return cmpNode;
+          return st;
+        }),
+      ])
+    );
   }
 
   // add to module map

--- a/src/compiler/transformers/static-to-meta/component.ts
+++ b/src/compiler/transformers/static-to-meta/component.ts
@@ -79,7 +79,7 @@ export const parseStaticComponentMeta = (
     legacyConnect: getStaticValue(staticMembers, 'connectProps') || [],
     legacyContext: getStaticValue(staticMembers, 'contextProps') || [],
     internal: isInternal(docs),
-    isFormAssociated: hasFormAssociated(srcNode.statements),
+    isFormAssociated: hasFormAssociated(srcNode.statements, cmpNode),
     assetsDirs: parseAssetsDirs(staticMembers, moduleFile.jsFilePath),
     styleDocs: [],
     docs,

--- a/src/compiler/transformers/static-to-meta/formassociated.ts
+++ b/src/compiler/transformers/static-to-meta/formassociated.ts
@@ -3,16 +3,20 @@ import ts from 'typescript';
 export const hasFormAssociated = (statements: ts.NodeArray<ts.Statement>, classNode: ts.ClassDeclaration) => {
   const className = classNode.name.getText();
 
-  return !!statements.find(
-    (st: ts.ExpressionStatement) =>
-      st.kind === ts.SyntaxKind.ExpressionStatement &&
-      st.expression &&
-      st.expression.kind === ts.SyntaxKind.BinaryExpression &&
-      (st.expression as ts.BinaryExpression).left.kind === ts.SyntaxKind.PropertyAccessExpression &&
-      ((st.expression as ts.BinaryExpression).left as ts.PropertyAccessExpression).expression?.getText() ===
-        className &&
-      ((st.expression as ts.BinaryExpression).left as ts.PropertyAccessExpression).name?.getText() ===
-        'formAssociated' &&
-      (st.expression as ts.BinaryExpression).right.kind === ts.SyntaxKind.TrueKeyword
-  );
+  try {
+    return !!statements.find(
+      (st: ts.ExpressionStatement) =>
+        st.kind === ts.SyntaxKind.ExpressionStatement &&
+        st.expression &&
+        st.expression.kind === ts.SyntaxKind.BinaryExpression &&
+        (st.expression as ts.BinaryExpression).left.kind === ts.SyntaxKind.PropertyAccessExpression &&
+        ((st.expression as ts.BinaryExpression).left as ts.PropertyAccessExpression).expression?.getText() ===
+          className &&
+        ((st.expression as ts.BinaryExpression).left as ts.PropertyAccessExpression).name?.getText() ===
+          'formAssociated' &&
+        (st.expression as ts.BinaryExpression).right.kind === ts.SyntaxKind.TrueKeyword
+    );
+  } catch (e) {
+    return false;
+  }
 };

--- a/src/compiler/transformers/static-to-meta/formassociated.ts
+++ b/src/compiler/transformers/static-to-meta/formassociated.ts
@@ -1,12 +1,14 @@
 import ts from 'typescript';
 
 export const hasFormAssociated = (statements: ts.NodeArray<ts.Statement>) => {
-  return !!statements.find((st: ts.ExpressionStatement) =>
+  return !!statements.find(
+    (st: ts.ExpressionStatement) =>
       st.kind === ts.SyntaxKind.ExpressionStatement &&
       st.expression &&
       st.expression.kind === ts.SyntaxKind.BinaryExpression &&
       (st.expression as ts.BinaryExpression).left.kind === ts.SyntaxKind.PropertyAccessExpression &&
-      ((st.expression as ts.BinaryExpression).left as ts.PropertyAccessExpression).name.getText() === 'formAssociated' &&
+      ((st.expression as ts.BinaryExpression).left as ts.PropertyAccessExpression).name.getText() ===
+        'formAssociated' &&
       (st.expression as ts.BinaryExpression).right.kind === ts.SyntaxKind.TrueKeyword
   );
 };

--- a/src/compiler/transformers/static-to-meta/formassociated.ts
+++ b/src/compiler/transformers/static-to-meta/formassociated.ts
@@ -9,7 +9,8 @@ export const hasFormAssociated = (statements: ts.NodeArray<ts.Statement>, classN
       st.expression &&
       st.expression.kind === ts.SyntaxKind.BinaryExpression &&
       (st.expression as ts.BinaryExpression).left.kind === ts.SyntaxKind.PropertyAccessExpression &&
-      ((st.expression as ts.BinaryExpression).left as ts.PropertyAccessExpression).expression?.getText() === className &&
+      ((st.expression as ts.BinaryExpression).left as ts.PropertyAccessExpression).expression?.getText() ===
+        className &&
       ((st.expression as ts.BinaryExpression).left as ts.PropertyAccessExpression).name?.getText() ===
         'formAssociated' &&
       (st.expression as ts.BinaryExpression).right.kind === ts.SyntaxKind.TrueKeyword

--- a/src/compiler/transformers/static-to-meta/formassociated.ts
+++ b/src/compiler/transformers/static-to-meta/formassociated.ts
@@ -1,13 +1,16 @@
 import ts from 'typescript';
 
-export const hasFormAssociated = (statements: ts.NodeArray<ts.Statement>) => {
+export const hasFormAssociated = (statements: ts.NodeArray<ts.Statement>, classNode: ts.ClassDeclaration) => {
+  const className = classNode.name.getText();
+
   return !!statements.find(
     (st: ts.ExpressionStatement) =>
       st.kind === ts.SyntaxKind.ExpressionStatement &&
       st.expression &&
       st.expression.kind === ts.SyntaxKind.BinaryExpression &&
       (st.expression as ts.BinaryExpression).left.kind === ts.SyntaxKind.PropertyAccessExpression &&
-      ((st.expression as ts.BinaryExpression).left as ts.PropertyAccessExpression).name.getText() ===
+      ((st.expression as ts.BinaryExpression).left as ts.PropertyAccessExpression).expression?.getText() === className &&
+      ((st.expression as ts.BinaryExpression).left as ts.PropertyAccessExpression).name?.getText() ===
         'formAssociated' &&
       (st.expression as ts.BinaryExpression).right.kind === ts.SyntaxKind.TrueKeyword
   );

--- a/src/compiler/transformers/static-to-meta/formassociated.ts
+++ b/src/compiler/transformers/static-to-meta/formassociated.ts
@@ -1,0 +1,12 @@
+import ts from 'typescript';
+
+export const hasFormAssociated = (statements: ts.NodeArray<ts.Statement>) => {
+  return !!statements.find((st: ts.ExpressionStatement) =>
+      st.kind === ts.SyntaxKind.ExpressionStatement &&
+      st.expression &&
+      st.expression.kind === ts.SyntaxKind.BinaryExpression &&
+      (st.expression as ts.BinaryExpression).left.kind === ts.SyntaxKind.PropertyAccessExpression &&
+      ((st.expression as ts.BinaryExpression).left as ts.PropertyAccessExpression).name.getText() === 'formAssociated' &&
+      (st.expression as ts.BinaryExpression).right.kind === ts.SyntaxKind.TrueKeyword
+  );
+};

--- a/src/compiler/transformers/static-to-meta/parse-static.ts
+++ b/src/compiler/transformers/static-to-meta/parse-static.ts
@@ -43,7 +43,7 @@ export const updateModule = (
   compilerCtx.changedModules.add(moduleFile.sourceFilePath);
 
   const visitNode = (node: ts.Node) => {
-    if (ts.isClassDeclaration(node)) {
+    if (ts.isSourceFile(node)) {
       parseStaticComponentMeta(compilerCtx, typeChecker, node, moduleFile);
       return;
     } else if (ts.isImportDeclaration(node)) {

--- a/src/compiler/transformers/static-to-meta/visitor.ts
+++ b/src/compiler/transformers/static-to-meta/visitor.ts
@@ -20,7 +20,7 @@ export const convertStaticToMeta = (
     let moduleFile: d.Module;
 
     const visitNode = (node: ts.Node): ts.VisitResult<ts.Node> => {
-      if (ts.isClassDeclaration(node)) {
+      if (ts.isSourceFile(node)) {
         return parseStaticComponentMeta(compilerCtx, typeChecker, node, moduleFile, transformOpts);
       } else if (ts.isImportDeclaration(node)) {
         parseModuleImport(config, compilerCtx, buildCtx, moduleFile, dirPath, node, !transformOpts.isolatedModules);

--- a/src/compiler/types/tests/ComponentCompilerMeta.stub.ts
+++ b/src/compiler/types/tests/ComponentCompilerMeta.stub.ts
@@ -71,6 +71,7 @@ export const stubComponentCompilerMeta = (
   htmlTagNames: [],
   internal: false,
   isCollectionDependency: false,
+  isFormAssociated: false,
   isPlain: false,
   isUpdateable: false,
   jsFilePath: '/some/stubbed/path/my-component.js',

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -798,6 +798,7 @@ export interface ComponentCompilerMeta extends ComponentCompilerFeatures {
   styles: StyleCompiler[];
   tagName: string;
   internal: boolean;
+  isFormAssociated: boolean;
   legacyConnect: ComponentCompilerLegacyConnect[];
   legacyContext: ComponentCompilerLegacyContext[];
 
@@ -980,6 +981,7 @@ export interface ComponentConstructor {
   cmpMeta?: ComponentRuntimeMeta;
   isProxied?: boolean;
   isStyleRegistered?: boolean;
+  formAssociated?: boolean;
 }
 
 export interface ComponentConstructorWatchers {

--- a/src/runtime/proxy-component.ts
+++ b/src/runtime/proxy-component.ts
@@ -2,7 +2,7 @@ import type * as d from '../declarations';
 import { BUILD } from '@app-data';
 import { consoleDevWarn, getHostRef, plt } from '@platform';
 import { getValue, setValue } from './set-value';
-import { HOST_FLAGS, MEMBER_FLAGS } from '../utils/constants';
+import { HOST_FLAGS, MEMBER_FLAGS, CMP_FLAGS } from '../utils/constants';
 import { PROXY_FLAGS } from './runtime-constants';
 
 export const proxyComponent = (Cstr: d.ComponentConstructor, cmpMeta: d.ComponentRuntimeMeta, flags: number) => {
@@ -138,6 +138,10 @@ export const proxyComponent = (Cstr: d.ComponentConstructor, cmpMeta: d.Componen
           return attrName;
         });
     }
+  }
+
+  if (BUILD.lazyLoad && (cmpMeta.$flags$ & CMP_FLAGS.isFormAssociated)) {
+    Cstr.formAssociated = true;
   }
 
   return Cstr;

--- a/src/runtime/proxy-component.ts
+++ b/src/runtime/proxy-component.ts
@@ -140,7 +140,7 @@ export const proxyComponent = (Cstr: d.ComponentConstructor, cmpMeta: d.Componen
     }
   }
 
-  if (BUILD.lazyLoad && (cmpMeta.$flags$ & CMP_FLAGS.isFormAssociated)) {
+  if (cmpMeta.$flags$ & CMP_FLAGS.isFormAssociated) {
     Cstr.formAssociated = true;
   }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -62,6 +62,7 @@ export const enum CMP_FLAGS {
   needsShadowDomShim = 1 << 3,
   shadowDelegatesFocus = 1 << 4,
   hasMode = 1 << 5,
+  isFormAssociated = 1 << 6,
   needsScopedEncapsulation = scopedCssEncapsulation | needsShadowDomShim,
 }
 

--- a/src/utils/format-component-runtime-meta.ts
+++ b/src/utils/format-component-runtime-meta.ts
@@ -27,6 +27,9 @@ export const formatComponentRuntimeMeta = (
   if (compilerMeta.hasMode) {
     flags |= CMP_FLAGS.hasMode;
   }
+  if (compilerMeta.isFormAssociated) {
+    flags |= CMP_FLAGS.isFormAssociated;
+  }
 
   const members = formatComponentRuntimeMembers(compilerMeta, includeMethods);
   const hostListeners = formatHostListeners(compilerMeta);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
