### PR TITLE
chore(release): re-enable custom release versions

### DIFF
--- a/scripts/release-tasks.ts
+++ b/scripts/release-tasks.ts
@@ -166,65 +166,65 @@ export function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<string>)
   }
 
   if (opts.isPublishRelease) {
-    // tasks.push(
-    //   {
-    //     title: 'Publish @stencil/core to npm',
-    //     task: () => {
-    //       const cmd = 'npm';
-    //       const cmdArgs = ['publish', '--otp', opts.otp].concat(opts.tag ? ['--tag', opts.tag] : []);
-    //
-    //       if (isDryRun) {
-    //         return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
-    //       }
-    //       return execa(cmd, cmdArgs, { cwd: rootDir });
-    //     },
-    //   },
-    //   {
-    //     title: 'Tagging the latest git commit',
-    //     task: () => {
-    //       const cmd = 'git';
-    //       const cmdArgs = ['tag', `v${opts.version}`];
-    //
-    //       if (isDryRun) {
-    //         return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
-    //       }
-    //       return execa(cmd, cmdArgs, { cwd: rootDir });
-    //     },
-    //   },
-    //   {
-    //     title: 'Pushing git commits',
-    //     task: () => {
-    //       const cmd = 'git';
-    //       const cmdArgs = ['push'];
-    //
-    //       if (isDryRun) {
-    //         return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
-    //       }
-    //       return execa(cmd, cmdArgs, { cwd: rootDir });
-    //     },
-    //   },
-    //   {
-    //     title: 'Pushing git tags',
-    //     task: () => {
-    //       const cmd = 'git';
-    //       const cmdArgs = ['push', '--tags'];
-    //
-    //       if (isDryRun) {
-    //         return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
-    //       }
-    //       return execa(cmd, cmdArgs, { cwd: rootDir });
-    //     },
-    //   }
-    // );
+    tasks.push(
+      {
+        title: 'Publish @stencil/core to npm',
+        task: () => {
+          const cmd = 'npm';
+          const cmdArgs = ['publish', '--otp', opts.otp].concat(opts.tag ? ['--tag', opts.tag] : []);
+
+          if (isDryRun) {
+            return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
+          }
+          return execa(cmd, cmdArgs, { cwd: rootDir });
+        },
+      },
+      {
+        title: 'Tagging the latest git commit',
+        task: () => {
+          const cmd = 'git';
+          const cmdArgs = ['tag', `v${opts.version}`];
+
+          if (isDryRun) {
+            return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
+          }
+          return execa(cmd, cmdArgs, { cwd: rootDir });
+        },
+      },
+      {
+        title: 'Pushing git commits',
+        task: () => {
+          const cmd = 'git';
+          const cmdArgs = ['push'];
+
+          if (isDryRun) {
+            return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
+          }
+          return execa(cmd, cmdArgs, { cwd: rootDir });
+        },
+      },
+      {
+        title: 'Pushing git tags',
+        task: () => {
+          const cmd = 'git';
+          const cmdArgs = ['push', '--tags'];
+
+          if (isDryRun) {
+            return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
+          }
+          return execa(cmd, cmdArgs, { cwd: rootDir });
+        },
+      }
+    );
   }
 
   if (opts.isPublishRelease) {
-    // tasks.push({
-    //   title: 'Create Github Release',
-    //   task: () => {
-    //     return postGithubRelease(opts);
-    //   },
-    // });
+    tasks.push({
+      title: 'Create Github Release',
+      task: () => {
+        return postGithubRelease(opts);
+      },
+    });
   }
 
   const listr = new Listr(tasks);
