### PR TITLE
fix(cli): ensure that argument order is correct for Jest

### DIFF
--- a/src/testing/jest/test/jest-config.spec.ts
+++ b/src/testing/jest/test/jest-config.spec.ts
@@ -42,7 +42,7 @@ describe('jest-config', () => {
     expect(jestArgv.maxWorkers).toBe(2);
   });
 
-  it('forces --maxWorkers=4 arg when e2e test and --ci', () => {
+  it('passes default --maxWorkers=0 arg when e2e test and --ci', () => {
     const args = ['test', '--ci', '--e2e'];
     const config = mockValidatedConfig();
     config.flags = parseFlags(args);
@@ -53,6 +53,20 @@ describe('jest-config', () => {
     const jestArgv = buildJestArgv(config);
     expect(jestArgv.ci).toBe(true);
     expect(jestArgv.maxWorkers).toBe(0);
+  });
+
+  it('passed default --maxWorkers=0 arg when e2e test and --ci with filepath', () => {
+    const args = ['test', '--ci', '--e2e', '--', 'my-specfile.spec.ts'];
+    const config = mockValidatedConfig();
+    config.flags = parseFlags(args);
+
+    expect(config.flags.args).toEqual(['--ci', '--e2e', '--', 'my-specfile.spec.ts']);
+    expect(config.flags.unknownArgs).toEqual(['--', 'my-specfile.spec.ts']);
+
+    const jestArgv = buildJestArgv(config);
+    expect(jestArgv.ci).toBe(true);
+    expect(jestArgv.maxWorkers).toBe(0);
+    expect(jestArgv._).toEqual(['my-specfile.spec.ts']);
   });
 
   it('pass --maxWorkers=2 arg to jest', () => {
@@ -200,5 +214,15 @@ describe('jest-config', () => {
 
     const jestArgv = buildJestArgv(config);
     expect(jestArgv.json).toBe(true);
+    // the `_` field holds any filename pattern matches
+    expect(jestArgv._).toEqual(['my-component.spec.ts']);
+  });
+
+  it('should parse multiple file patterns', () => {
+    const args = ['test', '--spec', '--json', '--', 'foobar/*', 'my-spec.ts'];
+    const jestArgv = buildJestArgv(mockValidatedConfig({ flags: parseFlags(args) }));
+    expect(jestArgv.json).toBe(true);
+    // the `_` field holds any filename pattern matches
+    expect(jestArgv._).toEqual(['foobar/*', 'my-spec.ts']);
   });
 });


### PR DESCRIPTION
This ensures that CLI arguments are ordered correctly when we pass them to Jest. In particular, we want to ensure that all flags of the type `--maxWorkers=0` and the like are _before_ any flags which we don't know about, like `my-spec-file.ts` (the latter being actually a match pattern for which spec files to run).

In other words, if the user passes arguments like this:

```
--e2e foo.spec.ts
```

or

```
--e2e -- foo.spec.ts
```

We need to ensure we use something like

```
["--e2e", "foo.spec.ts"]
```

to generate the Jest config.

The wrinkle is that after we've parsed our known CLI arguments (in the `cli` module) we do some addition modification of the arguments, based on values set in the `Config`, in the `buildJestArgv` function. In particular, we'll look to see if a `maxWorkers` flag is already passed and, if not, we add one to the args before they're used to build the Jest configuration.

Before this change that would result in an array like this being passed to Jest:

```
["--e2e", "foo.spec.ts", "--maxWorkers=0"]
```

because we simply stuck the new `--maxWorkers` arg right on the end of the already-combined array (combined because it's basically `knownArgs + unknownArgs`). No good!

Instead, we modify a copy of `knownArgs` with flags like this and then produce a new, combined array to pass to Jest when we're all done, so it looks like this instead:

```
["--e2e", "--maxWorkers=0", "foo.spec.ts"]
```

Much better!

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

In certain cases passing a filename pattern to `stencil test` will not cause the right test files to run. Boo!


## What is the new behavior?

The bug is fixed by re-ordering arguments before they're using to generate a Jest configuration.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

There are reproductions linked in both #3785 and #3825. I confirmed that the fix addressed both of those issues, and also added regression tests which fail without the fix.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
