### PR TITLE
chore(repo): format additional files in repo

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,62 +10,69 @@ module.exports = {
     'prettier',
   ],
   rules: {
-    '@typescript-eslint/no-unused-vars': ['error', {
-      "argsIgnorePattern": "^_",
-      // TODO(STENCIL-452): Investigate using eslint-plugin-react to remove the need for varsIgnorePattern
-      "varsIgnorePattern": "^(h|Fragment)$"
-    }],
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        argsIgnorePattern: '^_',
+        // TODO(STENCIL-452): Investigate using eslint-plugin-react to remove the need for varsIgnorePattern
+        varsIgnorePattern: '^(h|Fragment)$',
+      },
+    ],
     /**
-     * Configuration for Jest rules can be found here: 
+     * Configuration for Jest rules can be found here:
      * https://github.com/jest-community/eslint-plugin-jest/tree/main/docs/rules
      */
-    "jest/expect-expect": [
-      "error",
+    'jest/expect-expect': [
+      'error',
       {
         // we set this to `expect*` so that any function whose name starts with expect will be counted
         // as an assertion function, allowing us to use functions to DRY up test suites.
-        "assertFunctionNames": ["expect*"],
-      }
+        assertFunctionNames: ['expect*'],
+      },
     ],
     // we...have a number of things disabled :)
     // TODO(STENCIL-488): Turn this rule back on once there are no violations of it remaining
-    "jest/no-disabled-tests": ["off"],
+    'jest/no-disabled-tests': ['off'],
     // we use this in enough places that we don't want to do per-line disables
-    "jest/no-conditional-expect": ["off"],
+    'jest/no-conditional-expect': ['off'],
     // this enforces that Jest hooks (e.g. `beforeEach`) are declared in test files in their execution order
     // see here for details: https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-hooks-in-order.md
-    "jest/prefer-hooks-in-order": ["warn"],
+    'jest/prefer-hooks-in-order': ['warn'],
     // this enforces that Jest hooks (e.g. `beforeEach`) are declared at the top of `describe` blocks
-    "jest/prefer-hooks-on-top": ["warn"],
+    'jest/prefer-hooks-on-top': ['warn'],
     /**
      * Configuration for the JSDoc plugin rules can be found at:
      * https://github.com/gajus/eslint-plugin-jsdoc
      */
     // validates that the name immediately following `@param` matches the parameter name in the function signature
     // this works in conjunction with "jsdoc/require-param"
-    "jsdoc/check-param-names": [
-      "error", {
-      // if `checkStructured` is `true`, it asks that the JSDoc describe the fields being destructured.
-      // turn this off to not leak function internals/discourage describing them
-      checkDestructured: false,
-    }],
+    'jsdoc/check-param-names': [
+      'error',
+      {
+        // if `checkStructured` is `true`, it asks that the JSDoc describe the fields being destructured.
+        // turn this off to not leak function internals/discourage describing them
+        checkDestructured: false,
+      },
+    ],
     // require that jsdoc attached to a method/function require one `@param` per parameter
-    "jsdoc/require-param": [
-      "error", {
+    'jsdoc/require-param': [
+      'error',
+      {
         // if `checkStructured` is `true`, it asks that the JSDoc describe the fields being destructured.
         // turn this off to not leak function internals/discourage describing them
         checkDestructured: false,
         // always check setters as they should require a parameter (by definition)
-        checkSetters: true
-      }],
+        checkSetters: true,
+      },
+    ],
     // rely on TypeScript types to be the source of truth, minimize verbosity in comments
-    "jsdoc/require-param-type": ["off"],
-    "jsdoc/require-param-description": ["error"],
-    "jsdoc/require-returns-check": ["error"],
-    "jsdoc/require-returns-description": ["error"],
+    'jsdoc/require-param-type': ['off'],
+    'jsdoc/require-param-description': ['error'],
+    'jsdoc/require-returns-check': ['error'],
+    'jsdoc/require-returns-description': ['error'],
     // rely on TypeScript types to be the source of truth, minimize verbosity in comments
-    "jsdoc/require-returns-type": ["off"],
-    "jsdoc/require-returns": ["error"],
+    'jsdoc/require-returns-type': ['off'],
+    'jsdoc/require-returns': ['error'],
     'prefer-const': 'error',
     'no-var': 'error',
     'prefer-rest-params': 'error',
