### PR TITLE
feat(typescript): support typescript 4.8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       - dependency-name: '@types/node'
         versions: ['17', '18']
       - dependency-name: 'typescript'
-        versions: ['4.8']
+        versions: ['>=4.9']
       # disable Jest updates until the new testing architecture is in place
       - dependency-name: '@types/jest'
         versions: ['>=28']

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "semver": "^7.3.7",
         "sizzle": "^2.3.6",
         "terser": "5.6.1",
-        "typescript": "4.7.4",
+        "typescript": "4.8.4",
         "webpack": "^4.46.0",
         "ws": "7.4.6"
       },
@@ -12732,9 +12732,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -23685,9 +23685,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "semver": "^7.3.7",
     "sizzle": "^2.3.6",
     "terser": "5.6.1",
-    "typescript": "4.7.4",
+    "typescript": "4.8.4",
     "webpack": "^4.46.0",
     "ws": "7.4.6"
   },

--- a/src/compiler/sys/dependencies.json
+++ b/src/compiler/sys/dependencies.json
@@ -64,6 +64,7 @@
         "compiler/lib.es2022.full.d.ts",
         "compiler/lib.es2022.intl.d.ts",
         "compiler/lib.es2022.object.d.ts",
+        "compiler/lib.es2022.sharedmemory.d.ts",
         "compiler/lib.es2022.string.d.ts",
         "compiler/lib.es5.d.ts",
         "compiler/lib.es6.d.ts",

--- a/src/compiler/transformers/add-component-meta-static.ts
+++ b/src/compiler/transformers/add-component-meta-static.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
 
 import type * as d from '../../declarations';
