### PR TITLE
chore(cli): add types to finding config

### DIFF
--- a/src/cli/find-config.ts
+++ b/src/cli/find-config.ts
@@ -1,19 +1,42 @@
 import type { CompilerSystem, Diagnostic } from '../declarations';
 import { isString, normalizePath, buildError } from '@utils';
 
-export const findConfig = async (opts: { sys: CompilerSystem; configPath: string }) => {
+/**
+ * An object containing the {@link CompilerSystem} used to find the configuration file, as well as the location on disk
+ * to search for a Stencil configuration
+ */
+export type FindConfigOptions = {
+  sys: CompilerSystem;
+  configPath: string;
+};
+
+/**
+ * The results of attempting to find a Stencil configuration file on disk
+ */
+export type FindConfigResults = {
+  configPath: string;
+  rootDir: string;
+  diagnostics: Diagnostic[];
+};
+
+/**
+ * Attempt to find a Stencil configuration file on the file system
+ * @param opts the options needed to find the configuration file
+ * @returns the results of attempting to find a configuration file on disk
+ */
+export const findConfig = async (opts: FindConfigOptions): Promise<FindConfigResults> => {
   const sys = opts.sys;
   const cwd = sys.getCurrentDirectory();
-  const results = {
+  const results: FindConfigResults = {
     configPath: null as string,
     rootDir: normalizePath(cwd),
-    diagnostics: [] as Diagnostic[],
+    diagnostics: [],
   };
   let configPath = opts.configPath;
 
   if (isString(configPath)) {
     if (!sys.platformPath.isAbsolute(configPath)) {
-      // passed in a custom stencil config location
+      // passed in a custom stencil config location,
       // but it's relative, so prefix the cwd
       configPath = normalizePath(sys.platformPath.join(cwd, configPath));
     } else {


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
See new behavior 

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit adds additional types for the function that finds a user's
configuration file on disk in the hope of adding clarity and removing a
type assertion in the function

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
 N/A - compiler continues to pass type checks

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

i had this commit sitting around, with no great place to add it to an
existing pr. i decided to just put it up on its own instead of continuing to
maintain it locally