@@ -233,11 +233,11 @@ export function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<string>)
     .run()
     .then(() => {
       if (opts.isPublishRelease) {
-        // console.log(
-        //   `\n ${opts.vermoji}  ${color.bold.magenta(pkg.name)} ${color.bold.yellow(newVersion)} published!! ${
-        //     opts.vermoji
-        //   }\n`
-        // );
+        console.log(
+          `\n ${opts.vermoji}  ${color.bold.magenta(pkg.name)} ${color.bold.yellow(newVersion)} published!! ${
+            opts.vermoji
+          }\n`
+        );
       } else {
         console.log(
           `\n ${opts.vermoji}  ${color.bold.magenta(pkg.name)} ${color.bold.yellow(

--- a/scripts/release-tasks.ts
+++ b/scripts/release-tasks.ts
@@ -166,65 +166,65 @@ export function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<string>)
   }
 
   if (opts.isPublishRelease) {
-    tasks.push(
-      {
-        title: 'Publish @stencil/core to npm',
-        task: () => {
-          const cmd = 'npm';
-          const cmdArgs = ['publish', '--otp', opts.otp].concat(opts.tag ? ['--tag', opts.tag] : []);
-
-          if (isDryRun) {
-            return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
-          }
-          return execa(cmd, cmdArgs, { cwd: rootDir });
-        },
-      },
-      {
-        title: 'Tagging the latest git commit',
-        task: () => {
-          const cmd = 'git';
-          const cmdArgs = ['tag', `v${opts.version}`];
-
-          if (isDryRun) {
-            return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
-          }
-          return execa(cmd, cmdArgs, { cwd: rootDir });
-        },
-      },
-      {
-        title: 'Pushing git commits',
-        task: () => {
-          const cmd = 'git';
-          const cmdArgs = ['push'];
-
-          if (isDryRun) {
-            return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
-          }
-          return execa(cmd, cmdArgs, { cwd: rootDir });
-        },
-      },
-      {
-        title: 'Pushing git tags',
-        task: () => {
-          const cmd = 'git';
-          const cmdArgs = ['push', '--tags'];
-
-          if (isDryRun) {
-            return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
-          }
-          return execa(cmd, cmdArgs, { cwd: rootDir });
-        },
-      }
-    );
+    // tasks.push(
+    //   {
+    //     title: 'Publish @stencil/core to npm',
+    //     task: () => {
+    //       const cmd = 'npm';
+    //       const cmdArgs = ['publish', '--otp', opts.otp].concat(opts.tag ? ['--tag', opts.tag] : []);
+    //
+    //       if (isDryRun) {
+    //         return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
+    //       }
+    //       return execa(cmd, cmdArgs, { cwd: rootDir });
+    //     },
+    //   },
+    //   {
+    //     title: 'Tagging the latest git commit',
+    //     task: () => {
+    //       const cmd = 'git';
+    //       const cmdArgs = ['tag', `v${opts.version}`];
+    //
+    //       if (isDryRun) {
+    //         return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
+    //       }
+    //       return execa(cmd, cmdArgs, { cwd: rootDir });
+    //     },
+    //   },
+    //   {
+    //     title: 'Pushing git commits',
+    //     task: () => {
+    //       const cmd = 'git';
+    //       const cmdArgs = ['push'];
+    //
+    //       if (isDryRun) {
+    //         return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
+    //       }
+    //       return execa(cmd, cmdArgs, { cwd: rootDir });
+    //     },
+    //   },
+    //   {
+    //     title: 'Pushing git tags',
+    //     task: () => {
+    //       const cmd = 'git';
+    //       const cmdArgs = ['push', '--tags'];
+    //
+    //       if (isDryRun) {
+    //         return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
+    //       }
+    //       return execa(cmd, cmdArgs, { cwd: rootDir });
+    //     },
+    //   }
+    // );
   }
 
   if (opts.isPublishRelease) {
-    tasks.push({
-      title: 'Create Github Release',
-      task: () => {
-        return postGithubRelease(opts);
-      },
-    });
+    // tasks.push({
+    //   title: 'Create Github Release',
+    //   task: () => {
+    //     return postGithubRelease(opts);
+    //   },
+    // });
   }
 
   const listr = new Listr(tasks);
@@ -233,11 +233,11 @@ export function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<string>)
     .run()
     .then(() => {
       if (opts.isPublishRelease) {
-        console.log(
-          `\n ${opts.vermoji}  ${color.bold.magenta(pkg.name)} ${color.bold.yellow(newVersion)} published!! ${
-            opts.vermoji
-          }\n`
-        );
+        // console.log(
+        //   `\n ${opts.vermoji}  ${color.bold.magenta(pkg.name)} ${color.bold.yellow(newVersion)} published!! ${
+        //     opts.vermoji
+        //   }\n`
+        // );
       } else {
         console.log(
           `\n ${opts.vermoji}  ${color.bold.magenta(pkg.name)} ${color.bold.yellow(

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -111,7 +111,7 @@ async function prepareRelease(opts: BuildOptions, args: ReadonlyArray<string>, r
     .prompt(prompts)
     .then((answers) => {
       if (answers.confirm) {
-        opts.version = answers.version || answers.specifiedVersion;
+        opts.version = answers.version ?? answers.specifiedVersion;
         // write `release-data.json`
         fs.writeJsonSync(releaseDataPath, opts, { spaces: 2 });
         runReleaseTasks(opts, args);

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -84,7 +84,8 @@ async function prepareRelease(opts: BuildOptions, args: ReadonlyArray<string>, r
     },
     {
       type: 'input',
-      // this name is intentionally different from 'version' above. if they collide, this input prompt will not run.
+      // this name is intentionally different from 'version' above to make the `when` check below work properly
+      // (this prompt should only run if `version` was not already input)
       name: 'specifiedVersion',
       message: 'Specify Version',
       when: (answers: any) => !answers.version,

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -84,13 +84,14 @@ async function prepareRelease(opts: BuildOptions, args: ReadonlyArray<string>, r
     },
     {
       type: 'input',
-      name: 'version',
-      message: 'Version',
+      // this name is intentionally different from 'version' above. if they collide, this input prompt will not run.
+      name: 'specifiedVersion',
+      message: 'Specify Version',
       when: (answers: any) => !answers.version,
       filter: (input: string) => (isValidVersionInput(input) ? getNewVersion(pkg.version, input) : input),
       validate: (input: string) => {
         if (!isValidVersionInput(input)) {
-          return 'Please specify a valid semver, for example, `1.2.3`. See http://semver.org';
+          return 'Please specify a valid semver, for example, `1.2.3`, or `3.0.0-alpha.0`. See http://semver.org';
         }
         return true;
       },
@@ -99,7 +100,8 @@ async function prepareRelease(opts: BuildOptions, args: ReadonlyArray<string>, r
       type: 'confirm',
       name: 'confirm',
       message: (answers: any) => {
-        return `Prepare release ${opts.vermoji}  ${color.yellow(answers.version)} from ${oldVersion}. Continue?`;
+        const version = answers.version ?? answers.specifiedVersion;
+        return `Prepare release ${opts.vermoji}  ${color.yellow(version)} from ${oldVersion}. Continue?`;
       },
     },
   ];
@@ -108,7 +110,7 @@ async function prepareRelease(opts: BuildOptions, args: ReadonlyArray<string>, r
     .prompt(prompts)
     .then((answers) => {
       if (answers.confirm) {
-        opts.version = answers.version;
+        opts.version = answers.version || answers.specifiedVersion;
         // write `release-data.json`
         fs.writeJsonSync(releaseDataPath, opts, { spaces: 2 });
         runReleaseTasks(opts, args);
@@ -169,14 +171,15 @@ async function publishRelease(opts: BuildOptions, args: ReadonlyArray<string>): 
     },
     {
       type: 'input',
-      name: 'tag',
-      message: 'Tag',
+      // this name is intentionally different from 'tag' above. if they collide, this input prompt will not run.
+      name: 'specifiedTag',
+      message: 'Specify Tag',
       when: (answers: any) => !pkg.private && isPrereleaseVersion(opts.version) && !answers.tag,
       validate: (input: any) => {
         if (input.length === 0) {
-          return 'Please specify a tag, for example, `next`.';
+          return 'Please specify a tag, for example, `next` or `3.0.0-alpha.0`.';
         } else if (input.toLowerCase() === 'latest') {
-          return "It's not possible to publish pre-releases under the `latest` tag. Please specify something else, for example, `next`.";
+          return "It's not possible to publish pre-releases under the `latest` tag. Please specify something else, for example, `next` or `3.0.0-alpha.0`.";
         }
         return true;
       },
@@ -185,7 +188,7 @@ async function publishRelease(opts: BuildOptions, args: ReadonlyArray<string>): 
       type: 'confirm',
       name: 'confirm',
       message: (answers: any) => {
-        opts.tag = answers.tag;
+        opts.tag = answers.tag ?? answers.specifiedTag;
         const tagPart = opts.tag ? ` and tag this release in npm as ${color.yellow(opts.tag)}` : '';
         return `Will publish ${opts.vermoji}  ${color.yellow(opts.version)}${tagPart}. Continue?`;
       },


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Release-related changes


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When attempting to release Stencil with a custom version, the ability to
choose a custom semver-compliant name is broken. The prompt for
specifying a version gets skipped as such:
![Screenshot 2022-11-28 at 8 11 51 AM](https://user-images.githubusercontent.com/1930213/204286126-13cead37-d65a-4dfc-8b96-d69311066767.png)
<Hit Enter>
![Screenshot 2022-11-28 at 8 12 07 AM](https://user-images.githubusercontent.com/1930213/204286188-1713b8ab-dc66-44f7-bbce-f65c380fc5ee.png)
Note the empty version number to the right of the 🌹 vermoji


GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the prompts for the release scripts to allow for
custom versions and tags to be specified. an issue was occurring where
two inputs with the same name would only allow the first to be run. this
commit updates the second version & tag prompts to have a unique name,
where the two values are coalesced after either question is asked.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

This PR includes a second commit, e9f80f983510ac1aefcb7337e21dbb0326b64845, which comments out all tagging/pushing/etc. I tested this with that commit of this branch. From the pre-release:

![Screenshot 2022-11-28 at 8 13 59 AM](https://user-images.githubusercontent.com/1930213/204286557-b0f707d6-11d2-4a2f-9300-50346ec3e80d.png)
![Screenshot 2022-11-28 at 8 14 26 AM](https://user-images.githubusercontent.com/1930213/204286646-353ed509-6fb0-4548-8867-368b8aa1a9e8.png)
![Screenshot 2022-11-28 at 8 14 42 AM](https://user-images.githubusercontent.com/1930213/204286694-08dbe24a-02ca-43d3-ae03-4f85be101789.png)
![Screenshot 2022-11-28 at 8 18 37 AM](https://user-images.githubusercontent.com/1930213/204287520-8080c178-e83e-4642-901c-94d9dc3beefd.png)

Verified the version gets bumped to the changelog correctly (contents will be wonky, and that's OK, since we target `main` for this PR, it's not actually the v3.0.0-alpha.0 branch):
![Screenshot 2022-11-28 at 8 19 51 AM](https://user-images.githubusercontent.com/1930213/204287879-365d999f-f286-45b0-80c5-6dcb7c9d681b.png)

From the release:
![Screenshot 2022-11-28 at 8 21 15 AM](https://user-images.githubusercontent.com/1930213/204287967-702f6d5a-a67d-4bf0-a558-688828b9760a.png)
![Screenshot 2022-11-28 at 8 21 39 AM](https://user-images.githubusercontent.com/1930213/204288062-26954290-d9e1-492a-ba6c-60da9b7229c8.png)


## Other information


<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
