### PR TITLE
chore(config): mark `cssVarShim` as deprecated

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -103,8 +103,8 @@ export const config: Config = {
 
 `extras.cssVarShim` causes Stencil to include a polyfill for [CSS
 variables](https://developer.mozilla.org/en-US/docs/Web/CSS/--*). For Stencil
-v3.0.0 this field is renamed to `__deprecated__cssVarsShim`, and thus to retain
-the previous behavior the new option can be set in your projects
+v3.0.0 this field is renamed to `__deprecated__cssVarsShim`. To retain the
+previous behavior the new option can be set in your project's
 `stencil.config.ts`:
 
 ```ts

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -16,6 +16,7 @@ This is a comprehensive list of the breaking changes introduced in the major ver
     * [`dist-custom-elements` Type Declarations](#dist-custom-elements-type-declarations)
   * [Legacy Browser Support Fields Deprecated](#legacy-browser-support-fields-deprecated)
     * [`dynamicImportShim`](#dynamicimportshim)
+    * [`cssVarShim`](#cssvarshim)
   * [Deprecated `assetsDir` Removed from `@Component()` decorator](#deprecated-assetsdir-removed-from-component-decorator)
   * [Drop Node 12 Support](#drop-node-12-support)
   * [Strongly Typed Inputs](#strongly-typed-inputs)
@@ -94,6 +95,25 @@ import { Config } from '@stencil/core';
 export const config: Config = {
   extras: {
     __deprecated__dynamicImportShim: true
+  }
+};
+```
+
+##### `cssVarShim`
+
+`extras.cssVarShim` causes Stencil to include a polyfill for [CSS
+variables](https://developer.mozilla.org/en-US/docs/Web/CSS/--*). For Stencil
+v3.0.0 this field is renamed to `__deprecated__cssVarsShim`, and thus to retain
+the previous behavior the new option can be set in your projects
+`stencil.config.ts`:
+
+```ts
+// stencil.config.ts
+import { Config } from '@stencil/core';
+
+export const config: Config = {
+  extras: {
+    __deprecated__cssVarsShim: true
   }
 };
 ```

--- a/src/app-data/index.ts
+++ b/src/app-data/index.ts
@@ -72,6 +72,7 @@ export const BUILD: BuildConditionals = {
   propBoolean: true,
   propNumber: true,
   propString: true,
+  // TODO(STENCIL-659): Remove code implementing the CSS variable shim
   cssVarShim: false,
   constructableCSS: true,
   cmpShouldUpdate: true,

--- a/src/client/client-patch-browser.ts
+++ b/src/client/client-patch-browser.ts
@@ -10,6 +10,7 @@ export const patchBrowser = (): Promise<d.CustomElementsDefineOptions> => {
     consoleDevInfo('Running in development mode.');
   }
 
+  // TODO(STENCIL-659): Remove code implementing the CSS variable shim
   if (BUILD.cssVarShim) {
     // shim css vars
     plt.$cssShim$ = (win as any).__cssshim;

--- a/src/client/client-patch-browser.ts
+++ b/src/client/client-patch-browser.ts
@@ -13,6 +13,7 @@ export const patchBrowser = (): Promise<d.CustomElementsDefineOptions> => {
   // TODO(STENCIL-659): Remove code implementing the CSS variable shim
   if (BUILD.cssVarShim) {
     // shim css vars
+    // TODO(STENCIL-659): Remove code implementing the CSS variable shim
     plt.$cssShim$ = (win as any).__cssshim;
   }
 

--- a/src/client/client-patch-esm.ts
+++ b/src/client/client-patch-esm.ts
@@ -9,6 +9,7 @@ export const patchEsm = () => {
     // @ts-ignore
     return import(/* webpackChunkName: "polyfills-css-shim" */ './polyfills/css-shim.js').then(() => {
       if ((plt.$cssShim$ = (win as any).__cssshim)) {
+        // TODO(STENCIL-659): Remove code implementing the CSS variable shim
         return plt.$cssShim$.i();
       } else {
         // for better minification

--- a/src/client/client-patch-esm.ts
+++ b/src/client/client-patch-esm.ts
@@ -3,6 +3,7 @@ import { CSS, plt, promiseResolve, win } from '@platform';
 
 export const patchEsm = () => {
   // NOTE!! This fn cannot use async/await!
+  // TODO(STENCIL-659): Remove code implementing the CSS variable shim
   // @ts-ignore
   if (BUILD.cssVarShim && !(CSS && CSS.supports && CSS.supports('color', 'var(--c)'))) {
     // @ts-ignore

--- a/src/client/client-window.ts
+++ b/src/client/client-window.ts
@@ -4,6 +4,7 @@ import type * as d from '../declarations';
 
 export const win = typeof window !== 'undefined' ? window : ({} as Window);
 
+// TODO(STENCIL-659): Remove code implementing the CSS variable shim
 export const CSS = BUILD.cssVarShim ? (win as any).CSS : null;
 
 export const doc = win.document || ({ head: {} } as Document);

--- a/src/client/polyfills/css-shim/css-parser.ts
+++ b/src/client/polyfills/css-shim/css-parser.ts
@@ -1,3 +1,4 @@
+// TODO(STENCIL-659): Remove code implementing the CSS variable shim
 /*
 Extremely simple css parser. Intended to be not more than what we need
 and definitely not necessarily correct =).

--- a/src/client/polyfills/css-shim/custom-style.ts
+++ b/src/client/polyfills/css-shim/custom-style.ts
@@ -6,6 +6,7 @@ import { addGlobalStyle, parseCSS, reScope, updateGlobalScopes } from './scope';
 import { getActiveSelectors, resolveValues } from './selectors';
 import { executeTemplate } from './template';
 
+// TODO(STENCIL-659): Remove code implementing the CSS variable shim
 export class CustomStyle implements CssVarShim {
   private count = 0;
   private hostStyleMap = new WeakMap<HTMLElement, HTMLStyleElement>();

--- a/src/client/polyfills/css-shim/custom-style.ts
+++ b/src/client/polyfills/css-shim/custom-style.ts
@@ -1,3 +1,4 @@
+// TODO(STENCIL-659): Remove code implementing the CSS variable shim
 import { CssVarShim } from '../../../declarations';
 import { CSSScope } from './interfaces';
 import { addGlobalLink, loadDocument, startWatcher } from './load-link-styles';

--- a/src/client/polyfills/css-shim/index.ts
+++ b/src/client/polyfills/css-shim/index.ts
@@ -1,3 +1,4 @@
+// TODO(STENCIL-659): Remove code implementing the CSS variable shim
 import { CustomStyle } from './custom-style';
 
 (function (win: any) {

--- a/src/client/polyfills/css-shim/interfaces.ts
+++ b/src/client/polyfills/css-shim/interfaces.ts
@@ -1,3 +1,4 @@
+// TODO(STENCIL-659): Remove code implementing the CSS variable shim
 export type CSSVariables = { [prop: string]: string };
 export type CSSEval = (p: CSSVariables) => string;
 export type CSSSegment = string | CSSEval;

--- a/src/client/polyfills/css-shim/load-link-styles.ts
+++ b/src/client/polyfills/css-shim/load-link-styles.ts
@@ -1,3 +1,4 @@
+// TODO(STENCIL-659): Remove code implementing the CSS variable shim
 import { CSSScope } from './interfaces';
 import { addGlobalStyle, updateGlobalScopes } from './scope';
 

--- a/src/client/polyfills/css-shim/regex.ts
+++ b/src/client/polyfills/css-shim/regex.ts
@@ -1,3 +1,4 @@
+// TODO(STENCIL-659): Remove code implementing the CSS variable shim
 export const VAR_USAGE_START = /\bvar\(/;
 export const VAR_ASSIGN_START = /\B--[\w-]+\s*:/;
 

--- a/src/client/polyfills/css-shim/scope.ts
+++ b/src/client/polyfills/css-shim/scope.ts
@@ -1,3 +1,4 @@
+// TODO(STENCIL-659): Remove code implementing the CSS variable shim
 import { parse } from './css-parser';
 import { CSSScope } from './interfaces';
 import { getSelectors, getSelectorsForScopes, resolveValues } from './selectors';

--- a/src/client/polyfills/css-shim/selectors.ts
+++ b/src/client/polyfills/css-shim/selectors.ts
@@ -1,3 +1,4 @@
+// TODO(STENCIL-659): Remove code implementing the CSS variable shim
 import { StyleNode, types } from './css-parser';
 import { CSSScope, CSSSelector, CSSTemplate, Declaration } from './interfaces';
 import { compileTemplate, executeTemplate } from './template';

--- a/src/client/polyfills/css-shim/template.ts
+++ b/src/client/polyfills/css-shim/template.ts
@@ -1,3 +1,4 @@
+// TODO(STENCIL-659): Remove code implementing the CSS variable shim
 import { CSSTemplate, CSSVariables } from './interfaces';
 import { COMMENTS, TRAILING_LINES, VAR_ASSIGN_START, VAR_USAGE_START } from './regex';
 import { findRegex } from './utils';

--- a/src/client/polyfills/css-shim/test/compiler.spec.ts
+++ b/src/client/polyfills/css-shim/test/compiler.spec.ts
@@ -1,3 +1,4 @@
+// TODO(STENCIL-659): Remove code implementing the CSS variable shim
 import { compileTemplate, compileVar, executeTemplate, findVarEndIndex, parseVar } from '../template';
 
 describe('compiler', () => {

--- a/src/client/polyfills/css-shim/test/css-shim.spec.ts
+++ b/src/client/polyfills/css-shim/test/css-shim.spec.ts
@@ -1,3 +1,4 @@
+// TODO(STENCIL-659): Remove code implementing the CSS variable shim
 import { mockWindow } from '@stencil/core/testing';
 
 import { CustomStyle } from '../custom-style';

--- a/src/client/polyfills/css-shim/test/init-css-shim.spec.ts
+++ b/src/client/polyfills/css-shim/test/init-css-shim.spec.ts
@@ -1,3 +1,4 @@
+// TODO(STENCIL-659): Remove code implementing the CSS variable shim
 import { fixRelativeUrls, hasCssVariables, hasRelativeUrls } from '../load-link-styles';
 
 describe('hasCssVariables', () => {

--- a/src/client/polyfills/css-shim/test/utils.spec.ts
+++ b/src/client/polyfills/css-shim/test/utils.spec.ts
@@ -1,3 +1,4 @@
+// TODO(STENCIL-659): Remove code implementing the CSS variable shim
 import { CSSSelector, Declaration } from '../interfaces';
 import { parseCSS } from '../scope';
 import { getDeclarations, normalizeValue, resolveValues } from '../selectors';

--- a/src/client/polyfills/css-shim/utils.ts
+++ b/src/client/polyfills/css-shim/utils.ts
@@ -1,3 +1,4 @@
+// TODO(STENCIL-659): Remove code implementing the CSS variable shim
 export const GLOBAL_SCOPE = ':root';
 
 export function findRegex(regex: RegExp, cssText: string, offset: number) {

--- a/src/compiler/app-core/app-polyfills.ts
+++ b/src/compiler/app-core/app-polyfills.ts
@@ -19,7 +19,8 @@ export const getAppBrowserCorePolyfills = async (config: d.Config, compilerCtx: 
   // read all the polyfill content, in this particular order
   const polyfills = INLINE_POLYFILLS.slice();
 
-  if (config.extras.cssVarsShim) {
+  // TODO(STENCIL-659): Remove code implementing the CSS variable shim
+  if (config.extras.__deprecated__cssVarsShim) {
     polyfills.push(INLINE_CSS_SHIM);
   }
 

--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -354,7 +354,8 @@ describe('validation', () => {
     const { config } = validateConfig(userConfig, bootstrapConfig);
     expect(config.extras.appendChildSlotFix).toBe(false);
     expect(config.extras.cloneNodeFix).toBe(false);
-    expect(config.extras.cssVarsShim).toBe(false);
+    // TODO(STENCIL-659): Remove code implementing the CSS variable shim
+    expect(config.extras.__deprecated__cssVarsShim).toBe(false);
     // TODO(STENCIL-661): Remove code related to the dynamic import shim
     expect(config.extras.__deprecated__dynamicImportShim).toBe(false);
     expect(config.extras.lifecycleDOMEvents).toBe(false);

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -71,7 +71,8 @@ export const validateConfig = (
   validatedConfig.extras = validatedConfig.extras || {};
   validatedConfig.extras.appendChildSlotFix = !!validatedConfig.extras.appendChildSlotFix;
   validatedConfig.extras.cloneNodeFix = !!validatedConfig.extras.cloneNodeFix;
-  validatedConfig.extras.cssVarsShim = !!validatedConfig.extras.cssVarsShim;
+  // TODO(STENCIL-659): Remove code implementing the CSS variable shim
+  validatedConfig.extras.__deprecated__cssVarsShim = !!validatedConfig.extras.__deprecated__cssVarsShim;
   // TODO(STENCIL-661): Remove code related to the dynamic import shim
   validatedConfig.extras.__deprecated__dynamicImportShim = !!validatedConfig.extras.__deprecated__dynamicImportShim;
   validatedConfig.extras.lifecycleDOMEvents = !!validatedConfig.extras.lifecycleDOMEvents;

--- a/src/compiler/output-targets/dist-hydrate-script/hydrate-build-conditionals.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/hydrate-build-conditionals.ts
@@ -7,6 +7,7 @@ export const getHydrateBuildConditionals = (cmps: d.ComponentCompilerMeta[]) => 
   build.slotRelocation = true;
   build.lazyLoad = true;
   build.hydrateServerSide = true;
+  // TODO(STENCIL-659): Remove code implementing the CSS variable shim
   build.cssVarShim = false;
   build.hydrateClientSide = true;
   build.isDebug = false;

--- a/src/compiler/output-targets/dist-lazy/lazy-build-conditionals.ts
+++ b/src/compiler/output-targets/dist-lazy/lazy-build-conditionals.ts
@@ -10,7 +10,8 @@ export const getLazyBuildConditionals = (
 
   build.lazyLoad = true;
   build.hydrateServerSide = false;
-  build.cssVarShim = config.extras.cssVarsShim;
+  // TODO(STENCIL-659): Remove code implementing the CSS variable shim
+  build.cssVarShim = config.extras.__deprecated__cssVarsShim;
   build.transformTagName = config.extras.tagNameTransform;
   build.asyncQueue = config.taskQueue === 'congestionAsync';
   build.taskQueue = config.taskQueue !== 'immediate';

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -1080,6 +1080,7 @@ export interface HostRuleHeader {
   value?: string;
 }
 
+// TODO(STENCIL-659): Remove code implementing the CSS variable shim
 export interface CssVarShim {
   i(): Promise<any>;
   addLink(linkEl: HTMLLinkElement): Promise<any>;
@@ -1695,6 +1696,7 @@ export interface HostRef {
 }
 
 export interface PlatformRuntime {
+  // TODO(STENCIL-659): Remove code implementing the CSS variable shim
   $cssShim$?: CssVarShim;
   $flags$: number;
   $orgLocNodes$?: Map<string, RenderNode>;

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -169,6 +169,7 @@ export interface BuildConditionals extends Partial<BuildFeatures> {
   cssAnnotations?: boolean;
   lazyLoad?: boolean;
   profile?: boolean;
+  // TODO(STENCIL-659): Remove code implementing the CSS variable shim
   cssVarShim?: boolean;
   constructableCSS?: boolean;
   appendChildSlotFix?: boolean;

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -267,11 +267,12 @@ export interface ConfigExtras {
    */
   cloneNodeFix?: boolean;
 
+  // TODO(STENCIL-659): Remove code implementing the CSS variable shim
   /**
    * Include the CSS Custom Property polyfill/shim for legacy browsers. ESM builds will
    * not include the css vars shim. Defaults to `false`
    */
-  cssVarsShim?: boolean;
+  __deprecated__cssVarsShim?: boolean;
 
   // TODO(STENCIL-661): Remove code related to the dynamic import shim
   /**

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -271,6 +271,9 @@ export interface ConfigExtras {
   /**
    * Include the CSS Custom Property polyfill/shim for legacy browsers. ESM builds will
    * not include the css vars shim. Defaults to `false`
+   *
+   * @deprecated Since Stencil v3.0.0. IE 11, Edge <= 18, and old Safari
+   * versions are no longer supported.
    */
   __deprecated__cssVarsShim?: boolean;
 

--- a/src/runtime/disconnected-callback.ts
+++ b/src/runtime/disconnected-callback.ts
@@ -18,6 +18,7 @@ export const disconnectedCallback = (elm: d.HostElement) => {
     }
 
     // clear CSS var-shim tracking
+    // TODO(STENCIL-659): Remove code implementing the CSS variable shim
     if (BUILD.cssVarShim && plt.$cssShim$) {
       plt.$cssShim$.removeHost(elm);
     }

--- a/src/runtime/disconnected-callback.ts
+++ b/src/runtime/disconnected-callback.ts
@@ -20,6 +20,7 @@ export const disconnectedCallback = (elm: d.HostElement) => {
     // clear CSS var-shim tracking
     // TODO(STENCIL-659): Remove code implementing the CSS variable shim
     if (BUILD.cssVarShim && plt.$cssShim$) {
+      // TODO(STENCIL-659): Remove code implementing the CSS variable shim
       plt.$cssShim$.removeHost(elm);
     }
 

--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -56,6 +56,7 @@ export const addStyle = (
           // This is only happening on native shadow-dom, do not needs CSS var shim
           styleElm.innerHTML = style;
         } else {
+          // TODO(STENCIL-659): Remove code implementing the CSS variable shim
           if (BUILD.cssVarShim && plt.$cssShim$) {
             styleElm = plt.$cssShim$.createHostStyle(
               hostElm,

--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -58,6 +58,7 @@ export const addStyle = (
         } else {
           // TODO(STENCIL-659): Remove code implementing the CSS variable shim
           if (BUILD.cssVarShim && plt.$cssShim$) {
+            // TODO(STENCIL-659): Remove code implementing the CSS variable shim
             styleElm = plt.$cssShim$.createHostStyle(
               hostElm,
               scopeId,

--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -87,6 +87,7 @@ const updateComponent = async (hostRef: d.HostRef, instance: any, isInitialLoad:
   } else {
     callRender(hostRef, instance, elm);
   }
+  // TODO(STENCIL-659): Remove code implementing the CSS variable shim
   if (BUILD.cssVarShim && plt.$cssShim$) {
     plt.$cssShim$.updateHost(elm);
   }

--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -89,6 +89,7 @@ const updateComponent = async (hostRef: d.HostRef, instance: any, isInitialLoad:
   }
   // TODO(STENCIL-659): Remove code implementing the CSS variable shim
   if (BUILD.cssVarShim && plt.$cssShim$) {
+    // TODO(STENCIL-659): Remove code implementing the CSS variable shim
     plt.$cssShim$.updateHost(elm);
   }
   if (BUILD.isDev) {

--- a/src/testing/platform/testing-platform.ts
+++ b/src/testing/platform/testing-platform.ts
@@ -26,6 +26,7 @@ export const setPlatformHelpers = (helpers: {
   Object.assign(plt, helpers);
 };
 
+// TODO(STENCIL-659): Remove code implementing the CSS variable shim
 export const cssVarShim: d.CssVarShim = false as any;
 export const supportsListenerOptions = true;
 export const supportsConstructableStylesheets = false;


### PR DESCRIPTION
This marks the `extras.cssVarsShim` field on the Stencil configuration interface as deprecated, and introduces TODO comments for removing all of the relevant code (that I could find).

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

We want to remove Stencil's built-in support for including polyfills for old browsers. Before we remove it, we want to mark fields for deprecation.


## What is the new behavior?

the field is renamed from `cssVarShim` to `__deprecated_cssVarShim`.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