@@ -73,7 +80,7 @@ module.exports = {
   },
   // inform ESLint about the global variables defined in a Jest context
   // see https://github.com/jest-community/eslint-plugin-jest/#usage
-  "env": {
-    "jest/globals": true
-  }
+  env: {
+    'jest/globals': true,
+  },
 };

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -43,7 +43,7 @@ body:
       description: Please reproduce this issue in a blank Stencil starter application and provide a link to the repo. Run `npm init stencil` to quickly spin up a Stencil project. This is the best way to ensure this issue is triaged quickly. Issues without a code reproduction may be closed if the Stencil Team cannot reproduce the issue you are reporting.
       placeholder: https://github.com/...
     validations:
-      required: true 
+      required: true
   - type: textarea
     attributes:
       label: Additional Information

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,16 +3,16 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: 'npm' # See documentation for possible values
+    directory: '/' # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: 'daily'
     open-pull-requests-limit: 5
     # Disable rebasing for pull requests, as having several open pull requests all get simultaneously rebased gets
     # noisy from a notification standpoint
-    rebase-strategy: "disabled"
+    rebase-strategy: 'disabled'
     ignore:
-      - dependency-name: "@types/node"
-        versions: ["17", "18"]
-      - dependency-name: "typescript"
-        versions: ["4.8"]
+      - dependency-name: '@types/node'
+        versions: ['17', '18']
+      - dependency-name: 'typescript'
+        versions: ['4.8']

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -4,7 +4,7 @@ triage:
 
 closeAndLock:
   labels:
