### PR TITLE
chore(config): add `rootDir` to the validated config type

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -133,9 +133,9 @@ export const runTask = async (
     flags: createConfigFlags(config.flags ?? { task }),
     logger,
     outputTargets: config.outputTargets ?? [],
+    rootDir: config.rootDir ?? '/',
     sys: sys ?? config.sys ?? coreCompiler.createSystem({ logger }),
     testing: config.testing ?? {},
-    rootDir: config.rootDir ?? '/',
   };
 
   switch (task) {

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -135,6 +135,7 @@ export const runTask = async (
     outputTargets: config.outputTargets ?? [],
     sys: sys ?? config.sys ?? coreCompiler.createSystem({ logger }),
     testing: config.testing ?? {},
+    rootDir: config.rootDir ?? '/',
   };
 
   switch (task) {

--- a/src/compiler/config/test/validate-service-worker.spec.ts
+++ b/src/compiler/config/test/validate-service-worker.spec.ts
@@ -12,6 +12,7 @@ describe('validateServiceWorker', () => {
   beforeEach(() => {
     config = {
       fsNamespace: 'app',
+      rootDir: '/',
       sys: mockCompilerSystem(),
       devMode: false,
       flags: createConfigFlags(),

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -53,9 +53,9 @@ export const validateConfig = (
     flags: JSON.parse(JSON.stringify(config.flags || {})),
     logger,
     outputTargets: config.outputTargets ?? [],
+    rootDir: typeof config.rootDir === 'string' ? config.rootDir : '/',
     sys: config.sys ?? bootstrapConfig.sys ?? createSystem({ logger }),
     testing: config.testing ?? {},
-    rootDir: typeof config.rootDir === 'string' ? config.rootDir : '/',
   };
 
   // default devMode false

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -55,6 +55,7 @@ export const validateConfig = (
     outputTargets: config.outputTargets ?? [],
     sys: config.sys ?? bootstrapConfig.sys ?? createSystem({ logger }),
     testing: config.testing ?? {},
+    rootDir: typeof config.rootDir === 'string' ? config.rootDir : '/',
   };
 
   // default devMode false

--- a/src/compiler/config/validate-paths.ts
+++ b/src/compiler/config/validate-paths.ts
@@ -1,7 +1,14 @@
 import type * as d from '../../declarations';
 import { isAbsolute, join } from 'path';
 
-export const validatePaths = (config: d.UnvalidatedConfig) => {
+/**
+ * Do logical-level validation (as opposed to type-level validation)
+ * for various properties in the user-supplied config which represent
+ * filesystem paths.
+ *
+ * @param config a validated user-supplied configuration
+ */
+export const validatePaths = (config: d.ValidatedConfig) => {
   if (typeof config.rootDir !== 'string') {
     config.rootDir = '/';
   }

--- a/src/compiler/sys/config.ts
+++ b/src/compiler/sys/config.ts
@@ -11,9 +11,9 @@ export const getConfig = (userConfig: d.Config): d.ValidatedConfig => {
     flags: createConfigFlags(userConfig.flags ?? {}),
     logger,
     outputTargets: userConfig.outputTargets ?? [],
+    rootDir: userConfig.rootDir ?? '/',
     sys: userConfig.sys ?? createSystem({ logger }),
     testing: userConfig ?? {},
-    rootDir: userConfig.rootDir ?? '/',
   };
 
   setPlatformPath(config.sys.platformPath);

--- a/src/compiler/sys/config.ts
+++ b/src/compiler/sys/config.ts
@@ -13,6 +13,7 @@ export const getConfig = (userConfig: d.Config): d.ValidatedConfig => {
     outputTargets: userConfig.outputTargets ?? [],
     sys: userConfig.sys ?? createSystem({ logger }),
     testing: userConfig ?? {},
+    rootDir: userConfig.rootDir ?? '/',
   };
 
   setPlatformPath(config.sys.platformPath);

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -410,7 +410,7 @@ type RequireFields<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 /**
  * Fields in {@link Config} to make required for {@link ValidatedConfig}
  */
-type StrictConfigFields = 'flags' | 'logger' | 'outputTargets' | 'sys' | 'testing' | 'rootDir';
+type StrictConfigFields = 'flags' | 'logger' | 'outputTargets' | 'rootDir' | 'sys' | 'testing';
 
 /**
  * A version of {@link Config} that makes certain fields required. This type represents a valid configuration entity.

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -410,7 +410,7 @@ type RequireFields<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 /**
  * Fields in {@link Config} to make required for {@link ValidatedConfig}
  */
-type StrictConfigFields = 'flags' | 'logger' | 'outputTargets' | 'sys' | 'testing';
+type StrictConfigFields = 'flags' | 'logger' | 'outputTargets' | 'sys' | 'testing' | 'rootDir';
 
 /**
  * A version of {@link Config} that makes certain fields required. This type represents a valid configuration entity.

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -35,9 +35,9 @@ export function mockValidatedConfig(overrides: Partial<ValidatedConfig> = {}): V
     flags: createConfigFlags(),
     logger: mockLogger(),
     outputTargets: baseConfig.outputTargets ?? [],
+    rootDir: path.resolve('/'),
     sys: createTestingSystem(),
     testing: {},
-    rootDir: path.resolve('/'),
     ...overrides,
   };
 }

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -37,6 +37,7 @@ export function mockValidatedConfig(overrides: Partial<ValidatedConfig> = {}): V
     outputTargets: baseConfig.outputTargets ?? [],
     sys: createTestingSystem(),
     testing: {},
+    rootDir: path.resolve('/'),
     ...overrides,
   };
 }


### PR DESCRIPTION
This adds `rootDir` to the validated config type, adding some logic
where necessary to set a basic default if it's not present.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?

Just adding `.rootDir` as a required field on the `ValidatedConfig` type, cutting down our null check violations a little bit.

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
