### PR TITLE
chore(compiler): update `ts.create*` methods to `ts.factory`

### DIFF
--- a/src/compiler/transformers/component-lazy/lazy-constructor.ts
+++ b/src/compiler/transformers/component-lazy/lazy-constructor.ts
@@ -39,7 +39,7 @@ export const updateLazyComponentConstructor = (
       undefined,
       undefined,
       cstrMethodArgs,
-      ts.createBlock(
+      ts.factory.createBlock(
         [
           registerInstanceStatement(moduleFile),
           ...addCreateEvents(moduleFile, cmp),
@@ -56,8 +56,8 @@ const registerInstanceStatement = (moduleFile: d.Module) => {
   addCoreRuntimeApi(moduleFile, RUNTIME_APIS.registerInstance);
 
   return ts.createStatement(
-    ts.createCall(ts.factory.createIdentifier(REGISTER_INSTANCE), undefined, [
-      ts.createThis(),
+    ts.factory.createCallExpression(ts.factory.createIdentifier(REGISTER_INSTANCE), undefined, [
+      ts.factory.createThis(),
       ts.factory.createIdentifier(HOST_REF_ARG),
     ])
   );

--- a/src/compiler/transformers/component-lazy/lazy-element-getter.ts
+++ b/src/compiler/transformers/component-lazy/lazy-element-getter.ts
@@ -21,8 +21,12 @@ export const addLazyElementGetter = (
         cmp.elementRef,
         [],
         undefined,
-        ts.createBlock([
-          ts.createReturn(ts.createCall(ts.factory.createIdentifier(GET_ELEMENT), undefined, [ts.createThis()])),
+        ts.factory.createBlock([
+          ts.createReturn(
+            ts.factory.createCallExpression(ts.factory.createIdentifier(GET_ELEMENT), undefined, [
+              ts.factory.createThis(),
+            ])
+          ),
         ])
       )
     );

--- a/src/compiler/transformers/component-native/native-connected-callback.ts
+++ b/src/compiler/transformers/component-native/native-connected-callback.ts
@@ -7,10 +7,14 @@ export const addNativeConnectedCallback = (classMembers: ts.ClassElement[], cmp:
 
   // TODO: fast path
   if (cmp.isPlain && cmp.hasRenderFn) {
-    const fnCall = ts.createExpressionStatement(
-      ts.createAssignment(
-        ts.createPropertyAccess(ts.createThis(), 'textContent'),
-        ts.createCall(ts.createPropertyAccess(ts.createThis(), 'render'), undefined, undefined)
+    const fnCall = ts.factory.createExpressionStatement(
+      ts.factory.createAssignment(
+        ts.factory.createPropertyAccessExpression(ts.factory.createThis(), 'textContent'),
+        ts.factory.createCallExpression(
+          ts.factory.createPropertyAccessExpression(ts.factory.createThis(), 'render'),
+          undefined,
+          undefined
+        )
       )
     );
     const connectedCallback = classMembers.find((classMember) => {
@@ -19,7 +23,7 @@ export const addNativeConnectedCallback = (classMembers: ts.ClassElement[], cmp:
 
     if (connectedCallback != null) {
       // class already has a connectedCallback(), so update it
-      const callbackMethod = ts.createMethod(
+      const callbackMethod = ts.factory.createMethodDeclaration(
         undefined,
         undefined,
         undefined,
@@ -28,13 +32,13 @@ export const addNativeConnectedCallback = (classMembers: ts.ClassElement[], cmp:
         undefined,
         undefined,
         undefined,
-        ts.createBlock([fnCall, ...connectedCallback.body.statements], true)
+        ts.factory.createBlock([fnCall, ...connectedCallback.body.statements], true)
       );
       const index = classMembers.indexOf(connectedCallback);
       classMembers[index] = callbackMethod;
     } else {
       // class doesn't have a connectedCallback(), so add it
-      const callbackMethod = ts.createMethod(
+      const callbackMethod = ts.factory.createMethodDeclaration(
         undefined,
         undefined,
         undefined,
@@ -43,7 +47,7 @@ export const addNativeConnectedCallback = (classMembers: ts.ClassElement[], cmp:
         undefined,
         undefined,
         undefined,
-        ts.createBlock([fnCall], true)
+        ts.factory.createBlock([fnCall], true)
       );
       classMembers.push(callbackMethod);
     }

--- a/src/compiler/transformers/component-native/native-constructor.ts
+++ b/src/compiler/transformers/component-native/native-constructor.ts
@@ -53,7 +53,7 @@ export const updateNativeConstructor = (
       statements = [createNativeConstructorSuper(), ...statements];
     }
 
-    const cstrMethod = ts.createConstructor(undefined, undefined, undefined, ts.createBlock(statements, true));
+    const cstrMethod = ts.createConstructor(undefined, undefined, undefined, ts.factory.createBlock(statements, true));
     classMembers.unshift(cstrMethod);
   }
 };
@@ -74,8 +74,8 @@ const nativeInit = (moduleFile: d.Module, cmp: d.ComponentCompilerMeta): Readonl
 
 const nativeRegisterHostStatement = () => {
   return ts.createStatement(
-    ts.createCall(
-      ts.createPropertyAccess(ts.createThis(), ts.factory.createIdentifier('__registerHost')),
+    ts.factory.createCallExpression(
+      ts.factory.createPropertyAccessExpression(ts.factory.createThis(), ts.factory.createIdentifier('__registerHost')),
       undefined,
       undefined
     )
@@ -100,5 +100,7 @@ const nativeAttachShadowStatement = (moduleFile: d.Module): ts.ExpressionStateme
 };
 
 const createNativeConstructorSuper = () => {
-  return ts.createExpressionStatement(ts.createCall(ts.factory.createIdentifier('super'), undefined, undefined));
+  return ts.factory.createExpressionStatement(
+    ts.factory.createCallExpression(ts.factory.createIdentifier('super'), undefined, undefined)
+  );
 };

--- a/src/compiler/transformers/component-native/native-element-getter.ts
+++ b/src/compiler/transformers/component-native/native-element-getter.ts
@@ -14,7 +14,7 @@ export const addNativeElementGetter = (classMembers: ts.ClassElement[], cmp: d.C
         cmp.elementRef,
         [],
         undefined,
-        ts.createBlock([ts.createReturn(ts.createThis())])
+        ts.factory.createBlock([ts.createReturn(ts.factory.createThis())])
       )
     );
   }

--- a/src/compiler/transformers/create-event.ts
+++ b/src/compiler/transformers/create-event.ts
@@ -9,10 +9,10 @@ export const addCreateEvents = (moduleFile: d.Module, cmp: d.ComponentCompilerMe
     addCoreRuntimeApi(moduleFile, RUNTIME_APIS.createEvent);
 
     return ts.createStatement(
-      ts.createAssignment(
-        ts.createPropertyAccess(ts.createThis(), ts.factory.createIdentifier(ev.method)),
-        ts.createCall(ts.factory.createIdentifier(CREATE_EVENT), undefined, [
-          ts.createThis(),
+      ts.factory.createAssignment(
+        ts.factory.createPropertyAccessExpression(ts.factory.createThis(), ts.factory.createIdentifier(ev.method)),
+        ts.factory.createCallExpression(ts.factory.createIdentifier(CREATE_EVENT), undefined, [
+          ts.factory.createThis(),
           ts.createLiteral(ev.name),
           ts.createLiteral(computeFlags(ev)),
         ])

--- a/src/compiler/transformers/define-custom-element.ts
+++ b/src/compiler/transformers/define-custom-element.ts
@@ -30,8 +30,11 @@ const addDefineCustomElement = (moduleFile: d.Module, compilerMeta: d.ComponentC
   if (compilerMeta.isPlain) {
     // add customElements.define('cmp-a', CmpClass);
     return ts.createStatement(
-      ts.createCall(
-        ts.createPropertyAccess(ts.factory.createIdentifier('customElements'), ts.factory.createIdentifier('define')),
+      ts.factory.createCallExpression(
+        ts.factory.createPropertyAccessExpression(
+          ts.factory.createIdentifier('customElements'),
+          ts.factory.createIdentifier('define')
+        ),
         [],
         [ts.createLiteral(compilerMeta.tagName), ts.factory.createIdentifier(compilerMeta.componentClassName)]
       )
@@ -45,7 +48,11 @@ const addDefineCustomElement = (moduleFile: d.Module, compilerMeta: d.ComponentC
   const liternalMeta = convertValueToLiteral(compactMeta);
 
   return ts.createStatement(
-    ts.createCall(ts.factory.createIdentifier(DEFINE_CUSTOM_ELEMENT), [], [liternalCmpClassName, liternalMeta])
+    ts.factory.createCallExpression(
+      ts.factory.createIdentifier(DEFINE_CUSTOM_ELEMENT),
+      [],
+      [liternalCmpClassName, liternalMeta]
+    )
   );
 };
 

--- a/src/compiler/transformers/host-data-transform.ts
+++ b/src/compiler/transformers/host-data-transform.ts
@@ -38,12 +38,20 @@ const syntheticRender = (moduleFile: d.Module, hasRender: boolean) => {
     // __stencil_Host
     ts.factory.createIdentifier(HOST),
     // this.hostData()
-    ts.createCall(ts.createPropertyAccess(ts.createThis(), 'hostData'), undefined, undefined),
+    ts.factory.createCallExpression(
+      ts.factory.createPropertyAccessExpression(ts.factory.createThis(), 'hostData'),
+      undefined,
+      undefined
+    ),
   ];
   if (hasRender) {
     hArguments.push(
       // this.render()
-      ts.createCall(ts.createPropertyAccess(ts.createThis(), INTERNAL_RENDER), undefined, undefined)
+      ts.factory.createCallExpression(
+        ts.factory.createPropertyAccessExpression(ts.factory.createThis(), INTERNAL_RENDER),
+        undefined,
+        undefined
+      )
     );
   }
 
@@ -52,7 +60,7 @@ const syntheticRender = (moduleFile: d.Module, hasRender: boolean) => {
    *   return h(arguments);
    * }
    */
-  return ts.createMethod(
+  return ts.factory.createMethodDeclaration(
     undefined,
     undefined,
     undefined,
@@ -61,7 +69,9 @@ const syntheticRender = (moduleFile: d.Module, hasRender: boolean) => {
     undefined,
     undefined,
     undefined,
-    ts.createBlock([ts.createReturn(ts.createCall(ts.factory.createIdentifier(H), undefined, hArguments))])
+    ts.factory.createBlock([
+      ts.createReturn(ts.factory.createCallExpression(ts.factory.createIdentifier(H), undefined, hArguments)),
+    ])
   );
 };
 

--- a/src/compiler/transformers/legacy-props.ts
+++ b/src/compiler/transformers/legacy-props.ts
@@ -19,10 +19,13 @@ export const addLegacyProps = (moduleFile: d.Module, cmp: d.ComponentCompilerMet
 };
 
 const getStatement = (propName: string, method: string, arg: string) => {
-  return ts.createExpressionStatement(
-    ts.createAssignment(
-      ts.createPropertyAccess(ts.createThis(), propName),
-      ts.createCall(ts.factory.createIdentifier(method), undefined, [ts.createThis(), ts.createLiteral(arg)])
+  return ts.factory.createExpressionStatement(
+    ts.factory.createAssignment(
+      ts.factory.createPropertyAccessExpression(ts.factory.createThis(), propName),
+      ts.factory.createCallExpression(ts.factory.createIdentifier(method), undefined, [
+        ts.factory.createThis(),
+        ts.createLiteral(arg),
+      ])
     )
   );
 };

--- a/src/compiler/transformers/style-imports.ts
+++ b/src/compiler/transformers/style-imports.ts
@@ -142,7 +142,7 @@ const createCjsStyleRequire = (
         ts.createVariableDeclaration(
           importName,
           undefined,
-          ts.createCall(ts.factory.createIdentifier('require'), [], [ts.createLiteral(importPath)])
+          ts.factory.createCallExpression(ts.factory.createIdentifier('require'), [], [ts.createLiteral(importPath)])
         ),
       ],
       ts.NodeFlags.Const

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -738,7 +738,7 @@ export const createRequireStatement = (importFnNames: string[], importPath: stri
         ts.createVariableDeclaration(
           importBinding,
           undefined,
-          ts.createCall(ts.factory.createIdentifier('require'), [], [ts.createLiteral(importPath)])
+          ts.factory.createCallExpression(ts.factory.createIdentifier('require'), [], [ts.createLiteral(importPath)])
         ),
       ],
       ts.NodeFlags.Const


### PR DESCRIPTION
This updates some more `ts.create` methods to use the equivalent under `ts.factory`. Like in #3713 I selected a file (`src/compiler/transformers/component-native/native-connected-callback.ts`) to 'branch out' from and then did a project-wide find and replace to fix all usages of the `ts.create*` methods used in that particular file.

That turned out to be:

- `ts.createExpressionStatement` -> `ts.factory.createExpressionStatement`
- `ts.createAssignment` -> `ts.factory.createAssignment`
- `ts.createPropertyAccess` -> `ts.factory.createPropertyAccessExpression`
- `ts.createThis` -> `ts.factory.createThis`
- `ts.createCall` -> `ts.factory.createCallExpression`
- `ts.createMethod` -> `ts.factory.createMethodDeclaration`
- `ts.createBlock` -> `ts.factory.createBlock`


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

We still have a lot of usage of these deprecated functions around, so it's a good idea for us to gradually clean them up.


## What is the new behavior?

Nothing should change at all about how Stencil works.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I built Stencil with these changes and did some smoke testing in Framework to check that there were no errors.
