### PR TITLE
fix(runtime): replaceSync usage matches webAPI spec

### DIFF
--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -14,7 +14,7 @@ export const registerStyle = (scopeId: string, cssText: string, allowCS: boolean
     if (typeof style === 'string') {
       style = cssText;
     } else {
-      style.replaceSync(cssText);
+      style.replaceSync(cssText ?? '');
     }
   } else {
     style = cssText;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When SSR/mock environments like Happy DOM monkey-patch the [CSSStyleSheet API](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/replaceSync) and invoke `replaceSync` an exception can be thrown. Happy DOM expects the CSS text to be defined, but when `replaceSync` is called from Stencil, the contents can be `undefined`. 

The behavior regressed in this commit: https://github.com/ionic-team/stencil/commit/c47cec6581d4409e8261b3516b78532b5c49d079

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updates the usage of `replaceSync` to pass an empty string when the CSS text contents are undefined.
- Stencil web components can be tested with Happy DOM (and likely other mock environments with this monkey-patch pattern).

The proposed changes have zero impact on existing Stencil developers. The WebAPI implementation of `replaceSync` returns the same result when invoked with: `replaceSync(undefined)` or `replaceSync('')` (both return `undefined`). 

The WebAPI spec has this note regarding the `text` parameter of `replaceSync`:
> A string containing the style rules to replace the content of the stylesheet. If the string does not contain a parseable list of rules, then the value will be set to an empty string.

This makes me think that this change is appropriate to Stencil instead of making a change to Happy DOM's internals. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

- Created an Ionic React Starter
- Installed [`@happy-dom/jest-environment`](https://www.npmjs.com/package/@happy-dom/jest-environment)
- Updated the `test` script to assign the jest environment
- Install Ionic Dev build (due to this issue: https://github.com/ionic-team/ionic-framework/issues/25900)
```
npm install @ionic/react@6.2.7-dev.11662662897.1987afe4 @ionic/react-router@6.2.7-dev.11662662897.1987afe4
```
- Run the test suite
- Observed: Exception is thrown for trying to perform `.replace` on `undefined`:
```
/Users/sean/Documents/ionic/issues/react-happy-dom/node_modules/happy-dom/lib/css/CSSParser.js:25
        const css = cssText.replace(COMMENT_REGEXP, '');
                            ^

TypeError: Cannot read properties of undefined (reading 'replace')
    at Function.parseFromString (/Users/sean/Documents/ionic/issues/react-happy-dom/node_modules/happy-dom/src/css/CSSParser.ts:23:23)
    at CSSStyleSheet.replaceSync (/Users/sean/Documents/ionic/issues/react-happy-dom/node_modules/happy-dom/src/css/CSSStyleSheet.ts:129:3)
    at registerStyle (/Users/sean/Documents/ionic/issues/react-happy-dom/node_modules/@stencil/core/internal/client/index.js:233:19)
```

- Manually updated the compiled output to the changes proposed in this PR
- Re-ran test suite
- Observed: No exception is raised

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