-import { convertValueToLiteral, createStaticGetter } from './transform-utils';
+import { convertValueToLiteral, createStaticGetter, retrieveModifierLike } from './transform-utils';
 
 /**
  * Update an instance of TypeScript's Intermediate Representation (IR) for a
@@ -24,8 +24,7 @@ export const addComponentMetaStatic = (
 
   return ts.factory.updateClassDeclaration(
     cmpNode,
-    cmpNode.decorators,
-    cmpNode.modifiers,
+    retrieveModifierLike(cmpNode),
     cmpNode.name,
     cmpNode.typeParameters,
     cmpNode.heritageClauses,

--- a/src/compiler/transformers/component-hydrate/hydrate-component.ts
+++ b/src/compiler/transformers/component-hydrate/hydrate-component.ts
@@ -5,6 +5,7 @@ import { updateLazyComponentConstructor } from '../component-lazy/lazy-construct
 import { addLazyElementGetter } from '../component-lazy/lazy-element-getter';
 import { transformHostData } from '../host-data-transform';
 import { removeStaticMetaProperties } from '../remove-static-meta-properties';
+import { retrieveModifierLike } from '../transform-utils';
 import { addWatchers } from '../watcher-meta-transform';
 import { addHydrateRuntimeCmpMeta } from './hydrate-runtime-cmp-meta';
 
@@ -15,8 +16,7 @@ export const updateHydrateComponentClass = (
 ) => {
   return ts.factory.updateClassDeclaration(
     classNode,
-    classNode.decorators,
-    classNode.modifiers,
+    retrieveModifierLike(classNode),
     classNode.name,
     classNode.typeParameters,
     classNode.heritageClauses,

--- a/src/compiler/transformers/component-lazy/lazy-constructor.ts
+++ b/src/compiler/transformers/component-lazy/lazy-constructor.ts
@@ -4,6 +4,7 @@ import type * as d from '../../../declarations';
 import { addCoreRuntimeApi, REGISTER_INSTANCE, RUNTIME_APIS } from '../core-runtime-apis';
 import { addCreateEvents } from '../create-event';
 import { addLegacyProps } from '../legacy-props';
+import { retrieveTsModifiers } from '../transform-utils';
 
 export const updateLazyComponentConstructor = (
   classMembers: ts.ClassElement[],
@@ -11,7 +12,7 @@ export const updateLazyComponentConstructor = (
   cmp: d.ComponentCompilerMeta
 ) => {
   const cstrMethodArgs = [
-    ts.factory.createParameterDeclaration(undefined, undefined, undefined, ts.factory.createIdentifier(HOST_REF_ARG)),
+    ts.factory.createParameterDeclaration(undefined, undefined, ts.factory.createIdentifier(HOST_REF_ARG)),
   ];
 
   const cstrMethodIndex = classMembers.findIndex((m) => m.kind === ts.SyntaxKind.Constructor);
@@ -28,15 +29,13 @@ export const updateLazyComponentConstructor = (
 
     classMembers[cstrMethodIndex] = ts.factory.updateConstructorDeclaration(
       cstrMethod,
-      cstrMethod.decorators,
-      cstrMethod.modifiers,
+      retrieveTsModifiers(cstrMethod),
       cstrMethodArgs,
       body
     );
   } else {
     // create a constructor()
     const cstrMethod = ts.factory.createConstructorDeclaration(
-      undefined,
       undefined,
       cstrMethodArgs,
       ts.factory.createBlock(

--- a/src/compiler/transformers/component-lazy/lazy-element-getter.ts
+++ b/src/compiler/transformers/component-lazy/lazy-element-getter.ts
@@ -17,7 +17,6 @@ export const addLazyElementGetter = (
     classMembers.push(
       ts.factory.createGetAccessorDeclaration(
         undefined,
-        undefined,
         cmp.elementRef,
         [],
         undefined,

--- a/src/compiler/transformers/component-native/add-define-custom-element-function.ts
+++ b/src/compiler/transformers/component-native/add-define-custom-element-function.ts
@@ -154,12 +154,11 @@ const addDefineCustomElementFunction = (
   caseStatements: ts.CaseClause[]
 ) => {
   const newExpression = ts.factory.createFunctionDeclaration(
-    undefined,
     [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
     undefined,
     ts.factory.createIdentifier('defineCustomElement'),
     undefined,
-    undefined,
+    [],
     undefined,
     ts.factory.createBlock(
       [
@@ -196,7 +195,6 @@ const addDefineCustomElementFunction = (
                 undefined,
                 [
                   ts.factory.createParameterDeclaration(
-                    undefined,
                     undefined,
                     undefined,
                     ts.factory.createIdentifier('tagName'),

--- a/src/compiler/transformers/component-native/native-connected-callback.ts
+++ b/src/compiler/transformers/component-native/native-connected-callback.ts
@@ -26,11 +26,10 @@ export const addNativeConnectedCallback = (classMembers: ts.ClassElement[], cmp:
       const callbackMethod = ts.factory.createMethodDeclaration(
         undefined,
         undefined,
-        undefined,
         'connectedCallback',
         undefined,
         undefined,
-        undefined,
+        [],
         undefined,
         ts.factory.createBlock([fnCall, ...connectedCallback.body.statements], true)
       );
@@ -41,11 +40,10 @@ export const addNativeConnectedCallback = (classMembers: ts.ClassElement[], cmp:
       const callbackMethod = ts.factory.createMethodDeclaration(
         undefined,
         undefined,
-        undefined,
         'connectedCallback',
         undefined,
         undefined,
-        undefined,
+        [],
         undefined,
         ts.factory.createBlock([fnCall], true)
       );

--- a/src/compiler/transformers/component-native/native-constructor.ts
+++ b/src/compiler/transformers/component-native/native-constructor.ts
@@ -4,6 +4,7 @@ import type * as d from '../../../declarations';
 import { addCoreRuntimeApi, RUNTIME_APIS } from '../core-runtime-apis';
 import { addCreateEvents } from '../create-event';
 import { addLegacyProps } from '../legacy-props';
+import { retrieveTsModifiers } from '../transform-utils';
 
 export const updateNativeConstructor = (
   classMembers: ts.ClassElement[],
@@ -36,8 +37,7 @@ export const updateNativeConstructor = (
 
     classMembers[cstrMethodIndex] = ts.factory.updateConstructorDeclaration(
       cstrMethod,
-      cstrMethod.decorators,
-      cstrMethod.modifiers,
+      retrieveTsModifiers(cstrMethod),
       cstrMethod.parameters,
       ts.factory.updateBlock(cstrMethod.body, statements)
     );
@@ -53,12 +53,7 @@ export const updateNativeConstructor = (
       statements = [createNativeConstructorSuper(), ...statements];
     }
 
-    const cstrMethod = ts.factory.createConstructorDeclaration(
-      undefined,
-      undefined,
-      undefined,
-      ts.factory.createBlock(statements, true)
-    );
+    const cstrMethod = ts.factory.createConstructorDeclaration(undefined, [], ts.factory.createBlock(statements, true));
     classMembers.unshift(cstrMethod);
   }
 };

--- a/src/compiler/transformers/component-native/native-element-getter.ts
+++ b/src/compiler/transformers/component-native/native-element-getter.ts
@@ -10,7 +10,6 @@ export const addNativeElementGetter = (classMembers: ts.ClassElement[], cmp: d.C
     classMembers.push(
       ts.factory.createGetAccessorDeclaration(
         undefined,
-        undefined,
         cmp.elementRef,
         [],
         undefined,

--- a/src/compiler/transformers/decorators-to-static/component-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/component-decorator.ts
@@ -2,7 +2,7 @@ import { augmentDiagnosticWithNode, buildError, buildWarn, isString, validateCom
 import ts from 'typescript';
 
 import type * as d from '../../../declarations';
-import { convertValueToLiteral, createStaticGetter } from '../transform-utils';
+import { convertValueToLiteral, createStaticGetter, retrieveTsDecorators } from '../transform-utils';
 import { getDeclarationParameters } from './decorator-utils';
 import { styleToStatic } from './style-to-static';
 
@@ -88,7 +88,7 @@ const validateComponent = (
   }
 
   // check if class has more than one decorator
-  const otherDecorator = cmpNode.decorators && cmpNode.decorators.find((d) => d !== componentDecorator);
+  const otherDecorator = retrieveTsDecorators(cmpNode)?.find((d) => d !== componentDecorator);
   if (otherDecorator) {
     const err = buildError(diagnostics);
     err.messageText = `Classes decorated with @Component can not be decorated with more decorators.

--- a/src/compiler/transformers/decorators-to-static/element-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/element-decorator.ts
@@ -2,7 +2,7 @@ import { buildError } from '@utils';
 import ts from 'typescript';
 
 import type * as d from '../../../declarations';
-import { createStaticGetter } from '../transform-utils';
+import { createStaticGetter, retrieveTsDecorators } from '../transform-utils';
 import { isDecoratorNamed } from './decorator-utils';
 
 export const elementDecoratorsToStatic = (
@@ -29,8 +29,8 @@ const parseElementDecorator = (
   _diagnostics: d.Diagnostic[],
   _typeChecker: ts.TypeChecker,
   prop: ts.PropertyDeclaration
-) => {
-  const elementDecorator = prop.decorators && prop.decorators.find(isDecoratorNamed('Element'));
+): string | null => {
+  const elementDecorator = retrieveTsDecorators(prop)?.find(isDecoratorNamed('Element'));
 
   if (elementDecorator == null) {
     return null;

--- a/src/compiler/transformers/decorators-to-static/event-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/event-decorator.ts
@@ -7,6 +7,7 @@ import {
   createStaticGetter,
   getAttributeTypeInfo,
   resolveType,
+  retrieveTsDecorators,
   serializeSymbol,
   validateReferences,
 } from '../transform-utils';
@@ -43,7 +44,7 @@ const parseEventDecorator = (
   typeChecker: ts.TypeChecker,
   prop: ts.PropertyDeclaration
 ): d.ComponentCompilerStaticEvent | null => {
-  const eventDecorator = prop.decorators?.find(isDecoratorNamed('Event'));
+  const eventDecorator = retrieveTsDecorators(prop)?.find(isDecoratorNamed('Event'));
 
   if (eventDecorator == null) {
     return null;

--- a/src/compiler/transformers/decorators-to-static/listen-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/listen-decorator.ts
@@ -2,7 +2,7 @@ import { augmentDiagnosticWithNode, buildError, flatOne } from '@utils';
 import ts from 'typescript';
 
 import type * as d from '../../../declarations';
-import { convertValueToLiteral, createStaticGetter } from '../transform-utils';
+import { convertValueToLiteral, createStaticGetter, retrieveTsDecorators } from '../transform-utils';
 import { getDeclarationParameters, isDecoratorNamed } from './decorator-utils';
 
 export const listenDecoratorsToStatic = (
@@ -20,8 +20,11 @@ export const listenDecoratorsToStatic = (
   }
 };
 
-const parseListenDecorators = (diagnostics: d.Diagnostic[], method: ts.MethodDeclaration) => {
-  const listenDecorators = method.decorators.filter(isDecoratorNamed('Listen'));
+const parseListenDecorators = (
+  diagnostics: d.Diagnostic[],
+  method: ts.MethodDeclaration
+): d.ComponentCompilerListener[] => {
+  const listenDecorators = (retrieveTsDecorators(method) ?? []).filter(isDecoratorNamed('Listen'));
   if (listenDecorators.length === 0) {
     return [];
   }

--- a/src/compiler/transformers/decorators-to-static/method-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/method-decorator.ts
@@ -9,6 +9,8 @@ import {
   getAttributeTypeInfo,
   isMemberPrivate,
   mapJSDocTagInfo,
+  retrieveTsDecorators,
+  retrieveTsModifiers,
   serializeSymbol,
   typeToString,
   validateReferences,
@@ -40,8 +42,8 @@ const parseMethodDecorator = (
   tsSourceFile: ts.SourceFile,
   typeChecker: ts.TypeChecker,
   method: ts.MethodDeclaration
-) => {
-  const methodDecorator = method.decorators.find(isDecoratorNamed('Method'));
+): ts.PropertyAssignment | null => {
+  const methodDecorator = retrieveTsDecorators(method)?.find(isDecoratorNamed('Method'));
   if (methodDecorator == null) {
     return null;
   }
@@ -79,7 +81,7 @@ const parseMethodDecorator = (
     const err = buildError(diagnostics);
     err.messageText =
       'Methods decorated with the @Method() decorator cannot be "private" nor "protected". More info: https://stenciljs.com/docs/methods';
-    augmentDiagnosticWithNode(err, method.modifiers[0]);
+    augmentDiagnosticWithNode(err, retrieveTsModifiers(method)![0]);
   }
 
   // Validate if the method name does not conflict with existing public names

--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -9,6 +9,8 @@ import {
   getAttributeTypeInfo,
   isMemberPrivate,
   resolveType,
+  retrieveTsDecorators,
+  retrieveTsModifiers,
   serializeSymbol,
   typeToString,
   validateReferences,
@@ -37,7 +39,7 @@ export const propDecoratorsToStatic = (
   const properties = decoratedProps
     .filter(ts.isPropertyDeclaration)
     .map((prop) => parsePropDecorator(diagnostics, typeChecker, prop, watchable))
-    .filter((prop) => prop != null);
+    .filter((prop): prop is ts.PropertyAssignment => prop != null);
 
   if (properties.length > 0) {
     newMembers.push(createStaticGetter('properties', ts.factory.createObjectLiteralExpression(properties, true)));
@@ -58,8 +60,8 @@ const parsePropDecorator = (
   typeChecker: ts.TypeChecker,
   prop: ts.PropertyDeclaration,
   watchable: Set<string>
-): ts.PropertyAssignment => {
-  const propDecorator = prop.decorators.find(isDecoratorNamed('Prop'));
+): ts.PropertyAssignment | null => {
+  const propDecorator = retrieveTsDecorators(prop)?.find(isDecoratorNamed('Prop'));
   if (propDecorator == null) {
     return null;
   }
@@ -73,7 +75,7 @@ const parsePropDecorator = (
     const err = buildError(diagnostics);
     err.messageText =
       'Properties decorated with the @Prop() decorator cannot be "private" nor "protected". More info: https://stenciljs.com/docs/properties';
-    augmentDiagnosticWithNode(err, prop.modifiers[0]);
+    augmentDiagnosticWithNode(err, retrieveTsModifiers(prop)![0]);
   }
 
   if (/^on(-|[A-Z])/.test(propName)) {

--- a/src/compiler/transformers/decorators-to-static/state-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/state-decorator.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
 
-import { createStaticGetter } from '../transform-utils';
+import { createStaticGetter, retrieveTsDecorators } from '../transform-utils';
 import { isDecoratorNamed } from './decorator-utils';
 
 /**
@@ -22,7 +22,7 @@ export const stateDecoratorsToStatic = (
   const states = decoratedProps
     .filter(ts.isPropertyDeclaration)
     .map((prop) => stateDecoratorToStatic(prop, watchable))
-    .filter((state) => !!state);
+    .filter((state): state is ts.PropertyAssignment => !!state);
 
   if (states.length > 0) {
     newMembers.push(createStaticGetter('states', ts.factory.createObjectLiteralExpression(states, true)));
@@ -43,7 +43,7 @@ export const stateDecoratorsToStatic = (
  * prop to an empty object
  */
 const stateDecoratorToStatic = (prop: ts.PropertyDeclaration, watchable: Set<string>): ts.PropertyAssignment | null => {
-  const stateDecorator = prop.decorators.find(isDecoratorNamed('State'));
+  const stateDecorator = retrieveTsDecorators(prop)?.find(isDecoratorNamed('State'));
   if (stateDecorator == null) {
     return null;
   }

--- a/src/compiler/transformers/decorators-to-static/watch-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/watch-decorator.ts
@@ -2,7 +2,7 @@ import { augmentDiagnosticWithNode, buildError, buildWarn, flatOne } from '@util
 import ts from 'typescript';
 
 import type * as d from '../../../declarations';
-import { convertValueToLiteral, createStaticGetter } from '../transform-utils';
+import { convertValueToLiteral, createStaticGetter, retrieveTsDecorators } from '../transform-utils';
 import { getDeclarationParameters, isDecoratorNamed } from './decorator-utils';
 
 export const watchDecoratorsToStatic = (
@@ -30,7 +30,8 @@ const parseWatchDecorator = (
   method: ts.MethodDeclaration
 ): d.ComponentCompilerWatch[] => {
   const methodName = method.name.getText();
-  return method.decorators.filter(isDecoratorNamed('Watch')).map((decorator) => {
+  const decorators = retrieveTsDecorators(method) ?? [];
+  return decorators.filter(isDecoratorNamed('Watch')).map((decorator) => {
     const [propName] = getDeclarationParameters<string>(decorator);
     if (!watchable.has(propName)) {
       const diagnostic = config.devMode ? buildWarn(diagnostics) : buildError(diagnostics);

--- a/src/compiler/transformers/host-data-transform.ts
+++ b/src/compiler/transformers/host-data-transform.ts
@@ -2,6 +2,7 @@ import ts from 'typescript';
 
 import type * as d from '../../declarations';
 import { addCoreRuntimeApi, H, HOST, RUNTIME_APIS } from './core-runtime-apis';
+import { retrieveModifierLike } from './transform-utils';
 
 export const transformHostData = (classElements: ts.ClassElement[], moduleFile: d.Module) => {
   const hasHostData = classElements.some(
@@ -15,8 +16,7 @@ export const transformHostData = (classElements: ts.ClassElement[], moduleFile: 
       const renderMethod = classElements[renderIndex] as ts.MethodDeclaration;
       classElements[renderIndex] = ts.factory.updateMethodDeclaration(
         renderMethod,
-        renderMethod.decorators,
-        renderMethod.modifiers,
+        retrieveModifierLike(renderMethod),
         renderMethod.asteriskToken,
         ts.factory.createIdentifier(INTERNAL_RENDER),
         renderMethod.questionToken,
@@ -63,11 +63,10 @@ const syntheticRender = (moduleFile: d.Module, hasRender: boolean) => {
   return ts.factory.createMethodDeclaration(
     undefined,
     undefined,
-    undefined,
     'render',
     undefined,
     undefined,
-    undefined,
+    [],
     undefined,
     ts.factory.createBlock([
       ts.factory.createReturnStatement(

--- a/src/compiler/transformers/map-imports-to-path-aliases.ts
+++ b/src/compiler/transformers/map-imports-to-path-aliases.ts
@@ -3,6 +3,7 @@ import { dirname, relative } from 'path';
 import ts from 'typescript';
 
 import type * as d from '../../declarations';
+import { retrieveTsModifiers } from './transform-utils';
 
 /**
  * This method is responsible for replacing user-defined import path aliases ({@link https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping})
@@ -78,8 +79,7 @@ export const mapImportsToPathAliases = (
 
           return transformCtx.factory.updateImportDeclaration(
             node,
-            node.decorators,
-            node.modifiers,
+            retrieveTsModifiers(node),
             node.importClause,
             transformCtx.factory.createStringLiteral(importPath),
             node.assertClause

--- a/src/compiler/transformers/remove-static-meta-properties.ts
+++ b/src/compiler/transformers/remove-static-meta-properties.ts
@@ -1,16 +1,16 @@
 import ts from 'typescript';
 
-export const removeStaticMetaProperties = (classNode: ts.ClassDeclaration) => {
+import { retrieveTsModifiers } from './transform-utils';
+
+export const removeStaticMetaProperties = (classNode: ts.ClassDeclaration): ts.ClassElement[] => {
   if (classNode.members == null) {
     return [];
   }
   return classNode.members.filter((classMember) => {
-    if (classMember.modifiers) {
-      if (classMember.modifiers.some((m) => m.kind === ts.SyntaxKind.StaticKeyword)) {
-        const memberName = (classMember.name as any).escapedText;
-        if (REMOVE_STATIC_GETTERS.has(memberName)) {
-          return false;
-        }
+    if (retrieveTsModifiers(classMember)?.some((m) => m.kind === ts.SyntaxKind.StaticKeyword)) {
+      const memberName = (classMember.name as any).escapedText;
+      if (REMOVE_STATIC_GETTERS.has(memberName)) {
+        return false;
       }
     }
     return true;

--- a/src/compiler/transformers/style-imports.ts
+++ b/src/compiler/transformers/style-imports.ts
@@ -2,6 +2,7 @@ import ts from 'typescript';
 
 import type * as d from '../../declarations';
 import { serializeImportPath } from './stencil-import-path';
+import { retrieveTsModifiers } from './transform-utils';
 
 export const updateStyleImports = (
   transformOpts: d.TransformOptions,
@@ -63,7 +64,7 @@ const updateEsmStyleImportPath = (
   statements: ts.Statement[],
   cmp: d.ComponentCompilerMeta,
   style: d.StyleCompiler
-) => {
+): ts.Statement[] => {
   for (let i = 0; i < statements.length; i++) {
     const n = statements[i];
     if (ts.isImportDeclaration(n) && n.importClause && n.moduleSpecifier && ts.isStringLiteral(n.moduleSpecifier)) {
@@ -73,8 +74,7 @@ const updateEsmStyleImportPath = (
 
         statements[i] = ts.factory.updateImportDeclaration(
           n,
-          n.decorators,
-          n.modifiers,
+          retrieveTsModifiers(n),
           n.importClause,
           ts.factory.createStringLiteral(importPath),
           undefined
@@ -96,7 +96,6 @@ const createEsmStyleImport = (
   const importPath = getStyleImportPath(transformOpts, tsSourceFile, cmp, style, style.externalStyles[0].absolutePath);
 
   return ts.factory.createImportDeclaration(
-    undefined,
     undefined,
     ts.factory.createImportClause(false, importName, undefined),
     ts.factory.createStringLiteral(importPath)

--- a/src/compiler/transformers/test/add-component-meta-proxy.spec.ts
+++ b/src/compiler/transformers/test/add-component-meta-proxy.spec.ts
@@ -29,11 +29,10 @@ describe('add-component-meta-proxy', () => {
 
       classExpr = ts.factory.createClassExpression(
         undefined,
-        undefined,
         'MyComponent',
         undefined,
         [htmlElementHeritageClause],
-        undefined
+        []
       );
       literalMetadata = ts.factory.createStringLiteral('MyComponent');
 

--- a/src/compiler/transformers/test/convert-decorators.spec.ts
+++ b/src/compiler/transformers/test/convert-decorators.spec.ts
@@ -334,68 +334,30 @@ describe('convert-decorators', () => {
   });
 
   describe('filterDecorators', () => {
-    /**
-     * Create a decorated class member, 'classMemberVariable: string;', as it would exist in a class. No class
-     * declaration is created.
-     *
-     * The property declaration will have any decorators provided applied to it.
-     *
-     * @example
-     * // By default, no decorators will be applied, and the following will be returned:
-     * createClassMemberWithDecorators(); // Node representing 'classMemberVariable: string;'
-     *
-     * // Otherwise, the provided modifier will be applied to the method:
-     * const propDecorator = ts.factory.createDecorator(
-     *   ts.factory.createCallExpression(ts.factory.createIdentifier('Prop'), undefined, [])
-     * );
-     * createClassMemberWithDecorators([propDecorator]); // '@Prop() classMemberVariable: string;'
-     *
-     * @param decorators the decorators to apply to the property declaration
-     * @returns the created property declaration
-     */
-    const createClassMemberWithDecorators = (decorators?: ReadonlyArray<ts.Decorator>): ts.PropertyDeclaration => {
-      const decoratorsToUse = decorators ? [...decorators] : undefined;
-      return ts.factory.createPropertyDeclaration(
-        decoratorsToUse,
-        undefined,
-        ts.factory.createIdentifier('classMemberVariable'),
-        undefined,
-        ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
-        undefined
-      );
-    };
-
-    it("returns undefined if a node doesn't have any decorators", () => {
-      // create a class member, 'classMemberVariable: string;', as it would exist in a class
-      const member = createClassMemberWithDecorators(undefined);
-
-      const filteredDecorators = filterDecorators(member.decorators, []);
+    it('returns undefined when no decorators are provided', () => {
+      const filteredDecorators = filterDecorators(undefined, []);
 
       expect(filteredDecorators).toBeUndefined();
     });
 
-    it('returns undefined if a node has an empty list of decorators', () => {
-      // create a class member, 'classMemberVariable: string;', as it would exist in a class
-      const member = createClassMemberWithDecorators([]);
-
-      const filteredDecorators = filterDecorators(member.decorators, []);
+    it('returns undefined for an empty list of decorators', () => {
+      const filteredDecorators = filterDecorators([], []);
 
       expect(filteredDecorators).toBeUndefined();
     });
 
-    it("returns a node's decorator if it is not a call expression", () => {
-      // create a decorated class member, '@Decorator classMemberVariable: string;', as it would exist in a class
-      // note the lack of '()' after the decorator, making it an identifier expression, rather than a class expression
+    it('returns a decorator if it is not a call expression', () => {
+      // create a decorator, '@Decorator'. note the lack of '()' after the decorator, making it an identifier
+      // expression, rather than a call expression
       const decorator = ts.factory.createDecorator(ts.factory.createIdentifier('Decorator'));
-      const member = createClassMemberWithDecorators([decorator]);
 
-      const filteredDecorators = filterDecorators(member.decorators, []);
+      const filteredDecorators = filterDecorators([decorator], []);
 
       expect(filteredDecorators).toHaveLength(1);
-      expect(filteredDecorators[0]).toBe(decorator);
+      expect(filteredDecorators![0]).toBe(decorator);
     });
 
-    it("doesn't return any decorators when all decorators on a node exist in the exclude list", () => {
+    it("doesn't return any decorators when all decorators in the exclude list", () => {
       // create a '@CustomProp()' decorator
       const customDecorator = ts.factory.createDecorator(
         ts.factory.createCallExpression(ts.factory.createIdentifier('CustomProp'), undefined, [])
@@ -404,14 +366,13 @@ describe('convert-decorators', () => {
       const decorator = ts.factory.createDecorator(
         ts.factory.createCallExpression(ts.factory.createIdentifier('Prop'), undefined, [])
       );
-      const member = createClassMemberWithDecorators([customDecorator, decorator]);
 
-      const filteredDecorators = filterDecorators(member.decorators, ['Prop', 'CustomProp']);
+      const filteredDecorators = filterDecorators([customDecorator, decorator], ['Prop', 'CustomProp']);
 
       expect(filteredDecorators).toBeUndefined();
     });
 
-    it('returns any decorators on a node, not in the exclude list', () => {
+    it('returns any decorators not in the exclude list', () => {
       // create a '@CustomProp()' decorator
       const customDecorator = ts.factory.createDecorator(
         ts.factory.createCallExpression(ts.factory.createIdentifier('CustomProp'), undefined, [])
@@ -420,12 +381,11 @@ describe('convert-decorators', () => {
       const decorator = ts.factory.createDecorator(
         ts.factory.createCallExpression(ts.factory.createIdentifier('Prop'), undefined, [])
       );
-      const member = createClassMemberWithDecorators([customDecorator, decorator]);
 
-      const filteredDecorators = filterDecorators(member.decorators, ['Prop']);
+      const filteredDecorators = filterDecorators([customDecorator, decorator], ['Prop']);
 
       expect(filteredDecorators).toHaveLength(1);
-      expect(filteredDecorators[0]).toBe(customDecorator);
+      expect(filteredDecorators![0]).toBe(customDecorator);
     });
   });
 });

--- a/src/compiler/transformers/test/convert-decorators.spec.ts
+++ b/src/compiler/transformers/test/convert-decorators.spec.ts
@@ -334,17 +334,23 @@ describe('convert-decorators', () => {
   });
 
   describe('filterDecorators', () => {
-    it('returns undefined when no decorators are provided', () => {
-      const filteredDecorators = filterDecorators(undefined, []);
+    it.each<ReadonlyArray<ReadonlyArray<string>>>([[[]], [['ExcludedDecorator']]])(
+      'returns undefined when no decorators are provided',
+      (excludeList: ReadonlyArray<string>) => {
+        const filteredDecorators = filterDecorators(undefined, excludeList);
 
-      expect(filteredDecorators).toBeUndefined();
-    });
+        expect(filteredDecorators).toBeUndefined();
+      }
+    );
 
-    it('returns undefined for an empty list of decorators', () => {
-      const filteredDecorators = filterDecorators([], []);
+    it.each<ReadonlyArray<ReadonlyArray<string>>>([[[]], [['ExcludedDecorator']]])(
+      'returns undefined for an empty list of decorators',
+      (excludeList: ReadonlyArray<string>) => {
+        const filteredDecorators = filterDecorators([], excludeList);
 
-      expect(filteredDecorators).toBeUndefined();
-    });
+        expect(filteredDecorators).toBeUndefined();
+      }
+    );
 
     it('returns a decorator if it is not a call expression', () => {
       // create a decorator, '@Decorator'. note the lack of '()' after the decorator, making it an identifier

--- a/src/compiler/transformers/test/transform-utils.spec.ts
+++ b/src/compiler/transformers/test/transform-utils.spec.ts
@@ -1,8 +1,14 @@
 import * as ts from 'typescript';
 
-import { isMemberPrivate, mapJSDocTagInfo } from '../transform-utils';
+import {
+  isMemberPrivate,
+  mapJSDocTagInfo,
+  retrieveModifierLike,
+  retrieveTsDecorators,
+  retrieveTsModifiers,
+} from '../transform-utils';
 
-describe('transform utils', () => {
+describe('transform-utils', () => {
   it('flattens TypeScript JSDocTagInfo to Stencil JSDocTagInfo', () => {
     // tags corresponds to the following JSDoc
     /*
@@ -41,43 +47,43 @@ describe('transform utils', () => {
     ]);
   });
 
-  describe('isMemberPrivate', () => {
-    /**
-     * Helper method for creating an empty method named 'myMethod' with the provided modifier's.
-     *
-     * @example
-     * // By default, no modifier will be applied, and the following will be returned:
-     * createMemberWithModifier(); // myMethod() {}
-     *
-     * // Otherwise, the provided modifier will be applied to the method:
-     * createMemberWithModifier(ts.factory.createModifier(ts.SyntaxKind.PrivateKeyword)); // private myMethod() {}
-     *
-     * @param modifier the modifier to apply to the method. Defaults to applying no modifier if none is provided
-     * @returns a new empty method
-     */
-    const createMemberWithModifier = (modifier: ts.Modifier | undefined = undefined): ts.MethodDeclaration => {
-      const modifiers = modifier ? [modifier] : [];
-      return ts.factory.createMethodDeclaration(
-        undefined,
-        modifiers,
-        undefined,
-        ts.factory.createIdentifier('myMethod'),
-        undefined,
-        undefined,
-        [],
-        undefined,
-        ts.factory.createBlock([], false)
-      );
-    };
+  /**
+   * Helper method for creating an empty method named 'myMethod' with the provided modifiers.
+   *
+   * @example
+   * // By default, no modifiers will be applied, and the following will be returned:
+   * createMemberWithModifiers(); // myMethod() {}
+   *
+   * // Otherwise, the provided modifiers will be applied to the method:
+   * createMemberWithModifiers([ts.factory.createModifier(ts.SyntaxKind.PrivateKeyword)]); // private myMethod() {}
+   *
+   * @param modifiers the modifiers to apply to the method. Defaults to applying no modifiers if none are provided
+   * @returns a new empty method
+   */
+  const createMemberWithModifiers = (
+    modifiers: ReadonlyArray<ts.ModifierLike> | undefined = undefined
+  ): ts.MethodDeclaration => {
+    return ts.factory.createMethodDeclaration(
+      modifiers,
+      undefined,
+      ts.factory.createIdentifier('myMethod'),
+      undefined,
+      undefined,
+      [],
+      undefined,
+      ts.factory.createBlock([], false)
+    );
+  };
 
+  describe('isMemberPrivate', () => {
     it('returns false when the member has no modifiers', () => {
-      const methodDeclaration = createMemberWithModifier();
+      const methodDeclaration = createMemberWithModifiers();
 
       expect(isMemberPrivate(methodDeclaration)).toBe(false);
     });
 
     it('returns false when the member has a non-private modifier', () => {
-      const methodDeclaration = createMemberWithModifier(ts.factory.createModifier(ts.SyntaxKind.PublicKeyword));
+      const methodDeclaration = createMemberWithModifiers([ts.factory.createModifier(ts.SyntaxKind.PublicKeyword)]);
 
       expect(isMemberPrivate(methodDeclaration)).toBe(false);
     });
@@ -86,9 +92,112 @@ describe('transform utils', () => {
       ['private', ts.SyntaxKind.PrivateKeyword],
       ['protected', ts.SyntaxKind.ProtectedKeyword],
     ])('returns true when the member has a (%s) modifier', (_name, modifier) => {
-      const methodDeclaration = createMemberWithModifier(ts.factory.createModifier(modifier));
+      const methodDeclaration = createMemberWithModifiers([ts.factory.createModifier(modifier)]);
 
       expect(isMemberPrivate(methodDeclaration)).toBe(true);
+    });
+  });
+
+  describe('retrieveModifierLike', () => {
+    it("returns an empty array when no ModifierLike's are present", () => {
+      const methodDeclaration = createMemberWithModifiers();
+
+      expect(retrieveModifierLike(methodDeclaration)).toEqual([]);
+    });
+
+    it('returns all decorators and modifiers on a node', () => {
+      const privateModifier = ts.factory.createModifier(ts.SyntaxKind.PrivateKeyword);
+      const nonSenseDecorator = ts.factory.createDecorator(ts.factory.createStringLiteral('NonSenseDecorator'));
+
+      const methodDeclaration = createMemberWithModifiers([privateModifier, nonSenseDecorator]);
+      const modifierLikes = retrieveModifierLike(methodDeclaration);
+
+      expect(modifierLikes).toHaveLength(2);
+      expect(modifierLikes).toContain(privateModifier);
+      expect(modifierLikes).toContain(nonSenseDecorator);
+    });
+  });
+
+  describe('retrieveTsDecorators', () => {
+    it('returns undefined when a node cannot have decorators', () => {
+      const node = ts.factory.createNumericLiteral(123);
+
+      const decorators = retrieveTsDecorators(node);
+
+      expect(decorators).toEqual(undefined);
+    });
+
+    it('returns undefined when a node has undefined decorators', () => {
+      // create a class declaration with name 'MyClass' and no decorators
+      const node = ts.factory.createClassDeclaration(undefined, 'MyClass', undefined, undefined, []);
+
+      const decorators = retrieveTsDecorators(node);
+
+      expect(decorators).toEqual(undefined);
+    });
+
+    it('returns undefined when a node has no decorators', () => {
+      // create a class declaration with name 'MyClass' and no decorators
+      const node = ts.factory.createClassDeclaration([], 'MyClass', undefined, undefined, []);
+
+      const decorators = retrieveTsDecorators(node);
+
+      expect(decorators).toEqual(undefined);
+    });
+
+    it("returns a node's decorators", () => {
+      const initialDecorators = [
+        // no-op decorator, but it's good enough for testing purposes
+        ts.factory.createDecorator(ts.factory.createStringLiteral('NonSenseDecorator')),
+      ];
+
+      // create a class declaration with name 'MyClass' and a decorator
+      const node = ts.factory.createClassDeclaration(initialDecorators, 'MyClass', undefined, undefined, []);
+
+      const decorators = retrieveTsDecorators(node);
+
+      expect(decorators).toHaveLength(1);
+      expect(decorators![0]).toEqual(initialDecorators[0]);
+    });
+  });
+
+  describe('retrieveTsModifiers', () => {
+    it('returns undefined when a node cannot have modifiers', () => {
+      const node = ts.factory.createNumericLiteral(123);
+
+      const modifiers = retrieveTsModifiers(node);
+
+      expect(modifiers).toEqual(undefined);
+    });
+
+    it('returns undefined when a node has undefined modifiers', () => {
+      // create a class declaration with name 'MyClass' and no modifiers
+      const node = ts.factory.createClassDeclaration(undefined, 'MyClass', undefined, undefined, []);
+
+      const modifiers = retrieveTsModifiers(node);
+
+      expect(modifiers).toEqual(undefined);
+    });
+
+    it('returns undefined when a node has no modifiers', () => {
+      // create a class declaration with name 'MyClass' and no modifiers
+      const node = ts.factory.createClassDeclaration([], 'MyClass', undefined, undefined, []);
+
+      const modifiers = retrieveTsModifiers(node);
+
+      expect(modifiers).toEqual(undefined);
+    });
+
+    it("returns a node's modifiers", () => {
+      const initialModifiers = [ts.factory.createModifier(ts.SyntaxKind.AbstractKeyword)];
+
+      // create a class declaration with name 'MyClass' and a 'abstract' modifier
+      const node = ts.factory.createClassDeclaration(initialModifiers, 'MyClass', undefined, undefined, []);
+
+      const modifiers = retrieveTsModifiers(node);
+
+      expect(modifiers).toHaveLength(1);
+      expect(modifiers![0]).toEqual(initialModifiers[0]);
     });
   });
 });

--- a/src/compiler/transformers/update-stencil-core-import.ts
+++ b/src/compiler/transformers/update-stencil-core-import.ts
@@ -29,7 +29,6 @@ export const updateStencilCoreImports = (updatedCoreImportPath: string): ts.Tran
                   const newImport = ts.factory.updateImportDeclaration(
                     s,
                     undefined,
-                    undefined,
                     ts.factory.createImportClause(
                       false,
                       undefined,

--- a/src/testing/puppeteer/puppeteer-element.ts
+++ b/src/testing/puppeteer/puppeteer-element.ts
@@ -472,12 +472,15 @@ export class E2EElement extends MockHTMLElement implements pd.E2EElementInternal
   async e2eSync() {
     const executionContext = this._elmHandle.executionContext();
 
-    const { outerHTML, shadowRootHTML } = await executionContext.evaluate((elm: HTMLElement) => {
-      return {
-        outerHTML: elm.outerHTML,
-        shadowRootHTML: elm.shadowRoot ? elm.shadowRoot.innerHTML : null,
-      };
-    }, this._elmHandle);
+    const { outerHTML, shadowRootHTML } = await executionContext.evaluate<{ outerHTML: any; shadowRootHTML: any }>(
+      (elm: HTMLElement) => {
+        return {
+          outerHTML: elm.outerHTML,
+          shadowRootHTML: elm.shadowRoot ? elm.shadowRoot.innerHTML : null,
+        };
+      },
+      this._elmHandle
+    );
 
     if (typeof shadowRootHTML === 'string') {
       (this as any).shadowRoot = parseHtmlToFragment(shadowRootHTML) as any;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->
## Note

- [X] Please review/land https://github.com/ionic-team/stencil/pull/3835 first
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
    - See https://github.com/ionic-team/stencil-site/pull/934
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Stencil uses up to and through TypeScript v4.7.4

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this pr updates typescript for stencil to v4.8.4. it leverages the work done
in [#3748](https://github.com/ionic-team/stencil/pull/3748) (a043e5d) in order to facilitate the
creation of nodes in the syntax tree that contain `ModifierLike` entities.
it also leverages the work from [#3835](https://github.com/ionic-team/stencil/pull/3835) in order
to provide testing to a more fickle aspect of the codebase.

starting with typescript 4.8, decorators are not longer directly accessible on a
syntax tree node. this is a result of the decorators proposal reaching stage 3, and
soon to be implemented by the typescript team. in order to prepare for the
implementation, where decorators are stored has changed. more information on
this change can be found in https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#decorators-are-placed-on-modifiers-on-typescripts-syntax-trees.

in order for decorators to be retrieved, typescript provides a series of helper
functions to retrieve both decorators and modifiers off of a node. this pr
introduces helper methods of our own that abstract over typescript's own. this
is done to reduce some of the verbosity in attempting to retrieve decorators/modifiers
off of a node. these functions return either the found decorators/modifiers on a node,
`undefined` if the node can have a decorator/modifier but does not have any, or
`undefined` if the node cannot have a decorator/modifier on it. this is an intentional
design decision, as opposed to returning an empty array in place of `undefined` for the
latter two cases. The reason for which is that there are cases in Stencil where an empty 
array and undefined have specific meaning that i did not feel was worth the 
additional effort in the context of this effort

with typescript 4.8, several node factory methods no longer accept an
explicit argument for decorators. instead, the parameters for decorators and
modifiers have been coalesced into a single parameter of type `ModifierLike[]`.
as a result, many calls to these factory functions with an argument of `undefined`
for decorators have been updated to reflect this change

## Does this introduce a breaking change?

- [ ] Yes
- [x] No - Updates to TypeScript always introduce the possibility of upgrade pains. This may land and be released in a minor version of Stencil, in adherence to our [Versioning Policy](https://stenciljs.com/docs/versioning)

> A minor release will be published when a new feature is added or API changes that are non-breaking are introduced. We will heavily test any changes so that we are confident with the release, but with new code comes the potential for new issues. ...
> * This statement applies to the Stencil team upgrading its version of TypeScript as well. For more information, please see the team's [support policy regarding TypeScript](https://stenciljs.com/docs/support-policy#typescript-support)

and our [support policy regarding TypeScript](https://stenciljs.com/docs/support-policy#typescript-support)
> The Stencil team acknowledges that TypeScript minor version releases may contain breaking changes. The Stencil team will do everything in its power to avoid propagating breaking changes to its user base.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
This commit is best tested in a real project, such as the Ionic Framework. To do so, first build this branch:
```sh
npm run clean && \
npm ci && \
npm run build && \
npm pack
```
which ought to result in a tarball (which will be the last line of the output)

Next, pull down the Framework repository, install this branch in the core package, build and test:
```sh
cd code && \
npm i [TARBALL] --force && \
npm ci --force && \
npm run build && \
npm t
```

Next, we can look at components on an individual basis, by running a dev server from `core/`:
```sh
npm start
```

Navigate to `src/components` in the browser window that pops up. For each component dir (most of them) there's a `test` sub directory that can be entered to smoke test components
## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

- #3748 was a pre-requisite to this PR. That changeset is required for this one to work properly (both at compile and run time) 
- I've added PR comments to call out all the changed fn signatures. I tried not to duplicate ones already called out (but I think one or two slipped through)