### PR TITLE
fix(compiler): account for an existing constructor in convert-decorators

### DIFF
--- a/src/compiler/transformers/decorators-to-static/convert-decorators.ts
+++ b/src/compiler/transformers/decorators-to-static/convert-decorators.ts
@@ -381,13 +381,13 @@ export const updateConstructor = (
       // 1. the `super()` call
       // 2. the new statements we've created to initialize fields
       // 3. the statements currently comprising the body of the constructor
-      statements = [createConstructorBodyWithSuper(), ...statements, ...constructorMethod.body?.statements ?? []];
+      statements = [createConstructorBodyWithSuper(), ...statements, ...(constructorMethod.body?.statements ?? [])];
     } else {
       // if no super is needed then the body of the constructor should be:
       //
       // 1. the new statements we've created to initialize fields
       // 2. the statements currently comprising the body of the constructor
-      statements = [...statements, ...constructorMethod.body?.statements ?? []];
+      statements = [...statements, ...(constructorMethod.body?.statements ?? [])];
     }
 
     classMembers[constructorIndex] = ts.factory.updateConstructorDeclaration(
@@ -405,12 +405,7 @@ export const updateConstructor = (
     }
 
     classMembers = [
-      ts.factory.createConstructorDeclaration(
-        undefined,
-        undefined,
-        [],
-        ts.factory.createBlock(statements, true)
-      ),
+      ts.factory.createConstructorDeclaration(undefined, undefined, [], ts.factory.createBlock(statements, true)),
       ...classMembers,
     ];
   }

