### PR TITLE
chore(telemetry): remove additional properties

### DIFF
--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -200,7 +200,7 @@ const CONFIG_PROPS_TO_ANONYMIZE: ReadonlyArray<ConfigStringKeys> = [
 // Props we delete entirely from the config for telemetry
 //
 // TODO(STENCIL-469): Investigate improving anonymization for tsCompilerOptions and devServer
-const CONFIG_PROPS_TO_DELETE: ReadonlyArray<keyof d.Config> = ['sys', 'logger', 'tsCompilerOptions', 'devServer'];
+const CONFIG_PROPS_TO_DELETE: ReadonlyArray<keyof d.Config> = ['commonjs', 'env', 'rollupConfig', 'sys', 'testing', 'logger', 'tsCompilerOptions', 'devServer'];
 
 /**
  * Anonymize the config for telemetry, replacing potentially revealing config props

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -200,7 +200,7 @@ const CONFIG_PROPS_TO_ANONYMIZE: ReadonlyArray<ConfigStringKeys> = [
 // Props we delete entirely from the config for telemetry
 //
 // TODO(STENCIL-469): Investigate improving anonymization for tsCompilerOptions and devServer
-const CONFIG_PROPS_TO_DELETE: ReadonlyArray<keyof d.Config> = ['commonjs', 'env', 'rollupConfig', 'sys', 'testing', 'logger', 'tsCompilerOptions', 'devServer'];
+const CONFIG_PROPS_TO_DELETE: ReadonlyArray<keyof d.Config> = ['commonjs','devServer', 'env', 'logger', 'rollupConfig', 'sys', 'testing', 'tsCompilerOptions'];
 
 /**
  * Anonymize the config for telemetry, replacing potentially revealing config props

--- a/src/cli/telemetry/telemetry.ts
+++ b/src/cli/telemetry/telemetry.ts
@@ -200,7 +200,16 @@ const CONFIG_PROPS_TO_ANONYMIZE: ReadonlyArray<ConfigStringKeys> = [
 // Props we delete entirely from the config for telemetry
 //
 // TODO(STENCIL-469): Investigate improving anonymization for tsCompilerOptions and devServer
-const CONFIG_PROPS_TO_DELETE: ReadonlyArray<keyof d.Config> = ['commonjs','devServer', 'env', 'logger', 'rollupConfig', 'sys', 'testing', 'tsCompilerOptions'];
+const CONFIG_PROPS_TO_DELETE: ReadonlyArray<keyof d.Config> = [
+  'commonjs',
+  'devServer',
+  'env',
+  'logger',
+  'rollupConfig',
+  'sys',
+  'testing',
+  'tsCompilerOptions',
+];
 
 /**
  * Anonymize the config for telemetry, replacing potentially revealing config props

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -265,7 +265,7 @@ describe('anonymizeConfigForTelemetry', () => {
     expect(anonymizedConfig.outputTargets).toEqual([]);
   });
 
-  it.each<keyof d.ValidatedConfig>(['sys', 'logger', 'devServer', 'tsCompilerOptions'])(
+  it.each<keyof d.ValidatedConfig>(['commonjs', 'env', 'rollupConfig', 'sys', 'testing', 'logger', 'devServer', 'tsCompilerOptions'])(
     "should remove objects under prop '%s'",
     (prop: keyof d.ValidatedConfig) => {
       const anonymizedConfig = anonymizeConfigForTelemetry({ ...config, [prop]: {}, outputTargets: [] });

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -265,7 +265,7 @@ describe('anonymizeConfigForTelemetry', () => {
     expect(anonymizedConfig.outputTargets).toEqual([]);
   });
 
-  it.each<keyof d.ValidatedConfig>(['commonjs', 'env', 'rollupConfig', 'sys', 'testing', 'logger', 'devServer', 'tsCompilerOptions'])(
+  it.each<keyof d.ValidatedConfig>(['commonjs','devServer', 'env', 'logger', 'rollupConfig', 'sys', 'testing', 'tsCompilerOptions'])(
     "should remove objects under prop '%s'",
     (prop: keyof d.ValidatedConfig) => {
       const anonymizedConfig = anonymizeConfigForTelemetry({ ...config, [prop]: {}, outputTargets: [] });

--- a/src/cli/telemetry/test/telemetry.spec.ts
+++ b/src/cli/telemetry/test/telemetry.spec.ts
@@ -265,14 +265,20 @@ describe('anonymizeConfigForTelemetry', () => {
     expect(anonymizedConfig.outputTargets).toEqual([]);
   });
 
-  it.each<keyof d.ValidatedConfig>(['commonjs','devServer', 'env', 'logger', 'rollupConfig', 'sys', 'testing', 'tsCompilerOptions'])(
-    "should remove objects under prop '%s'",
-    (prop: keyof d.ValidatedConfig) => {
-      const anonymizedConfig = anonymizeConfigForTelemetry({ ...config, [prop]: {}, outputTargets: [] });
-      expect(anonymizedConfig.hasOwnProperty(prop)).toBe(false);
-      expect(anonymizedConfig.outputTargets).toEqual([]);
-    }
-  );
+  it.each<keyof d.ValidatedConfig>([
+    'commonjs',
+    'devServer',
+    'env',
+    'logger',
+    'rollupConfig',
+    'sys',
+    'testing',
+    'tsCompilerOptions',
+  ])("should remove objects under prop '%s'", (prop: keyof d.ValidatedConfig) => {
+    const anonymizedConfig = anonymizeConfigForTelemetry({ ...config, [prop]: {}, outputTargets: [] });
+    expect(anonymizedConfig.hasOwnProperty(prop)).toBe(false);
+    expect(anonymizedConfig.outputTargets).toEqual([]);
+  });
 
   it('should retain outputTarget props on the keep list', () => {
     const anonymizedConfig = anonymizeConfigForTelemetry({


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Values that we're not interested in (ie garbage) can be added to a telemetry payload. We can delete those easily, but we need to stop sending them too.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit removes additional properties from our telemetry payload.
these properties have a tendency to allow for free-form keys, are of no
use to us. the properties being removed are:
- commonjs
- env
- rollupConfig
- testing

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Unit tests have been updated
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other Info

All the work is done in the first commit. The second commit alphabetizes the keys, and the third runs the formatter