### PR TITLE
chore(ci): fix build out-of-memory errors

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# By default, Node allocates 2 GB for a process to run.
+# When building Stencil, it may reach that point before the garbage collector is invoked, causing an out-of-memory
+# related failure.
+# If this value is changed, please ensure that it works both locally and in a continuous integration environment in
+# a repeatable manner (i.e. it can run many times, one after the other, without failing due to out-of-memory errors).
+node_options=--max-old-space-size=4096

--- a/.npmrc
+++ b/.npmrc
@@ -3,4 +3,4 @@
 # related failure.
 # If this value is changed, please ensure that it works both locally and in a continuous integration environment in
 # a repeatable manner (i.e. it can run many times, one after the other, without failing due to out-of-memory errors).
-node_options=--max-old-space-size=4096
+node_options=--max-old-space-size=1024

--- a/.npmrc
+++ b/.npmrc
@@ -3,4 +3,4 @@
 # related failure.
 # If this value is changed, please ensure that it works both locally and in a continuous integration environment in
 # a repeatable manner (i.e. it can run many times, one after the other, without failing due to out-of-memory errors).
-node_options=--max-old-space-size=1024
+node_options=--max-old-space-size=4096


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

we're seeing sporadic build errors in ci, which makes us sad

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit introduces an `.npmrc` file to the project that specifies a new value for `--max-old-space-size`. by default, node allocates 2GB of memory to a process. it is possible for stencil builds to near this limit, causing an out of memory failure. we have seen this more often in continuous integration (github actions) than anywhere else.

an `.npmrc` file was chosen here as an operating system, shell, and build-agnostic solution. that is, this solution is intended to work:
- on linux, macos, and windows (although we only use linux for building, and the team develops solely on macos)
- on any shell (no hacks to the run command either in `package.json` or in the ci job for building the project)
- we use the same value in ci and locally (machine configuraton parity)

the value of '4096' was chosen for this configuration field by doubling the existing default of '2048'


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

I've run the build step 18 times (9 regular builds, 9 for browserstack), which is probably enough to instill some confidence. Worst case scenario, we revert it

I then pushed [09c5955](https://github.com/ionic-team/stencil/pull/3628/commits/09c5955ece3c7eb4e62f0480e10e7e92fd81cc02), which drops the memory ceiling to 1GB to verify that the setting was being picked up by CI (I did the same thing locally first) ([failing log example 1](https://github.com/ionic-team/stencil/actions/runs/3100550170/jobs/5020955511), [failing log example 2](https://github.com/ionic-team/stencil/actions/runs/3100550091/jobs/5020955137)), then reverted it. That revert gives us 2 extra builds, so that's a total of 20 times we'd build with this working.
## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
