### PR TITLE
fix(compiler): move `inlineDynamicImports` to Rollup output

### DIFF
--- a/src/compiler/bundle/bundle-output.ts
+++ b/src/compiler/bundle/bundle-output.ts
@@ -96,6 +96,10 @@ export const getRollupOptions = (
   const afterPlugins = config.rollupPlugins.after || [];
   const rollupOptions: RollupOptions = {
     input: bundleOpts.inputs,
+    output: {
+      // This option cannot be set if multiple inputs are provided
+      inlineDynamicImports: bundleOpts.inlineDynamicImports ? Object.keys(bundleOpts.inputs).length <= 1 : false,
+    },
 
     plugins: [
       coreResolvePlugin(config, compilerCtx, bundleOpts.platform, bundleOpts.externalRuntime),
@@ -129,7 +133,6 @@ export const getRollupOptions = (
     ],
 
     treeshake: getTreeshakeOption(config, bundleOpts),
-    inlineDynamicImports: bundleOpts.inlineDynamicImports,
     preserveEntrySignatures: bundleOpts.preserveEntrySignatures ?? 'strict',
 
     onwarn: createOnWarnFn(buildCtx.diagnostics),

--- a/src/compiler/bundle/test/bundle-output.spec.ts
+++ b/src/compiler/bundle/test/bundle-output.spec.ts
@@ -1,0 +1,52 @@
+import { mockBuildCtx, mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { OutputOptions } from 'rollup';
+
+import { BuildCtx, CompilerCtx, ValidatedConfig } from '../../../declarations';
+import { BundleOptions } from '../bundle-interface';
+import { getRollupOptions } from '../bundle-output';
+
+describe('bundle output', () => {
+  describe('getRollupOptions', () => {
+    let config: ValidatedConfig;
+    let compilerCtx: CompilerCtx;
+    let buildCtx: BuildCtx;
+    let bundleOptions: BundleOptions;
+
+    beforeEach(() => {
+      config = mockValidatedConfig();
+      compilerCtx = mockCompilerCtx(config);
+      buildCtx = mockBuildCtx(config, compilerCtx);
+      bundleOptions = {
+        id: 'customElements',
+        platform: 'client',
+        inputs: {
+          index: 'core',
+        },
+      };
+    });
+
+    it('should default `inlineDynamicImports` to `false` in the output section', () => {
+      const options = getRollupOptions(config, compilerCtx, buildCtx, bundleOptions);
+
+      expect((options.output as OutputOptions).inlineDynamicImports).toBe(false);
+    });
+
+    it('should allow `inlineDynamicImports` to be `true` in the output section if only one input is provided', () => {
+      bundleOptions.inlineDynamicImports = true;
+      const options = getRollupOptions(config, compilerCtx, buildCtx, bundleOptions);
+
+      expect((options.output as OutputOptions).inlineDynamicImports).toBe(true);
+    });
+
+    it('should not allow `inlineDynamicImports` to be `true` in the output section if multiple inputs are provided', () => {
+      bundleOptions.inlineDynamicImports = true;
+      bundleOptions.inputs = {
+        ...bundleOptions.inputs,
+        test: 'Test',
+      };
+      const options = getRollupOptions(config, compilerCtx, buildCtx, bundleOptions);
+
+      expect((options.output as OutputOptions).inlineDynamicImports).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
This commit updates the `inlineDyamicImports` Rollup config option to be moved to the `output` section of the config as the root-level config is deprecated. This also resolves an issue that was causing build errors when the flag was set on `dist-custom-elements` due to multiple inputs

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Unit tests (`npm test`) were run locally and passed
- [X] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [X] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, setting `inlineDynamicImports` on the `dist-custom-elements` output target will result in a build error

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updates our mapping of `inlineDynamicImports` in our `BundleOptions` interface to a Rollup config so that the option is set as a part of the `output` config object. This is the new approach as the root option was marked as deprecated (https://rollupjs.org/guide/en/#outputinlinedynamicimports)
- Also adds logic so the option can only be set when the number of inputs to the bundler is 1 or fewer (this is the error that was being thrown during the build process before)

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

- Verified the build was successful
- Added unit tests for the changes and conditional logic

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

I looked at Amplitude to see if the option was actual used on `dist-custom-elements` and looked like there were some instances of it recently (not sure how since builds likely would've been failing). But, for now I think we should keep that option around
