### PR TITLE
fix(jest): adjust conversion of CLI args to Jest args

### DIFF
--- a/src/testing/jest/jest-config.ts
+++ b/src/testing/jest/jest-config.ts
@@ -46,7 +46,7 @@ function getLegacyJestOptions(): Record<string, boolean | number | string> {
 export function buildJestArgv(config: d.ValidatedConfig): Config.Argv {
   const yargs = require('yargs');
 
-  const args = [...config.flags.unknownArgs.slice(), ...config.flags.knownArgs.slice()];
+  const args = [...config.flags.knownArgs.slice(), ...config.flags.unknownArgs.slice()];
 
   if (!args.some((a) => a.startsWith('--max-workers') || a.startsWith('--maxWorkers'))) {
     args.push(`--max-workers=${config.maxConcurrentWorkers}`);

--- a/src/testing/jest/test/jest-config.spec.ts
+++ b/src/testing/jest/test/jest-config.spec.ts
@@ -189,4 +189,16 @@ describe('jest-config', () => {
     expect(jestArgv.spec).toBe(true);
     expect(jestArgv.passWithNoTests).toBe(true);
   });
+
+  it('should parse a setup with a filepath constraint', () => {
+    const args = ['test', '--spec', '--json', '--', 'my-component.spec.ts'];
+    const config = mockValidatedConfig();
+    config.flags = parseFlags(args);
+
+    expect(config.flags.args).toEqual(['--spec', '--json', '--', 'my-component.spec.ts']);
+    expect(config.flags.unknownArgs).toEqual(['--', 'my-component.spec.ts']);
+
+    const jestArgv = buildJestArgv(config);
+    expect(jestArgv.json).toBe(true);
+  });
 });


### PR DESCRIPTION
This adjusts the conversion of CLI args (parsed by our `cli/parse-flags` module) to arguments for Jest to fix a problematic situation when passing an argument which is not recognized by our `parse-flags` module.

A common pattern in Jest is to use a filename filter to narrow which tests are matched and run by the test runner, like so:

```
jest -- some-file-name.test.ts
```

Our CLI arg parsing module recognizes all Jest CLI args (like `--json`, `--watch`, and more) as 'first class' args and parses them into a `ConfigFlags` object. For the arguments shown above (`'--'`, `'some-file-name.test.ts'`), however, it will _not_ recognize them as first-class arguments and will instead preserve them in the `unknownArgs` array on the `ConfigFlags` object.

The flags (known and unknown) parsed by the `parse-flags` module are then converted into settings for Jest using the `buildJestArgv` function. Prior to this commit we took the known and unknown args off of the `ConfigFlags` object like so:

```ts
const args = [...config.flags.unknownArgs.slice(), ...config.flags.knownArgs.slice()];
```

If a filename match pattern is used alone (as in the example above) this will result in an array that looks like this:

```ts
const args = ['--', 'some-file-name.test.ts'];
```

That will translate correctly to what we want to communicate to Jest, and it will only run test files which match the pattern.

The problem comes in when a filename match pattern is used in conjunction with a boolean flag, like so:

```
jest --json -- some-file-name.test.ts
```

Or, in a Stencil context, doing something like this:

```
npx stencil test --spec --json -- my-component.spec.ts
```

which would result in the following `args` array being passed to Jest:

```ts
const args = [
  '--',
  'some-file-name.test.ts',
  '--spec',
  '--json',
];
```

Jest expects that `'--'` is _only_ followed by filename patterns and that all boolean flags like `--json` are before it in the argument list, so it will interpret this array as trying to match filenames which contain the string `'--json'`, rather than setting the `.json` flag on the Jest config.

The solution to this is to switch the order of the arguments passed to Jest, passing the known arguments _first_, followed by the unknown arguments.

Note: this used to work properly before #3444 because a flag like `--json` would have been stuck in the `unknownArgs` array, so the argument array passed to Jest would have looked like:

```ts
const args = [
  '--json',
  '--',
  'some-file-name.test.ts'
];
```

When we added explicit support for all Jest args this behavior was broken.

This commit adds a regression test which fails without the fix (changing the argument order) and adds the fix as well.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

GitHub Issue Number: #3724


## What is the new behavior?

This fixes how we pass known and unknown CLI args to Jest to fix an issue where the `--json` flag was being interpreted as a filename path to match against.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

I followed the reproduction steps in the issue and confirmed that this change fixes the issue. I don't believe it will have any other consequences.
