### PR TITLE
refactor(docs): add jsdoc to parts, slots

### DIFF
--- a/src/compiler/docs/generate-doc-data.ts
+++ b/src/compiler/docs/generate-doc-data.ts
@@ -127,6 +127,11 @@ const getDocsEncapsulation = (cmp: d.ComponentCompilerMeta): 'shadow' | 'scoped'
   }
 };
 
+/**
+ * Generate a collection of JSDoc metadata for both real and virtual props
+ * @param cmpMeta the component metadata to derive JSDoc metadata from
+ * @returns the derived metadata
+ */
 const getDocsProperties = (cmpMeta: d.ComponentCompilerMeta): d.JsonDocsProp[] => {
   return sortBy(
     [...getRealProperties(cmpMeta.properties), ...getVirtualProperties(cmpMeta.virtualProperties)],
@@ -134,6 +139,11 @@ const getDocsProperties = (cmpMeta: d.ComponentCompilerMeta): d.JsonDocsProp[] =
   );
 };
 
+/**
+ * Generate a collection of JSDoc metadata for props on a component
+ * @param properties the component's property metadata to derive JSDoc metadata from
+ * @returns the derived metadata
+ */
 const getRealProperties = (properties: d.ComponentCompilerProperty[]): d.JsonDocsProp[] => {
   return properties
     .filter((member) => !member.internal)
@@ -154,6 +164,11 @@ const getRealProperties = (properties: d.ComponentCompilerProperty[]): d.JsonDoc
     }));
 };
 
