### PR TITLE
Only add HYDRATED_CSS when cmpTags are set

### DIFF
--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -185,7 +185,7 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
     });
   });
 
-  if (BUILD.invisiblePrehydration && (BUILD.hydratedClass || BUILD.hydratedAttribute)) {
+  if (cmpTags.length > 0 && BUILD.invisiblePrehydration && (BUILD.hydratedClass || BUILD.hydratedAttribute)) {
     visibilityStyle.innerHTML = cmpTags + HYDRATED_CSS;
     visibilityStyle.setAttribute('data-styles', '');
 

--- a/src/runtime/test/bootstrap-lazy.spec.tsx
+++ b/src/runtime/test/bootstrap-lazy.spec.tsx
@@ -1,11 +1,9 @@
-import { bootstrapLazy } from '../bootstrap-lazy';
 import { doc } from '@platform';
 
+import { bootstrapLazy } from '../bootstrap-lazy';
 
 describe('assets', () => {
-
-
-  it('should not append broken css', async () => {
+  it('should not append broken css', () => {
     const spy = jest.spyOn(doc.head, 'insertBefore');
 
     /**
@@ -15,13 +13,18 @@ describe('assets', () => {
      */
     bootstrapLazy([]);
 
-    expect(spy).not.toHaveBeenCalledWith(expect.objectContaining({
-      sheet: expect.objectContaining({
-        cssRules: [expect.objectContaining({
-          // This html is not valid since it does not start with a selector for the visibility hidden block
-          cssText: '{visibility:hidden}.hydrated{visibility:inherit}'
-        })]
-      })
-    }), null);
+    expect(spy).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        sheet: expect.objectContaining({
+          cssRules: [
+            expect.objectContaining({
+              // This html is not valid since it does not start with a selector for the visibility hidden block
+              cssText: '{visibility:hidden}.hydrated{visibility:inherit}',
+            }),
+          ],
+        }),
+      }),
+      null,
+    );
   });
 });

--- a/src/runtime/test/bootstrap-lazy.spec.tsx
+++ b/src/runtime/test/bootstrap-lazy.spec.tsx
@@ -1,0 +1,27 @@
+import { bootstrapLazy } from '../bootstrap-lazy';
+import { doc } from '@platform';
+
+
+describe('assets', () => {
+
+
+  it('should not append broken css', async () => {
+    const spy = jest.spyOn(doc.head, 'insertBefore');
+
+    /**
+     * To make the test shorter I called bootstrapLazy without any bundles
+     * When a user call defineCustomElements multiple times it will prevent defining the same elements within
+     * the bootstrapLazy method. Although this works it does still add the broken css.
+     */
+    bootstrapLazy([]);
+
+    expect(spy).not.toHaveBeenCalledWith(expect.objectContaining({
+      sheet: expect.objectContaining({
+        cssRules: [expect.objectContaining({
+          // This html is not valid since it does not start with a selector for the visibility hidden block
+          cssText: '{visibility:hidden}.hydrated{visibility:inherit}'
+        })]
+      })
+    }), null);
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
An invalid piece of CSS is injected when cmpTags are empty. If this happens in JSDOM it will throw an invalid css error.

GitHub Issue Number: N/A


## What is the new behavior?
The CSS will only be added to the head when cmpTags are defined (making the css always valid).

## Does this introduce a breaking change?

- [ ] Yes
- [x] No



## Testing

Manually tested the change in the compiled code, no error where thrown again.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
