### PR TITLE
chore(lint): lint the bin directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "clean": "rm -rf build/ cli/ compiler/ dev-server/ internal/ mock-doc/ sys/ testing/ && npm run clean-scripts",
     "clean-scripts": "rm -rf scripts/build",
     "license": "node scripts --license",
-    "lint": "eslint 'scripts/*.ts' 'scripts/**/*.ts' 'src/*.ts' 'src/**/*.ts' 'src/**/*.tsx'",
+    "lint": "eslint 'bin/*' 'scripts/*.ts' 'scripts/**/*.ts' 'src/*.ts' 'src/**/*.ts' 'src/**/*.tsx'",
     "prettier": "npm run prettier.base -- --write",
     "prettier.base": "prettier \"./({bin,scripts,src,test}/**/*.{ts,tsx,js,jsx})|bin/stencil|.github/(**/)?*.(yml|yaml)|*.js\"",
     "prettier.dry-run": "npm run prettier.base -- --list-different",


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

we do not lint `bin/stencil`

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates our lint configuration to lint the contents of `bin/` which contains the entrypoint of stencil. this is an omission in our linting scripts. we should have always linted this file, but simply missed it

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I tested this locally against the `head` of `main` (0ee91f3a86c1ce7e4a930e7a23be3438b33fd4dd). Which yielded
```
➜  stencil git:(ap/reporters-flag) ✗ npm run lint

> @stencil/core@2.19.2 lint
> eslint "bin/*" "src/*.ts" "src/**/*.ts" "src/**/*.tsx"


stencil/bin/stencil
   4:1  error  Unexpected var, use let or const instead  no-var
   5:1  error  Unexpected var, use let or const instead  no-var
   6:1  error  Unexpected var, use let or const instead  no-var
   7:1  error  Unexpected var, use let or const instead  no-var
  10:3  error  Unexpected var, use let or const instead  no-var
  11:3  error  Unexpected var, use let or const instead  no-var
  40:1  error  Unexpected var, use let or const instead  no-var
  41:1  error  Unexpected var, use let or const instead  no-var
  42:1  error  Unexpected var, use let or const instead  no-var
  43:1  error  Unexpected var, use let or const instead  no-var

✖ 10 problems (10 errors, 0 warnings)
  2 errors and 0 warnings potentially fixable with the `--fix` option.
```

Once #3794 lands, this error will subside (but it tells us we're picking up the file just fine)
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
