### PR TITLE
refactor(decorators): fix `strictNullCheck` violation

### DIFF
--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -137,24 +137,6 @@ export const createStaticGetter = (propName: string, returnExpression: ts.Expres
   );
 };
 
-export const removeDecorators = (node: ts.Node, decoratorNames: Set<string>) => {
-  if (node.decorators) {
-    const updatedDecoratorList = node.decorators.filter((dec) => {
-      const name =
-        ts.isCallExpression(dec.expression) &&
-        ts.isIdentifier(dec.expression.expression) &&
-        dec.expression.expression.text;
-      return !decoratorNames.has(name);
-    });
-    if (updatedDecoratorList.length === 0) {
-      return undefined;
-    } else if (updatedDecoratorList.length !== node.decorators.length) {
-      return ts.createNodeArray(updatedDecoratorList);
-    }
-  }
-  return node.decorators;
-};
-
 export const getStaticValue = (staticMembers: ts.ClassElement[], staticName: string): any => {
   const staticMember: ts.GetAccessorDeclaration = staticMembers.find(
     (member) => (member.name as any).escapedText === staticName


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
there's a single `strictNullCheck` violation in the file in this PR, which coincidentally has its code
duplicated elsewhere
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit fixes a single `strictNullChecks` violation where the result of an expression could set a local variable to be of type `string | false`, where `false` was not an accepted value on `Set.prototype.has`. this change ought to be backwards compatible, as no `Set` provided to this function includes `false` (or any value that is coerced to `false`).

the function signature was updated to include a return type, and the function name was updated to provide a better description of what the function does.

the deprecated call to `createNodeArray` has been moved to the `ts.factory` for general code health.

during this exercise, it was discovered there was an unused instance of `removeDecorators` in the project's utilities. it has been removed as a part of this commit


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Smoke tested locally by building this branch (`npm clean && npm run build && npm pack`) into a locally spun up component lib (`npm init stencil component test-lib`). Build works as expected with the following diff applied:

```diff
--- a/src/components/my-component/my-component.tsx
+++ b/src/components/my-component/my-component.tsx
@@ -1,5 +1,9 @@
 import { Component, Prop, h } from '@stencil/core';
 import { format } from '../../utils/utils';
+const printMemberName = (_target: any, memberName: string) => {
+  console.log(memberName);
+};
+
 
 @Component({
   tag: 'my-component',
@@ -10,8 +14,8 @@ export class MyComponent {
   /**
    * The first name
    */
-  @Prop() first: string;
+  @Prop() @printMemberName first: string;
```
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

Sadly, our 'unused exports' check never picked up the deleted code :-(
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
