### PR TITLE
feat(typescript): add support for typescript 4.9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       - dependency-name: '@types/node'
         versions: ['17', '18']
       - dependency-name: 'typescript'
-        versions: ['>=4.9']
+        versions: ['>=4.10', '>=5.0']
       # disable Jest updates until the new testing architecture is in place
       - dependency-name: '@types/jest'
         versions: ['>=28']

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "semver": "^7.3.7",
         "sizzle": "^2.3.6",
         "terser": "5.6.1",
-        "typescript": "4.8.4",
+        "typescript": "4.9.3",
         "webpack": "^4.46.0",
         "ws": "7.4.6"
       },
@@ -12733,9 +12733,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -23687,9 +23687,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "semver": "^7.3.7",
     "sizzle": "^2.3.6",
     "terser": "5.6.1",
-    "typescript": "4.8.4",
+    "typescript": "4.9.3",
     "webpack": "^4.46.0",
     "ws": "7.4.6"
   },

--- a/src/compiler/config/test/validate-dev-server.spec.ts
+++ b/src/compiler/config/test/validate-dev-server.spec.ts
@@ -161,6 +161,14 @@ describe('validateDevServer', () => {
     expect(config.devServer.historyApiFallback.index).toBe('index.html');
   });
 
+  it.each([1, []])('should default historyApiFallback when an invalid value (%s) is provided', (badValue) => {
+    // this test explicitly checks for a bad value in the stencil.config file, hence the type assertion
+    (inputConfig.devServer.historyApiFallback as any) = badValue;
+    const { config } = validateConfig(inputConfig, mockLoadConfigInit());
+    expect(config.devServer.historyApiFallback).toBeDefined();
+    expect(config.devServer.historyApiFallback.index).toBe('index.html');
+  });
+
   it('should set historyApiFallback', () => {
     inputConfig.devServer = { ...inputDevServerConfig, historyApiFallback: {} };
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());

--- a/src/compiler/config/test/validate-hydrated.spec.ts
+++ b/src/compiler/config/test/validate-hydrated.spec.ts
@@ -14,11 +14,24 @@ describe('validate-hydrated', () => {
       };
     });
 
-    it.each([null, [], true, false])('returns undefined for hydratedFlag=%s', (badValue) => {
+    it.each([null, false])('returns undefined for hydratedFlag=%s', (badValue) => {
       // this test explicitly checks for a bad value in the stencil.config file, hence the type assertion
       (inputConfig.hydratedFlag as any) = badValue;
       const actual = validateHydrated(inputConfig);
       expect(actual).toBeUndefined();
+    });
+
+    it.each([[], true])('returns a default value when hydratedFlag=%s', (badValue) => {
+      // this test explicitly checks for a bad value in the stencil.config file, hence the type assertion
+      (inputConfig.hydratedFlag as any) = badValue;
+      const actual = validateHydrated(inputConfig);
+      expect(actual).toEqual<d.HydratedFlag>({
+        hydratedValue: 'inherit',
+        initialValue: 'hidden',
+        name: 'hydrated',
+        property: 'visibility',
+        selector: 'class',
+      });
     });
   });
 });

--- a/src/compiler/config/test/validate-hydrated.spec.ts
+++ b/src/compiler/config/test/validate-hydrated.spec.ts
@@ -1,0 +1,24 @@
+import * as d from '@stencil/core/declarations';
+
+import { validateHydrated } from '../validate-hydrated';
+
+describe('validate-hydrated', () => {
+  describe('validateHydrated', () => {
+    let inputConfig: d.UnvalidatedConfig;
+    let inputHydrateFlagConfig: d.HydratedFlag;
+
+    beforeEach(() => {
+      inputHydrateFlagConfig = {};
+      inputConfig = {
+        hydratedFlag: inputHydrateFlagConfig,
+      };
+    });
+
+    it.each([null, [], true, false])('returns undefined for hydratedFlag=%s', (badValue) => {
+      // this test explicitly checks for a bad value in the stencil.config file, hence the type assertion
+      (inputConfig.hydratedFlag as any) = badValue;
+      const actual = validateHydrated(inputConfig);
+      expect(actual).toBeUndefined();
+    });
+  });
+});

