### PR TITLE
convert more `ts.create{Whatever}` methods to `ts.factory.create{Whatever}`

### DIFF
--- a/src/compiler/transformers/component-lazy/lazy-constructor.ts
+++ b/src/compiler/transformers/component-lazy/lazy-constructor.ts
@@ -10,7 +10,9 @@ export const updateLazyComponentConstructor = (
   moduleFile: d.Module,
   cmp: d.ComponentCompilerMeta
 ) => {
-  const cstrMethodArgs = [ts.createParameter(undefined, undefined, undefined, ts.createIdentifier(HOST_REF_ARG))];
+  const cstrMethodArgs = [
+    ts.createParameter(undefined, undefined, undefined, ts.factory.createIdentifier(HOST_REF_ARG)),
+  ];
 
   const cstrMethodIndex = classMembers.findIndex((m) => m.kind === ts.SyntaxKind.Constructor);
   if (cstrMethodIndex >= 0) {
@@ -54,9 +56,9 @@ const registerInstanceStatement = (moduleFile: d.Module) => {
   addCoreRuntimeApi(moduleFile, RUNTIME_APIS.registerInstance);
 
   return ts.createStatement(
-    ts.createCall(ts.createIdentifier(REGISTER_INSTANCE), undefined, [
+    ts.createCall(ts.factory.createIdentifier(REGISTER_INSTANCE), undefined, [
       ts.createThis(),
-      ts.createIdentifier(HOST_REF_ARG),
+      ts.factory.createIdentifier(HOST_REF_ARG),
     ])
   );
 };

--- a/src/compiler/transformers/component-lazy/lazy-element-getter.ts
+++ b/src/compiler/transformers/component-lazy/lazy-element-getter.ts
@@ -21,7 +21,9 @@ export const addLazyElementGetter = (
         cmp.elementRef,
         [],
         undefined,
-        ts.createBlock([ts.createReturn(ts.createCall(ts.createIdentifier(GET_ELEMENT), undefined, [ts.createThis()]))])
+        ts.createBlock([
+          ts.createReturn(ts.createCall(ts.factory.createIdentifier(GET_ELEMENT), undefined, [ts.createThis()])),
+        ])
       )
     );
   }

--- a/src/compiler/transformers/component-native/native-constructor.ts
+++ b/src/compiler/transformers/component-native/native-constructor.ts
@@ -74,7 +74,11 @@ const nativeInit = (moduleFile: d.Module, cmp: d.ComponentCompilerMeta): Readonl
 
 const nativeRegisterHostStatement = () => {
   return ts.createStatement(
-    ts.createCall(ts.createPropertyAccess(ts.createThis(), ts.createIdentifier('__registerHost')), undefined, undefined)
+    ts.createCall(
+      ts.createPropertyAccess(ts.createThis(), ts.factory.createIdentifier('__registerHost')),
+      undefined,
+      undefined
+    )
   );
 };
 
@@ -96,5 +100,5 @@ const nativeAttachShadowStatement = (moduleFile: d.Module): ts.ExpressionStateme
 };
 
 const createNativeConstructorSuper = () => {
-  return ts.createExpressionStatement(ts.createCall(ts.createIdentifier('super'), undefined, undefined));
+  return ts.createExpressionStatement(ts.createCall(ts.factory.createIdentifier('super'), undefined, undefined));
 };

--- a/src/compiler/transformers/component-native/native-static-style.ts
+++ b/src/compiler/transformers/component-native/native-static-style.ts
@@ -30,26 +30,26 @@ const addMultipleModeStyleGetter = (
       // inline the style string
       // static get style() { return { "ios": "string" }; }
       const styleLiteral = createStyleLiteral(cmp, style);
-      const propStr = ts.createPropertyAssignment(style.modeName, styleLiteral);
+      const propStr = ts.factory.createPropertyAssignment(style.modeName, styleLiteral);
       styleModes.push(propStr);
     } else if (typeof style.styleIdentifier === 'string') {
       // direct import already written in the source code
       // import myTagIosStyle from './import-path.css';
       // static get style() { return { "ios": myTagIosStyle }; }
-      const styleIdentifier = ts.createIdentifier(style.styleIdentifier);
-      const propIdentifier = ts.createPropertyAssignment(style.modeName, styleIdentifier);
+      const styleIdentifier = ts.factory.createIdentifier(style.styleIdentifier);
+      const propIdentifier = ts.factory.createPropertyAssignment(style.modeName, styleIdentifier);
       styleModes.push(propIdentifier);
     } else if (Array.isArray(style.externalStyles) && style.externalStyles.length > 0) {
       // import generated from @Component() styleUrls option
       // import myTagIosStyle from './import-path.css';
       // static get style() { return { "ios": myTagIosStyle }; }
       const styleUrlIdentifier = createStyleIdentifierFromUrl(cmp, style);
-      const propUrlIdentifier = ts.createPropertyAssignment(style.modeName, styleUrlIdentifier);
+      const propUrlIdentifier = ts.factory.createPropertyAssignment(style.modeName, styleUrlIdentifier);
       styleModes.push(propUrlIdentifier);
     }
   });
 
