### PR TITLE
chore(compiler): convert a Set to a readonly array

### DIFF
--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -1,4 +1,4 @@
-import { dashToPascalCase, toDashCase } from '@utils';
+import { dashToPascalCase, toDashCase, readOnlyArrayHasStringMember } from '@utils';
 
 import { CompilerSystem, LOG_LEVELS, LogLevel, TaskCommand } from '../declarations';
 import {
@@ -329,9 +329,4 @@ export const parseEqualsArg = (arg: string): [string, string] => {
  * @returns whether this is a `LogLevel`
  */
 const isLogLevel = (maybeLogLevel: string): maybeLogLevel is LogLevel =>
-  // unfortunately `includes` is typed on `ReadonlyArray<T>` as `(el: T):
-  // boolean` so a `string` cannot be passed to `includes` on a
-  // `ReadonlyArray` 😢 thus we `as any`
-  //
-  // see microsoft/TypeScript#31018 for some discussion of this
-  LOG_LEVELS.includes(maybeLogLevel as any);
+  readOnlyArrayHasStringMember(LOG_LEVELS, maybeLogLevel);

--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -1,4 +1,4 @@
-import { dashToPascalCase, toDashCase, readOnlyArrayHasStringMember } from '@utils';
+import { dashToPascalCase, readOnlyArrayHasStringMember,toDashCase } from '@utils';
 
 import { CompilerSystem, LOG_LEVELS, LogLevel, TaskCommand } from '../declarations';
 import {

--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -1,4 +1,4 @@
-import { dashToPascalCase, readOnlyArrayHasStringMember,toDashCase } from '@utils';
+import { dashToPascalCase, readOnlyArrayHasStringMember, toDashCase } from '@utils';
 
 import { CompilerSystem, LOG_LEVELS, LogLevel, TaskCommand } from '../declarations';
 import {

--- a/src/compiler/transformers/decorators-to-static/convert-decorators.ts
+++ b/src/compiler/transformers/decorators-to-static/convert-decorators.ts
@@ -123,14 +123,17 @@ const removeStencilDecorators = (classMembers: ts.ClassElement[]) => {
  * - there are no decorators on the node
  * - the node contains only decorators in the provided list
  */
-const filterDecorators = (node: ts.Node, decoratorNames: Set<string>): ts.NodeArray<ts.Decorator> | undefined => {
+const filterDecorators = (
+  node: ts.Node,
+  decoratorNames: ReadonlyArray<string>
+): ts.NodeArray<ts.Decorator> | undefined => {
   if (node.decorators) {
     const updatedDecoratorList = node.decorators.filter((dec) => {
       const name =
         ts.isCallExpression(dec.expression) &&
         ts.isIdentifier(dec.expression.expression) &&
         dec.expression.expression.text;
-      return typeof name === 'boolean' || !decoratorNames.has(name);
+      return typeof name === 'boolean' || !decoratorNames.includes(name);
     });
     if (updatedDecoratorList.length === 0) {
       return undefined;

--- a/src/compiler/transformers/decorators-to-static/decorators-constants.ts
+++ b/src/compiler/transformers/decorators-to-static/decorators-constants.ts
@@ -1,6 +1,14 @@
-export const CLASS_DECORATORS_TO_REMOVE = new Set(['Component']);
+/**
+ * Decorators on class declarations that we remove as part of the compilation
+ * process
+ */
+export const CLASS_DECORATORS_TO_REMOVE = ['Component'] as const;
 
-export const MEMBER_DECORATORS_TO_REMOVE = new Set([
+/**
+ * Decorators on class members that we remove as part of the compilation
+ * process
+ */
+export const MEMBER_DECORATORS_TO_REMOVE = [
   'Element',
   'Event',
   'Listen',
@@ -10,4 +18,4 @@ export const MEMBER_DECORATORS_TO_REMOVE = new Set([
   'PropWillChange',
   'State',
   'Watch',
-]);
+] as const;

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -1,4 +1,4 @@
-import { augmentDiagnosticWithNode, buildError, normalizePath } from '@utils';
+import { augmentDiagnosticWithNode, buildError, normalizePath, readOnlyArrayHasStringMember } from '@utils';
 import ts from 'typescript';
 
 import type * as d from '../../declarations';
@@ -415,7 +415,7 @@ export const validateReferences = (
 ) => {
   Object.keys(references).forEach((refName) => {
     const ref = references[refName];
-    if (ref.path === '@stencil/core' && MEMBER_DECORATORS_TO_REMOVE.includes(refName as any)) {
+    if (ref.path === '@stencil/core' && readOnlyArrayHasStringMember(MEMBER_DECORATORS_TO_REMOVE, refName)) {
       const err = buildError(diagnostics);
       augmentDiagnosticWithNode(err, node);
     }

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -415,7 +415,7 @@ export const validateReferences = (
 ) => {
   Object.keys(references).forEach((refName) => {
     const ref = references[refName];
-    if (ref.path === '@stencil/core' && MEMBER_DECORATORS_TO_REMOVE.has(refName)) {
+    if (ref.path === '@stencil/core' && MEMBER_DECORATORS_TO_REMOVE.includes(refName as any)) {
       const err = buildError(diagnostics);
       augmentDiagnosticWithNode(err, node);
     }

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -154,3 +154,22 @@ export const parsePackageJson = (pkgJsonStr: string, pkgJsonFilePath: string): P
 };
 
 const SKIP_DEPS = ['@stencil/core'];
+
+/**
+ * Check whether a string is a member of a ReadonlyArray<string>
+ *
+ * We need a little helper for this because unfortunately `includes` is typed
+ * on `ReadonlyArray<T>` as `(el: T): boolean` so a `string` cannot be passed
+ * to `includes` on a `ReadonlyArray` 😢 thus we have a little helper function
+ * where we do the type coercion just once.
+ *
+ * see microsoft/TypeScript#31018 for some discussion of this
+ *
+ * @param readOnlyArray the array we're checking
+ * @param maybeMember a value which is possibly a member of the array
+ * @returns whether the array contains the member or not
+ */
+export const readOnlyArrayHasStringMember = <T extends string>(
+  readOnlyArray: ReadonlyArray<T>,
+  maybeMember: T | string
+): boolean => readOnlyArray.includes(maybeMember as typeof readOnlyArray[number]);


### PR DESCRIPTION
This converts a Set of decorators that we remove during compilation from `Set<string>` to `ReadonlyArray<string>` because by doing so we get much better type hint popups.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?

We have two `Set` objects which basically should really be constants, since they are never modified at runtime. This just changes them to be `ReadonlyArray<string>` in order to push that information into the type system (and get some better type hints when you run across these things in a file).

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
