### PR TITLE
revert(terser): terser version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "rollup-plugin-sourcemaps": "^0.6.3",
         "semver": "^7.3.7",
         "sizzle": "^2.3.6",
-        "terser": "5.16.0",
+        "terser": "5.15.1",
         "typescript": "4.8.4",
         "webpack": "^4.46.0",
         "ws": "7.4.6"
@@ -12374,9 +12374,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.0.tgz",
-      "integrity": "sha512-KjTV81QKStSfwbNiwlBXfcgMcOloyuRdb62/iLFPGBcVNF4EXjhdYBhYHmbJpiBrVxZhDvltE11j+LBQUxEEJg==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
@@ -23423,9 +23423,9 @@
       }
     },
     "terser": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.0.tgz",
-      "integrity": "sha512-KjTV81QKStSfwbNiwlBXfcgMcOloyuRdb62/iLFPGBcVNF4EXjhdYBhYHmbJpiBrVxZhDvltE11j+LBQUxEEJg==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
       "dev": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "rollup-plugin-sourcemaps": "^0.6.3",
         "semver": "^7.3.7",
         "sizzle": "^2.3.6",
-        "terser": "5.15.1",
+        "terser": "5.6.1",
         "typescript": "4.8.4",
         "webpack": "^4.46.0",
         "ws": "7.4.6"
@@ -1173,30 +1173,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
       "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
-    "node_modules/@jridgewell/source-map/node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      },
       "engines": {
         "node": ">=6.0.0"
       }
@@ -11843,9 +11819,9 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
       "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -12374,15 +12350,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
-      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.6.1.tgz",
+      "integrity": "sha512-yv9YLFQQ+3ZqgWCUk+pvNJwgUTdlIxUk1WTN+RnaFJe2L7ipG2csPT0ra2XRm7Cs8cxN7QXmK1rFzEwYEQkzXw==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.19"
       },
       "bin": {
         "terser": "bin/terser"
@@ -12438,6 +12413,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/terser/node_modules/source-map": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/test-exclude": {
@@ -14533,29 +14517,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
       "dev": true
-    },
-    "@jridgewell/source-map": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      },
-      "dependencies": {
-        "@jridgewell/gen-mapping": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-          "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-          "dev": true,
-          "requires": {
-            "@jridgewell/set-array": "^1.0.1",
-            "@jridgewell/sourcemap-codec": "^1.4.10",
-            "@jridgewell/trace-mapping": "^0.3.9"
-          }
-        }
-      }
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
@@ -22979,9 +22940,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -23423,15 +23384,22 @@
       }
     },
     "terser": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
-      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.6.1.tgz",
+      "integrity": "sha512-yv9YLFQQ+3ZqgWCUk+pvNJwgUTdlIxUk1WTN+RnaFJe2L7ipG2csPT0ra2XRm7Cs8cxN7QXmK1rFzEwYEQkzXw==",
       "dev": true,
       "requires": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.19"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        }
       }
     },
     "terser-webpack-plugin": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "rollup-plugin-sourcemaps": "^0.6.3",
     "semver": "^7.3.7",
     "sizzle": "^2.3.6",
-    "terser": "5.16.0",
+    "terser": "5.15.1",
     "typescript": "4.8.4",
     "webpack": "^4.46.0",
     "ws": "7.4.6"

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "rollup-plugin-sourcemaps": "^0.6.3",
     "semver": "^7.3.7",
     "sizzle": "^2.3.6",
-    "terser": "5.15.1",
+    "terser": "5.6.1",
     "typescript": "4.8.4",
     "webpack": "^4.46.0",
     "ws": "7.4.6"

--- a/src/compiler/optimize/optimize-module.ts
+++ b/src/compiler/optimize/optimize-module.ts
@@ -59,7 +59,7 @@ export const optimizeModule = async (
   if (opts.sourceTarget === 'es5' || opts.minify) {
     minifyOpts = getTerserOptions(config, opts.sourceTarget, isDebug);
     if (config.sourceMap) {
-      minifyOpts.sourceMap = { content: { ...opts.sourceMap, version: 3 } };
+      minifyOpts.sourceMap = { content: opts.sourceMap };
     }
 
     const compressOpts = minifyOpts.compress as CompressOptions;
@@ -206,12 +206,7 @@ export const prepareModule = async (
         (minifyOpts.sourceMap as SourceMapOptions)?.content as SourceMap,
         JSON.parse(tsResults.sourceMapText)
       );
-      minifyOpts.sourceMap = {
-        content: {
-          ...mergeMap,
-          version: 3,
-        },
-      };
+      minifyOpts.sourceMap = { content: mergeMap };
     }
   }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): See below


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

On Monday, 2022.11.28, we had the [v3.0.0-alpha.0 release](7f4968b230903cc4a7e8f444de14b28ad1390c14). Following the release (I did this on Thursday, 2022.12.01), I merged the head of `main` into the `v3.0.0-dev` branch. [CI began to fail for the branch](https://github.com/ionic-team/stencil/actions/runs/3593285846) during our Analysis Tests:
```
 TypeError: Cannot read property 'map' of undefined
    at new TraceMap (/home/runner/work/stencil/stencil/compiler/stencil.js:9552:38)
    at new AnyMap (/home/runner/work/stencil/stencil/compiler/stencil.js:9415:12)
    at new SourceMapConsumer (/home/runner/work/stencil/stencil/compiler/stencil.js:9805:32)
    at SourceMap$4 (/home/runner/work/stencil/stencil/compiler/stencil.js:9838:322415)
    at minify (/home/runner/work/stencil/stencil/compiler/stencil.js:9838:478176)
    at minifyJs (/home/runner/work/stencil/stencil/compiler/stencil.js:9871:33)
    at prepareModule (/home/runner/work/stencil/stencil/compiler/stencil.js:10137:12)
    at /home/runner/work/stencil/stencil/compiler/stencil.js:13104:14
    at process.<anonymous> (/home/runner/work/stencil/stencil/sys/node/worker.js:42:28)
    at process.emit (events.js:400:28)
```

We know that the [v3.0.0-alpha.0 release](7f4968b230903cc4a7e8f444de14b28ad1390c14) has CI passing, so something introduced to `main` that wasn't in the `v3.0.0-dev` branch is either:
- directly causing the failure
- interacting with another change in the v3 branch to cause the failure

For some preliminary debugging, I checked out the `v3.0.0-alpha.0` tag (which passes CI) and applied the first of the two Terser changes we made to `main` - https://github.com/ionic-team/stencil/commit/87e4037894b9388dfb44a9925a814cfded19416d and was able to replicate.

This leads me to believe _that_ commit is the one that's causing the issue (either directly or indirectly). This aligns with the stacktrace, which points to [this section of code](https://github.com/ionic-team/stencil/commit/87e4037894b9388dfb44a9925a814cfded19416d#diff-2678363c62dd041b9e0bac8aa46483afe41c93ca8479093fbe48ba764ad4e7b3R209)

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This commit reverts the Terser changes to unblock Monday's upcoming Alpha release.

`main` is the target branch - we will land this revert in `main` and propagate it to `v3.0.0-dev`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

I originally pointed this change at `v3.0.0-dev` to ensure that CI passed
## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