--- a/src/compiler/config/validate-dev-server.ts
+++ b/src/compiler/config/validate-dev-server.ts
@@ -100,7 +100,7 @@ export const validateDevServer = (
     devServer.protocol = devServer.https ? 'https' : addressProtocol ? addressProtocol : 'http';
   }
 
-  if (devServer.historyApiFallback !== null && devServer.historyApiFallback !== false) {
+  if (devServer.historyApiFallback !== null) {
     devServer.historyApiFallback = devServer.historyApiFallback || {};
 
     if (!isString(devServer.historyApiFallback.index)) {

--- a/src/compiler/config/validate-dev-server.ts
+++ b/src/compiler/config/validate-dev-server.ts
@@ -101,7 +101,9 @@ export const validateDevServer = (
   }
 
   if (devServer.historyApiFallback !== null) {
-    devServer.historyApiFallback = devServer.historyApiFallback || {};
+    if (Array.isArray(devServer.historyApiFallback) || typeof devServer.historyApiFallback !== 'object') {
+      devServer.historyApiFallback = {};
+    }
 
     if (!isString(devServer.historyApiFallback.index)) {
       devServer.historyApiFallback.index = 'index.html';

--- a/src/compiler/config/validate-hydrated.ts
+++ b/src/compiler/config/validate-hydrated.ts
@@ -12,11 +12,12 @@ export const validateHydrated = (config: UnvalidatedConfig): HydratedFlag | unde
   /**
    * If `config.hydratedFlag` is set to `null` that is an explicit signal that we
    * should _not_ create a default configuration when validating and should instead
-   * just return `undefined`.
+   * just return `undefined`. It may also have been set to `false`; this is an invalid
+   * value as far as the type system is concerned, but users may ignore its.
    *
    * See {@link HydratedFlag} for more details.
    */
-  if (config.hydratedFlag === null || Array.isArray(config.hydratedFlag) || typeof config.hydratedFlag !== 'object') {
+  if (config.hydratedFlag === null || (config.hydratedFlag as unknown as boolean) === false) {
     return undefined;
   }
 

--- a/src/compiler/config/validate-hydrated.ts
+++ b/src/compiler/config/validate-hydrated.ts
@@ -16,7 +16,7 @@ export const validateHydrated = (config: UnvalidatedConfig): HydratedFlag | unde
    *
    * See {@link HydratedFlag} for more details.
    */
-  if (config.hydratedFlag === null || config.hydratedFlag === false) {
+  if (config.hydratedFlag === null) {
     return undefined;
   }
 

--- a/src/compiler/config/validate-hydrated.ts
+++ b/src/compiler/config/validate-hydrated.ts
@@ -13,7 +13,7 @@ export const validateHydrated = (config: UnvalidatedConfig): HydratedFlag | unde
    * If `config.hydratedFlag` is set to `null` that is an explicit signal that we
    * should _not_ create a default configuration when validating and should instead
    * just return `undefined`. It may also have been set to `false`; this is an invalid
-   * value as far as the type system is concerned, but users may ignore its.
+   * value as far as the type system is concerned, but users may ignore this.
    *
    * See {@link HydratedFlag} for more details.
    */

--- a/src/compiler/config/validate-hydrated.ts
+++ b/src/compiler/config/validate-hydrated.ts
@@ -16,7 +16,7 @@ export const validateHydrated = (config: UnvalidatedConfig): HydratedFlag | unde
    *
    * See {@link HydratedFlag} for more details.
    */
-  if (config.hydratedFlag === null) {
+  if (config.hydratedFlag === null || Array.isArray(config.hydratedFlag) || typeof config.hydratedFlag !== 'object') {
     return undefined;
   }
 

--- a/src/compiler/config/validate-service-worker.ts
+++ b/src/compiler/config/validate-service-worker.ts
@@ -17,9 +17,7 @@ export const validateServiceWorker = (config: d.ValidatedConfig, outputTarget: d
     return;
   }
 
-  if (outputTarget.serviceWorker === true) {
-    outputTarget.serviceWorker = {};
-  } else if (!outputTarget.serviceWorker && config.devMode) {
+  if (!outputTarget.serviceWorker && config.devMode) {
     outputTarget.serviceWorker = null;
     return;
   }

--- a/src/compiler/style/css-parser/parse-css.ts
+++ b/src/compiler/style/css-parser/parse-css.ts
@@ -1,5 +1,5 @@
 import type * as d from '../../../declarations';
-import { CssNode, CssNodeType, CssParsePosition, ParseCssResults } from './css-parse-declarations';
+import { type CssNode, type CssParsePosition, type ParseCssResults, CssNodeType } from './css-parse-declarations';
 
 export const parseCss = (css: string, filePath?: string): ParseCssResults => {
   let lineno = 1;
@@ -104,10 +104,8 @@ export const parseCss = (css: string, filePath?: string): ParseCssResults => {
     comments(rules);
 
     while (css.length && css.charAt(0) !== '}' && (node = atrule() || rule())) {
-      if (node !== false) {
-        rules.push(node);
-        comments(rules);
-      }
+      rules.push(node);
+      comments(rules);
     }
     return rules;
   };
@@ -122,9 +120,7 @@ export const parseCss = (css: string, filePath?: string): ParseCssResults => {
     let c;
     rules = rules || [];
     while ((c = comment())) {
-      if (c !== false) {
-        rules.push(c);
-      }
+      rules.push(c);
     }
     return rules;
   };
@@ -202,10 +198,8 @@ export const parseCss = (css: string, filePath?: string): ParseCssResults => {
     // declarations
     let decl;
     while ((decl = declaration())) {
-      if (decl !== false) {
-        decls.push(decl);
-        comments(decls);
-      }
+      decls.push(decl);
+      comments(decls);
     }
 
     if (!close()) return error(`missing '}'`);

--- a/src/compiler/sys/dependencies.json
+++ b/src/compiler/sys/dependencies.json
@@ -39,6 +39,7 @@
         "compiler/lib.es2019.array.d.ts",
         "compiler/lib.es2019.d.ts",
         "compiler/lib.es2019.full.d.ts",
+        "compiler/lib.es2019.intl.d.ts",
         "compiler/lib.es2019.object.d.ts",
         "compiler/lib.es2019.string.d.ts",
         "compiler/lib.es2019.symbol.d.ts",

--- a/test/bundler/package-lock.json
+++ b/test/bundler/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "devDependencies": {
         "@types/karma": "^6.3.3",
+        "@types/node": "^14.18.34",
         "karma": "^6.3.17",
         "karma-chrome-launcher": "^3.1.0",
         "karma-jasmine": "^5.0.0",
@@ -487,9 +488,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "14.18.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.13.tgz",
-      "integrity": "sha512-Z6/KzgyWOga3pJNS42A+zayjhPbf2zM3hegRQaOPnLOzEi86VV++6FLDWgR1LGrVCRufP/ph2daa3tEa5br1zA==",
+      "version": "14.18.34",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.34.tgz",
+      "integrity": "sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA==",
       "dev": true
     },
     "node_modules/accepts": {
@@ -4306,9 +4307,9 @@
       }
     },
     "@types/node": {
-      "version": "14.18.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.13.tgz",
-      "integrity": "sha512-Z6/KzgyWOga3pJNS42A+zayjhPbf2zM3hegRQaOPnLOzEi86VV++6FLDWgR1LGrVCRufP/ph2daa3tEa5br1zA==",
+      "version": "14.18.34",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.34.tgz",
+      "integrity": "sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA==",
       "dev": true
     },
     "accepts": {

--- a/test/bundler/package.json
+++ b/test/bundler/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@types/karma": "^6.3.3",
+    "@types/node": "^14.18.34",
     "karma": "^6.3.17",
     "karma-chrome-launcher": "^3.1.0",
     "karma-jasmine": "^5.0.0",

--- a/test/karma/package-lock.json
+++ b/test/karma/package-lock.json
@@ -376,9 +376,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
-      "integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==",
+      "version": "14.18.34",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.34.tgz",
+      "integrity": "sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA==",
       "dev": true
     },
     "@webpack-cli/configtest": {

--- a/test/karma/package.json
+++ b/test/karma/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@stencil/sass": "^1.3.2",
-    "@types/node": "^14.18.12",
+    "@types/node": "^14.18.34",
     "bootstrap": "^4.5.1",
     "karma": "^6.4.1",
     "karma-browserstack-launcher": "^1.6.0",


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - https://github.com/ionic-team/stencil-site/pull/939 
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We support TS 4.7 (the 4.8 work has landed, just hasn't been released as of this writing)
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
this commit increments typescript to v4.9 for the project, and updates the dependabot configuration to not create a pull request for a version of typescript newer than 4.9.

the `@types/node` package for the karma test suite is updated as a part of this commit, as the currently installed version has the following error when being type checked by v4.9:

```
[ ERROR ]  TypeScript: ../node_modules/@types/node/globals.d.ts:114:13
           Subsequent variable declarations must have the same type. Variable
           'AbortSignal' must be of type '{ new (): AbortSignal; prototype:
           AbortSignal; abort(reason?: any): AbortSignal; timeout(milliseconds:
           number): AbortSignal; }', but here has type '{ new (): AbortSignal;
           prototype: AbortSignal; }'.
```

similarly `@types/node` were previously a child dependency for our bundler tests. it has been explictly
installed to prevent that very error.

the remainder of the changes in this pr are for fixing type errors where there is no overlap between two types being compared. this occurs in two scenarios:

  1. parsing css. in the css parser, there were three cases where an overlap did not occur in a comparison. in reading through the code, i cannot find a scenario where such a value could be returned such that the comparison is valid. as a result, such comparisons are removed.

     prior to removing these comparisons, an alternative (else block) was written with a logging statement in it. stencil's unit/karma tests were run, as well as the ionic framework's tests with this branch installed. the logging statement was never triggered. that in addition to the rich testing available for css, makes us confident that this change is safe to make.

  2. validation of a configuration flag. this occurred for the dev server, hydration config, and service worker config. these fields _should_ be properly set via type checking. if users are providing invalid values, we may want to reconsider some of the "silent failures" occurring and defaults we're setting in cases like this.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
 
Updates to TypeScript always introduce the possibility of upgrade pains. This may land and be released in a minor version of Stencil, in adherence to our [Versioning Policy](https://stenciljs.com/docs/versioning)

> A minor release will be published when a new feature is added or API changes that are non-breaking are introduced. We will heavily test any changes so that we are confident with the release, but with new code comes the potential for new issues. ...
> * This statement applies to the Stencil team upgrading its version of TypeScript as well. For more information, please see the team's [support policy regarding TypeScript](https://stenciljs.com/docs/support-policy#typescript-support)

and our [support policy regarding TypeScript](https://stenciljs.com/docs/support-policy#typescript-support)
> The Stencil team acknowledges that TypeScript minor version releases may contain breaking changes. The Stencil team will do everything in its power to avoid propagating breaking changes to its user base.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
This commit is best tested in a real project, such as the Ionic Framework. To do so, first build this branch:
```sh
npm run clean && \
npm ci && \
npm run build && \
npm pack
```
which ought to result in a tarball (which will be the last line of the output)

Next, pull down the Framework repository, install this branch in the core package, build and test:
```sh
cd core && \
npm i [TARBALL] --force && \
npm ci --force && \
npm run build && \
npm t
```

Next, we can look at components on an individual basis, by running a dev server from `core/`:
```sh
npm start
```

Navigate to `src/components` in the browser window that pops up. For each component dir (most of them) there's a `test` sub directory that can be entered to smoke test components

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

For folks performing the upgrade and are seeing an error like:
```
[ ERROR ]  TypeScript: ../node_modules/@types/node/globals.d.ts:114:13
           Subsequent variable declarations must have the same type. Variable
           'AbortSignal' must be of type '{ new (): AbortSignal; prototype:
           AbortSignal; abort(reason?: any): AbortSignal; timeout(milliseconds:
           number): AbortSignal; }', but here has type '{ new (): AbortSignal;
           prototype: AbortSignal; }'.
```
Please try updating your `@types/node` version to the latest minor version for the version of Node you're developing against. If `@types/node` is not explicitly installed (e.g. isn't in the `dev-dependencies` section of `package.json`), you may have it as a sub-dependency. You can check this with `npm ls @types/node` to determine where the package is being pulled in. In this scenario, please install `@types/node` as an explicit (dev) dependency