### PR TITLE
fix up null checks in some mock-doc code

### DIFF
--- a/src/mock-doc/attribute.ts
+++ b/src/mock-doc/attribute.ts
@@ -53,7 +53,7 @@ export class MockAttributeMap {
     return this.getNamedItemNS(null, attrName);
   }
 
-  getNamedItemNS(namespaceURI: string, attrName: string) {
+  getNamedItemNS(namespaceURI: string | null, attrName: string) {
     namespaceURI = getNamespaceURI(namespaceURI);
     return (
       this.__items.find((attr) => attr.name === attrName && getNamespaceURI(attr.namespaceURI) === namespaceURI) || null
@@ -89,7 +89,7 @@ export class MockAttributeMap {
   }
 }
 
-function getNamespaceURI(namespaceURI: string) {
+function getNamespaceURI(namespaceURI: string | null) {
   return namespaceURI === XLINK_NS ? null : namespaceURI;
 }
 
@@ -129,9 +129,9 @@ function sortAttributes(a: MockAttr, b: MockAttr) {
 export class MockAttr {
   private _name: string;
   private _value: string;
-  private _namespaceURI: string;
+  private _namespaceURI: string | null;
 
-  constructor(attrName: string, attrValue: string, namespaceURI: string = null) {
+  constructor(attrName: string, attrValue: string, namespaceURI: string | null = null) {
     this._name = attrName;
     this._value = String(attrValue);
     this._namespaceURI = namespaceURI;

--- a/src/mock-doc/custom-element-registry.ts
+++ b/src/mock-doc/custom-element-registry.ts
@@ -212,7 +212,7 @@ export function disconnectNode(node: MockNode) {
   }
 }
 
-export function attributeChanged(node: MockNode, attrName: string, oldValue: string, newValue: string) {
+export function attributeChanged(node: MockNode, attrName: string, oldValue: string | null, newValue: string | null) {
   attrName = attrName.toLowerCase();
 
   const observedAttributes = (node as any).constructor.observedAttributes as string[];

--- a/src/mock-doc/node.ts
+++ b/src/mock-doc/node.ts
@@ -196,7 +196,7 @@ export class MockNode {
   }
 
   get textContent() {
-    return this._nodeValue;
+    return this._nodeValue ?? "";
   }
   set textContent(value: string) {
     this._nodeValue = String(value);
@@ -225,7 +225,7 @@ export class MockNodeList {
 
 export class MockElement extends MockNode {
   namespaceURI: string | null;
-  __attributeMap: MockAttributeMap | null;
+  __attributeMap: MockAttributeMap | null | undefined;
   __shadowRoot: ShadowRoot | null | undefined;
   __style: MockCSSStyleDeclaration | null | undefined;
 
@@ -266,8 +266,8 @@ export class MockElement extends MockNode {
     }
   }
 
-  get attributes() {
-    if (this.__attributeMap === null) {
+  get attributes(): MockAttributeMap {
+    if (this.__attributeMap == null) {
       const attrMap = createAttributeProxy(false)
       this.__attributeMap = attrMap
       return attrMap
@@ -495,7 +495,7 @@ export class MockElement extends MockNode {
     return this.getAttribute(attrName) !== null;
   }
 
-  hasAttributeNS(namespaceURI: string, name: string) {
+  hasAttributeNS(namespaceURI: string | null, name: string) {
     return this.getAttributeNS(namespaceURI, name) !== null;
   }
 
@@ -602,7 +602,7 @@ export class MockElement extends MockNode {
     }
   }
 
-  removeAttributeNS(namespaceURI: string, attrName: string) {
+  removeAttributeNS(namespaceURI: string | null, attrName: string) {
     const attr = this.attributes.getNamedItemNS(namespaceURI, attrName);
     if (attr != null) {
       this.attributes.removeNamedItemNS(attr);
@@ -1024,7 +1024,7 @@ function getElementsByTagName(elm: MockElement, tagName: string, foundElms: Mock
   const children = elm.children;
   for (let i = 0, ii = children.length; i < ii; i++) {
     const childElm = children[i];
-    if (tagName === '*' || childElm.nodeName.toLowerCase() === tagName) {
+    if (tagName === '*' || (childElm.nodeName ?? "").toLowerCase() === tagName) {
       foundElms.push(childElm);
     }
     getElementsByTagName(childElm, tagName, foundElms);

--- a/src/mock-doc/node.ts
+++ b/src/mock-doc/node.ts
@@ -700,7 +700,7 @@ export class MockElement extends MockNode {
   }
 
   get tagName() {
-    return this.nodeName;
+    return this.nodeName ?? "";
   }
   set tagName(value: string) {
     this.nodeName = value;

--- a/src/mock-doc/node.ts
+++ b/src/mock-doc/node.ts
@@ -1078,7 +1078,7 @@ export class MockHTMLElement extends MockElement {
   override get attributes(): MockAttributeMap {
     if (this.__attributeMap == null) {
       const attrMap = createAttributeProxy(true);
-      this.__attributeMap = createAttributeProxy(true);
+      this.__attributeMap = attrMap;
       return attrMap;
     }
     return this.__attributeMap;

--- a/src/mock-doc/node.ts
+++ b/src/mock-doc/node.ts
@@ -304,7 +304,8 @@ export class MockElement extends MockNode {
 
   override cloneNode(_deep?: boolean): MockElement {
     // implemented on MockElement.prototype from within element.ts
-    return this;
+    // @ts-ignore - implemented on MockElement.prototype from within element.ts
+    return null;
   }
 
   closest(selector: string) {

--- a/src/mock-doc/node.ts
+++ b/src/mock-doc/node.ts
@@ -125,7 +125,7 @@ export class MockNode {
   }
 
   get nodeValue() {
-    return this._nodeValue ?? "";
+    return this._nodeValue ?? '';
   }
   set nodeValue(value: string) {
     this._nodeValue = value;
@@ -196,7 +196,7 @@ export class MockNode {
   }
 
   get textContent() {
-    return this._nodeValue ?? "";
+    return this._nodeValue ?? '';
   }
   set textContent(value: string) {
     this._nodeValue = String(value);
@@ -268,11 +268,11 @@ export class MockElement extends MockNode {
 
   get attributes(): MockAttributeMap {
     if (this.__attributeMap == null) {
-      const attrMap = createAttributeProxy(false)
-      this.__attributeMap = attrMap
-      return attrMap
+      const attrMap = createAttributeProxy(false);
+      this.__attributeMap = attrMap;
+      return attrMap;
     }
-    return this.__attributeMap
+    return this.__attributeMap;
   }
 
   set attributes(attrs: MockAttributeMap) {
@@ -304,7 +304,7 @@ export class MockElement extends MockNode {
 
   override cloneNode(_deep?: boolean): MockElement {
     // implemented on MockElement.prototype from within element.ts
-    return null;
+    return this;
   }
 
   closest(selector: string) {
@@ -415,7 +415,7 @@ export class MockElement extends MockNode {
   }
 
   set innerHTML(html: string) {
-    if (NON_ESCAPABLE_CONTENT.has(this.nodeName ?? "") === true) {
+    if (NON_ESCAPABLE_CONTENT.has(this.nodeName ?? '') === true) {
       setTextContent(this, html);
     } else {
       for (let i = this.childNodes.length - 1; i >= 0; i--) {
@@ -700,7 +700,7 @@ export class MockElement extends MockNode {
   }
 
   get tagName() {
-    return this.nodeName ?? "";
+    return this.nodeName ?? '';
   }
   set tagName(value: string) {
     this.nodeName = value;
@@ -1024,7 +1024,7 @@ function getElementsByTagName(elm: MockElement, tagName: string, foundElms: Mock
   const children = elm.children;
   for (let i = 0, ii = children.length; i < ii; i++) {
     const childElm = children[i];
-    if (tagName === '*' || (childElm.nodeName ?? "").toLowerCase() === tagName) {
+    if (tagName === '*' || (childElm.nodeName ?? '').toLowerCase() === tagName) {
       foundElms.push(childElm);
     }
     getElementsByTagName(childElm, tagName, foundElms);
@@ -1069,19 +1069,21 @@ export class MockHTMLElement extends MockElement {
   }
 
   override get tagName() {
-    return this.nodeName ?? "";
+    return this.nodeName ?? '';
   }
   override set tagName(value: string) {
     this.nodeName = value;
   }
 
-  override get attributes() {
+  override get attributes(): MockAttributeMap {
     if (this.__attributeMap == null) {
+      const attrMap = createAttributeProxy(true);
       this.__attributeMap = createAttributeProxy(true);
+      return attrMap;
     }
-    // @ts-ignore
     return this.__attributeMap;
   }
+
   override set attributes(attrs: MockAttributeMap) {
     this.__attributeMap = attrs;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "strict": true,
     "alwaysStrict": true,
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "alwaysStrict": true,
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,


### PR DESCRIPTION
This PR basically just entails fixing (some!) strict null checks errors in a few `mock-doc`-related files. I don't pretend to have fixed them _all_, but mainly tried to adjust the TS types so that they're more inline with how the code is actually used. For instance, we had a number of places where something was typed `string` but actually called with both strings and `null`. I tried to just smooth out some of that inconsistency where I could while changing as little actual code as possible.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?

I just tried to change the types in `src/mock-doc/node.ts` to reflect the values they actually are at runtime. I think I eliminated the null check errors from that file. There are a few ancillary changes to other files that sort of followed on from those changes.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Just made sure the tests are all passing.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
