### PR TITLE
fix(compiler): revert component barrel export for `dist-custom-elements`

### DIFF
--- a/src/compiler/output-targets/test/output-targets-dist-custom-elements.spec.ts
+++ b/src/compiler/output-targets/test/output-targets-dist-custom-elements.spec.ts
@@ -146,13 +146,11 @@ describe('Custom Elements output target', () => {
         config.outputTargets[0] as OutputTargetDistCustomElements
       );
       addCustomElementInputs(buildCtx, bundleOptions);
-      expect(bundleOptions.loader['\0core']).toEqual(
+      expect(bundleOptions.loader['\0core']).toContain(
         `export { setAssetPath, setPlatformOptions } from '${STENCIL_INTERNAL_CLIENT_ID}';
 export * from '${USER_INDEX_ENTRY_ID}';
 import { globalScripts } from '${STENCIL_APP_GLOBALS_ID}';
-globalScripts();
-export { StubCmp, defineCustomElement as defineCustomElementStubCmp } from '\0StubCmp';
-export { MyBestComponent, defineCustomElement as defineCustomElementMyBestComponent } from '\0MyBestComponent';`
+globalScripts();`
       );
     });
 
@@ -172,12 +170,11 @@ export { MyBestComponent, defineCustomElement as defineCustomElementMyBestCompon
         config.outputTargets[0] as OutputTargetDistCustomElements
       );
       addCustomElementInputs(buildCtx, bundleOptions);
-      expect(bundleOptions.loader['\0core']).toEqual(
+      expect(bundleOptions.loader['\0core']).toContain(
         `export { setAssetPath, setPlatformOptions } from '${STENCIL_INTERNAL_CLIENT_ID}';
 export * from '${USER_INDEX_ENTRY_ID}';
 import { globalScripts } from '${STENCIL_APP_GLOBALS_ID}';
-globalScripts();
-export { ComponentWithJsx, defineCustomElement as defineCustomElementComponentWithJsx } from '\0ComponentWithJsx';`
+globalScripts();`
       );
     });
   });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Unit tests (`npm test`) were run locally and passed
- [X] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [X] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: https://github.com/ionic-team/stencil/issues/3470


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This commit reverts a change made to the `dist-custom-elements` output target that re-exported all component classes and `defineCustomElement` functions from a single `index.js` file in the output directory. This addresses the issue reported in STENCIL-500. Future improvements may be made as a result of STENCIL-457

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
This will be released with Stencil V3. More changes related to this and the migration plan will come as a result of STENCIL-457

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
Unit and E2E tests continue to pass locally. Validated `dist-custom-elements` output target output on an example repo.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
