### PR TITLE
chore(dev-deps): remove unneeded @types/is-glob

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "@types/glob": "^7.1.2",
         "@types/graceful-fs": "^4.1.5",
         "@types/inquirer": "^7.3.1",
-        "@types/is-glob": "^4.0.1",
         "@types/jest": "^27.0.3",
         "@types/listr": "^0.14.2",
         "@types/mime-types": "^2.1.0",
@@ -1479,12 +1478,6 @@
         "@types/through": "*",
         "rxjs": "^6.4.0"
       }
-    },
-    "node_modules/@types/is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-k3RS5HyBPu4h+5hTmIEfPB2rl5P3LnGdQEZrV2b9OWTJVtsUQ2VBcedqYKGqxvZqle5UALUXdSfVA8nf3HfyWQ==",
-      "dev": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -14436,12 +14429,6 @@
         "@types/through": "*",
         "rxjs": "^6.4.0"
       }
-    },
-    "@types/is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-k3RS5HyBPu4h+5hTmIEfPB2rl5P3LnGdQEZrV2b9OWTJVtsUQ2VBcedqYKGqxvZqle5UALUXdSfVA8nf3HfyWQ==",
-      "dev": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "@types/glob": "^7.1.2",
     "@types/graceful-fs": "^4.1.5",
     "@types/inquirer": "^7.3.1",
-    "@types/is-glob": "^4.0.1",
     "@types/jest": "^27.0.3",
     "@types/listr": "^0.14.2",
     "@types/mime-types": "^2.1.0",


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I believe that we have a `@types` dep that is not needed anymore

Supersedes: #3547


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit removes `@types/is-glob` from the project's root manifest.
`is-glob` does not appear to be used in the project at this time. it
appears it once was in the project, but was removed prior to v1.16.0
(it was removed in 0522e66b5213cb80de72e544ff5e3185f389dd32,
specifically).

this commit is motivated by dependabot attempting to bump the version of
this package in https://github.com/ionic-team/stencil/pull/3547. rather
than bump the version, we should prefer to remove packages we do not use

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Ran the type checker and tests locally, we'll see what CI has to say
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