--- a/src/compiler/transformers/decorators-to-static/convert-decorators.ts
+++ b/src/compiler/transformers/decorators-to-static/convert-decorators.ts
@@ -372,7 +372,9 @@ export const updateConstructor = (
   const constructorMethod = classMembers[constructorIndex];
 
   if (constructorIndex >= 0 && ts.isConstructorDeclaration(constructorMethod)) {
-    const hasSuper = (constructorMethod.body?.statements ?? []).some((s) => s.kind === ts.SyntaxKind.SuperKeyword);
+    const constructorBodyStatements: ts.NodeArray<ts.Statement> =
+      constructorMethod.body?.statements ?? ts.factory.createNodeArray();
+    const hasSuper = constructorBodyStatements.some((s) => s.kind === ts.SyntaxKind.SuperKeyword);
 
     if (!hasSuper && needsSuper(classNode)) {
       // if there is no super and it needs one the statements comprising the
@@ -381,13 +383,13 @@ export const updateConstructor = (
       // 1. the `super()` call
       // 2. the new statements we've created to initialize fields
       // 3. the statements currently comprising the body of the constructor
-      statements = [createConstructorBodyWithSuper(), ...statements, ...(constructorMethod.body?.statements ?? [])];
+      statements = [createConstructorBodyWithSuper(), ...statements, ...constructorBodyStatements];
     } else {
       // if no super is needed then the body of the constructor should be:
       //
       // 1. the new statements we've created to initialize fields
       // 2. the statements currently comprising the body of the constructor
-      statements = [...statements, ...(constructorMethod.body?.statements ?? [])];
+      statements = [...statements, ...constructorBodyStatements];
     }
 
     classMembers[constructorIndex] = ts.factory.updateConstructorDeclaration(

--- a/src/compiler/transformers/decorators-to-static/convert-decorators.ts
+++ b/src/compiler/transformers/decorators-to-static/convert-decorators.ts
@@ -372,10 +372,22 @@ export const updateConstructor = (
   const constructorMethod = classMembers[constructorIndex];
 
   if (constructorIndex >= 0 && ts.isConstructorDeclaration(constructorMethod)) {
-    const hasSuper = constructorMethod.body.statements.some((s) => s.kind === ts.SyntaxKind.SuperKeyword);
+    const hasSuper = (constructorMethod.body?.statements ?? []).some((s) => s.kind === ts.SyntaxKind.SuperKeyword);
 
     if (!hasSuper && needsSuper(classNode)) {
-      statements = [createConstructorBodyWithSuper(), ...statements];
+      // if there is no super and it needs one the statements comprising the
+      // body of the constructor should be:
+      //
+      // 1. the `super()` call
+      // 2. the new statements we've created to initialize fields
+      // 3. the statements currently comprising the body of the constructor
+      statements = [createConstructorBodyWithSuper(), ...statements, ...constructorMethod.body?.statements ?? []];
+    } else {
+      // if no super is needed then the body of the constructor should be:
+      //
+      // 1. the new statements we've created to initialize fields
+      // 2. the statements currently comprising the body of the constructor
+      statements = [...statements, ...constructorMethod.body?.statements ?? []];
     }
 
     classMembers[constructorIndex] = ts.factory.updateConstructorDeclaration(
@@ -383,7 +395,7 @@ export const updateConstructor = (
       constructorMethod.decorators,
       constructorMethod.modifiers,
       constructorMethod.parameters,
-      ts.factory.updateBlock(constructorMethod.body, statements)
+      ts.factory.updateBlock(constructorMethod?.body ?? ts.factory.createBlock([]), statements)
     );
   } else {
     // we don't seem to have a constructor, so let's create one and stick it
@@ -396,7 +408,7 @@ export const updateConstructor = (
       ts.factory.createConstructorDeclaration(
         undefined,
         undefined,
-        undefined,
+        [],
         ts.factory.createBlock(statements, true)
       ),
       ...classMembers,

--- a/src/compiler/transformers/test/convert-decorators.spec.ts
+++ b/src/compiler/transformers/test/convert-decorators.spec.ts
@@ -149,7 +149,96 @@ describe('convert-decorators', () => {
     );
   });
 
-  it('should not add a super call to the constructor if necessary', () => {
+  it('should preserve statements in an existing constructor', () => {
+    const t = transpileModule(`
+    @Component({
+      tag: 'my-component',
+    })
+    export class MyComponent {
+      constructor() {
+        console.log('boop');
+      }
+    }`);
+
+    expect(t.outputText).toBe(
+      c`export class MyComponent {
+        constructor() {
+          console.log('boop');
+        }
+
+        static get is() {
+          return "my-component";
+      }}`
+    );
+  });
+
+  it('should preserve statements in an existing constructor w/ @Prop', () => {
+    const t = transpileModule(`
+    @Component({
+      tag: 'my-component',
+    })
+    export class MyComponent {
+      @Prop() count: number;
+
+      constructor() {
+        console.log('boop');
+      }
+    }`);
+
+    expect(t.outputText).toContain(
+      c`constructor() {
+          this.count = undefined;
+          console.log('boop');
+        }`
+    );
+  });
+
+  it('should allow user to initialize field in an existing constructor w/ @Prop', () => {
+    const t = transpileModule(`
+    @Component({
+      tag: 'my-component',
+    })
+    export class MyComponent {
+      @Prop() count: number;
+
+      constructor() {
+        this.count = 3;
+      }
+    }`);
+
+    // the initialization we do to `undefined` (since no value is present)
+    // should be before the user's `this.count = 3` to ensure that their code
+    // wins.
+    expect(t.outputText).toContain(
+      c`constructor() {
+          this.count = undefined;
+          this.count = 3;
+        }`
+    );
+  });
+
+  it('should preserve statements in an existing constructor w/ non-decorated field', () => {
+    const t = transpileModule(`
+    @Component({
+      tag: 'example',
+    })
+    export class Example implements RhclComponent {
+      private classProps: Array<string>;
+
+      constructor() {
+        this.classProps = ["variant", "theme"];
+      }
+    }`);
+
+    expect(t.outputText).toBe(
+      c`export class Example {
+        constructor() {
+          this.classProps = ["variant", "theme"];
+        }}`
+    );
+  });
+
+  it('should not add a super call to the constructor if not necessary', () => {
     const t = transpileModule(`
     @Component({tag: 'cmp-a'})
       export class CmpA implements Foobar {

--- a/src/compiler/transformers/test/convert-decorators.spec.ts
+++ b/src/compiler/transformers/test/convert-decorators.spec.ts
@@ -222,7 +222,7 @@ describe('convert-decorators', () => {
     @Component({
       tag: 'example',
     })
-    export class Example implements RhclComponent {
+    export class Example implements FooBar {
       private classProps: Array<string>;
 
       constructor() {
@@ -235,6 +235,28 @@ describe('convert-decorators', () => {
         constructor() {
           this.classProps = ["variant", "theme"];
         }}`
+    );
+  });
+
+  it('should preserve statements in an existing constructor super, decorated field', () => {
+    const t = transpileModule(`
+    @Component({
+      tag: 'example',
+    })
+    export class Example extends Parent {
+      @Prop() foo: string = "bar";
+
+      constructor() {
+        console.log("hello!")
+      }
+    }`);
+
+    expect(t.outputText).toContain(
+      c`constructor() {
+        super();
+        this.foo = "bar";
+        console.log("hello!");
+      }`
     );
   });
 


### PR DESCRIPTION
This change ensures that statements in an existing constructor are not thrown on the floor in the case that we need to edit a constructor (i.e. when there is a field with `@Prop` that we need to initialize in the constructor).

In f97783029274f9ee5ea58ba74ab15905c5113c93 we made a change to initialize any class fields decorated with `@Prop()` in a constructor. The code to do this would look for a constructor on the class and, if found, update the body of the constructor with statements to initialize the field.

Unfortunately, that commit would drop all existing statements in the constructor on the floor! This broke how some Stencil users initialize fields or do certain side effects, since no code they wrote in their constructors would make it through to the built output.

This commit fixes the issue by instead setting the constructor body to be all of our newly created statements followed by any existing statements. This will allow users to initialize fields to custom values in the constructor if they so chose.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

When Stencil converts decorated class fields it will not preserve any statements that are present in the constructor method already defined on a class. Not good!

GitHub Issue Number: #3773


## What is the new behavior?

Statements in an existing constructor on a Stencil component are now preserved instead of being inadvertently deleted.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

You can confirm that the repo linked in #3773 is fixed by this.

## Other information

