### PR TITLE
chore(compiler): add JSDoc to validate-service-worker.ts

### DIFF
--- a/src/compiler/config/validate-service-worker.ts
+++ b/src/compiler/config/validate-service-worker.ts
@@ -12,11 +12,11 @@ import type * as d from '../../declarations';
  * assets on the client. More here: https://developer.chrome.com/docs/workbox/
  *
  * This function first checks that the service worker config set on the
- * supplied `OutputTarget` is not any of it's possible empty values and that we
- * are not currently in development mode. In those cases it will early return.
+ * supplied `OutputTarget` is not empty and that we are not currently in
+ * development mode. In those cases it will early return.
  *
- * If we do find a service worker configuration then we do some validation to
- * ensure that things are set up correctly.
+ * If we do find a service worker configuration we do some validation to ensure
+ * that things are set up correctly.
  *
  * @param config the current, validated configuration
  * @param outputTarget the `www` outputTarget whose service worker

--- a/src/compiler/config/validate-service-worker.ts
+++ b/src/compiler/config/validate-service-worker.ts
@@ -42,9 +42,10 @@ export const validateServiceWorker = (config: d.ValidatedConfig, outputTarget: d
     return;
   }
 
-  const globDirectory = typeof outputTarget.serviceWorker?.globDirectory === 'string'
-    ? outputTarget.serviceWorker.globDirectory
-    : outputTarget.appDir;
+  const globDirectory =
+    typeof outputTarget.serviceWorker?.globDirectory === 'string'
+      ? outputTarget.serviceWorker.globDirectory
+      : outputTarget.appDir;
 
   outputTarget.serviceWorker = {
     ...outputTarget.serviceWorker,

--- a/src/compiler/config/validate-service-worker.ts
+++ b/src/compiler/config/validate-service-worker.ts
@@ -42,11 +42,15 @@ export const validateServiceWorker = (config: d.ValidatedConfig, outputTarget: d
     return;
   }
 
+  const globDirectory = typeof outputTarget.serviceWorker?.globDirectory === 'string'
+    ? outputTarget.serviceWorker.globDirectory
+    : outputTarget.appDir;
+
   outputTarget.serviceWorker = {
     ...outputTarget.serviceWorker,
-    globDirectory: outputTarget.serviceWorker?.globDirectory ?? outputTarget.appDir,
+    globDirectory,
     swDest: isString(outputTarget.serviceWorker?.swDest)
-      ? outputTarget.serviceWorker?.swDest
+      ? outputTarget.serviceWorker.swDest
       : join(outputTarget.appDir ?? '', DEFAULT_FILENAME),
   };
 

--- a/src/compiler/config/validate-service-worker.ts
+++ b/src/compiler/config/validate-service-worker.ts
@@ -3,7 +3,27 @@ import { isAbsolute, join } from 'path';
 
 import type * as d from '../../declarations';
 
-export const validateServiceWorker = (config: d.ValidatedConfig, outputTarget: d.OutputTargetWww) => {
+/**
+ * Validate that a service worker configuration is valid, if it is present and
+ * accounted for.
+ *
+ * Note that our service worker configuration / support is based on
+ * Workbox, a package for automatically generating Service Workers to cache
+ * assets on the client. More here: https://developer.chrome.com/docs/workbox/
+ *
+ * This function first checks that the service worker config set on the
+ * supplied `OutputTarget` is not any of it's possible empty values and that we
+ * are not currently in development mode. In those cases it will early return.
+ *
+ * If we do find a service worker configuration then we do some validation to
+ * ensure that things are set up correctly.
+ *
+ * @param config the current, validated configuration
+ * @param outputTarget the `www` outputTarget whose service worker
+ * configuration we want to validate. **Note**: the `.serviceWorker` object
+ * _will be mutated_ if it is present.
+ */
+export const validateServiceWorker = (config: d.ValidatedConfig, outputTarget: d.OutputTargetWww): void => {
   if (outputTarget.serviceWorker === false) {
     return;
   }
@@ -22,11 +42,11 @@ export const validateServiceWorker = (config: d.ValidatedConfig, outputTarget: d
     return;
   }
 
-  if (typeof outputTarget.serviceWorker !== 'object') {
-    // what was passed in could have been a boolean
-    // in that case let's just turn it into an empty obj so Object.assign doesn't crash
-    outputTarget.serviceWorker = {};
-  }
+  outputTarget.serviceWorker = {
+    ...outputTarget.serviceWorker,
+    globDirectory: outputTarget.serviceWorker?.globDirectory ?? outputTarget.appDir,
+    swDest: outputTarget.serviceWorker?.swDest ?? join(outputTarget.appDir, DEFAULT_FILENAME),
+  };
 
   if (!Array.isArray(outputTarget.serviceWorker.globPatterns)) {
     if (typeof outputTarget.serviceWorker.globPatterns === 'string') {
@@ -34,10 +54,6 @@ export const validateServiceWorker = (config: d.ValidatedConfig, outputTarget: d
     } else if (typeof outputTarget.serviceWorker.globPatterns !== 'string') {
       outputTarget.serviceWorker.globPatterns = DEFAULT_GLOB_PATTERNS.slice();
     }
-  }
-
-  if (typeof outputTarget.serviceWorker.globDirectory !== 'string') {
-    outputTarget.serviceWorker.globDirectory = outputTarget.appDir;
   }
 
   if (typeof outputTarget.serviceWorker.globIgnores === 'string') {
@@ -54,16 +70,19 @@ export const validateServiceWorker = (config: d.ValidatedConfig, outputTarget: d
     outputTarget.serviceWorker.swSrc = join(config.rootDir, outputTarget.serviceWorker.swSrc);
   }
 
-  if (!isString(outputTarget.serviceWorker.swDest)) {
-    outputTarget.serviceWorker.swDest = join(outputTarget.appDir, DEFAULT_FILENAME);
-  }
-
   if (!isAbsolute(outputTarget.serviceWorker.swDest)) {
     outputTarget.serviceWorker.swDest = join(outputTarget.appDir, outputTarget.serviceWorker.swDest);
   }
 };
 
-const addGlobIgnores = (config: d.Config, globIgnores: string[]) => {
+/**
+ * Add file glob patterns to the `globIgnores` for files we don't want to cache
+ * with the service worker.
+ *
+ * @param config the current, validated configuration
+ * @param globIgnores list of file ignore patterns. **Note**: will be mutated.
+ */
+const addGlobIgnores = (config: d.ValidatedConfig, globIgnores: string[]) => {
   globIgnores.push(
     `**/host.config.json`, // the filename of the host configuration
     `**/*.system.entry.js`,

--- a/src/compiler/config/validate-service-worker.ts
+++ b/src/compiler/config/validate-service-worker.ts
@@ -46,7 +46,7 @@ export const validateServiceWorker = (config: d.ValidatedConfig, outputTarget: d
     ...outputTarget.serviceWorker,
     globDirectory: outputTarget.serviceWorker?.globDirectory ?? outputTarget.appDir,
     swDest: isString(outputTarget.serviceWorker?.swDest)
-      ? outputTarget.serviceWorker?.swDest 
+      ? outputTarget.serviceWorker?.swDest
       : join(outputTarget.appDir ?? '', DEFAULT_FILENAME),
   };
 

--- a/src/compiler/config/validate-service-worker.ts
+++ b/src/compiler/config/validate-service-worker.ts
@@ -45,7 +45,9 @@ export const validateServiceWorker = (config: d.ValidatedConfig, outputTarget: d
   outputTarget.serviceWorker = {
     ...outputTarget.serviceWorker,
     globDirectory: outputTarget.serviceWorker?.globDirectory ?? outputTarget.appDir,
-    swDest: outputTarget.serviceWorker?.swDest ?? join(outputTarget.appDir ?? '', DEFAULT_FILENAME),
+    swDest: isString(outputTarget.serviceWorker?.swDest)
+      ? outputTarget.serviceWorker?.swDest 
+      : join(outputTarget.appDir ?? '', DEFAULT_FILENAME),
   };
 
   if (!Array.isArray(outputTarget.serviceWorker.globPatterns)) {

--- a/src/compiler/config/validate-service-worker.ts
+++ b/src/compiler/config/validate-service-worker.ts
@@ -45,7 +45,7 @@ export const validateServiceWorker = (config: d.ValidatedConfig, outputTarget: d
   outputTarget.serviceWorker = {
     ...outputTarget.serviceWorker,
     globDirectory: outputTarget.serviceWorker?.globDirectory ?? outputTarget.appDir,
-    swDest: outputTarget.serviceWorker?.swDest ?? join(outputTarget.appDir, DEFAULT_FILENAME),
+    swDest: outputTarget.serviceWorker?.swDest ?? join(outputTarget.appDir ?? '', DEFAULT_FILENAME),
   };
 
   if (!Array.isArray(outputTarget.serviceWorker.globPatterns)) {
@@ -70,8 +70,8 @@ export const validateServiceWorker = (config: d.ValidatedConfig, outputTarget: d
     outputTarget.serviceWorker.swSrc = join(config.rootDir, outputTarget.serviceWorker.swSrc);
   }
 
-  if (!isAbsolute(outputTarget.serviceWorker.swDest)) {
-    outputTarget.serviceWorker.swDest = join(outputTarget.appDir, outputTarget.serviceWorker.swDest);
+  if (isString(outputTarget.serviceWorker.swDest) && !isAbsolute(outputTarget.serviceWorker.swDest)) {
+    outputTarget.serviceWorker.swDest = join(outputTarget.appDir ?? '', outputTarget.serviceWorker.swDest);
   }
 };
 

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -2330,7 +2330,7 @@ export interface ServiceWorkerConfig {
   cacheId?: string | undefined;
 
   /**
-   * Whether or not Workbox should attempt to identify an delete any precaches
+   * Whether or not Workbox should attempt to identify and delete any precaches
    * created by older, incompatible versions.
    *
    * @default false

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -2290,248 +2290,34 @@ export type OutputTarget =
  * Although we are using Workbox we are unfortunately unable to depend on the
  * published types for the library because they must be compiled using the
  * `webworker` lib for TypeScript, which cannot be used at the same time as
- * the `dom` lib. As a workaround the properties are copy-pasted here from
+ * the `dom` lib. So as a workaround we maintain our own interface here. See
+ * here to refer to the published version:
  * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/c7b4dadae5b320ad1311a8f82242b8f2f41b7b8c/types/workbox-build/generate-sw.d.ts#L3
  */
 export interface ServiceWorkerConfig {
+  // https://developers.google.com/web/tools/workbox/modules/workbox-build#full_generatesw_config
   unregister?: boolean;
 
-  /**
-   * The path and filename of the service worker file that will be created by the
-   * build process, relative to the current working directory. It must end in '.js'.
-   */
   swDest?: string;
   swSrc?: string;
-  /**
-   * The local directory you wish to match `globPatterns` against. The path is
-   * relative to the current directory.
-   */
   globPatterns?: string[];
-  /**
-   * A set of patterns matching files to always exclude when generating the
-   * precache manifest. For more information, see the definition of `ignore` in the `glob`
-   * [documentation](https://github.com/isaacs/node-glob#options).
-   *
-   * @default ['node_modules/**']
-   */
- globDirectory?: string | string[];
-  /**
-   * Files matching any of these patterns will be included in the precache
-   * manifest. For more information, see the
-   * [`glob` primer](https://github.com/isaacs/node-glob#glob-primer).
-   *
-   * @default ['**.{js,css,html}']
-   */
+  globDirectory?: string | string[];
   globIgnores?: string | string[];
-  /**
-   * If a URL is rendered based on some server-side logic, its contents may depend
-   * on multiple files or on some other unique string value. The keys in this object
-   * are server-rendered URLs. If the values are an array of strings, they will be
-   * interpreted as `glob` patterns, and the contents of any files matching the
-   * patterns will be used to uniquely version the URL. If used with a single string,
-   * it will be interpreted as unique versioning information that you've generated
-   * for a given URL.
-   */
-  templatedURLs?: any;
-
-
-
-  /**
-   * A list of entries to be precached, in addition to any entries that are
-   * generated as part of the build configuration.
-   */
-  additionalManifestEntries?: any[] | undefined;
-
-  /**
-   * The [targets](https://babeljs.io/docs/en/babel-preset-env#targets) to pass to
-   * `babel-preset-env` when transpiling the service worker bundle.
-   *
-   * @default ['chrome >= 56']
-   */
-  babelPresetEnvTargets?: string[] | undefined;
-
-  /**
-   * An optional ID to be prepended to cache names. This is primarily useful for
-   * local development where multiple sites may be served from the same
-   * `http://localhost:port` origin.
-   */
-  cacheId?: string;
-
-  /**
-   * Whether or not Workbox should attempt to identify and delete any precaches
-   * created by older, incompatible versions.
-   *
-   * @default false
-   */
-  cleanupOutdatedCaches?: boolean | undefined;
-
-  /**
-   * Whether or not the service worker should [start controlling](https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#clientsclaim)
-   * any existing clients as soon as it activates.
-   *
-   * @default false
-   */
-  clientsClaim?: boolean;
-
-  /**
-   * If a navigation request for a URL ending in `/` fails to match a precached
-   * URL, this value will be appended to the URL and that will be checked for
-   * a precache match. This should be set to what your web server is using for
-   * its directory index.
-   *
-   * @default 'index.html'
-   */
-  directoryIndex?: string;
-
-  /**
-   * Assets that match this will be assumed to be uniquely versioned via their
-   * URL, and exempted from the normal HTTP cache-busting that's done when
-   * populating the precache. While not required, it's recommended that if your
-   * existing build process already inserts a `[hash]` value into each filename,
-   * you provide a RegExp that will detect that, as it will reduce the bandwidth
-   * consumed when precaching.
-   */
-  dontCacheBustURLsMatching?: RegExp;
-
-  /**
-   * Determines whether or not symlinks are followed when generating the precache
-   * manifest. For more information, see the definition of `follow` in the `glob`
-   * [documentation](https://github.com/isaacs/node-glob#options).
-   *
-   * @default true
-   */
-  globFollow?: boolean | undefined;
-
-  /**
-   * If true, an error reading a directory when generating a precache manifest
-   * will cause the build to fail. If false, the problematic directory will be
-   * skipped. For more information, see the definition of `strict` in the `glob`
-   * [documentation](https://github.com/isaacs/node-glob#options).
-   *
-   * @default true
-   */
-  globStrict?: boolean | undefined;
-
-  /**
-   * Any search parameter names that match against one of the RegExp in this array
-   * will be removed before looking for a precache match. This is useful if your
-   * users might request URLs that contain, for example, URL parameters used to
-   * track the source of the traffic.
-   *
-   * @default [/^utm_/]
-   */
-  ignoreURLParametersMatching?: any[];
-  handleFetch?: boolean;
-
-  /**
-   * A list of JavaScript files that should be passed to [`importScripts()`](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts)
-   * inside the generated service worker file. This is  useful when you want to
-   * let Workbox create your top-level service worker file, but want to include
-   * some additional code, such as a push event listener.
-   */
-  importScripts?: string[] | undefined;
-
-  /**
-   * Whether the runtime code for the Workbox library should be included in the
-   * top-level service worker, or split into a separate file that needs to be deployed
-   * alongside the service worker. Keeping the runtime separate means that users will
-   * not have to re-download the Workbox code each time your top-level service worker changes.
-   *
-   * @default false
-   */
-  inlineWorkboxRuntime?: boolean | undefined;
-
-  /**
-   * This value can be used to determine the maximum size of files that will be
-   * precached. This prevents you from inadvertently precaching very large files
-   * that might have accidentally matched one of your patterns.
-   *
-   * @default 2097152
-   */
+  templatedUrls?: any;
   maximumFileSizeToCacheInBytes?: number;
-  /**
-   * One or more functions which will be applied sequentially against the
-   * generated manifest. If `modifyURLPrefix` or `dontCacheBustURLsMatching` are
-   * also specified, their corresponding transformations will be applied first.
-   */
   manifestTransforms?: any;
-
-  /**
-   * If set to 'production', then an optimized service worker bundle that excludes
-   * debugging info will be produced. If not explicitly configured here, the `mode`
-   * value configured in the current `webpack` compiltion will be used.
-   */
-  mode?: string | undefined;
-
-  /**
-   * If specified, all [navigation requests](https://developers.google.com/web/fundamentals/primers/service-workers/high-performance-loading#first_what_are_navigation_requests)
-   * for URLs that aren't precached will be fulfilled with the HTML at the URL
-   * provided. You must pass in the URL of an HTML document that is listed in your
-   * precache manifest. This is meant to be used in a Single Page App scenario, in
-   * which you want all navigations to use common [App Shell HTML](https://developers.google.com/web/fundamentals/architecture/app-shell).
-   */
+  modifyUrlPrefix?: any;
+  dontCacheBustURLsMatching?: RegExp;
   navigateFallback?: string;
-
-  /**
-   * An optional array of regular expressions that restricts which URLs the configured
-   * `navigateFallback` behavior applies to. This is useful if only a subset of
-   * your site's URLs should be treated as being part of a
-   * [Single Page App](https://en.wikipedia.org/wiki/Single-page_application). If
-   * both `navigateFallbackDenylist` and `navigateFallbackAllowlist` are
-   * configured, the denylist takes precedent.
-   */
+  navigateFallbackWhitelist?: RegExp[];
   navigateFallbackBlacklist?: RegExp[];
-
-  /**
-   * An optional array of regular expressions that restricts which URLs the configured
-   * `navigateFallback` behavior applies to. This is useful if only a subset of
-   * your site's URLs should be treated as being part of a
-   * [Single Page App](https://en.wikipedia.org/wiki/Single-page_application). If
-   * both `navigateFallbackDenylist` and `navigateFallbackAllowlist` are
-   * configured, the denylist takes precedent.
-   */
-  navigateFallbackWhitelist?: RegExp[] | undefined;
-
-  /**
-   * Whether or not to enable [navigation preload](https://developers.google.com/web/tools/workbox/modules/workbox-navigation-preload)
-   * in the generated service worker. When set to true, you must also use
-   * `runtimeCaching` to set up an appropriate response strategy that will match
-   * navigation requests, and make use of the preloaded response.
-   *
-   * @default false
-   */
-  navigationPreload?: boolean | undefined;
-
-  /**
-   * Controls whether or not to include support for [offline Google Analytics](https://developers.google.com/web/tools/workbox/guides/enable-offline-analytics).
-   * When `true`, the call to `workbox-google-analytics`'s `initialize()` will be
-   * added to your generated service worker. When set to an `Object`, that object
-   * will be passed in to the `initialize()` call, allowing you to customize the
-   * behavior.
-   *
-   * @default false
-   */
-  offlineGoogleAnalytics?: boolean | object | undefined;
-
-  runtimeCaching?: any[];
-
-  /**
-   * Whether to add an unconditional call to [`skipWaiting()`](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-core#.skipWaiting)
-   * to the generated service worker. If `false`, then a `message` listener will
-   * be added instead, allowing you to conditionally call `skipWaiting()`.
-   *
-   * @default false
-   */
+  cacheId?: string;
   skipWaiting?: boolean;
-
-  /**
-   * Whether to create a sourcemap for the generated service worker files.
-   *
-   * @default true
-   */
-  sourcemap?: boolean | undefined;
-
-
+  clientsClaim?: boolean;
+  directoryIndex?: string;
+  runtimeCaching?: any[];
+  ignoreUrlParametersMatching?: any[];
+  handleFetch?: boolean;
 }
 
 export interface LoadConfigInit {

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -2283,30 +2283,268 @@ export type OutputTarget =
   | OutputTargetStats
   | OutputTargetDistTypes;
 
+/**
+ * Our custom configuration interface for generated caching Service Workers
+ * using the Workbox library (see https://developer.chrome.com/docs/workbox/).
+ *
+ * Although we are using Workbox we are unfortunately unable to depend on the
+ * published types for the library because they must be compiled using the
+ * `webworker` lib for TypeScript, which cannot be used at the same time as
+ * the `dom` lib. As a workaround the properties are copy-pasted here from
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/c7b4dadae5b320ad1311a8f82242b8f2f41b7b8c/types/workbox-build/generate-sw.d.ts#L3
+ */
 export interface ServiceWorkerConfig {
-  // https://developers.google.com/web/tools/workbox/modules/workbox-build#full_generatesw_config
+  swSrc?: string;
   unregister?: boolean;
 
+  /**
+   * The local directory you wish to match `globPatterns` against. The path is relative to the current directory.
+   */
+  globDirectory?: string;
+
+  /**
+   * The path and filename of the service worker file that will be created by the
+   * build process, relative to the current working directory. It must end in '.js'.
+   */
   swDest?: string;
-  swSrc?: string;
-  globPatterns?: string[];
-  globDirectory?: string | string[];
+
+  /**
+   * A list of entries to be precached, in addition to any entries that are
+   * generated as part of the build configuration.
+   */
+  additionalManifestEntries?: any[] | undefined;
+
+  /**
+   * The [targets](https://babeljs.io/docs/en/babel-preset-env#targets) to pass to
+   * `babel-preset-env` when transpiling the service worker bundle.
+   *
+   * @default ['chrome >= 56']
+   */
+  babelPresetEnvTargets?: string[] | undefined;
+
+  /**
+   * An optional ID to be prepended to cache names. This is primarily useful for
+   * local development where multiple sites may be served from the same
+   * `http://localhost:port` origin.
+   */
+  cacheId?: string | undefined;
+
+  /**
+   * Whether or not Workbox should attempt to identify an delete any precaches
+   * created by older, incompatible versions.
+   *
+   * @default false
+   */
+  cleanupOutdatedCaches?: boolean | undefined;
+
+  /**
+   * Whether or not the service worker should [start controlling](https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#clientsclaim)
+   * any existing clients as soon as it activates.
+   *
+   * @default false
+   */
+  clientsClaim?: boolean | undefined;
+
+  /**
+   * If a navigation request for a URL ending in `/` fails to match a precached
+   * URL, this value will be appended to the URL and that will be checked for
+   * a precache match. This should be set to what your web server is using for
+   * its directory index.
+   *
+   * @default 'index.html'
+   */
+  directoryIndex?: string | undefined;
+
+  /**
+   * Assets that match this will be assumed to be uniquely versioned via their
+   * URL, and exempted from the normal HTTP cache-busting that's done when
+   * populating the precache. While not required, it's recommended that if your
+   * existing build process already inserts a `[hash]` value into each filename,
+   * you provide a RegExp that will detect that, as it will reduce the bandwidth
+   * consumed when precaching.
+   */
+  dontCacheBustURLsMatching?: RegExp | undefined;
+
+  /**
+   * Determines whether or not symlinks are followed when generating the precache
+   * manifest. For more information, see the definition of `follow` in the `glob`
+   * [documentation](https://github.com/isaacs/node-glob#options).
+   *
+   * @default true
+   */
+  globFollow?: boolean | undefined;
+
+  /**
+   * A set of patterns matching files to always exclude when generating the
+   * precache manifest. For more information, see the definition of `ignore` in the `glob`
+   * [documentation](https://github.com/isaacs/node-glob#options).
+   *
+   * @default ['node_modules/**']
+   */
   globIgnores?: string | string[];
-  templatedUrls?: any;
-  maximumFileSizeToCacheInBytes?: number;
-  manifestTransforms?: any;
-  modifyUrlPrefix?: any;
-  dontCacheBustURLsMatching?: RegExp;
-  navigateFallback?: string;
-  navigateFallbackWhitelist?: RegExp[];
-  navigateFallbackBlacklist?: RegExp[];
-  cacheId?: string;
-  skipWaiting?: boolean;
-  clientsClaim?: boolean;
-  directoryIndex?: string;
-  runtimeCaching?: any[];
-  ignoreUrlParametersMatching?: any[];
-  handleFetch?: boolean;
+
+  /**
+   * Files matching any of these patterns will be included in the precache
+   * manifest. For more information, see the
+   * [`glob` primer](https://github.com/isaacs/node-glob#glob-primer).
+   *
+   * @default ['**.{js,css,html}']
+   */
+  globPatterns?: string[] | undefined;
+
+  /**
+   * If true, an error reading a directory when generating a precache manifest
+   * will cause the build to fail. If false, the problematic directory will be
+   * skipped. For more information, see the definition of `strict` in the `glob`
+   * [documentation](https://github.com/isaacs/node-glob#options).
+   *
+   * @default true
+   */
+  globStrict?: boolean | undefined;
+
+  /**
+   * Any search parameter names that match against one of the RegExp in this array
+   * will be removed before looking for a precache match. This is useful if your
+   * users might request URLs that contain, for example, URL parameters used to
+   * track the source of the traffic.
+   *
+   * @default [/^utm_/]
+   */
+  ignoreURLParametersMatching?: RegExp[] | undefined;
+
+  /**
+   * A list of JavaScript files that should be passed to [`importScripts()`](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts)
+   * inside the generated service worker file. This is  useful when you want to
+   * let Workbox create your top-level service worker file, but want to include
+   * some additional code, such as a push event listener.
+   */
+  importScripts?: string[] | undefined;
+
+  /**
+   * Whether the runtime code for the Workbox library should be included in the
+   * top-level service worker, or split into a separate file that needs to be deployed
+   * alongside the service worker. Keeping the runtime separate means that users will
+   * not have to re-download the Workbox code each time your top-level service worker changes.
+   *
+   * @default false
+   */
+  inlineWorkboxRuntime?: boolean | undefined;
+
+  /**
+   * One or more functions which will be applied sequentially against the
+   * generated manifest. If `modifyURLPrefix` or `dontCacheBustURLsMatching` are
+   * also specified, their corresponding transformations will be applied first.
+   */
+  manifestTransforms?: any[] | undefined;
+
+  /**
+   * This value can be used to determine the maximum size of files that will be
+   * precached. This prevents you from inadvertently precaching very large files
+   * that might have accidentally matched one of your patterns.
+   *
+   * @default 2097152
+   */
+  maximumFileSizeToCacheInBytes?: number | undefined;
+
+  /**
+   * If set to 'production', then an optimized service worker bundle that excludes
+   * debugging info will be produced. If not explicitly configured here, the `mode`
+   * value configured in the current `webpack` compiltion will be used.
+   */
+  mode?: string | undefined;
+
+  /**
+   * A mapping of prefixes that, if present in an entry in the precache manifest,
+   * will be replaced with the corresponding value. This can be used to, for example,
+   * remove or add a path prefix from a manifest entry if your web hosting setup
+   * doesn't match your local filesystem setup. As an alternative with more flexibility,
+   * you can use the `manifestTransforms` option and provide a function that modifies
+   * the entries in the manifest using whatever logic you provide.
+   */
+  modifyURLPrefix?:
+    | {
+        [key: string]: string;
+      }
+    | undefined;
+
+  /**
+   * If specified, all [navigation requests](https://developers.google.com/web/fundamentals/primers/service-workers/high-performance-loading#first_what_are_navigation_requests)
+   * for URLs that aren't precached will be fulfilled with the HTML at the URL
+   * provided. You must pass in the URL of an HTML document that is listed in your
+   * precache manifest. This is meant to be used in a Single Page App scenario, in
+   * which you want all navigations to use common [App Shell HTML](https://developers.google.com/web/fundamentals/architecture/app-shell).
+   */
+  navigateFallback?: string | undefined;
+
+  /**
+   * An optional array of regular expressions that restricts which URLs the configured
+   * `navigateFallback` behavior applies to. This is useful if only a subset of
+   * your site's URLs should be treated as being part of a
+   * [Single Page App](https://en.wikipedia.org/wiki/Single-page_application). If
+   * both `navigateFallbackDenylist` and `navigateFallbackAllowlist` are
+   * configured, the denylist takes precedent.
+   */
+  navigateFallbackDenylist?: RegExp[] | undefined;
+
+  /**
+   * An optional array of regular expressions that restricts which URLs the configured
+   * `navigateFallback` behavior applies to. This is useful if only a subset of
+   * your site's URLs should be treated as being part of a
+   * [Single Page App](https://en.wikipedia.org/wiki/Single-page_application). If
+   * both `navigateFallbackDenylist` and `navigateFallbackAllowlist` are
+   * configured, the denylist takes precedent.
+   */
+  navigateFallbackAllowlist?: RegExp[] | undefined;
+
+  /**
+   * Whether or not to enable [navigation preload](https://developers.google.com/web/tools/workbox/modules/workbox-navigation-preload)
+   * in the generated service worker. When set to true, you must also use
+   * `runtimeCaching` to set up an appropriate response strategy that will match
+   * navigation requests, and make use of the preloaded response.
+   *
+   * @default false
+   */
+  navigationPreload?: boolean | undefined;
+
+  /**
+   * Controls whether or not to include support for [offline Google Analytics](https://developers.google.com/web/tools/workbox/guides/enable-offline-analytics).
+   * When `true`, the call to `workbox-google-analytics`'s `initialize()` will be
+   * added to your generated service worker. When set to an `Object`, that object
+   * will be passed in to the `initialize()` call, allowing you to customize the
+   * behavior.
+   *
+   * @default false
+   */
+  offlineGoogleAnalytics?: boolean | object | undefined;
+
+  runtimeCaching?: any[] | undefined;
+
+  /**
+   * Whether to add an unconditional call to [`skipWaiting()`](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-core#.skipWaiting)
+   * to the generated service worker. If `false`, then a `message` listener will
+   * be added instead, allowing you to conditionally call `skipWaiting()`.
+   *
+   * @default false
+   */
+  skipWaiting?: boolean | undefined;
+
+  /**
+   * Whether to create a sourcemap for the generated service worker files.
+   *
+   * @default true
+   */
+  sourcemap?: boolean | undefined;
+
+  /**
+   * If a URL is rendered based on some server-side logic, its contents may depend
+   * on multiple files or on some other unique string value. The keys in this object
+   * are server-rendered URLs. If the values are an array of strings, they will be
+   * interpreted as `glob` patterns, and the contents of any files matching the
+   * patterns will be used to uniquely version the URL. If used with a single string,
+   * it will be interpreted as unique versioning information that you've generated
+   * for a given URL.
+   */
+  templatedURLs?: object | undefined;
 }
 
 export interface LoadConfigInit {

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -2294,19 +2294,47 @@ export type OutputTarget =
  * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/c7b4dadae5b320ad1311a8f82242b8f2f41b7b8c/types/workbox-build/generate-sw.d.ts#L3
  */
 export interface ServiceWorkerConfig {
-  swSrc?: string;
   unregister?: boolean;
-
-  /**
-   * The local directory you wish to match `globPatterns` against. The path is relative to the current directory.
-   */
-  globDirectory?: string;
 
   /**
    * The path and filename of the service worker file that will be created by the
    * build process, relative to the current working directory. It must end in '.js'.
    */
   swDest?: string;
+  swSrc?: string;
+  /**
+   * The local directory you wish to match `globPatterns` against. The path is
+   * relative to the current directory.
+   */
+  globPatterns?: string[];
+  /**
+   * A set of patterns matching files to always exclude when generating the
+   * precache manifest. For more information, see the definition of `ignore` in the `glob`
+   * [documentation](https://github.com/isaacs/node-glob#options).
+   *
+   * @default ['node_modules/**']
+   */
+ globDirectory?: string | string[];
+  /**
+   * Files matching any of these patterns will be included in the precache
+   * manifest. For more information, see the
+   * [`glob` primer](https://github.com/isaacs/node-glob#glob-primer).
+   *
+   * @default ['**.{js,css,html}']
+   */
+  globIgnores?: string | string[];
+  /**
+   * If a URL is rendered based on some server-side logic, its contents may depend
+   * on multiple files or on some other unique string value. The keys in this object
+   * are server-rendered URLs. If the values are an array of strings, they will be
+   * interpreted as `glob` patterns, and the contents of any files matching the
+   * patterns will be used to uniquely version the URL. If used with a single string,
+   * it will be interpreted as unique versioning information that you've generated
+   * for a given URL.
+   */
+  templatedURLs?: any;
+
+
 
   /**
    * A list of entries to be precached, in addition to any entries that are
@@ -2327,7 +2355,7 @@ export interface ServiceWorkerConfig {
    * local development where multiple sites may be served from the same
    * `http://localhost:port` origin.
    */
-  cacheId?: string | undefined;
+  cacheId?: string;
 
   /**
    * Whether or not Workbox should attempt to identify and delete any precaches
@@ -2343,7 +2371,7 @@ export interface ServiceWorkerConfig {
    *
    * @default false
    */
-  clientsClaim?: boolean | undefined;
+  clientsClaim?: boolean;
 
   /**
    * If a navigation request for a URL ending in `/` fails to match a precached
@@ -2353,7 +2381,7 @@ export interface ServiceWorkerConfig {
    *
    * @default 'index.html'
    */
-  directoryIndex?: string | undefined;
+  directoryIndex?: string;
 
   /**
    * Assets that match this will be assumed to be uniquely versioned via their
@@ -2363,7 +2391,7 @@ export interface ServiceWorkerConfig {
    * you provide a RegExp that will detect that, as it will reduce the bandwidth
    * consumed when precaching.
    */
-  dontCacheBustURLsMatching?: RegExp | undefined;
+  dontCacheBustURLsMatching?: RegExp;
 
   /**
    * Determines whether or not symlinks are followed when generating the precache
@@ -2373,24 +2401,6 @@ export interface ServiceWorkerConfig {
    * @default true
    */
   globFollow?: boolean | undefined;
-
-  /**
-   * A set of patterns matching files to always exclude when generating the
-   * precache manifest. For more information, see the definition of `ignore` in the `glob`
-   * [documentation](https://github.com/isaacs/node-glob#options).
-   *
-   * @default ['node_modules/**']
-   */
-  globIgnores?: string | string[];
-
-  /**
-   * Files matching any of these patterns will be included in the precache
-   * manifest. For more information, see the
-   * [`glob` primer](https://github.com/isaacs/node-glob#glob-primer).
-   *
-   * @default ['**.{js,css,html}']
-   */
-  globPatterns?: string[] | undefined;
 
   /**
    * If true, an error reading a directory when generating a precache manifest
@@ -2410,7 +2420,8 @@ export interface ServiceWorkerConfig {
    *
    * @default [/^utm_/]
    */
-  ignoreURLParametersMatching?: RegExp[] | undefined;
+  ignoreURLParametersMatching?: any[];
+  handleFetch?: boolean;
 
   /**
    * A list of JavaScript files that should be passed to [`importScripts()`](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts)
@@ -2431,20 +2442,19 @@ export interface ServiceWorkerConfig {
   inlineWorkboxRuntime?: boolean | undefined;
 
   /**
-   * One or more functions which will be applied sequentially against the
-   * generated manifest. If `modifyURLPrefix` or `dontCacheBustURLsMatching` are
-   * also specified, their corresponding transformations will be applied first.
-   */
-  manifestTransforms?: any[] | undefined;
-
-  /**
    * This value can be used to determine the maximum size of files that will be
    * precached. This prevents you from inadvertently precaching very large files
    * that might have accidentally matched one of your patterns.
    *
    * @default 2097152
    */
-  maximumFileSizeToCacheInBytes?: number | undefined;
+  maximumFileSizeToCacheInBytes?: number;
+  /**
+   * One or more functions which will be applied sequentially against the
+   * generated manifest. If `modifyURLPrefix` or `dontCacheBustURLsMatching` are
+   * also specified, their corresponding transformations will be applied first.
+   */
+  manifestTransforms?: any;
 
   /**
    * If set to 'production', then an optimized service worker bundle that excludes
@@ -2454,27 +2464,13 @@ export interface ServiceWorkerConfig {
   mode?: string | undefined;
 
   /**
-   * A mapping of prefixes that, if present in an entry in the precache manifest,
-   * will be replaced with the corresponding value. This can be used to, for example,
-   * remove or add a path prefix from a manifest entry if your web hosting setup
-   * doesn't match your local filesystem setup. As an alternative with more flexibility,
-   * you can use the `manifestTransforms` option and provide a function that modifies
-   * the entries in the manifest using whatever logic you provide.
-   */
-  modifyURLPrefix?:
-    | {
-        [key: string]: string;
-      }
-    | undefined;
-
-  /**
    * If specified, all [navigation requests](https://developers.google.com/web/fundamentals/primers/service-workers/high-performance-loading#first_what_are_navigation_requests)
    * for URLs that aren't precached will be fulfilled with the HTML at the URL
    * provided. You must pass in the URL of an HTML document that is listed in your
    * precache manifest. This is meant to be used in a Single Page App scenario, in
    * which you want all navigations to use common [App Shell HTML](https://developers.google.com/web/fundamentals/architecture/app-shell).
    */
-  navigateFallback?: string | undefined;
+  navigateFallback?: string;
 
   /**
    * An optional array of regular expressions that restricts which URLs the configured
@@ -2484,7 +2480,7 @@ export interface ServiceWorkerConfig {
    * both `navigateFallbackDenylist` and `navigateFallbackAllowlist` are
    * configured, the denylist takes precedent.
    */
-  navigateFallbackDenylist?: RegExp[] | undefined;
+  navigateFallbackBlacklist?: RegExp[];
 
   /**
    * An optional array of regular expressions that restricts which URLs the configured
@@ -2494,7 +2490,7 @@ export interface ServiceWorkerConfig {
    * both `navigateFallbackDenylist` and `navigateFallbackAllowlist` are
    * configured, the denylist takes precedent.
    */
-  navigateFallbackAllowlist?: RegExp[] | undefined;
+  navigateFallbackWhitelist?: RegExp[] | undefined;
 
   /**
    * Whether or not to enable [navigation preload](https://developers.google.com/web/tools/workbox/modules/workbox-navigation-preload)
@@ -2517,7 +2513,7 @@ export interface ServiceWorkerConfig {
    */
   offlineGoogleAnalytics?: boolean | object | undefined;
 
-  runtimeCaching?: any[] | undefined;
+  runtimeCaching?: any[];
 
   /**
    * Whether to add an unconditional call to [`skipWaiting()`](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-core#.skipWaiting)
@@ -2526,7 +2522,7 @@ export interface ServiceWorkerConfig {
    *
    * @default false
    */
-  skipWaiting?: boolean | undefined;
+  skipWaiting?: boolean;
 
   /**
    * Whether to create a sourcemap for the generated service worker files.
@@ -2535,16 +2531,7 @@ export interface ServiceWorkerConfig {
    */
   sourcemap?: boolean | undefined;
 
-  /**
-   * If a URL is rendered based on some server-side logic, its contents may depend
-   * on multiple files or on some other unique string value. The keys in this object
-   * are server-rendered URLs. If the values are an array of strings, they will be
-   * interpreted as `glob` patterns, and the contents of any files matching the
-   * patterns will be used to uniquely version the URL. If used with a single string,
-   * it will be interpreted as unique versioning information that you've generated
-   * for a given URL.
-   */
-  templatedURLs?: object | undefined;
+
 }
 
 export interface LoadConfigInit {


### PR DESCRIPTION
This adds JSDoc comments to validate-service-worker.ts, and does a (very light) refactor just moving around a bit of logic.

This service worker configuration is using the Workbox library for generating a caching service worker automatically, but at present we do not depend on the published types for Workbox. Since there is an compatibility issue using web worker typings alongside the DOM typings we're already using (by setting the `lib` property in `tsconfig.json`) we can't depend on those published typings directly until we can separately set compilation options in the code (using project references, for instance). As a workaround the current typings for the options interface for Workbox are copied into the code.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

No JSDocs in the validation code for service worker configuration!

## What is the new behavior?

Now we have JSDocs in this module!

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
