### PR TITLE
fix(cli): refactor CLI argument parser

### DIFF
--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -1,20 +1,17 @@
-import { dashToPascalCase, readOnlyArrayHasStringMember, toDashCase } from '@utils';
+import { readOnlyArrayHasStringMember, toCamelCase } from '@utils';
 
 import { CompilerSystem, LOG_LEVELS, LogLevel, TaskCommand } from '../declarations';
 import {
-  BOOLEAN_CLI_ARGS,
-  BooleanCLIArg,
-  CLI_ARG_ALIASES,
+  BOOLEAN_CLI_FLAGS,
+  CLI_FLAG_ALIASES,
+  CLI_FLAG_REGEX,
   ConfigFlags,
   createConfigFlags,
-  LOG_LEVEL_CLI_ARGS,
-  LogCLIArg,
-  NUMBER_CLI_ARGS,
-  NumberCLIArg,
-  STRING_CLI_ARGS,
-  STRING_NUMBER_CLI_ARGS,
-  StringCLIArg,
-  StringNumberCLIArg,
+  LOG_LEVEL_CLI_FLAGS,
+  NUMBER_CLI_FLAGS,
+  STRING_ARRAY_CLI_FLAGS,
+  STRING_CLI_FLAGS,
+  STRING_NUMBER_CLI_FLAGS,
 } from './config-flags';
 
 /**
@@ -32,8 +29,13 @@ export const parseFlags = (args: string[], _sys?: CompilerSystem): ConfigFlags =
   flags.args = Array.isArray(args) ? args.slice() : [];
   if (flags.args.length > 0 && flags.args[0] && !flags.args[0].startsWith('-')) {
     flags.task = flags.args[0] as TaskCommand;
+    // if the first argument was a "task" (like `build`, `test`, etc) then
+    // we go on to parse the _rest_ of the CLI args
+    parseArgs(flags, args.slice(1));
+  } else {
+    // we didn't find a leading flag, so we should just parse them all
+    parseArgs(flags, flags.args);
   }
-  parseArgs(flags, flags.args);
 
   if (flags.task != null) {
     const i = flags.args.indexOf(flags.task);
@@ -54,131 +56,272 @@ export const parseFlags = (args: string[], _sys?: CompilerSystem): ConfigFlags =
 };
 
 /**
- * Parse command line arguments that are enumerated in the `config-flags`
- * module. Handles leading dashes on arguments, aliases that are defined for a
- * small number of arguments, and parsing values for non-boolean arguments
- * (e.g. port number for the dev server).
+ * Parse the supported command line flags which are enumerated in the
+ * `config-flags` module. Handles leading dashes on arguments, aliases that are
+ * defined for a small number of arguments, and parsing values for non-boolean
+ * arguments (e.g. port number for the dev server).
+ *
+ * This parses the following grammar:
+ *
+ * CLIArguments    → ""
+ *                 | CLITerm ( " " CLITerm )* ;
+ * CLITerm         → EqualsArg
+ *                 | AliasEqualsArg
+ *                 | AliasArg
+ *                 | NegativeDashArg
+ *                 | NegativeArg
+ *                 | SimpleArg ;
+ * EqualsArg       → "--" ArgName "=" CLIValue ;
+ * AliasEqualsArg  → "-" AliasName "=" CLIValue ;
+ * AliasArg        → "-" AliasName ( " " CLIValue )? ;
+ * NegativeDashArg → "--no-" ArgName ;
+ * NegativeArg     → "--no" ArgName ;
+ * SimpleArg       → "--" ArgName ( " " CLIValue )? ;
+ * ArgName         → /^[a-zA-Z-]+$/ ;
+ * AliasName       → /^[a-z]{1}$/ ;
+ * CLIValue        → '"' /^[a-zA-Z0-9]+$/ '"'
+ *                 | /^[a-zA-Z0-9]+$/ ;
+ *
+ * There are additional constraints (not shown in the grammar for brevity's sake)
+ * on the type of `CLIValue` which will be associated with a particular argument.
+ * We enforce this by declaring lists of boolean, string, etc arguments and
+ * checking the types of values before setting them.
+ *
+ * We don't need to turn the list of CLI arg tokens into any kind of
+ * intermediate representation since we aren't concerned with doing anything
+ * other than setting the correct values on our ConfigFlags object. So we just
+ * parse the array of string arguments using a recursive-descent approach
+ * (which is not very deep since our grammar is pretty simple) and make the
+ * modifications we need to make to the {@link ConfigFlags} object as we go.
  *
  * @param flags a ConfigFlags object to which parsed arguments will be added
  * @param args  an array of command-line arguments to parse
  */
 const parseArgs = (flags: ConfigFlags, args: string[]) => {
-  BOOLEAN_CLI_ARGS.forEach((argName) => parseBooleanArg(flags, args, argName));
-  STRING_CLI_ARGS.forEach((argName) => parseStringArg(flags, args, argName));
-  NUMBER_CLI_ARGS.forEach((argName) => parseNumberArg(flags, args, argName));
-  STRING_NUMBER_CLI_ARGS.forEach((argName) => parseStringNumberArg(flags, args, argName));
-  LOG_LEVEL_CLI_ARGS.forEach((argName) => parseLogLevelArg(flags, args, argName));
-};
-
-/**
- * Parse a boolean CLI argument. For these, we support the following formats:
- *
- * - `--booleanArg`
- * - `--boolean-arg`
- * - `--noBooleanArg`
- * - `--no-boolean-arg`
- *
- * The final two variants should be parsed to a value of `false` on the config
- * object.
- *
- * @param flags the config flags object, while we'll modify
- * @param args our CLI arguments
- * @param configCaseName the argument we want to look at right now
- */
-const parseBooleanArg = (flags: ConfigFlags, args: string[], configCaseName: BooleanCLIArg) => {
-  // we support both dash-case and PascalCase versions of the parameter
-  // argName is 'configCase' version which can be found in BOOLEAN_ARG_OPTS
-  const alias = CLI_ARG_ALIASES[configCaseName];
-  const dashCaseName = toDashCase(configCaseName);
-
-  if (typeof flags[configCaseName] !== 'boolean') {
-    flags[configCaseName] = null;
-  }
-
-  args.forEach((cmdArg) => {
-    let value;
-
-    if (cmdArg === `--${configCaseName}` || cmdArg === `--${dashCaseName}`) {
-      value = true;
-    } else if (cmdArg === `--no-${dashCaseName}` || cmdArg === `--no${dashToPascalCase(dashCaseName)}`) {
-      value = false;
-    } else if (alias && cmdArg === `-${alias}`) {
-      value = true;
-    }
-
-    if (value !== undefined && cmdArg !== undefined) {
-      flags[configCaseName] = value;
-      flags.knownArgs.push(cmdArg);
-    }
-  });
-};
-
-/**
- * Parse a string CLI argument
- *
- * @param flags the config flags object, while we'll modify
- * @param args our CLI arguments
- * @param configCaseName the argument we want to look at right now
- */
-const parseStringArg = (flags: ConfigFlags, args: string[], configCaseName: StringCLIArg) => {
-  if (typeof flags[configCaseName] !== 'string') {
-    flags[configCaseName] = null;
-  }
-
-  const { value, matchingArg } = getValue(args, configCaseName);
-
-  if (value !== undefined && matchingArg !== undefined) {
-    flags[configCaseName] = value;
-    flags.knownArgs.push(matchingArg);
-    flags.knownArgs.push(value);
+  const argsCopy = args.concat();
+  while (argsCopy.length > 0) {
+    // there are still unprocessed args to deal with
+    parseCLITerm(flags, argsCopy);
   }
 };
 
 /**
- * Parse a number CLI argument
+ * Given an array of CLI arguments, parse it and perform a series of side
+ * effects (setting values on the provided `ConfigFlags` object).
  *
- * @param flags the config flags object, while we'll modify
- * @param args our CLI arguments
- * @param configCaseName the argument we want to look at right now
+ * @param flags a {@link ConfigFlags} object which is updated as we parse the CLI
+ * arguments
+ * @param args a list of args to work through. This function (and some functions
+ * it calls) calls `Array.prototype.shift` to get the next argument to look at,
+ * so this parameter will be modified.
  */
-const parseNumberArg = (flags: ConfigFlags, args: string[], configCaseName: NumberCLIArg) => {
-  if (typeof flags[configCaseName] !== 'number') {
-    flags[configCaseName] = null;
+const parseCLITerm = (flags: ConfigFlags, args: string[]) => {
+  // pull off the first arg from the argument array
+  const arg = args.shift();
+
+  // array is empty, we're done!
+  if (arg === undefined) return;
+
+  // EqualsArg → "--" ArgName "=" CLIValue ;
+  if (arg.startsWith('--') && arg.includes('=')) {
+    // we're dealing with an EqualsArg, we have a special helper for that
+    const [originalArg, value] = parseEqualsArg(arg);
+    setCLIArg(flags, arg.split('=')[0], normalizeFlagName(originalArg), value);
   }
 
-  const { value, matchingArg } = getValue(args, configCaseName);
-
-  if (value !== undefined && matchingArg !== undefined) {
-    flags[configCaseName] = parseInt(value, 10);
-    flags.knownArgs.push(matchingArg);
-    flags.knownArgs.push(value);
+  // AliasEqualsArg  → "-" AliasName "=" CLIValue ;
+  else if (arg.startsWith('-') && arg.includes('=')) {
+    // we're dealing with an AliasEqualsArg, we have a special helper for that
+    const [originalArg, value] = parseEqualsArg(arg);
+    setCLIArg(flags, arg.split('=')[0], normalizeFlagName(originalArg), value);
   }
+
+  // AliasArg → "-" AliasName ( " " CLIValue )? ;
+  else if (CLI_FLAG_REGEX.test(arg)) {
+    // this is a short alias, like `-c` for Config
+    setCLIArg(flags, arg, normalizeFlagName(arg), parseCLIValue(args));
+  }
+
+  // NegativeDashArg → "--no-" ArgName ;
+  else if (arg.startsWith('--no-') && arg.length > '--no-'.length) {
+    // this is a `NegativeDashArg` term, so we need to normalize the negative
+    // flag name and then set an appropriate value
+    const normalized = normalizeNegativeFlagName(arg);
+    setCLIArg(flags, arg, normalized, '');
+  }
+
+  // NegativeArg → "--no" ArgName ;
+  else if (
+    arg.startsWith('--no') &&
+    !readOnlyArrayHasStringMember(BOOLEAN_CLI_FLAGS, normalizeFlagName(arg)) &&
+    readOnlyArrayHasStringMember(BOOLEAN_CLI_FLAGS, normalizeNegativeFlagName(arg))
+  ) {
+    // possibly dealing with a `NegativeArg` here. There is a little ambiguity
+    // here because we have arguments that already begin with `no` like
+    // `notify`, so we need to test if a normalized form of the raw argument is
+    // a valid and supported boolean flag.
+    setCLIArg(flags, arg, normalizeNegativeFlagName(arg), '');
+  }
+
+  // SimpleArg → "--" ArgName ( " " CLIValue )? ;
+  else if (arg.startsWith('--') && arg.length > '--'.length) {
+    setCLIArg(flags, arg, normalizeFlagName(arg), parseCLIValue(args));
+  }
+
+  // if we get here it is not an argument in our list of supported arguments.
+  // This doesn't necessarily mean we want to report an error or anything
+  // though! Instead, with unknown / unrecognized arguments we stick them into
+  // the `unknownArgs` array, which is used when we pass CLI args to Jest, for
+  // instance. So we just return void here.
 };
 
 /**
- * Parse a CLI argument which may be either a string or a number
+ * Normalize a 'negative' flag name, just to do a little pre-processing before
+ * we pass it to `setCLIArg`.
  *
- * @param flags the config flags object, while we'll modify
- * @param args our CLI arguments
- * @param configCaseName the argument we want to look at right now
+ * @param flagName the flag name to normalize
+ * @returns a normalized flag name
  */
-const parseStringNumberArg = (flags: ConfigFlags, args: string[], configCaseName: StringNumberCLIArg) => {
-  if (!['number', 'string'].includes(typeof flags[configCaseName])) {
-    flags[configCaseName] = null;
+const normalizeNegativeFlagName = (flagName: string): string => {
+  const trimmed = flagName.replace(/^--no[-]?/, '');
+  return normalizeFlagName(trimmed.charAt(0).toLowerCase() + trimmed.slice(1));
+};
+
+/**
+ * Normalize a flag name by:
+ *
+ * - replacing any leading dashes (`--foo` -> `foo`)
+ * - converting `dash-case` to camelCase (if necessary)
+ *
+ * Normalizing in this context basically means converting the various
+ * supported flag spelling variants to the variant defined in our lists of
+ * supported arguments (e.g. BOOLEAN_CLI_FLAGS, etc). So, for instance,
+ * `--log-level` should be converted to `logLevel`.
+ *
+ * @param flagName the flag name to normalize
+ * @returns a normalized flag name
+ *
+ */
+const normalizeFlagName = (flagName: string): string => {
+  const trimmed = flagName.replace(/^-+/, '');
+  return trimmed.includes('-') ? toCamelCase(trimmed) : trimmed;
+};
+
+/**
+ * Set a value on a provided {@link ConfigFlags} object, given an argument
+ * name and a raw string value. This function dispatches to other functions
+ * which make sure that the string value can be properly parsed into a JS
+ * runtime value of the right type (e.g. number, string, etc).
+ *
+ * @throws if a value cannot be parsed to the right type for a given flag
+ * @param flags a {@link ConfigFlags} object
+ * @param rawArg the raw argument name matched by the parser
+ * @param normalizedArg an argument with leading control characters (`--`,
+ * `--no-`, etc) removed
+ * @param value the raw value to be set onto the config flags object
+ */
+const setCLIArg = (flags: ConfigFlags, rawArg: string, normalizedArg: string, value: CLIValueResult) => {
+  normalizedArg = dereferenceAlias(normalizedArg);
+
+  // We're setting a boolean!
+  if (readOnlyArrayHasStringMember(BOOLEAN_CLI_FLAGS, normalizedArg)) {
+    flags[normalizedArg] =
+      typeof value === 'string'
+        ? Boolean(value)
+        : // no value was supplied, default to true
+          true;
+    flags.knownArgs.push(rawArg);
   }
 
-  const { value, matchingArg } = getValue(args, configCaseName);
-
-  if (value !== undefined && matchingArg !== undefined) {
-    if (CLI_ARG_STRING_REGEX.test(value)) {
-      // if it matches the regex we treat it like a string
-      flags[configCaseName] = value;
+  // We're setting a string!
+  else if (readOnlyArrayHasStringMember(STRING_CLI_FLAGS, normalizedArg)) {
+    if (typeof value === 'string') {
+      flags[normalizedArg] = value;
+      flags.knownArgs.push(rawArg);
+      flags.knownArgs.push(value);
     } else {
-      // it was a number, great!
-      flags[configCaseName] = Number(value);
+      throwCLIParsingError(rawArg, 'expected a string argument but received nothing');
     }
-    flags.knownArgs.push(matchingArg);
-    flags.knownArgs.push(value);
+  }
+
+  // We're setting a string, but it's one where the user can pass multiple values,
+  // like `--reporters="default" --reporters="jest-junit"`
+  else if (readOnlyArrayHasStringMember(STRING_ARRAY_CLI_FLAGS, normalizedArg)) {
+    if (typeof value === 'string') {
+      if (!Array.isArray(flags[normalizedArg])) {
+        flags[normalizedArg] = [];
+      }
+
+      const targetArray = flags[normalizedArg];
+      // this is irritating, but TS doesn't know that the `!Array.isArray`
+      // check above guarantees we have an array to work with here, and it
+      // doesn't want to narrow the type of `flags[normalizedArg]`, so we need
+      // to grab a reference to that array and then `Array.isArray` that. Bah!
+      if (Array.isArray(targetArray)) {
+        targetArray.push(value);
+        flags.knownArgs.push(rawArg);
+        flags.knownArgs.push(value);
+      }
+    } else {
+      throwCLIParsingError(rawArg, 'expected a string argument but received nothing');
+    }
+  }
+
+  // We're setting a number!
+  else if (readOnlyArrayHasStringMember(NUMBER_CLI_FLAGS, normalizedArg)) {
+    if (typeof value === 'string') {
+      const parsed = parseInt(value, 10);
+
+      if (isNaN(parsed)) {
+        throwNumberParsingError(rawArg, value);
+      } else {
+        flags[normalizedArg] = parsed;
+        flags.knownArgs.push(rawArg);
+        flags.knownArgs.push(value);
+      }
+    } else {
+      throwCLIParsingError(rawArg, 'expected a number argument but received nothing');
+    }
+  }
+
+  // We're setting a value which could be either a string _or_ a number
+  else if (readOnlyArrayHasStringMember(STRING_NUMBER_CLI_FLAGS, normalizedArg)) {
+    if (typeof value === 'string') {
+      if (CLI_ARG_STRING_REGEX.test(value)) {
+        // if it matches the regex we treat it like a string
+        flags[normalizedArg] = value;
+      } else {
+        const parsed = Number(value);
+
+        if (isNaN(parsed)) {
+          // parsing didn't go so well, we gotta get out of here
+          // this is unlikely given our regex guard above
+          // but hey, this is ultimately JS so let's be safe
+          throwNumberParsingError(rawArg, value);
+        } else {
+          flags[normalizedArg] = parsed;
+        }
+      }
+      flags.knownArgs.push(rawArg);
+      flags.knownArgs.push(value);
+    } else {
+      throwCLIParsingError(rawArg, 'expected a string or a number but received nothing');
+    }
+  }
+
+  // We're setting the log level, which can only be a set of specific string values
+  else if (readOnlyArrayHasStringMember(LOG_LEVEL_CLI_FLAGS, normalizedArg)) {
+    if (typeof value === 'string') {
+      if (isLogLevel(value)) {
+        flags[normalizedArg] = value;
+        flags.knownArgs.push(rawArg);
+        flags.knownArgs.push(value);
+      } else {
+        throwCLIParsingError(rawArg, `expected to receive a valid log level but received "${String(value)}"`);
+      }
+    } else {
+      throwCLIParsingError(rawArg, 'expected to receive a valid log level but received nothing');
+    }
   }
 };
 
@@ -201,86 +344,44 @@ const parseStringNumberArg = (flags: ConfigFlags, args: string[], configCaseName
  */
 const CLI_ARG_STRING_REGEX = /[^\d\.Ee\+\-]+/g;
 
-/**
- * Parse a LogLevel CLI argument. These can be only a specific
- * set of strings, so this function takes care of validating that
- * the value is correct.
- *
- * @param flags the config flags object, while we'll modify
- * @param args our CLI arguments
- * @param configCaseName the argument we want to look at right now
- */
-const parseLogLevelArg = (flags: ConfigFlags, args: string[], configCaseName: LogCLIArg) => {
-  if (typeof flags[configCaseName] !== 'string') {
-    flags[configCaseName] = null;
-  }
-
-  const { value, matchingArg } = getValue(args, configCaseName);
-
-  if (value !== undefined && matchingArg !== undefined && isLogLevel(value)) {
-    flags[configCaseName] = value;
-    flags.knownArgs.push(matchingArg);
-    flags.knownArgs.push(value);
-  }
-};
+export const Empty = Symbol('Empty');
 
 /**
- * Helper for pulling values out from the raw array of CLI arguments. This logic
- * is shared between a few different types of CLI args.
- *
- * We look for arguments in the following formats:
- *
- * - `--my-cli-argument value`
- * - `--my-cli-argument=value`
- * - `--myCliArgument value`
- * - `--myCliArgument=value`
- *
- * We also check for shortened aliases, which we define for a few arguments.
- *
- * @param args the CLI args we're dealing with
- * @param configCaseName the ConfigFlag key which we're looking to pull out a value for
- * @returns the value for the flag as well as the exact string which it matched from
- * the user input.
+ * The result of trying to parse a CLI arg. This will be a `string` if a
+ * well-formed value is present, or `Empty` to indicate that nothing was matched
+ * or that the input was malformed.
  */
-const getValue = (
-  args: string[],
-  configCaseName: StringCLIArg | NumberCLIArg | StringNumberCLIArg | LogCLIArg
-): CLIArgValue => {
-  // for some CLI args we have a short alias, like 'c' for 'config'
-  const alias = CLI_ARG_ALIASES[configCaseName];
-  // we support supplying arguments in both dash-case and configCase
-  // for ease of use
-  const dashCaseName = toDashCase(configCaseName);
+type CLIValueResult = string | typeof Empty;
 
-  let value: string | undefined;
-  let matchingArg: string | undefined;
+/**
+ * A little helper which tries to parse a CLI value (as opposed to a flag) off
+ * of the argument array.
+ *
+ * We support a variety of different argument formats, but all of them start
+ * with `-`, so we can check the first character to test whether the next token
+ * in our array of CLI arguments is a flag name or a value.
+ *
+ * @param args an array of CLI args
+ * @returns either a string result or an Empty sentinel
+ */
+const parseCLIValue = (args: string[]): CLIValueResult => {
+  // it's possible the arguments array is empty, if so, return empty
+  if (args[0] === undefined) {
+    return Empty;
+  }
 
-  args.forEach((arg, i) => {
-    if (arg.startsWith(`--${dashCaseName}=`) || arg.startsWith(`--${configCaseName}=`)) {
-      // our argument was passed at the command-line in the format --argName=arg-value
-      [matchingArg, value] = parseEqualsArg(arg);
-    } else if (arg === `--${dashCaseName}` || arg === `--${configCaseName}`) {
-      // the next value in the array is assumed to be a value for this argument
-      value = args[i + 1];
-      matchingArg = arg;
-    } else if (alias) {
-      if (arg.startsWith(`-${alias}=`)) {
-        [matchingArg, value] = parseEqualsArg(arg);
-      } else if (arg === `-${alias}`) {
-        value = args[i + 1];
-        matchingArg = arg;
-      }
+  // all we're concerned with here is that it does not start with `"-"`,
+  // which would indicate it should be parsed as a CLI flag and not a value.
+  if (!args[0].startsWith('-')) {
+    // It's not a flag, so we return the value and defer any specific parsing
+    // until later on.
+    const value = args.shift();
+    if (typeof value === 'string') {
+      return value;
     }
-  });
-  return { value, matchingArg };
+  }
+  return Empty;
 };
-
-interface CLIArgValue {
-  // the concrete value pulled from the CLI args
-  value: string;
-  // the matching argument key
-  matchingArg: string;
-}
 
 /**
  * Parse an 'equals' argument, which is a CLI argument-value pair in the
@@ -315,10 +416,11 @@ interface CLIArgValue {
  * @param arg the arg in question
  * @returns a tuple containing the arg name and the value (if present)
  */
-export const parseEqualsArg = (arg: string): [string, string] => {
-  const [originalArg, ...value] = arg.split('=');
+export const parseEqualsArg = (arg: string): [string, CLIValueResult] => {
+  const [originalArg, ...splitSections] = arg.split('=');
+  const value = splitSections.join('=');
 
-  return [originalArg, value.join('=')];
+  return [originalArg, value === '' ? Empty : value];
 };
 
 /**
@@ -330,3 +432,46 @@ export const parseEqualsArg = (arg: string): [string, string] => {
  */
 const isLogLevel = (maybeLogLevel: string): maybeLogLevel is LogLevel =>
   readOnlyArrayHasStringMember(LOG_LEVELS, maybeLogLevel);
+
+/**
+ * A little helper for constructing and throwing an error message with info
+ * about what went wrong
+ *
+ * @param flag the flag which encountered the error
+ * @param message a message specific to the error which was encountered
+ */
+const throwCLIParsingError = (flag: string, message: string) => {
+  throw new Error(`when parsing CLI flag "${flag}": ${message}`);
+};
+
+/**
+ * Throw a specific error for the situation where we ran into an issue parsing
+ * a number.
+ *
+ * @param flag the flag for which we encountered the issue
+ * @param value what we were trying to parse
+ */
+const throwNumberParsingError = (flag: string, value: string) => {
+  throwCLIParsingError(flag, `expected a number but received "${value}"`);
+};
+
+/**
+ * A little helper to 'dereference' a flag alias, which if you squint a little
+ * you can think of like a pointer to a full flag name. Thus 'c' is like a
+ * pointer to 'config', so here we're doing something like `*c`. Of course, this
+ * being JS, this is just a metaphor!
+ *
+ * If no 'dereference' is found for the possible alias we just return the
+ * passed string unmodified.
+ *
+ * @param maybeAlias a string which _could_ be an alias to a full flag name
+ * @returns the full aliased flag name, if found, or the passed string if not
+ */
+const dereferenceAlias = (maybeAlias: string): string => {
+  const possibleDereference = CLI_FLAG_ALIASES[maybeAlias];
+
+  if (typeof possibleDereference === 'string') {
+    return possibleDereference;
+  }
+  return maybeAlias;
+};

--- a/src/cli/test/parse-flags.spec.ts
+++ b/src/cli/test/parse-flags.spec.ts
@@ -1,8 +1,14 @@
 import { toDashCase } from '@utils';
 
 import { LogLevel } from '../../declarations';
-import { BOOLEAN_CLI_ARGS, NUMBER_CLI_ARGS, STRING_CLI_ARGS } from '../config-flags';
-import { parseEqualsArg, parseFlags } from '../parse-flags';
+import {
+  BOOLEAN_CLI_FLAGS,
+  NUMBER_CLI_FLAGS,
+  STRING_ARRAY_CLI_FLAGS,
+  STRING_CLI_FLAGS,
+  StringArrayCLIFlag,
+} from '../config-flags';
+import { Empty, parseEqualsArg, parseFlags } from '../parse-flags';
 
 describe('parseFlags', () => {
   it('should get known and unknown args', () => {
@@ -54,7 +60,7 @@ describe('parseFlags', () => {
    * will result in a value like `[true, true]` being set on ConfigFlags, which
    * will cause these tests to start failing.
    */
-  describe.each(BOOLEAN_CLI_ARGS)('should parse boolean flag %s', (cliArg) => {
+  describe.each(BOOLEAN_CLI_FLAGS)('should parse boolean flag %s', (cliArg) => {
     it('should parse arg', () => {
       const flags = parseFlags([`--${cliArg}`]);
       expect(flags.knownArgs).toEqual([`--${cliArg}`]);
@@ -75,14 +81,14 @@ describe('parseFlags', () => {
       expect(flags[cliArg]).toBe(false);
     });
 
-    it('should set value to null if not present', () => {
+    it('should not set value if not present', () => {
       const flags = parseFlags([]);
       expect(flags.knownArgs).toEqual([]);
-      expect(flags[cliArg]).toBe(null);
+      expect(flags[cliArg]).toBe(undefined);
     });
   });
 
-  describe.each(STRING_CLI_ARGS)('should parse string flag %s', (cliArg) => {
+  describe.each(STRING_CLI_FLAGS)('should parse string flag %s', (cliArg) => {
     it(`should parse "--${cliArg} value"`, () => {
       const flags = parseFlags([`--${cliArg}`, 'test-value']);
       expect(flags.knownArgs).toEqual([`--${cliArg}`, 'test-value']);
@@ -112,7 +118,7 @@ describe('parseFlags', () => {
     });
   });
 
-  it.each(NUMBER_CLI_ARGS)('should parse number flag %s', (cliArg) => {
+  it.each(NUMBER_CLI_FLAGS)('should parse number flag %s', (cliArg) => {
     const flags = parseFlags([`--${cliArg}`, '42']);
     expect(flags.knownArgs).toEqual([`--${cliArg}`, '42']);
     expect(flags.unknownArgs).toEqual([]);
@@ -194,7 +200,7 @@ describe('parseFlags', () => {
 
     it('should not parse --max-workers', () => {
       const flags = parseFlags([]);
-      expect(flags.maxWorkers).toBe(null);
+      expect(flags.maxWorkers).toBe(undefined);
     });
   });
 
@@ -246,12 +252,136 @@ describe('parseFlags', () => {
       ['--fooBar=baz', '--fooBar', 'baz'],
       ['--foo-bar=4', '--foo-bar', '4'],
       ['--fooBar=twenty=3*4', '--fooBar', 'twenty=3*4'],
-      ['--fooBar', '--fooBar', ''],
-      ['--foo-bar', '--foo-bar', ''],
+      ['--fooBar', '--fooBar', Empty],
+      ['--foo-bar', '--foo-bar', Empty],
+      ['--foo-bar=""', '--foo-bar', '""'],
     ])('should parse %s correctly', (testArg, expectedArg, expectedValue) => {
       const [arg, value] = parseEqualsArg(testArg);
       expect(arg).toBe(expectedArg);
-      expect(value).toBe(expectedValue);
+      expect(value).toEqual(expectedValue);
+    });
+  });
+
+  describe.each(STRING_ARRAY_CLI_FLAGS)('should parse string flag %s', (cliArg: StringArrayCLIFlag) => {
+    it(`should parse single value: "--${cliArg} test-value"`, () => {
+      const flags = parseFlags([`--${cliArg}`, 'test-value']);
+      expect(flags.knownArgs).toEqual([`--${cliArg}`, 'test-value']);
+      expect(flags.unknownArgs).toEqual([]);
+      expect(flags[cliArg]).toEqual(['test-value']);
+    });
+
+    it(`should parse multiple values: "--${cliArg} test-value"`, () => {
+      const flags = parseFlags([`--${cliArg}`, 'test-value', `--${cliArg}`, 'second-test-value']);
+      expect(flags.knownArgs).toEqual([`--${cliArg}`, 'test-value', `--${cliArg}`, 'second-test-value']);
+      expect(flags.unknownArgs).toEqual([]);
+      expect(flags[cliArg]).toEqual(['test-value', 'second-test-value']);
+    });
+
+    it(`should parse "--${cliArg}=value"`, () => {
+      const flags = parseFlags([`--${cliArg}=path/to/file.js`]);
+      expect(flags.knownArgs).toEqual([`--${cliArg}`, 'path/to/file.js']);
+      expect(flags.unknownArgs).toEqual([]);
+      expect(flags[cliArg]).toEqual(['path/to/file.js']);
+    });
+
+    it(`should parse multiple values: "--${cliArg}=test-value"`, () => {
+      const flags = parseFlags([`--${cliArg}=test-value`, `--${cliArg}=second-test-value`]);
+      expect(flags.knownArgs).toEqual([`--${cliArg}`, 'test-value', `--${cliArg}`, 'second-test-value']);
+      expect(flags.unknownArgs).toEqual([]);
+      expect(flags[cliArg]).toEqual(['test-value', 'second-test-value']);
+    });
+
+    it(`should parse "--${toDashCase(cliArg)} value"`, () => {
+      const flags = parseFlags([`--${toDashCase(cliArg)}`, 'path/to/file.js']);
+      expect(flags.knownArgs).toEqual([`--${toDashCase(cliArg)}`, 'path/to/file.js']);
+      expect(flags.unknownArgs).toEqual([]);
+      expect(flags[cliArg]).toEqual(['path/to/file.js']);
+    });
+
+    it(`should parse multiple values: "--${toDashCase(cliArg)} test-value"`, () => {
+      const flags = parseFlags([
+        `--${toDashCase(cliArg)}`,
+        'test-value',
+        `--${toDashCase(cliArg)}`,
+        'second-test-value',
+      ]);
+      expect(flags.knownArgs).toEqual([
+        `--${toDashCase(cliArg)}`,
+        'test-value',
+        `--${toDashCase(cliArg)}`,
+        'second-test-value',
+      ]);
+      expect(flags.unknownArgs).toEqual([]);
+      expect(flags[cliArg]).toEqual(['test-value', 'second-test-value']);
+    });
+
+    it(`should parse "--${toDashCase(cliArg)}=value"`, () => {
+      const flags = parseFlags([`--${toDashCase(cliArg)}=path/to/file.js`]);
+      expect(flags.knownArgs).toEqual([`--${toDashCase(cliArg)}`, 'path/to/file.js']);
+      expect(flags.unknownArgs).toEqual([]);
+      expect(flags[cliArg]).toEqual(['path/to/file.js']);
+    });
+
+    it(`should parse multiple values: "--${toDashCase(cliArg)}=test-value"`, () => {
+      const flags = parseFlags([`--${toDashCase(cliArg)}=test-value`, `--${toDashCase(cliArg)}=second-test-value`]);
+      expect(flags.knownArgs).toEqual([
+        `--${toDashCase(cliArg)}`,
+        'test-value',
+        `--${toDashCase(cliArg)}`,
+        'second-test-value',
+      ]);
+      expect(flags.unknownArgs).toEqual([]);
+      expect(flags[cliArg]).toEqual(['test-value', 'second-test-value']);
+    });
+  });
+
+  describe('error reporting', () => {
+    it('should throw if you pass no argument to a string flag', () => {
+      expect(() => {
+        parseFlags(['--cacheDirectory', '--someOtherFlag']);
+      }).toThrow('when parsing CLI flag "--cacheDirectory": expected a string argument but received nothing');
+    });
+
+    it('should throw if you pass no argument to a string array flag', () => {
+      expect(() => {
+        parseFlags(['--reporters', '--someOtherFlag']);
+      }).toThrow('when parsing CLI flag "--reporters": expected a string argument but received nothing');
+    });
+
+    it('should throw if you pass no argument to a number flag', () => {
+      expect(() => {
+        parseFlags(['--port', '--someOtherFlag']);
+      }).toThrow('when parsing CLI flag "--port": expected a number argument but received nothing');
+    });
+
+    it('should throw if you pass a non-number argument to a number flag', () => {
+      expect(() => {
+        parseFlags(['--port', 'stringy']);
+      }).toThrow('when parsing CLI flag "--port": expected a number but received "stringy"');
+    });
+
+    it('should throw if you pass a bad number argument to a number flag', () => {
+      expect(() => {
+        parseFlags(['--port=NaN']);
+      }).toThrow('when parsing CLI flag "--port": expected a number but received "NaN"');
+    });
+
+    it('should throw if you pass no argument to a string/number flag', () => {
+      expect(() => {
+        parseFlags(['--maxWorkers']);
+      }).toThrow('when parsing CLI flag "--maxWorkers": expected a string or a number but received nothing');
+    });
+
+    it('should throw if you pass an invalid log level for --logLevel', () => {
+      expect(() => {
+        parseFlags(['--logLevel', 'potato']);
+      }).toThrow('when parsing CLI flag "--logLevel": expected to receive a valid log level but received "potato"');
+    });
+
+    it('should throw if you pass no argument to --logLevel', () => {
+      expect(() => {
+        parseFlags(['--logLevel']);
+      }).toThrow('when parsing CLI flag "--logLevel": expected to receive a valid log level but received nothing');
     });
   });
 });

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -28,6 +28,17 @@ export const dashToPascalCase = (str: string): string =>
     .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
     .join('');
 
+/**
+ * Convert a string to 'camelCase'
+ *
+ * @param str the string to convert
+ * @returns the converted string
+ */
+export const toCamelCase = (str: string) => {
+  const pascalCase = dashToPascalCase(str);
+  return pascalCase.charAt(0).toLowerCase() + pascalCase.slice(1);
+};
+
 export const toTitleCase = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
 
 export const noop = (): any => {

--- a/src/utils/test/helpers.spec.ts
+++ b/src/utils/test/helpers.spec.ts
@@ -1,4 +1,4 @@
-import { dashToPascalCase, isDef, isPromise, toDashCase } from '../helpers';
+import { dashToPascalCase, isDef, isPromise, toCamelCase, toDashCase } from '../helpers';
 
 describe('util helpers', () => {
   describe('isPromise', () => {
@@ -42,6 +42,16 @@ describe('util helpers', () => {
 
     it('wisconsin => Wisconsin', () => {
       expect(dashToPascalCase('wisconsin')).toBe('Wisconsin');
+    });
+  });
+
+  describe('toCamelCase', () => {
+    it.each([
+      ['my-3d-component', 'my3dComponent'],
+      ['madison-wisconsin', 'madisonWisconsin'],
+      ['wisconsin', 'wisconsin'],
+    ])('%s => %s', (input: string, exp: string) => {
+      expect(toCamelCase(input)).toBe(exp);
     });
   });
 

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -172,4 +172,4 @@ const SKIP_DEPS = ['@stencil/core'];
 export const readOnlyArrayHasStringMember = <T extends string>(
   readOnlyArray: ReadonlyArray<T>,
   maybeMember: T | string
-): boolean => readOnlyArray.includes(maybeMember as typeof readOnlyArray[number]);
+): maybeMember is T => readOnlyArray.includes(maybeMember as typeof readOnlyArray[number]);


### PR DESCRIPTION
Jest supports passing certain arguments multiple times. For instance, in the following example:

```
jest --coverage --reporters="default" --reporters="jest-junit"
```

all of the values for the `--reporters` flag ("default" and "jest-junit") should be collected into an array of values, instead of simply recording whichever value is farther to the right (Stencil's behavior before this commit).

To support passing such arguments to the `stencil test` subcommand this commit adds a new recursive-descent parser in `src/cli/parse-flags.ts` to replace the somewhat ad-hoc approach that was there previously. It parses the following grammar:

```
CLIArgments     → ""
                | CLITerm ( " " CLITerm )* ;
CLITerm         → EqualsArg
                | AliasEqualsArg
                | AliasArg
                | NegativeDashArg
                | NegativeArg
                | SimpleArg ;
EqualsArg       → "--" ArgName "=" CLIValue ;
AliasEqualsArg  → "-" AliasName "=" CLIValue ;
AliasArg        → "-" AliasName ( " " CLIValue )? ;
NegativeDashArg → "--no-" ArgName ;
NegativeArg     → "--no" ArgName ;
SimpleArg       → "--" ArgName ( " " CLIValue )? ;
ArgName         → /^[a-zA-Z-]+$/ ;
AliasName       → /^[a-z]{1}$/ ;
CLIValue        → ('"')? /^[a-zA-Z0-9]+$/ ('"')? ;
```

(the regexes are a little fuzzy, but this is sort of an informal presentation).

Refactoring this to use a proper parser (albeit a pretty simple one) allows our implementation to much more clearly conform to this defined grammar, and should hopefully both help us avoid other bugs in the future and be easier to maintain.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #3712

Passing flags like the Jest flag `--reporters` which should accept multiple values, like

```
stencil test --coverage --reporters="default" --reporters="jest-junit"
```

doesn't work at present. Instead of bundling together the two inputs into an array like `["default", "jest-junit"]` instead the rightmost one just wins :/


## What is the new behavior?

This refactors the parser for the CLI, starting by defining a grammar for CLI flags and values and implementing a recursive-descent parser (not a very deep one 😄) which parses that grammar and, as it traverses the arguments, sets values as we intend on the `ConfigFlags` object.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I confirmed that this works with the provided reproduction case. It should be tested pretty exhaustively! Please find the bugs!!! 🐛🐞

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
