### PR TITLE
chore(tests): commit file generated by compiling to 'todo' analysis app (v3)

### DIFF
--- a/test/todo-app/src/components.d.ts
+++ b/test/todo-app/src/components.d.ts
@@ -15,6 +15,14 @@ export namespace Components {
         "text": string;
     }
 }
+export interface TodoInputCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLTodoInputElement;
+}
+export interface TodoItemCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLTodoItemElement;
+}
 declare global {
     interface HTMLAppRootElement extends Components.AppRoot, HTMLStencilElement {
     }
@@ -44,12 +52,12 @@ declare namespace LocalJSX {
     interface AppRoot {
     }
     interface TodoInput {
-        "onInputSubmit"?: (event: CustomEvent<any>) => void;
+        "onInputSubmit"?: (event: TodoInputCustomEvent<any>) => void;
     }
     interface TodoItem {
         "checked"?: boolean;
-        "onItemCheck"?: (event: CustomEvent<any>) => void;
-        "onItemRemove"?: (event: CustomEvent<any>) => void;
+        "onItemCheck"?: (event: TodoItemCustomEvent<any>) => void;
+        "onItemRemove"?: (event: TodoItemCustomEvent<any>) => void;
         "text"?: string;
     }
     interface IntrinsicElements {


### PR DESCRIPTION
This just commits a `components.d.ts` file generated by building the
'todo' app as part of the `test.analysis` script.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?

No behavior changes, just committing a file that changes if you run the `test.analysis` script locally.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
