### PR TITLE
chore(ci): fix dirty git context for browserstack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,11 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+        with:
+          # the pull_request_target event will consider the HEAD of `main` to be the SHA to use.
+          # attempt to use the SHA associated with a pull request and fallback to HEAD of `main`
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.number) || '' }}
+          persist-credentials: false
 
       - name: Get Core Dependencies
         uses: ./.github/workflows/actions/get-core-dependencies


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

ci fails when we modify the `scripts/` directory of the project

this is a symptom of a larger issue where the incorrect branch was built for browserstack tests,
we never noticed before because `scripts` contains both compiled and source code we archive,
and this is the first time we've modified it since the bug in CI was introduced

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit modifies the `build_core` reusable workflow for stencil's ci
to take into account the event name when checking out the code to be
built. depending on the event name, the `HEAD` value used to check out
the code can differ. for event's with name 'pull_request_target', `HEAD`
is the head of the primary branch, in our case, `main`.

this lead to an issue in the stencil repo where two workflows would run
in order to build/run browserstack:

1. `build_core`, which would use `main@HEAD` when building the repo, and
   subesquently archiving the results for the next step
2. `Browserstack Tests`, which would checkout the code associated with
   the pull request, the unpack the saved dependencies from `main` over
   the contents of the pull request

because step 2 would take on files from `main` when the build archive was
unpacked, we would fail the git status check, because files from `main` would
clash with files on the checked out commit associated with the pr

this bug was originally introduced in 1cef74ff (#3454)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Testing

We use this same logic for checking code out when we run browserstack

Unfortunately, pull_request_target code needs to land to be tested 😢 so we're rolling the dice here 🎲 
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
