### PR TITLE
fix(declarations): correct event handler names for composition events

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -19,7 +19,7 @@ This is a comprehensive list of the breaking changes introduced in the major ver
   * [Strongly Typed Inputs](#strongly-typed-inputs)
   * [Narrowed Typing for `autocapitalize` Attribute](#narrowed-typing-for-autocapitalize-attribute)
   * [Custom Types for Props and Events are now Exported from `components.d.ts`](#custom-types-for-props-and-events-are-now-exported-from-componentsdts)
-  * [Event Handlers for Composition Events Renamed)(#event-handlers-for-composition-events-renamed)
+  * [Event Handlers for Composition Events Renamed](#event-handlers-for-composition-events-renamed)
 * [Output Targets](#output-targets)
   * [`dist-custom-elements` Output Target](#dist-custom-elements-output-target)
     * [Add `customElementsExportBehavior` to Control Export Behavior](#add-customelementsexportbehavior-to-control-export-behavior)

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -19,6 +19,7 @@ This is a comprehensive list of the breaking changes introduced in the major ver
   * [Strongly Typed Inputs](#strongly-typed-inputs)
   * [Narrowed Typing for `autocapitalize` Attribute](#narrowed-typing-for-autocapitalize-attribute)
   * [Custom Types for Props and Events are now Exported from `components.d.ts`](#custom-types-for-props-and-events-are-now-exported-from-componentsdts)
+  * [Event Handlers for Composition Events Renamed)(#event-handlers-for-composition-events-renamed)
 * [Output Targets](#output-targets)
   * [`dist-custom-elements` Output Target](#dist-custom-elements-output-target)
     * [Add `customElementsExportBehavior` to Control Export Behavior](#add-customelementsexportbehavior-to-control-export-behavior)
@@ -100,7 +101,7 @@ The [`autocaptialize` attribute](https://developer.mozilla.org/en-US/docs/Web/HT
 This change brings Stencil into closer alignment with TypeScript's typings for the attribute.
 No explicit changes are needed, unless a project was passing non-strings to the attribute.
 
-### Custom Types for Props and Events are now Exported from `components.d.ts`
+#### Custom Types for Props and Events are now Exported from `components.d.ts`
 
 Custom types for props and custom events are now re-exported from a project's `components.d.ts` file.
 
@@ -160,6 +161,21 @@ This _may_ clash with any manually created types in existing Stencil projects.
 Projects that manually create type definitions from `components.d.ts` will either need to:
 - remove the manually created type (if the types generated in `components.d.ts` suffice)
 - update their type creation logic to account for potential naming collisions with the newly generated types
+
+#### Event Handlers for Composition Events Renamed
+
+The names of Stencil's supported event handlers for composition events have
+been changed in order to correct a casing issue which prevented handlers from
+being called when events fired. The changes are as follows:
+
+| previous name                | new name                     |
+| ---------------------------- | ---------------------------- |
+| `onCompositionEnd`           | `onCompositionend`           |
+| `onCompositionEndCapture`    | `onCompositionendCapture`    |
+| `onCompositionStart`         | `onCompositionstart`         |
+| `onCompositionStartCapture`  | `onCompositionstartCapture`  |
+| `onCompositionUpdate`        | `onCompositionupdate`        |
+| `onCompositionUpdateCapture` | `onCompositionupdateCapture` |
 
 ### Output Targets
 

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -19,7 +19,7 @@ This is a comprehensive list of the breaking changes introduced in the major ver
   * [Strongly Typed Inputs](#strongly-typed-inputs)
   * [Narrowed Typing for `autocapitalize` Attribute](#narrowed-typing-for-autocapitalize-attribute)
   * [Custom Types for Props and Events are now Exported from `components.d.ts`](#custom-types-for-props-and-events-are-now-exported-from-componentsdts)
-  * [Event Handlers for Composition Events Renamed](#event-handlers-for-composition-events-renamed)
+  * [Composition Event Handlers Renamed](#composition-event-handlers-renamed)
 * [Output Targets](#output-targets)
   * [`dist-custom-elements` Output Target](#dist-custom-elements-output-target)
     * [Add `customElementsExportBehavior` to Control Export Behavior](#add-customelementsexportbehavior-to-control-export-behavior)
@@ -162,11 +162,11 @@ Projects that manually create type definitions from `components.d.ts` will eithe
 - remove the manually created type (if the types generated in `components.d.ts` suffice)
 - update their type creation logic to account for potential naming collisions with the newly generated types
 
-#### Event Handlers for Composition Events Renamed
+#### Composition Event Handlers Renamed
 
-The names of Stencil's supported event handlers for composition events have
-been changed in order to correct a casing issue which prevented handlers from
-being called when events fired. The changes are as follows:
+The names of Stencil's composition event handlers have been changed in order to
+correct a casing issue which prevented handlers from being called when events
+fired. The changes are as follows:
 
 | previous name                | new name                     |
 | ---------------------------- | ---------------------------- |

--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1612,12 +1612,12 @@ export namespace JSXBase {
     onPasteCapture?: (event: ClipboardEvent) => void;
 
     // Composition Events
-    onCompositionEnd?: (event: CompositionEvent) => void;
-    onCompositionEndCapture?: (event: CompositionEvent) => void;
-    onCompositionStart?: (event: CompositionEvent) => void;
-    onCompositionStartCapture?: (event: CompositionEvent) => void;
-    onCompositionUpdate?: (event: CompositionEvent) => void;
-    onCompositionUpdateCapture?: (event: CompositionEvent) => void;
+    onCompositionend?: (event: CompositionEvent) => void;
+    onCompositionendCapture?: (event: CompositionEvent) => void;
+    onCompositionstart?: (event: CompositionEvent) => void;
+    onCompositionstartCapture?: (event: CompositionEvent) => void;
+    onCompositionupdate?: (event: CompositionEvent) => void;
+    onCompositionupdateCapture?: (event: CompositionEvent) => void;
 
     // Focus Events
     onFocus?: (event: FocusEvent) => void;


### PR DESCRIPTION
This updates the event handler names in `src/declarations/stencil-public-runtime.ts` for the composition events to have the correct casing.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

Right now we have these cases like `onCompositionStart`, `onCompositionEnd`, etc when they should be `onCompositionstart`, `onCompositionend`.

This just changes the declarations to what they should be, which is all that's needed to get these events working correctly.

GitHub Issue Number: #3235


## What is the new behavior?

Now the spelling of the event names has been corrected, so they work! Great!

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] Maybe

This is technically a bugfix, and it won't _break_ anyone's code, but it anyone was (for some unfathomable reason) depending on the previous, non-working declarations their event handlers will start firing with this change, which could in some sense be construed as a breaking change (although I'd call it a fixing change!).

Still I think this is safe to merge to the 2.x branch since the impact is likely to be minimal (I doubt this is a very widely used event anyhow).

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

On the linked issue there is a reproduction, you can confirm that with the following changes (to follow the new spelling) the repro now works:

```diff
diff --git a/src/components/my-component/my-component.tsx b/src/components/my-component/my-component.tsx
index af46542..91d19c8 100644
--- a/src/components/my-component/my-component.tsx
+++ b/src/components/my-component/my-component.tsx
@@ -27,7 +27,17 @@ export class MyComponent {
     console.log('onCompositionEnd');
   };
 
+  private onCompositionUpdate = () => {
+    console.log('onCompositionUpdate');
+  };
+
   render() {
-    return <input ref={el => (this.inputEl = el)} type="text" onCompositionStart={this.onCompositionStart} onCompositionEnd={this.onCompositionEnd} />;
+    return <input
+      ref={el => (this.inputEl = el)}
+      type="text"
+      onCompositionstart={this.onCompositionStart}
+      onCompositionend={this.onCompositionEnd} 
+      onCompositionupdate={this.onCompositionUpdate}
+    />;
   }
 }
```

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
