### PR TITLE
fix(logger): fix possibly-null property access in logger-typescript.ts

### DIFF
--- a/src/utils/logger/logger-typescript.ts
+++ b/src/utils/logger/logger-typescript.ts
@@ -191,7 +191,7 @@ const flattenDiagnosticMessageText = (
 
   const ignoreCodes: number[] = [];
   // `tsDiagnostic.file` can be `undefined`, so we need to be a little careful here
-  const isStencilConfig = (tsDiagnostic?.file?.fileName ?? '').includes('stencil.config');
+  const isStencilConfig = (tsDiagnostic.file?.fileName ?? '').includes('stencil.config');
   if (isStencilConfig) {
     ignoreCodes.push(2322);
   }

--- a/src/utils/logger/logger-typescript.ts
+++ b/src/utils/logger/logger-typescript.ts
@@ -93,7 +93,14 @@ export const loadTypeScriptDiagnostics = (tsDiagnostics: readonly Diagnostic[]) 
   return diagnostics;
 };
 
-export const loadTypeScriptDiagnostic = (tsDiagnostic: Diagnostic) => {
+/**
+ * Convert a TypeScript diagnostic object into our internal, Stencil-specific
+ * diagnostic format
+ *
+ * @param tsDiagnostic a TypeScript diagnostic message record
+ * @returns a Stencil diagnostic, suitable for showing an error to the user
+ */
+export const loadTypeScriptDiagnostic = (tsDiagnostic: Diagnostic): d.Diagnostic => {
   const d: d.Diagnostic = {
     level: 'warn',
     type: 'typescript',
@@ -164,7 +171,18 @@ export const loadTypeScriptDiagnostic = (tsDiagnostic: Diagnostic) => {
   return d;
 };
 
-const flattenDiagnosticMessageText = (tsDiagnostic: Diagnostic, diag: string | DiagnosticMessageChain | undefined) => {
+/**
+ * Flatten a TypeScript diagnostic object into a string which can be easily
+ * included in a Stencil diagnostic record.
+ *
+ * @param tsDiagnostic a TypeScript diagnostic record
+ * @param diag a {@link DiagnosticMessageChain} or a string with further info
+ * @returns a string with the relevant error message
+ */
+const flattenDiagnosticMessageText = (
+  tsDiagnostic: Diagnostic,
+  diag: string | DiagnosticMessageChain | undefined
+): string => {
   if (typeof diag === 'string') {
     return diag;
   } else if (diag === undefined) {
@@ -172,7 +190,8 @@ const flattenDiagnosticMessageText = (tsDiagnostic: Diagnostic, diag: string | D
   }
 
   const ignoreCodes: number[] = [];
-  const isStencilConfig = tsDiagnostic.file.fileName.includes('stencil.config');
+  // `tsDiagnostic.file` can be `undefined`, so we need to be a little careful here
+  const isStencilConfig = (tsDiagnostic?.file?.fileName ?? '').includes('stencil.config');
   if (isStencilConfig) {
     ignoreCodes.push(2322);
   }


### PR DESCRIPTION
This fixes a small issue where we were accessing a possibly-undefined property on a TypeScript Diagnostic record.

This relates to the issue reported in #3443.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?

This fixes one part of the issue reported in #3443, basically just ensuring that we aren't assuming that a possibly-undefined property is always present.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

One thing to test is to confirm that if you build and install Stencil with this change into an example project you shouldn't see the particular error mentioned in #3443 about `TypeError: Cannot read property 'fileName' of undefined at flattenDiagnosticMessageText`...you very well may see other errors though! This PR only addresses the undefined property issue.