### PR TITLE
chore(types): remove type-check errors from spec-page 

### DIFF
--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -991,9 +991,9 @@ export interface ComponentTestingConstructor extends ComponentConstructor {
     componentWillLoad?: Function;
     componentWillUpdate?: Function;
     componentWillRender?: Function;
-    __componentWillLoad?: Function;
-    __componentWillUpdate?: Function;
-    __componentWillRender?: Function;
+    __componentWillLoad?: Function | null;
+    __componentWillUpdate?: Function | null;
+    __componentWillRender?: Function | null;
   };
 }
 

--- a/src/testing/platform/testing-host-ref.ts
+++ b/src/testing/platform/testing-host-ref.ts
@@ -2,7 +2,7 @@ import type * as d from '@stencil/core/internal';
 import { addHostEventListeners } from '@runtime';
 import { hostRefs } from './testing-constants';
 
-export const getHostRef = (elm: d.RuntimeRef) => {
+export const getHostRef = (elm: d.RuntimeRef | undefined) => {
   return hostRefs.get(elm);
 };
 

--- a/src/testing/spec-page.ts
+++ b/src/testing/spec-page.ts
@@ -226,20 +226,20 @@ export async function newSpecPage(opts: NewSpecPageOptions): Promise<SpecPage> {
 }
 
 function proxyComponentLifeCycles(Cstr: ComponentTestingConstructor) {
-  if (typeof Cstr.prototype.__componentWillLoad === 'function') {
+  if (typeof Cstr.prototype?.__componentWillLoad === 'function') {
     Cstr.prototype.componentWillLoad = Cstr.prototype.__componentWillLoad;
     Cstr.prototype.__componentWillLoad = null;
   }
-  if (typeof Cstr.prototype.__componentWillUpdate === 'function') {
+  if (typeof Cstr.prototype?.__componentWillUpdate === 'function') {
     Cstr.prototype.componentWillUpdate = Cstr.prototype.__componentWillUpdate;
     Cstr.prototype.__componentWillUpdate = null;
   }
-  if (typeof Cstr.prototype.__componentWillRender === 'function') {
+  if (typeof Cstr.prototype?.__componentWillRender === 'function') {
     Cstr.prototype.componentWillRender = Cstr.prototype.__componentWillRender;
     Cstr.prototype.__componentWillRender = null;
   }
 
-  if (typeof Cstr.prototype.componentWillLoad === 'function') {
+  if (typeof Cstr.prototype?.componentWillLoad === 'function') {
     Cstr.prototype.__componentWillLoad = Cstr.prototype.componentWillLoad;
     Cstr.prototype.componentWillLoad = function () {
       const result = this.__componentWillLoad();
@@ -252,7 +252,7 @@ function proxyComponentLifeCycles(Cstr: ComponentTestingConstructor) {
     };
   }
 
-  if (typeof Cstr.prototype.componentWillUpdate === 'function') {
+  if (typeof Cstr.prototype?.componentWillUpdate === 'function') {
     Cstr.prototype.__componentWillUpdate = Cstr.prototype.componentWillUpdate;
     Cstr.prototype.componentWillUpdate = function () {
       const result = this.__componentWillUpdate();
@@ -265,7 +265,7 @@ function proxyComponentLifeCycles(Cstr: ComponentTestingConstructor) {
     };
   }
 
-  if (typeof Cstr.prototype.componentWillRender === 'function') {
+  if (typeof Cstr.prototype?.componentWillRender === 'function') {
     Cstr.prototype.__componentWillRender = Cstr.prototype.componentWillRender;
     Cstr.prototype.componentWillRender = function () {
       const result = this.__componentWillRender();


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Stencil contains a number of `strictNullChecks` violations

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the typings for `spec-page.ts` to remove
`strictNullChecks` violations from the aforementioned file. the private
type `CompnentTestingConstructor` has some of its fields widened to
accepted `null` to reflect the state of the the existing assignments.
similarly, optional chaining is added to the conditionals to prevent
assignments/accesses that would otherwise be illegal

this commit also updates the function signature for `getHostRef` in the
testing package, to accept an argument of type undefined. today, it is
possible for the function to accept a value that is `undefined`; this
change only updates the type system to reflect that fact.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Type checking continues to pass

Smoke tested in a locally spun up version of a Stencil component library (`npm init stencil`) by installing this branch and running `npm t`
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
