### PR TITLE
test(transform-utils): add isMemberPrivate unit tests

### DIFF
--- a/src/compiler/transformers/test/transform-utils.spec.ts
+++ b/src/compiler/transformers/test/transform-utils.spec.ts
@@ -55,9 +55,10 @@ describe('transform utils', () => {
      * @param modifier the modifier to apply to the method. Defaults to applying no modifier if none is provided
      * @returns a new empty method
      */
-    const createMemberWithModifier = (modifier: ts.ModifierLike = undefined): ts.MethodDeclaration => {
+    const createMemberWithModifier = (modifier: ts.Modifier | undefined = undefined): ts.MethodDeclaration => {
       const modifiers = modifier ? [modifier] : [];
       return ts.factory.createMethodDeclaration(
+        undefined,
         modifiers,
         undefined,
         ts.factory.createIdentifier('myMethod'),

--- a/src/compiler/transformers/test/transform-utils.spec.ts
+++ b/src/compiler/transformers/test/transform-utils.spec.ts
@@ -1,4 +1,6 @@
-import { mapJSDocTagInfo } from '../transform-utils';
+import * as ts from 'typescript';
+
+import { isMemberPrivate, mapJSDocTagInfo } from '../transform-utils';
 
 describe('transform utils', () => {
   it('flattens TypeScript JSDocTagInfo to Stencil JSDocTagInfo', () => {
@@ -37,5 +39,55 @@ describe('transform utils', () => {
       { name: 'returns', text: undefined },
       { name: 'see', text: '{@link https://example.com}' },
     ]);
+  });
+
+  describe('isMemberPrivate', () => {
+    /**
+     * Helper method for creating an empty method named 'myMethod' with the provided modifier's.
+     *
+     * @example
+     * // By default, no modifier will be applied, and the following will be returned:
+     * createMemberWithModifier(); // myMethod() {}
+     *
+     * // Otherwise, the provided modifier will be applied to the method:
+     * createMemberWithModifier(ts.factory.createModifier(ts.SyntaxKind.PrivateKeyword)); // private myMethod() {}
+     *
+     * @param modifier the modifier to apply to the method. Defaults to applying no modifier if none is provided
+     * @returns a new empty method
+     */
+    const createMemberWithModifier = (modifier: ts.ModifierLike = undefined): ts.MethodDeclaration => {
+      const modifiers = modifier ? [modifier] : [];
+      return ts.factory.createMethodDeclaration(
+        modifiers,
+        undefined,
+        ts.factory.createIdentifier('myMethod'),
+        undefined,
+        undefined,
+        [],
+        undefined,
+        ts.factory.createBlock([], false)
+      );
+    };
+
+    it('returns false when the member has no modifiers', () => {
+      const methodDeclaration = createMemberWithModifier();
+
+      expect(isMemberPrivate(methodDeclaration)).toBe(false);
+    });
+
+    it('returns false when the member has a non-private modifier', () => {
+      const methodDeclaration = createMemberWithModifier(ts.factory.createModifier(ts.SyntaxKind.PublicKeyword));
+
+      expect(isMemberPrivate(methodDeclaration)).toBe(false);
+    });
+
+    it.each<[string, ts.ModifierSyntaxKind]>([
+      ['private', ts.SyntaxKind.PrivateKeyword],
+      ['protected', ts.SyntaxKind.ProtectedKeyword],
+    ])('returns true when the member has a (%s) modifier', (_name, modifier) => {
+      const methodDeclaration = createMemberWithModifier(ts.factory.createModifier(modifier));
+
+      expect(isMemberPrivate(methodDeclaration)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There are no unit tests for `isMemberPrivate`.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit adds unit tests to the `isMemberPrivate` function in the transform-utils module. this is being done in preparation for changes to the function that are to occur in the typescript 4.8 upgrade. adding unit tests will provide additional safety during the upgrade, but aren't strictly necessary for it. the hope is to land this commit to the primary branch prior to the upgrade.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Unit tests continue to pass. I tailed the execution of these in the debugger as well.
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