+/**
+ * Generate a collection of JSDoc metadata for props on a component
+ * @param virtualProps the component's virtual property metadata to derive JSDoc metadata from
+ * @returns the derived metadata
+ */
 const getVirtualProperties = (virtualProps: d.ComponentCompilerVirtualProperty[]): d.JsonDocsProp[] => {
   return virtualProps.map((member) => ({
     name: member.name,
@@ -172,7 +187,7 @@ const getVirtualProperties = (virtualProps: d.ComponentCompilerVirtualProperty[]
   }));
 };
 
-const parseTypeIntoValues = (type: string) => {
+const parseTypeIntoValues = (type: string): d.JsonDocsValue[] => {
   if (typeof type === 'string') {
     const unions = type.split('|').map((u) => u.trim());
     const parsedUnions: JsonDocsValue[] = [];

--- a/src/compiler/docs/readme/markdown-parts.ts
+++ b/src/compiler/docs/readme/markdown-parts.ts
@@ -1,7 +1,12 @@
 import type * as d from '../../../declarations';
 import { MarkdownTable } from './docs-util';
 
-export const partsToMarkdown = (parts: d.JsonDocsSlot[]) => {
+/**
+ * Converts a list of Shadow Parts metadata to a table written in Markdown
+ * @param parts the Shadow parts metadata to convert
+ * @returns a list of strings that make up the Markdown table
+ */
+export const partsToMarkdown = (parts: d.JsonDocsPart[]): ReadonlyArray<string> => {
   const content: string[] = [];
   if (parts.length === 0) {
     return content;

--- a/src/compiler/docs/readme/markdown-slots.ts
+++ b/src/compiler/docs/readme/markdown-slots.ts
@@ -1,7 +1,12 @@
 import type * as d from '../../../declarations';
 import { MarkdownTable } from './docs-util';
 
-export const slotsToMarkdown = (slots: d.JsonDocsSlot[]) => {
+/**
+ * Converts a list of Slots metadata to a table written in Markdown
+ * @param slots the Slots metadata to convert
+ * @returns a list of strings that make up the Markdown table
+ */
+export const slotsToMarkdown = (slots: d.JsonDocsSlot[]): ReadonlyArray<string> => {
   const content: string[] = [];
   if (slots.length === 0) {
     return content;

--- a/src/declarations/stencil-public-docs.ts
+++ b/src/declarations/stencil-public-docs.ts
@@ -1,39 +1,138 @@
+/**
+ * A container for JSDoc metadata for a project
+ */
 export interface JsonDocs {
+  /**
+   * The metadata for the JSDocs for each component in a Stencil project
+   */
   components: JsonDocsComponent[];
+  /**
+   * The timestamp at which the metadata was generated, in the format YYYY-MM-DDThh:mm:ss
+   */
   timestamp: string;
   compiler: {
+    /**
+     * The name of the compiler that generated the metadata
+     */
     name: string;
+    /**
+     * The version of the Stencil compiler that generated the metadata
+     */
     version: string;
+    /**
+     * The version of TypeScript that was used to generate the metadata
+     */
     typescriptVersion: string;
   };
 }
 
+/**
+ * Container for JSDoc metadata for a single Stencil component
+ */
 export interface JsonDocsComponent {
+  /**
+   * The directory containing the Stencil component, minus the file name.
+   *
+   * @example /workspaces/stencil-project/src/components/my-component
+   */
   dirPath?: string;
+  /**
+   * The name of the file containing the Stencil component, with no path
+   *
+   * @example my-component.tsx
+   */
   fileName?: string;
+  /**
+   * The full path of the file containing the Stencil component
+   *
+   * @example /workspaces/stencil-project/src/components/my-component/my-component.tsx
+   */
   filePath?: string;
+  /**
+   * The path to the component's `readme.md` file, including the filename
+   *
+   * @example /workspaces/stencil-project/src/components/my-component/readme.md
+   */
   readmePath?: string;
+  /**
+   * The path to the component's `usage` directory
+   *
+   * @example /workspaces/stencil-project/src/components/my-component/usage/
+   */
   usagesDir?: string;
+  /**
+   * The encapsulation strategy for a component
+   */
   encapsulation: 'shadow' | 'scoped' | 'none';
+  /**
+   * The tag name for the component, for use in HTML
+   */
   tag: string;
+  /**
+   * The contents of a component's `readme.md` that are user generated.
+   *
+   * Auto-generated contents are not stored in this reference.
+   */
   readme: string;
+  /**
+   * The description of a Stencil component, found in the JSDoc that sits above the component's declaration
+   */
   docs: string;
+  /**
+   * JSDoc tags found in the JSDoc comment written atop a component's declaration
+   */
   docsTags: JsonDocsTag[];
   /**
    * The text from the class-level JSDoc for a Stencil component, if present.
    */
   overview?: string;
+  /**
+   * A mapping of usage example file names to their contents for the component.
+   */
   usage: JsonDocsUsage;
+  /**
+   * Array of metadata for a component's `@Prop`s
+   */
   props: JsonDocsProp[];
+  /**
+   * Array of metadata for a component's `@Method`s
+   */
   methods: JsonDocsMethod[];
+  /**
+   * Array of metadata for a component's `@Event`s
+   */
   events: JsonDocsEvent[];
+  /**
+   * Array of metadata for a component's `@Listen` handlers
+   */
   listeners: JsonDocsListener[];
+  /**
+   * Array of metadata for a component's CSS styling information
+   */
   styles: JsonDocsStyle[];
+  /**
+   * Array of component Slot information, generated from `@slot` tags
+   */
   slots: JsonDocsSlot[];
+  /**
+   * Array of component Parts information, generate from `@part` tags
+   */
   parts: JsonDocsPart[];
+  /**
+   * Array of metadata describing where the current component is used
+   */
   dependents: string[];
+  /**
+   * Array of metadata listing the components which are used in current component
+   */
   dependencies: string[];
+  /**
+   * Describes a tree of components coupling
+   */
   dependencyGraph: JsonDocsDependencyGraph;
+  /**
+   * A deprecation reason/description found following a `@deprecated` tag
+   */
   deprecation?: string;
 }
 
@@ -41,8 +140,17 @@ export interface JsonDocsDependencyGraph {
   [tagName: string]: string[];
 }
 
+/**
+ * A descriptor for a single JSDoc tag found in a block comment
+ */
 export interface JsonDocsTag {
+  /**
+   * The tag name (immediately following the '@')
+   */
   name: string;
+  /**
+   * The description that immediately follows the tag name
+   */
   text?: string;
 }
 
@@ -75,21 +183,64 @@ export interface JsonDocsUsage {
   [key: string]: string;
 }
 
+/**
+ * An intermediate representation of a `@Prop` decorated member's JSDoc
+ */
 export interface JsonDocsProp {
+  /**
+   * the name of the prop
+   */
   name: string;
+  /**
+   * the type of the prop, in terms of the TypeScript type system (as opposed to JavaScript's or HTML's)
+   */
   type: string;
+  /**
+   * `true` if the prop was configured as "mutable" where it was declared, `false` otherwise
+   */
   mutable: boolean;
   /**
    * The name of the attribute that is exposed to configure a compiled web component
    */
   attr?: string;
+  /**
+   * `true` if the prop was configured to "reflect" back to HTML where it (the prop) was declared, `false` otherwise
+   */
   reflectToAttr: boolean;
+  /**
+   * the JSDoc description text associated with the prop
+   */
   docs: string;
+  /**
+   * JSDoc tags associated with the prop
+   */
   docsTags: JsonDocsTag[];
+  /**
+   * The default value of the prop
+   */
   default: string;
+  /**
+   * Deprecation text associated with the prop. This is the text that immediately follows a `@deprecated` tag
+   */
   deprecation?: string;
   values: JsonDocsValue[];
+  /**
+   * `true` if a component is declared with a '?', `false` otherwise
+   *
+   * @example
+   * ```tsx
+   * @Prop() componentProps?: any;
+   * ```
+   */
   optional: boolean;
+  /**
+   * `true` if a component is declared with a '!', `false` otherwise
+   *
+   * @example
+   * ```tsx
+   * @Prop() componentProps!: any;
+   * ```
+   */
   required: boolean;
 }
 
@@ -138,13 +289,36 @@ export interface JsonDocsListener {
   passive: boolean;
 }
 
+/**
+ * A descriptor for a slot
+ *
+ * Objects of this type are translated from the JSDoc tag, `@slot`
+ */
 export interface JsonDocsSlot {
+  /**
+   * The name of the slot. Defaults to an empty string for an unnamed slot.
+   */
   name: string;
+  /**
+   * A textual description of the slot.
+   */
   docs: string;
 }
 
+/**
+ * A descriptor of a CSS Shadow Part
+ *
+ * Objects of this type are translated from the JSDoc tag, `@part`, or the 'part'
+ * attribute on a component in TSX
+ */
 export interface JsonDocsPart {
+  /**
+   * The name of the Shadow part
+   */
   name: string;
+  /**
+   * A textual description of the Shadow part.
+   */
   docs: string;
 }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit adds JSDoc to the types and functions that relate to Shadow Parts and JSDocs. it also corrects a typing error with Shadow Parts, where the typing for Slots was used accidentally

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

N/A
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
