### PR TITLE
docs(compiler): add a few docstrings for `excludeHmr` functionality

### DIFF
--- a/src/compiler/build/build-hmr.ts
+++ b/src/compiler/build/build-hmr.ts
@@ -205,7 +205,17 @@ const getImagesUpdated = (buildCtx: d.BuildCtx, outputTargetsWww: d.OutputTarget
   return imageFiles.sort();
 };
 
-const excludeHmrFiles = (config: d.Config, excludeHmr: string[], filesChanged: string[]) => {
+/**
+ * Determine a list of files (if any) which should be excluded from HMR updates.
+ *
+ * @param config a user-supplied config
+ * @param excludeHmr a list of glob patterns that should be used to determine
+ * whether to exclude a file or not (a file will be excluded if it matches one
+ * @param filesChanged an array of files which are changed in the HMR update
+ * currently under consideration
+ * @returns a sorted list of files to exclude
+ */
+const excludeHmrFiles = (config: d.Config, excludeHmr: string[], filesChanged: string[]): string[] => {
   const excludeFiles: string[] = [];
 
   if (!excludeHmr || excludeHmr.length === 0) {

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -554,6 +554,10 @@ export interface StencilDevServerConfig {
 export interface DevServerConfig extends StencilDevServerConfig {
   browserUrl?: string;
   devServerDir?: string;
+  /**
+   * A list of glob patterns like `subdir/*.js`  to exclude from hot-module
+   * reloading updates.
+   */
   excludeHmr?: string[];
   historyApiFallback?: HistoryApiFallback;
   openBrowser?: boolean;

--- a/src/utils/is-glob.ts
+++ b/src/utils/is-glob.ts
@@ -1,4 +1,10 @@
-export const isGlob = (str: string) => {
+/**
+ * Check if a string is a glob pattern (e.g. 'src/*.js' or something like that)
+ *
+ * @param str a string to check
+ * @returns whether the string is a glob pattern or not
+ */
+export const isGlob = (str: string): boolean => {
   const chars: Record<string, string> = { '{': '}', '(': ')', '[': ']' };
   /* eslint-disable-next-line max-len */
   const regex = /\\(.)|(^!|\*|[\].+)]\?|\[[^\\\]]+\]|\{[^\\}]+\}|\(\?[:!=][^\\)]+\)|\([^|]+\|[^\\)]+\))/;


### PR DESCRIPTION
This adds a few docstrings for the setting on the dev server config which allows modules to be excluded from HMR updates (`excludeHmr`).

I just noticed this when looking at #3661 and figured why not add a few comments.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

no comments!


## What is the new behavior?

Just adding a few comments.

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
