### PR TITLE
chore(telemetry): add isBrowserEnv to telemetry payload

### DIFF
--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -1,4 +1,5 @@
 import { isOutputTargetHydrate, WWW } from '../../compiler/output-targets/output-utils';
+import { IS_BROWSER_ENV } from '../../compiler/sys/environment';
 import type * as d from '../../declarations';
 import { readConfig, updateConfig, writeConfig } from '../ionic-config';
 import { CoreCompiler } from '../load-compiler';
@@ -143,27 +144,29 @@ export const prepareData = async (
   const build = coreCompiler.buildId || 'unknown';
   const has_app_pwa_config = hasAppTarget(config);
   const anonymizedConfig = anonymizeConfigForTelemetry(config);
+  const is_browser_env = IS_BROWSER_ENV;
 
   return {
-    yarn,
-    duration_ms,
+    arguments: config.flags.args,
+    build,
     component_count,
-    targets,
+    config: anonymizedConfig,
+    cpu_model,
+    duration_ms,
+    has_app_pwa_config,
+    is_browser_env,
+    os_name,
+    os_version,
     packages,
     packages_no_versions: packagesNoVersions,
-    arguments: config.flags.args,
-    task: config.flags.task,
+    rollup,
     stencil,
     system,
     system_major: getMajorVersion(system),
-    os_name,
-    os_version,
-    cpu_model,
-    build,
+    targets,
+    task: config.flags.task,
     typescript,
-    rollup,
-    has_app_pwa_config,
-    config: anonymizedConfig,
+    yarn,
   };
 };
 

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -3,11 +3,20 @@ import { mockValidatedConfig } from '@stencil/core/testing';
 
 import { createConfigFlags } from '../../../cli/config-flags';
 import { DIST, DIST_CUSTOM_ELEMENTS, DIST_HYDRATE_SCRIPT, WWW } from '../../../compiler/output-targets/output-utils';
+import * as environment from '../../../compiler/sys/environment';
 import { createSystem } from '../../../compiler/sys/stencil-sys';
 import type * as d from '../../../declarations';
 import * as shouldTrack from '../shouldTrack';
 import * as telemetry from '../telemetry';
 import { anonymizeConfigForTelemetry } from '../telemetry';
+
+const browserEnvGetter = jest.fn().mockReturnValue(false);
+
+Object.defineProperty(environment, 'IS_BROWSER_ENV', {
+  get() {
+    return browserEnvGetter();
+  },
+});
 
 describe('telemetryBuildFinishedAction', () => {
   let config: d.ValidatedConfig;
@@ -167,6 +176,7 @@ describe('prepareData', () => {
       cpu_model: '',
       duration_ms: 1000,
       has_app_pwa_config: false,
+      is_browser_env: false,
       os_name: '',
       os_version: '',
       packages: [],
@@ -179,6 +189,14 @@ describe('prepareData', () => {
       task: null,
       typescript: coreCompiler.versions.typescript,
       yarn: false,
+    });
+  });
+
+  describe('it sets an "is_browser_env" property', () => {
+    it.each([true, false])('reports accurately when %p', async (isBrowserEnv: boolean) => {
+      browserEnvGetter.mockReturnValue(isBrowserEnv);
+      const data = await telemetry.prepareData(coreCompiler, config, sys, 1000);
+      expect(data.is_browser_env).toBe(isBrowserEnv);
     });
   });
 

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -2569,25 +2569,26 @@ export type TelemetryCallback = (...args: any[]) => void | Promise<void>;
  * The model for the data that's tracked.
  */
 export interface TrackableData {
-  yarn: boolean;
-  component_count?: number;
   arguments: string[];
-  targets: string[];
-  task: TaskCommand | null;
+  build: string;
+  component_count?: number;
+  config: Config;
+  cpu_model: string | undefined;
   duration_ms: number | undefined;
-  packages: string[];
-  packages_no_versions?: string[];
+  has_app_pwa_config: boolean;
+  is_browser_env: boolean;
   os_name: string | undefined;
   os_version: string | undefined;
-  cpu_model: string | undefined;
-  typescript: string;
+  packages: string[];
+  packages_no_versions?: string[];
   rollup: string;
+  stencil: string;
   system: string;
   system_major?: string;
-  build: string;
-  stencil: string;
-  has_app_pwa_config: boolean;
-  config: Config;
+  targets: string[];
+  task: TaskCommand | null;
+  typescript: string;
+  yarn: boolean;
 }
 
 /**


### PR DESCRIPTION
This adds the value of the `IS_BROWSER_ENV` helper to our telemetry payload, allowing us to track the usage level of Stencil in the browser.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

Is this technically a feature? 🤔 in any case it's a small one!


## What is the current behavior?

We don't have much insight into how often Stencil is used in a browser environment.

## What is the new behavior?

This just adds the value of the `IS_BROWSER_ENV` variable to our telemetry payload, so we can track this value over time.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

This can be tested by building Stencil, installing it into a project, and the running a Stencil sub-command with the `--debug` flag (that will print out the data sent to telemetry as a big JSON blob).