-  const styleObj = ts.createObjectLiteral(styleModes, true);
+  const styleObj = ts.factory.createObjectLiteralExpression(styleModes, true);
 
   classMembers.push(createStaticGetter('style', styleObj));
 };
@@ -68,7 +68,7 @@ const addSingleStyleGetter = (
     // direct import already written in the source code
     // import myTagStyle from './import-path.css';
     // static get style() { return myTagStyle; }
-    const styleIdentifier = ts.createIdentifier(style.styleIdentifier);
+    const styleIdentifier = ts.factory.createIdentifier(style.styleIdentifier);
     classMembers.push(createStaticGetter('style', styleIdentifier));
   } else if (Array.isArray(style.externalStyles) && style.externalStyles.length > 0) {
     // import generated from @Component() styleUrls option
@@ -83,10 +83,10 @@ const createStyleLiteral = (cmp: d.ComponentCompilerMeta, style: d.StyleCompiler
   if (cmp.encapsulation === 'scoped') {
     // scope the css first
     const scopeId = getScopeId(cmp.tagName, style.modeName);
-    return ts.createStringLiteral(scopeCss(style.styleStr, scopeId, false));
+    return ts.factory.createStringLiteral(scopeCss(style.styleStr, scopeId, false));
   }
 
-  return ts.createStringLiteral(style.styleStr);
+  return ts.factory.createStringLiteral(style.styleStr);
 };
 
 const createStyleIdentifierFromUrl = (cmp: d.ComponentCompilerMeta, style: d.StyleCompiler) => {
@@ -100,5 +100,5 @@ const createStyleIdentifierFromUrl = (cmp: d.ComponentCompilerMeta, style: d.Sty
   style.styleIdentifier += 'Style';
   style.externalStyles = [style.externalStyles[0]];
 
-  return ts.createIdentifier(style.styleIdentifier);
+  return ts.factory.createIdentifier(style.styleIdentifier);
 };

--- a/src/compiler/transformers/create-event.ts
+++ b/src/compiler/transformers/create-event.ts
@@ -10,8 +10,8 @@ export const addCreateEvents = (moduleFile: d.Module, cmp: d.ComponentCompilerMe
 
     return ts.createStatement(
       ts.createAssignment(
-        ts.createPropertyAccess(ts.createThis(), ts.createIdentifier(ev.method)),
-        ts.createCall(ts.createIdentifier(CREATE_EVENT), undefined, [
+        ts.createPropertyAccess(ts.createThis(), ts.factory.createIdentifier(ev.method)),
+        ts.createCall(ts.factory.createIdentifier(CREATE_EVENT), undefined, [
           ts.createThis(),
           ts.createLiteral(ev.name),
           ts.createLiteral(computeFlags(ev)),

--- a/src/compiler/transformers/decorators-to-static/method-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/method-decorator.ts
@@ -30,7 +30,7 @@ export const methodDecoratorsToStatic = (
     .filter((method) => !!method);
 
   if (methods.length > 0) {
-    newMembers.push(createStaticGetter('methods', ts.createObjectLiteral(methods, true)));
+    newMembers.push(createStaticGetter('methods', ts.factory.createObjectLiteralExpression(methods, true)));
   }
 };
 
@@ -102,7 +102,10 @@ const parseMethodDecorator = (
   };
   validateReferences(diagnostics, methodMeta.complexType.references, method.type || method.name);
 
-  const staticProp = ts.createPropertyAssignment(ts.createLiteral(methodName), convertValueToLiteral(methodMeta));
+  const staticProp = ts.factory.createPropertyAssignment(
+    ts.createLiteral(methodName),
+    convertValueToLiteral(methodMeta)
+  );
 
   return staticProp;
 };

--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -40,7 +40,7 @@ export const propDecoratorsToStatic = (
     .filter((prop) => prop != null);
 
   if (properties.length > 0) {
-    newMembers.push(createStaticGetter('properties', ts.createObjectLiteral(properties, true)));
+    newMembers.push(createStaticGetter('properties', ts.factory.createObjectLiteralExpression(properties, true)));
   }
 };
 
@@ -110,7 +110,7 @@ const parsePropDecorator = (
     propMeta.defaultValue = initializer.getText();
   }
 
-  const staticProp = ts.createPropertyAssignment(ts.createLiteral(propName), convertValueToLiteral(propMeta));
+  const staticProp = ts.factory.createPropertyAssignment(ts.createLiteral(propName), convertValueToLiteral(propMeta));
   watchable.add(propName);
   return staticProp;
 };

--- a/src/compiler/transformers/decorators-to-static/style-to-static.ts
+++ b/src/compiler/transformers/decorators-to-static/style-to-static.ts
@@ -54,7 +54,7 @@ export const styleToStatic = (newMembers: ts.ClassElement[], componentOptions: d
       //   styles
       // })
       const stylesIdentifier = convertIdentifier.__escapedText;
-      newMembers.push(createStaticGetter('styles', ts.createIdentifier(stylesIdentifier)));
+      newMembers.push(createStaticGetter('styles', ts.factory.createIdentifier(stylesIdentifier)));
     } else if (typeof convertIdentifier === 'object') {
       // import ios from './ios.css';
       // import md from './md.css';

--- a/src/compiler/transformers/define-custom-element.ts
+++ b/src/compiler/transformers/define-custom-element.ts
@@ -31,9 +31,9 @@ const addDefineCustomElement = (moduleFile: d.Module, compilerMeta: d.ComponentC
     // add customElements.define('cmp-a', CmpClass);
     return ts.createStatement(
       ts.createCall(
-        ts.createPropertyAccess(ts.createIdentifier('customElements'), ts.createIdentifier('define')),
+        ts.createPropertyAccess(ts.factory.createIdentifier('customElements'), ts.factory.createIdentifier('define')),
         [],
-        [ts.createLiteral(compilerMeta.tagName), ts.createIdentifier(compilerMeta.componentClassName)]
+        [ts.createLiteral(compilerMeta.tagName), ts.factory.createIdentifier(compilerMeta.componentClassName)]
       )
     );
   }
@@ -41,11 +41,11 @@ const addDefineCustomElement = (moduleFile: d.Module, compilerMeta: d.ComponentC
   addCoreRuntimeApi(moduleFile, RUNTIME_APIS.defineCustomElement);
   const compactMeta: d.ComponentRuntimeMetaCompact = formatComponentRuntimeMeta(compilerMeta, true);
 
-  const liternalCmpClassName = ts.createIdentifier(compilerMeta.componentClassName);
+  const liternalCmpClassName = ts.factory.createIdentifier(compilerMeta.componentClassName);
   const liternalMeta = convertValueToLiteral(compactMeta);
 
   return ts.createStatement(
-    ts.createCall(ts.createIdentifier(DEFINE_CUSTOM_ELEMENT), [], [liternalCmpClassName, liternalMeta])
+    ts.createCall(ts.factory.createIdentifier(DEFINE_CUSTOM_ELEMENT), [], [liternalCmpClassName, liternalMeta])
   );
 };
 

--- a/src/compiler/transformers/host-data-transform.ts
+++ b/src/compiler/transformers/host-data-transform.ts
@@ -18,7 +18,7 @@ export const transformHostData = (classElements: ts.ClassElement[], moduleFile: 
         renderMethod.decorators,
         renderMethod.modifiers,
         renderMethod.asteriskToken,
-        ts.createIdentifier(INTERNAL_RENDER),
+        ts.factory.createIdentifier(INTERNAL_RENDER),
         renderMethod.questionToken,
         renderMethod.typeParameters,
         renderMethod.parameters,
@@ -36,7 +36,7 @@ const syntheticRender = (moduleFile: d.Module, hasRender: boolean) => {
 
   const hArguments = [
     // __stencil_Host
-    ts.createIdentifier(HOST),
+    ts.factory.createIdentifier(HOST),
     // this.hostData()
     ts.createCall(ts.createPropertyAccess(ts.createThis(), 'hostData'), undefined, undefined),
   ];
@@ -61,7 +61,7 @@ const syntheticRender = (moduleFile: d.Module, hasRender: boolean) => {
     undefined,
     undefined,
     undefined,
-    ts.createBlock([ts.createReturn(ts.createCall(ts.createIdentifier(H), undefined, hArguments))])
+    ts.createBlock([ts.createReturn(ts.createCall(ts.factory.createIdentifier(H), undefined, hArguments))])
   );
 };
 

--- a/src/compiler/transformers/legacy-props.ts
+++ b/src/compiler/transformers/legacy-props.ts
@@ -22,7 +22,7 @@ const getStatement = (propName: string, method: string, arg: string) => {
   return ts.createExpressionStatement(
     ts.createAssignment(
       ts.createPropertyAccess(ts.createThis(), propName),
-      ts.createCall(ts.createIdentifier(method), undefined, [ts.createThis(), ts.createLiteral(arg)])
+      ts.createCall(ts.factory.createIdentifier(method), undefined, [ts.createThis(), ts.createLiteral(arg)])
     )
   );
 };

--- a/src/compiler/transformers/style-imports.ts
+++ b/src/compiler/transformers/style-imports.ts
@@ -92,7 +92,7 @@ const createEsmStyleImport = (
   cmp: d.ComponentCompilerMeta,
   style: d.StyleCompiler
 ) => {
-  const importName = ts.createIdentifier(style.styleIdentifier);
+  const importName = ts.factory.createIdentifier(style.styleIdentifier);
   const importPath = getStyleImportPath(transformOpts, tsSourceFile, cmp, style, style.externalStyles[0].absolutePath);
 
   return ts.createImportDeclaration(
@@ -132,7 +132,7 @@ const createCjsStyleRequire = (
   cmp: d.ComponentCompilerMeta,
   style: d.StyleCompiler
 ) => {
-  const importName = ts.createIdentifier(style.styleIdentifier);
+  const importName = ts.factory.createIdentifier(style.styleIdentifier);
   const importPath = getStyleImportPath(transformOpts, tsSourceFile, cmp, style, style.externalStyles[0].absolutePath);
 
   return ts.createVariableStatement(
@@ -142,7 +142,7 @@ const createCjsStyleRequire = (
         ts.createVariableDeclaration(
           importName,
           undefined,
-          ts.createCall(ts.createIdentifier('require'), [], [ts.createLiteral(importPath)])
+          ts.createCall(ts.factory.createIdentifier('require'), [], [ts.createLiteral(importPath)])
         ),
       ],
       ts.NodeFlags.Const

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -49,26 +49,26 @@ export const convertValueToLiteral = (
     refs = new WeakSet();
   }
   if (val === String) {
-    return ts.createIdentifier('String');
+    return ts.factory.createIdentifier('String');
   }
   if (val === Number) {
-    return ts.createIdentifier('Number');
+    return ts.factory.createIdentifier('Number');
   }
   if (val === Boolean) {
-    return ts.createIdentifier('Boolean');
+    return ts.factory.createIdentifier('Boolean');
   }
   if (val === undefined) {
-    return ts.createIdentifier('undefined');
+    return ts.factory.createIdentifier('undefined');
   }
   if (val === null) {
-    return ts.createIdentifier('null');
+    return ts.factory.createIdentifier('null');
   }
   if (Array.isArray(val)) {
     return arrayToArrayLiteral(val, refs);
   }
   if (typeof val === 'object') {
     if ((val as ConvertIdentifier).__identifier && (val as ConvertIdentifier).__escapedText) {
-      return ts.createIdentifier((val as ConvertIdentifier).__escapedText);
+      return ts.factory.createIdentifier((val as ConvertIdentifier).__escapedText);
     }
     return objectToObjectLiteral(val, refs);
   }
@@ -111,20 +111,20 @@ const arrayToArrayLiteral = (list: any[], refs: WeakSet<any>): ts.ArrayLiteralEx
  */
 const objectToObjectLiteral = (obj: { [key: string]: any }, refs: WeakSet<any>): ts.ObjectLiteralExpression => {
   if (refs.has(obj)) {
-    return ts.createIdentifier('undefined') as any;
+    return ts.factory.createIdentifier('undefined') as any;
   }
 
   refs.add(obj);
 
   const newProperties: ts.ObjectLiteralElementLike[] = Object.keys(obj).map((key) => {
-    const prop = ts.createPropertyAssignment(
+    const prop = ts.factory.createPropertyAssignment(
       ts.createLiteral(key),
       convertValueToLiteral(obj[key], refs) as ts.Expression
     );
     return prop;
   });
 
-  return ts.createObjectLiteral(newProperties, true);
+  return ts.factory.createObjectLiteralExpression(newProperties, true);
 };
 
 /**
@@ -738,7 +738,7 @@ export const createRequireStatement = (importFnNames: string[], importPath: stri
         ts.createVariableDeclaration(
           importBinding,
           undefined,
-          ts.createCall(ts.createIdentifier('require'), [], [ts.createLiteral(importPath)])
+          ts.createCall(ts.factory.createIdentifier('require'), [], [ts.createLiteral(importPath)])
         ),
       ],
       ts.NodeFlags.Const


### PR DESCRIPTION
I started with one file w/ a bunch of `ts.create{Whatever}` calls in it (`src/compiler/transformers/component-native/native-static-style.ts`) and then used a project-wide find and replace to change over the methods used in that file across the whole project. This resulted in changing `ts.createStringLiteral`, `ts.createObjectLiteral`, `ts.createPropertyAssignment`, and `ts.createIdentifier`.

I think this approach of starting with one file and then 'branching out' will let us make some steady progress without having to deal with overly large diffs.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

We have calls to a bunch of deprecated typescript methods (all of which are for creating AST nodes).


## What is the new behavior?

This moves a few of them to the newer namespace (`ts.factory`) updated the method name as well where necessary.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I build the compiler and then build the ionic framework, no issues there.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