-    - label: "ionitron: support"
+    - label: 'ionitron: support'
       message: >
         Thanks for the issue! This issue appears to be a support request. We use this issue tracker exclusively for
         bug reports and feature requests. Please use our [slack channel](https://stencil-worldwide.herokuapp.com/)
@@ -12,7 +12,7 @@ closeAndLock:
 
 
         Thank you for using Stencil!
-    - label: "ionitron: missing template"
+    - label: 'ionitron: missing template'
       message: >
         Thanks for the issue! It appears that you have not filled out the provided issue template. We use this issue
         template in order to gather more information and further assist you. Please create a new issue and ensure the
@@ -26,7 +26,7 @@ closeAndLock:
 
 comment:
   labels:
-    - label: "ionitron: needs reproduction"
+    - label: 'ionitron: needs reproduction'
       message: >
         Thanks for the issue! This issue has been labeled as `needs reproduction`. This label is added to issues that
         need a code reproduction.
@@ -56,7 +56,7 @@ noReply:
 noReproduction:
   days: 14
   maxIssuesPerRun: 100
-  label: "ionitron: needs reproduction"
+  label: 'ionitron: needs reproduction'
   responseLabel: triage
   exemptProjects: true
   exemptMilestones: true
@@ -74,18 +74,18 @@ stale:
   days: 30
   maxIssuesPerRun: 100
   exemptLabels:
-    - "Bug: Validated"
-    - "Feature: Want this? Upvote it!"
+    - 'Bug: Validated'
+    - 'Feature: Want this? Upvote it!'
     - good first issue
     - help wanted
     - Request For Comments
-    - "Resolution: Needs Investigation"
-    - "Resolution: Refine"
+    - 'Resolution: Needs Investigation'
+    - 'Resolution: Refine'
     - triage
   exemptAssigned: true
   exemptProjects: true
   exemptMilestones: true
-  label: "ionitron: stale issue"
+  label: 'ionitron: stale issue'
   message: >
     Thanks for the issue! This issue is being closed due to inactivity. If this is still
     an issue with the latest version of Stencil, please create a new issue and ensure the
@@ -99,7 +99,7 @@ stale:
 
 wrongRepo:
   repos:
-    - label: "ionitron: cli"
+    - label: 'ionitron: cli'
       repo: ionic-cli
       message: >
         Thanks for the issue! We use this issue tracker exclusively for bug reports and feature requests
@@ -108,7 +108,7 @@ wrongRepo:
 
 
         Thank you for using Stencil!
-    - label: "ionitron: ionic"
+    - label: 'ionitron: ionic'
       repo: ionic
       message: >
         Thanks for the issue! We use this issue tracker exclusively for bug reports and feature requests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,20 +24,20 @@ jobs:
 
   analysis_tests:
     name: Analysis Tests
-    needs: [ build_core ]
+    needs: [build_core]
     uses: ./.github/workflows/test-analysis.yml
 
   bundler_tests:
     name: Bundler Tests
-    needs: [ build_core ]
+    needs: [build_core]
     uses: ./.github/workflows/test-bundlers.yml
 
   e2e_tests:
     name: E2E Tests
-    needs: [ build_core ]
+    needs: [build_core]
     uses: ./.github/workflows/test-e2e.yml
 
   unit_tests:
     name: Unit Tests
-    needs: [ build_core ]
+    needs: [build_core]
     uses: ./.github/workflows/test-unit.yml

--- a/.github/workflows/tech-debt-burndown.yml
+++ b/.github/workflows/tech-debt-burndown.yml
@@ -15,7 +15,7 @@ jobs:
   strict_null_check: # TODO(STENCIL-446): Remove this workflow once `strictNullChecks` is enabled
     strategy:
       matrix:
-        branch: [ 'main', 'pr' ]
+        branch: ['main', 'pr']
     name: 'Get strictNullChecks errors on ${{ matrix.branch }}'
     runs-on: 'ubuntu-latest'
     steps:
@@ -53,7 +53,7 @@ jobs:
   unused_exports_check:
     strategy:
       matrix:
-        branch: [ 'main', 'pr' ]
+        branch: ['main', 'pr']
     name: Find unused variables on ${{ matrix.branch }}
     runs-on: 'ubuntu-latest'
     steps:
@@ -85,7 +85,7 @@ jobs:
           path: 'unused-exports-${{ matrix.branch }}.txt'
 
   format_report:
-    needs: [ "strict_null_check", "unused_exports_check" ]
+    needs: ['strict_null_check', 'unused_exports_check']
     name: Download error files and report
     runs-on: 'ubuntu-latest'
     steps:
@@ -130,7 +130,7 @@ jobs:
       - name: Set action output
         run: node scripts/build/tech-debt-burndown-report.js > $GITHUB_STEP_SUMMARY
 
-       # for syntax information, see https://github.com/peter-evans/create-or-update-comment#setting-the-comment-body-from-a-file
+        # for syntax information, see https://github.com/peter-evans/create-or-update-comment#setting-the-comment-body-from-a-file
       - name: Set comment body
         id: set-comment-body
         run: |

--- a/.github/workflows/test-analysis.yml
+++ b/.github/workflows/test-analysis.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [ '12', '14', '16' ]
-        os: [ 'ubuntu-latest', 'windows-latest' ]
+        node: ['12', '14', '16']
+        os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code

--- a/.github/workflows/test-browserstack.yml
+++ b/.github/workflows/test-browserstack.yml
@@ -40,7 +40,7 @@ jobs:
   run_browserstack:
     name: Run Browserstack
     runs-on: ubuntu-latest
-    needs: [ build_core ]
+    needs: [build_core]
 
     # The concurrency field allows us to block multiple invocations of this job across multiple workflow runs.
     # Stencil is only able to run 5 parallel tests in Browserstack, which is exceeded when more than one run of this

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [ '12', '14', '16' ]
-        os: [ 'ubuntu-latest', 'windows-latest' ]
+        node: ['12', '14', '16']
+        os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [ '12', '14', '16' ]
-        os: [ 'ubuntu-latest', 'windows-latest' ]
+        node: ['12', '14', '16']
+        os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code

--- a/jest.config.js
+++ b/jest.config.js
@@ -58,5 +58,5 @@ module.exports = {
   testRegex: '/(src|scripts)/.*\\.spec\\.(ts|tsx|js)$',
   // TODO(STENCIL-307): Move away from Jasmine runner for internal Stencil tests, which involves re-working environment
   // setup
-  testRunner: 'jest-jasmine2'
+  testRunner: 'jest-jasmine2',
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "license": "node scripts --license",
     "lint": "eslint \"src/*.ts\" \"src/**/*.ts\" \"src/**/*.tsx\"",
     "prettier": "npm run prettier.base -- --write",
-    "prettier.base": "prettier \"./({bin,scripts,src,test}/**/*.{ts,tsx,js,jsx})|bin/stencil\"",
+    "prettier.base": "prettier \"./({bin,scripts,src,test}/**/*.{ts,tsx,js,jsx})|bin/stencil|.github/(**/)?*.(yml|yaml)\"",
     "prettier.dry-run": "npm run prettier.base -- --list-different",
     "release": "node scripts --release --publish",
     "release.prepare": "node scripts --release --prepare",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "license": "node scripts --license",
     "lint": "eslint \"src/*.ts\" \"src/**/*.ts\" \"src/**/*.tsx\"",
     "prettier": "npm run prettier.base -- --write",
-    "prettier.base": "prettier \"./({bin,scripts,src,test}/**/*.{ts,tsx,js,jsx})|bin/stencil|.github/(**/)?*.(yml|yaml)\"",
+    "prettier.base": "prettier \"./({bin,scripts,src,test}/**/*.{ts,tsx,js,jsx})|bin/stencil|.github/(**/)?*.(yml|yaml)|*.js\"",
     "prettier.dry-run": "npm run prettier.base -- --list-different",
     "release": "node scripts --release --publish",
     "release.prepare": "node scripts --release --prepare",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,7 @@
 const { createBuild } = require('./scripts/build/build.js');
 const { getOptions } = require('./scripts/build/utils/options.js');
 
-module.exports = function(args) {
+module.exports = function (args) {
   const opts = getOptions(__dirname, {
     isProd: !!args['config-prod'],
     isCI: !!args['config-ci'],


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Our prettier config misses certain files that may be worthwhile to format

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this pr is broken into 2 commits:

### [chore(repo): format .github/](https://github.com/ionic-team/stencil/pull/3598/commits/68b6c0b8b88d71406f5ae0443c93db88755ce832)
[68b6c0b](https://github.com/ionic-team/stencil/pull/3598/commits/68b6c0b8b88d71406f5ae0443c93db88755ce832)

this commit updates our prettier configuration to format all yaml files
in the `.github` directory at the root of the the repo. both `.yml` and
`.yaml` were added. although the latter isn't used today, it is added as
a bit of 'future proofing'.

with the updated config, prettier was run on the repo. the only change
that is worth noting is that none of the double to single quote changes
_shouldn't_ be of issue, as the contents of the strings themselves don't
have an double quotes in them (e.g. `""something""`)

this was motivated by the fact whenever I work on CI, I know I'm always second guessing
the consistency of our files, and spacing/quotes have been called out on code reviews before.

### [chore(repo): format top level javascript](https://github.com/ionic-team/stencil/pull/3598/commits/7c14a2748e7de94feaf7079959a8c7533d9e1e8b)
[7c14a27](https://github.com/ionic-team/stencil/pull/3598/commits/7c14a2748e7de94feaf7079959a8c7533d9e1e8b)

this commit updates the prettier configuration for the project to format
all top level .js files. this commit then formats those files.

motivated by #3583, I want us to have an IDE agnostic way of formatting this file
 
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I ran prettier with the `main@HEAD` and this branch, each time piping the output to a text file.
In each text file, I removed the trailing time it took to format each file (because that changes between runs) using the regex `\s\d+ms` to capture things like ' 123ms' and ' 0ms'
I then `diff`ed those files, which resulted in the following:
```diff
7c7
< > prettier "./({bin,scripts,src,test}/**/*.{ts,tsx,js,jsx})|bin/stencil" "--write"
---
> > prettier "./({bin,scripts,src,test}/**/*.{ts,tsx,js,jsx})|bin/stencil|.github/(**/)?*.(yml|yaml)|*.js" "--write"
8a9,26
> .eslintrc.js
> .github/dependabot.yml
> .github/ionic-issue-bot.yml
> .github/ISSUE_TEMPLATE/bug_report.yml
> .github/ISSUE_TEMPLATE/config.yml
> .github/ISSUE_TEMPLATE/feature_request.yml
> .github/workflows/actions/download-archive/action.yml
> .github/workflows/actions/get-core-dependencies/action.yml
> .github/workflows/actions/upload-archive/action.yml
> .github/workflows/build.yml
> .github/workflows/lint-and-format.yml
> .github/workflows/main.yml
> .github/workflows/tech-debt-burndown.yml
> .github/workflows/test-analysis.yml
> .github/workflows/test-browserstack.yml
> .github/workflows/test-bundlers.yml
> .github/workflows/test-e2e.yml
> .github/workflows/test-unit.yml
9a28,29
> jest.config.js
> rollup.config.js

```
as we can see, only new files are added to our checks, and they match was the git commit messages state they check
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
