### PR TITLE
chore(util): update list of suppressed JSDoc tags to align with Framework

### DIFF
--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -2,7 +2,7 @@ import type * as d from '../declarations';
 import { dashToPascalCase, isString, toDashCase } from './helpers';
 import { buildError } from './message-utils';
 
-const SUPPRESSED_JSDOC_TAGS: string[] = ['internal'];
+const SUPPRESSED_JSDOC_TAGS: ReadonlyArray<string> = ['virtualProp', 'slot', 'part', 'internal'];
 
 /**
  * Create a stylistically-appropriate JS variable name from a filename

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -2,6 +2,10 @@ import type * as d from '../declarations';
 import { dashToPascalCase, isString, toDashCase } from './helpers';
 import { buildError } from './message-utils';
 
+/**
+ * A set of JSDoc tags which should be excluded from JSDoc comments
+ * included in output typedefs.
+ */
 const SUPPRESSED_JSDOC_TAGS: ReadonlyArray<string> = ['virtualProp', 'slot', 'part', 'internal'];
 
 /**
@@ -117,7 +121,8 @@ function formatDocBlock(docs: d.CompilerJsDoc, indentation: number = 0): string 
 }
 
 /**
- * Get all lines part of the doc block
+ * Get all lines which are part of the doc block
+ *
  * @param docs the compiled JS docs
  * @returns list of lines part of the doc block
  */

--- a/test/end-to-end/src/components.d.ts
+++ b/test/end-to-end/src/components.d.ts
@@ -16,8 +16,6 @@ export namespace Components {
     }
     /**
      * Component that helps display a list of cars
-     * @slot header - The slot for the header content.
-     * @part car - The shadow part to target to style the car.
      */
     interface CarList {
         "cars": CarData[];
@@ -52,9 +50,6 @@ export namespace Components {
     }
     interface PrerenderCmp {
     }
-    /**
-     * @virtualProp mode - Mode
-     */
     interface PropCmp {
         "first": string;
         "lastName": string;
@@ -102,8 +97,6 @@ declare global {
     };
     /**
      * Component that helps display a list of cars
-     * @slot header - The slot for the header content.
-     * @part car - The shadow part to target to style the car.
      */
     interface HTMLCarListElement extends Components.CarList, HTMLStencilElement {
     }
@@ -177,9 +170,6 @@ declare global {
         prototype: HTMLPrerenderCmpElement;
         new (): HTMLPrerenderCmpElement;
     };
-    /**
-     * @virtualProp mode - Mode
-     */
     interface HTMLPropCmpElement extends Components.PropCmp, HTMLStencilElement {
     }
     var HTMLPropCmpElement: {
@@ -243,8 +233,6 @@ declare namespace LocalJSX {
     }
     /**
      * Component that helps display a list of cars
-     * @slot header - The slot for the header content.
-     * @part car - The shadow part to target to style the car.
      */
     interface CarList {
         "cars"?: CarData[];
@@ -278,9 +266,6 @@ declare namespace LocalJSX {
     }
     interface PrerenderCmp {
     }
-    /**
-     * @virtualProp mode - Mode
-     */
     interface PropCmp {
         "first"?: string;
         "lastName"?: string;
@@ -330,8 +315,6 @@ declare module "@stencil/core" {
             "car-detail": LocalJSX.CarDetail & JSXBase.HTMLAttributes<HTMLCarDetailElement>;
             /**
              * Component that helps display a list of cars
-             * @slot header - The slot for the header content.
-             * @part car - The shadow part to target to style the car.
              */
             "car-list": LocalJSX.CarList & JSXBase.HTMLAttributes<HTMLCarListElement>;
             "dom-api": LocalJSX.DomApi & JSXBase.HTMLAttributes<HTMLDomApiElement>;
@@ -345,9 +328,6 @@ declare module "@stencil/core" {
             "method-cmp": LocalJSX.MethodCmp & JSXBase.HTMLAttributes<HTMLMethodCmpElement>;
             "path-alias-cmp": LocalJSX.PathAliasCmp & JSXBase.HTMLAttributes<HTMLPathAliasCmpElement>;
             "prerender-cmp": LocalJSX.PrerenderCmp & JSXBase.HTMLAttributes<HTMLPrerenderCmpElement>;
-            /**
-             * @virtualProp mode - Mode
-             */
             "prop-cmp": LocalJSX.PropCmp & JSXBase.HTMLAttributes<HTMLPropCmpElement>;
             "slot-cmp": LocalJSX.SlotCmp & JSXBase.HTMLAttributes<HTMLSlotCmpElement>;
             "slot-cmp-container": LocalJSX.SlotCmpContainer & JSXBase.HTMLAttributes<HTMLSlotCmpContainerElement>;

--- a/test/karma/test-app/components.d.ts
+++ b/test/karma/test-app/components.d.ts
@@ -226,9 +226,6 @@ export namespace Components {
     }
     interface ShadowDomBasicRoot {
     }
-    /**
-     * @virtualProp {string} colormode - The mode determines which platform styles to use.
-     */
     interface ShadowDomMode {
         /**
           * The mode determines which platform styles to use.
@@ -871,9 +868,6 @@ declare global {
         prototype: HTMLShadowDomBasicRootElement;
         new (): HTMLShadowDomBasicRootElement;
     };
-    /**
-     * @virtualProp {string} colormode - The mode determines which platform styles to use.
-     */
     interface HTMLShadowDomModeElement extends Components.ShadowDomMode, HTMLStencilElement {
     }
     var HTMLShadowDomModeElement: {
@@ -1496,9 +1490,6 @@ declare namespace LocalJSX {
     }
     interface ShadowDomBasicRoot {
     }
-    /**
-     * @virtualProp {string} colormode - The mode determines which platform styles to use.
-     */
     interface ShadowDomMode {
         /**
           * The mode determines which platform styles to use.
@@ -1822,9 +1813,6 @@ declare module "@stencil/core" {
             "shadow-dom-array-root": LocalJSX.ShadowDomArrayRoot & JSXBase.HTMLAttributes<HTMLShadowDomArrayRootElement>;
             "shadow-dom-basic": LocalJSX.ShadowDomBasic & JSXBase.HTMLAttributes<HTMLShadowDomBasicElement>;
             "shadow-dom-basic-root": LocalJSX.ShadowDomBasicRoot & JSXBase.HTMLAttributes<HTMLShadowDomBasicRootElement>;
-            /**
-             * @virtualProp {string} colormode - The mode determines which platform styles to use.
-             */
             "shadow-dom-mode": LocalJSX.ShadowDomMode & JSXBase.HTMLAttributes<HTMLShadowDomModeElement>;
             "shadow-dom-mode-root": LocalJSX.ShadowDomModeRoot & JSXBase.HTMLAttributes<HTMLShadowDomModeRootElement>;
             "shadow-dom-slot-basic": LocalJSX.ShadowDomSlotBasic & JSXBase.HTMLAttributes<HTMLShadowDomSlotBasicElement>;


### PR DESCRIPTION
When #3525 merged it contained a list of JSDoc tags which should be suppressed from component-level generated documentation in typedef files. This commit updates that list to add some tags that Framework would not like to have show up all over the place.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):


## What is the current behavior?

Currently the JSDoc tags `@slot`, `@part` and `@virtualProp` are included in docstring output for components.


## What is the new behavior?

This suppresses them, in particular to minimize churn in Framework where these tags are very heavily used.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
