### PR TITLE
chore(types): turn on `strictFunctionTypes` compiler flag

### DIFF
--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -244,7 +244,7 @@ describe('anonymizeConfigForTelemetry', () => {
     config = mockValidatedConfig({ sys });
   });
 
-  it.each([
+  it.each<keyof d.ValidatedConfig>([
     'rootDir',
     'fsNamespace',
     'packageJsonFilePath',
@@ -265,7 +265,7 @@ describe('anonymizeConfigForTelemetry', () => {
     expect(anonymizedConfig.outputTargets).toEqual([]);
   });
 
-  it.each(['sys', 'logger', 'devServer', 'tsCompilerOptions'])(
+  it.each<keyof d.ValidatedConfig>(['sys', 'logger', 'devServer', 'tsCompilerOptions'])(
     "should remove objects under prop '%s'",
     (prop: keyof d.ValidatedConfig) => {
       const anonymizedConfig = anonymizeConfigForTelemetry({ ...config, [prop]: {}, outputTargets: [] });

--- a/src/compiler/config/validate-testing.ts
+++ b/src/compiler/config/validate-testing.ts
@@ -74,8 +74,10 @@ export const validateTesting = (config: d.ValidatedConfig, diagnostics: d.Diagno
     });
 
     (config.outputTargets ?? [])
-      .filter((o) => (isOutputTargetDist(o) || isOutputTargetWww(o)) && o.dir)
-      .forEach((outputTarget: d.OutputTargetWww) => {
+      .filter(
+        (o): o is d.OutputTargetWww | d.OutputTargetDist => (isOutputTargetDist(o) || isOutputTargetWww(o)) && !!o.dir
+      )
+      .forEach((outputTarget) => {
         testing.testPathIgnorePatterns?.push(outputTarget.dir!);
       });
   }

--- a/src/compiler/output-targets/dist-lazy/generate-lazy-module.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-lazy-module.ts
@@ -27,7 +27,7 @@ export const generateLazyModules = async (
     return [];
   }
   const shouldMinify = config.minifyJs && isBrowserBuild;
-  const rollupResults = results.filter((r) => r.type === 'chunk') as d.RollupChunkResult[];
+  const rollupResults = results.filter((r): r is d.RollupChunkResult => r.type === 'chunk');
   const entryComponentsResults = rollupResults.filter((rollupResult) => rollupResult.isComponent);
   const chunkResults = rollupResults.filter((rollupResult) => !rollupResult.isComponent && !rollupResult.isEntry);
 
@@ -89,7 +89,7 @@ export const generateLazyModules = async (
 
   await Promise.all(
     results
-      .filter((r) => r.type === 'asset')
+      .filter((r): r is d.RollupAssetResult => r.type === 'asset')
       .map((r: d.RollupAssetResult) => {
         return Promise.all(
           destinations.map((dest) => {

--- a/src/compiler/sys/node-require.ts
+++ b/src/compiler/sys/node-require.ts
@@ -23,7 +23,7 @@ export const nodeRequire = (id: string) => {
 
       // let's override node's require for a second
       // don't worry, we'll revert this when we're done
-      require.extensions['.ts'] = (module: NodeModuleWithCompile, fileName: string) => {
+      require.extensions['.ts'] = (module: NodeJS.Module, fileName: string) => {
         let sourceText = fs.readFileSync(fileName, 'utf8');
 
         if (fileName.endsWith('.ts')) {
@@ -49,7 +49,10 @@ export const nodeRequire = (id: string) => {
         }
 
         try {
-          module._compile(sourceText, fileName);
+          // we need to coerce because of the requirements for the arguments to
+          // this function. It's safe enough since it's already wrapped in a
+          // `try { } catch`.
+          (module as NodeModuleWithCompile)._compile(sourceText, fileName);
         } catch (e: any) {
           catchError(results.diagnostics, e);
         }

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -415,7 +415,7 @@ const getAllTypeReferences = (node: ts.Node): ReadonlyArray<string> => {
       if (node.typeArguments) {
         // a type may contain types itself (e.g. generics - Foo<Bar>)
         node.typeArguments
-          .filter((typeArg: ts.TypeNode) => ts.isTypeReferenceNode(typeArg))
+          .filter((typeArg: ts.TypeNode): typeArg is ts.TypeReferenceNode => ts.isTypeReferenceNode(typeArg))
           .forEach((typeRef: ts.TypeReferenceNode) => {
             const typeName = typeRef.typeName as ts.Identifier;
             if (typeName && typeName.escapedText) {

--- a/src/compiler/types/update-import-refs.ts
+++ b/src/compiler/types/update-import-refs.ts
@@ -68,10 +68,10 @@ const updateImportReferenceFactory = (typeCounts: Map<string, number>, filePath:
     typeReferences: { [key: string]: d.ComponentCompilerTypeReference }
   ): d.TypesImportData => {
     Object.keys(typeReferences)
-      .map((typeName) => {
+      .map<[string, d.ComponentCompilerTypeReference]>((typeName) => {
         return [typeName, typeReferences[typeName]];
       })
-      .forEach(([typeName, typeReference]: [string, d.ComponentCompilerTypeReference]) => {
+      .forEach(([typeName, typeReference]) => {
         let importResolvedFile: string;
 
         // If global then there is no import statement needed

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -1145,7 +1145,7 @@ export interface DevServerContext {
   getBuildResults: () => Promise<CompilerBuildResults>;
   getCompilerRequest: (path: string) => Promise<CompilerRequestResponse>;
   isServerListening: boolean;
-  logRequest: (req: { method: string; pathname?: string }, status: number) => void;
+  logRequest: (req: HttpRequest, status: number) => void;
   prerenderConfig: PrerenderConfig;
   serve302: (req: any, res: any, pathname?: string) => void;
   serve404: (req: any, res: any, xSource: string, content?: string) => void;

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1202,6 +1202,7 @@ export interface BuildOnEvents {
 }
 
 export interface BuildEmitEvents {
+  emit(eventName: CompilerEventName, path: string): void;
   emit(eventName: CompilerEventFileAdd, path: string): void;
   emit(eventName: CompilerEventFileDelete, path: string): void;
   emit(eventName: CompilerEventFileUpdate, path: string): void;

--- a/src/dev-server/server-web-socket.ts
+++ b/src/dev-server/server-web-socket.ts
@@ -14,8 +14,11 @@ export function createWebSocket(
 
   const wsServer: ws.Server = new ws.Server(wsConfig);
 
-  function heartbeat(this: DevWS) {
-    this.isAlive = true;
+  function heartbeat(this: ws) {
+    // we need to coerce the `ws` type to our custom `DevWS` type here, since
+    // this function is going to be passed in to `ws.on('pong'` which expects
+    // to be passed a functon where `this` is bound to `ws`.
+    (this as DevWS).isAlive = true;
   }
 
   wsServer.on('connection', (ws: DevWS) => {
@@ -38,7 +41,7 @@ export function createWebSocket(
   });
 
   const pingInternval = setInterval(() => {
-    wsServer.clients.forEach((ws: DevWS) => {
+    (wsServer.clients as Set<DevWS>).forEach((ws: DevWS) => {
       if (!ws.isAlive) {
         return ws.close(1000);
       }

--- a/src/hydrate/runner/hydrate-factory.ts
+++ b/src/hydrate/runner/hydrate-factory.ts
@@ -1,12 +1,12 @@
 import type * as d from '../../declarations';
 
-export function hydrateFactory(
+export function hydrateFactory<DocOptions extends d.SerializeDocumentOptions>(
   win: Window,
   opts: d.HydrateDocumentOptions,
   results: d.HydrateResults,
   afterHydrate: (
     win: Window,
-    opts: d.SerializeDocumentOptions,
+    opts: DocOptions,
     results: d.HydrateResults,
     resolve: (results: d.HydrateResults) => void
   ) => void,

--- a/src/testing/jest/jest-serializer.ts
+++ b/src/testing/jest/jest-serializer.ts
@@ -1,7 +1,8 @@
 import { MockNode, serializeNodeToHtml } from '@stencil/core/mock-doc';
 
-const print = (val: HTMLElement | MockNode): string => {
-  return serializeNodeToHtml(val, {
+const print = (val: unknown): string => {
+  // we coerce here because Jest wants `val` to be unknown
+  return serializeNodeToHtml(val as MockNode | Node, {
     serializeShadowRoot: true,
     prettyHtml: true,
     outerHtml: true,

--- a/src/testing/jest/test/jest-serializer.spec.ts
+++ b/src/testing/jest/test/jest-serializer.spec.ts
@@ -4,6 +4,7 @@ import { HtmlSerializer } from '../jest-serializer';
 
 describe('serialize node', () => {
   let doc: MockDocument;
+
   beforeEach(() => {
     doc = new MockDocument();
     const div = doc.createElement('div');

--- a/src/utils/logger/logger-rollup.ts
+++ b/src/utils/logger/logger-rollup.ts
@@ -113,7 +113,7 @@ export const loadRollupDiagnostics = (
 export const createOnWarnFn = (diagnostics: d.Diagnostic[], bundleModulesFiles?: d.Module[]) => {
   const previousWarns = new Set<string>();
 
-  return function onWarningMessage(warning: { code: string; importer: string; message: string }) {
+  return function onWarningMessage(warning: { code?: string; importer?: string; message?: string }) {
     if (warning == null || ignoreWarnCodes.has(warning.code) || previousWarns.has(warning.message)) {
       return;
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "strictFunctionTypes": true,
     "outDir": "build",
     "pretty": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
This turns the `strictFunctionTypes` compiler flag on and fixes the errors uncovered by doing so.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

`strictFunctionTypes` is turned off.


## What is the new behavior?

`strictFunctionTypes` is turned on!

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

I ran the tests, made sure everything compiles. I believe these are all only typesystem-level changes.

