### PR TITLE
chore(ci): run tech debt burndown on forks

### DIFF
--- a/.github/workflows/tech-debt-burndown.yml
+++ b/.github/workflows/tech-debt-burndown.yml
@@ -7,7 +7,7 @@ name: Tech Debt Burndown
 # progress on them to each PR.
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - '**'
 
@@ -27,6 +27,11 @@ jobs:
 
       - name: Checkout PR branch
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+        with:
+          # the pull_request_target event will consider the HEAD of `main` to be the SHA to use.
+          # attempt to use the SHA associated with a pull request and fallback to HEAD of `main`
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.number) || '' }}
+          persist-credentials: false
         if: ${{ matrix.branch == 'pr' }}
 
       - name: Get Core Dependencies
@@ -60,6 +65,11 @@ jobs:
 
       - name: Checkout PR branch
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+        with:
+          # the pull_request_target event will consider the HEAD of `main` to be the SHA to use.
+          # attempt to use the SHA associated with a pull request and fallback to HEAD of `main`
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.number) || '' }}
+          persist-credentials: false
         if: ${{ matrix.branch == 'pr' }}
 
       - name: Install ts-prune
@@ -81,6 +91,11 @@ jobs:
     steps:
       - name: Checkout current branch
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+        with:
+          # the pull_request_target event will consider the HEAD of `main` to be the SHA to use.
+          # attempt to use the SHA associated with a pull request and fallback to HEAD of `main`
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.number) || '' }}
+          persist-credentials: false
 
       - name: Get Core Dependencies
         uses: ./.github/workflows/actions/get-core-dependencies


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

the tech-debt burndown fails for forks of this repo, due to security issues

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit changes the event type on the tech debt burndown list. the
pull_request event does not offer the ability run the
'peter-evans/create-or-update-comment' step (see
https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#restrictions-on-repository-forks)
for security reasons. in this commit, we use 'pull_request_target' in an
attempt to fix that.

however, this affects what branch is used from in ci from the branch
that the pr was opened with (pull_request), to the `HEAD` of `main`
(pull_request_target). as a result, `actions/checkout` steps must be
modified in order to account for the difference in branch

STENCIL-476: tech debt burndown CI job fails for external pull requests

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing
Unfortunately, pull_request_target code needs to land to be tested 😢 so we're rolling the dice here 🎲
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
