### PR TITLE
chore(dependabot): ignore @types/node versions for test/bundler

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,10 @@ updates:
     # Disable rebasing for pull requests, as having several open pull requests all get simultaneously rebased gets
     # noisy from a notification standpoint
     rebase-strategy: 'disabled'
+    ignore:
+      # These values should match the values ignored by Dependabot for the project's root `package.json` (above)
+      - dependency-name: '@types/node'
+        versions: [ '17', '18' ]
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,7 +42,7 @@ updates:
     ignore:
       # These values should match the values ignored by Dependabot for the project's root `package.json` (above)
       - dependency-name: '@types/node'
-        versions: [ '17', '18' ]
+        versions: ['17', '18']
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Dependabot configuration


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`@types/node` gets suggested by dependabot to be upgraded for the `test/bundler` dir, when it should not (see #3878). 

GitHub Issue Number: 
- Closes #3878 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit adds versions 17 & 18 of `@types/node` to the ignore list for the `test/bundler` directory. we add these valuse because when we run these tests locally & in a continuous integration env, we inherit the version of node that is declared under the `volta` key in this project's root level `package.json` file. to prevent version skew either between the version of node and @types/node within bundler, we need to add this property to the dependabot configuration.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
N/A, other than validating the YAML

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
