### PR TITLE
refactor(types): drop strictNullChecks count in cli

### DIFF
--- a/src/cli/find-config.ts
+++ b/src/cli/find-config.ts
@@ -28,11 +28,8 @@ export type FindConfigResults = {
 export const findConfig = async (opts: FindConfigOptions): Promise<FindConfigResults> => {
   const sys = opts.sys;
   const cwd = sys.getCurrentDirectory();
-  const results: FindConfigResults = {
-    configPath: null as string,
-    rootDir: normalizePath(cwd),
-    diagnostics: [],
-  };
+  const rootDir = normalizePath(cwd);
+
   let configPath = opts.configPath;
 
   if (isString(configPath)) {
@@ -46,8 +43,14 @@ export const findConfig = async (opts: FindConfigOptions): Promise<FindConfigRes
     }
   } else {
     // nothing was passed in, use the current working directory
-    configPath = results.rootDir;
+    configPath = rootDir;
   }
+
+  const results: FindConfigResults = {
+    configPath,
+    rootDir: normalizePath(cwd),
+    diagnostics: [],
+  };
 
   const stat = await sys.stat(configPath);
   if (stat.error) {

--- a/src/cli/ionic-config.ts
+++ b/src/cli/ionic-config.ts
@@ -24,7 +24,7 @@ export async function readConfig(sys: d.CompilerSystem): Promise<d.TelemetryConf
     };
 
     await writeConfig(sys, config);
-  } else if (!UUID_REGEX.test(config['tokens.telemetry'])) {
+  } else if (!config['tokens.telemetry'] || !UUID_REGEX.test(config['tokens.telemetry'])) {
     const newUuid = uuidv4();
     await writeConfig(sys, { ...config, 'tokens.telemetry': newUuid });
     config['tokens.telemetry'] = newUuid;

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -39,7 +39,7 @@ export const run = async (init: d.CliInitOptions) => {
       sys.applyGlobalPatch(sys.getCurrentDirectory());
     }
 
-    if (task === 'help' || flags.help) {
+    if (!task || task === 'help' || flags.help) {
       await taskHelp(createConfigFlags({ task: 'help', args }), logger, sys);
 
       return;

--- a/src/cli/telemetry/helpers.ts
+++ b/src/cli/telemetry/helpers.ts
@@ -18,7 +18,7 @@ export const isInteractive = (sys: d.CompilerSystem, flags: ConfigFlags, object?
       tty: sys.isTTY() ? true : false,
       ci:
         ['CI', 'BUILD_ID', 'BUILD_NUMBER', 'BITBUCKET_COMMIT', 'CODEBUILD_BUILD_ARN'].filter(
-          (v) => !!sys.getEnvironmentVar(v)
+          (v) => !!sys.getEnvironmentVar?.(v)
         ).length > 0 || !!flags.ci,
     });
 
@@ -54,7 +54,7 @@ export async function readJson(sys: d.CompilerSystem, path: string): Promise<any
  * @returns true if --debug has been passed, otherwise false
  */
 export function hasDebug(flags: ConfigFlags): boolean {
-  return flags.debug;
+  return !!flags.debug;
 }
 
 /**
@@ -63,5 +63,5 @@ export function hasDebug(flags: ConfigFlags): boolean {
  * @returns true if both --debug and --verbose have been passed, otherwise false
  */
 export function hasVerbose(flags: ConfigFlags): boolean {
-  return flags.verbose && hasDebug(flags);
+  return !!flags.verbose && hasDebug(flags);
 }

--- a/src/cli/telemetry/test/helpers.spec.ts
+++ b/src/cli/telemetry/test/helpers.spec.ts
@@ -3,7 +3,7 @@ import { ConfigFlags, createConfigFlags } from '../../config-flags';
 import { hasDebug, hasVerbose, isInteractive, tryFn, uuidv4 } from '../helpers';
 
 describe('hasDebug', () => {
-  it('returns true when the flag "true" flag is false', () => {
+  it('returns true when the "debug" flag is true', () => {
     const flags = createConfigFlags({
       debug: true,
     });

--- a/src/cli/telemetry/test/helpers.spec.ts
+++ b/src/cli/telemetry/test/helpers.spec.ts
@@ -1,53 +1,49 @@
 import { createSystem } from '../../../compiler/sys/stencil-sys';
-import { createConfigFlags } from '../../config-flags';
+import { ConfigFlags, createConfigFlags } from '../../config-flags';
 import { hasDebug, hasVerbose, isInteractive, tryFn, uuidv4 } from '../helpers';
 
 describe('hasDebug', () => {
-  it('Returns true when a flag is passed', () => {
+  it('returns true when the flag "true" flag is false', () => {
     const flags = createConfigFlags({
       debug: true,
-      verbose: false,
     });
 
     expect(hasDebug(flags)).toBe(true);
   });
 
-  it('Returns false when a flag is not passed', () => {
+  it('returns false when the flag "debug" flag is false', () => {
     const flags = createConfigFlags({
       debug: false,
-      verbose: false,
     });
+
+    expect(hasDebug(flags)).toBe(false);
+  });
+
+  it('returns false when a flag is not passed', () => {
+    const flags = createConfigFlags({});
 
     expect(hasDebug(flags)).toBe(false);
   });
 });
 
 describe('hasVerbose', () => {
-  it('Returns true when both flags are passed', () => {
+  it.each<Partial<ConfigFlags>>([
+    { debug: true, verbose: false },
+    { debug: false, verbose: true },
+    { debug: false, verbose: false },
+  ])('returns false when debug=$debug and verbose=$verbose', (flagOverrides) => {
+    const flags = createConfigFlags(flagOverrides);
+
+    expect(hasVerbose(flags)).toBe(false);
+  });
+
+  it('returns true when debug=true and verbose=true', () => {
     const flags = createConfigFlags({
       debug: true,
       verbose: true,
     });
 
     expect(hasVerbose(flags)).toBe(true);
-  });
-
-  it('Returns false when the verbose flag is passed, and debug is not', () => {
-    const flags = createConfigFlags({
-      debug: false,
-      verbose: true,
-    });
-
-    expect(hasVerbose(flags)).toBe(false);
-  });
-
-  it('Returns false when the flag is not passed', () => {
-    const flags = createConfigFlags({
-      debug: false,
-      verbose: false,
-    });
-
-    expect(hasVerbose(flags)).toBe(false);
   });
 });
 

--- a/src/cli/telemetry/test/helpers.spec.ts
+++ b/src/cli/telemetry/test/helpers.spec.ts
@@ -11,7 +11,7 @@ describe('hasDebug', () => {
     expect(hasDebug(flags)).toBe(true);
   });
 
-  it('returns false when the flag "debug" flag is false', () => {
+  it('returns false when the "debug" flag is false', () => {
     const flags = createConfigFlags({
       debug: false,
     });

--- a/src/cli/test/run.spec.ts
+++ b/src/cli/test/run.spec.ts
@@ -85,6 +85,30 @@ describe('run', () => {
         taskHelpSpy.mockRestore();
       });
 
+      it("calls the help task when the 'task' field is set to null", async () => {
+        parseFlagsSpy.mockReturnValue(
+          createConfigFlags({
+            task: null,
+          })
+        );
+
+        await run(cliInitOptions);
+
+        expect(taskHelpSpy).toHaveBeenCalledTimes(1);
+        expect(taskHelpSpy).toHaveBeenCalledWith(
+          {
+            task: 'help',
+            args: [],
+            knownArgs: [],
+            unknownArgs: [],
+          },
+          mockLogger,
+          mockSystem
+        );
+
+        taskHelpSpy.mockRestore();
+      });
+
       it("calls the help task when the 'help' field is set on flags", async () => {
         parseFlagsSpy.mockReturnValue(
           createConfigFlags({
@@ -138,7 +162,7 @@ describe('run', () => {
       sys = mockCompilerSystem();
       sys.exit = jest.fn();
 
-      unvalidatedConfig = mockConfig({ outputTargets: null, sys });
+      unvalidatedConfig = mockConfig({ outputTargets: [], sys });
 
       validatedConfig = mockValidatedConfig({ sys });
 

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -2555,13 +2555,13 @@ export interface TrackableData {
   component_count?: number;
   arguments: string[];
   targets: string[];
-  task: TaskCommand;
-  duration_ms: number;
+  task: TaskCommand | null;
+  duration_ms: number | undefined;
   packages: string[];
   packages_no_versions?: string[];
-  os_name: string;
-  os_version: string;
-  cpu_model: string;
+  os_name: string | undefined;
+  os_version: string | undefined;
+  cpu_model: string | undefined;
   typescript: string;
   rollup: string;
   system: string;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We have over 2158 SNC errors on `main`

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

[2b9aebb](https://github.com/ionic-team/stencil/pull/3632/commits/2b9aebb7178bd3759afdf8b48cadc9f10f83619b)

this commit explicitly handles the the case of a null task, which we
have decided to allow on a type-level. a new test case is added to
verify the new behavior: when the null task is found, we show the help
prompt

[2a56d33](https://github.com/ionic-team/stencil/pull/3632/commits/2a56d332e3ae97f114e2859da4ef9b05b49147e0)

this commit resolves a type error when finding a configuration. it is a
common paradigm in stencil to declare a 'result' object at the beginning
of a function. however this presents difficulty when a the fields of the
object's type are strictly typed (i.e. don't permit null values). that
is the case for this file, where the `FindConfigResults` type does not
permit a null config path. however, procedurally, we _always_ set this
value. to circumvent the type issues, move the declaration of the result
object to be right before its first meaningful use.

[a4150e7](https://github.com/ionic-team/stencil/pull/3632/commits/a4150e71e0e39ffbf2b5cb08d4b7020e3f502cee)

this commit cleans up the telemetry helper tests and the source code
they exercise by removing strict null check violations and improving the
coverage for the case where flags we use may not be a boolean value

[ce2b46a](https://github.com/ionic-team/stencil/pull/3632/commits/ce2b46a3ea0c2290bf987a90b223b6e65b80713a)

this commit widens various telemetry types to better reflect real
world scenarios/align better with the rest of the type system. most
of the issues resolved in this commit were introduced alongside the
feature.

[03ce0e2](https://github.com/ionic-team/stencil/pull/3632/commits/03ce0e24eec6d745934f37177c0dce4396df01b2)

this commit makes the reading of telemetry tokens a little type safer by
first checking if such a token exists before running it through the
`test()`. perhaps this was a premature optimization, but this was
preferred over nullish coalescing the property read inside of `test()`
to avoid invoking the regex engine

Over the course of several commits:

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Tests continue to pass, type checker is happy
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

I consider this to be low priority. I was hacking on this while traveling the other day

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
