### PR TITLE
chore(config): mark `config.extras.dynamicImportShim` as deprecated

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -14,7 +14,6 @@ This is a comprehensive list of the breaking changes introduced in the major ver
   * [New Configuration Defaults](#new-configuration-defaults)
     * [SourceMaps](#sourcemaps)
     * [`dist-custom-elements` Type Declarations](#dist-custom-elements-type-declarations)
-  * [Backwards-compat Configuration Fields Deprecated](#backwards-compat-configuration-fields-deprecated)
   * [Legacy Browser Support Fields Deprecated](#legacy-browser-support-fields-deprecated)
     * [`dynamicImportShim`](#dynamicimportshim)
   * [Deprecated `assetsDir` Removed from `@Component()` decorator](#deprecated-assetsdir-removed-from-component-decorator)

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -12,8 +12,10 @@ This is a comprehensive list of the breaking changes introduced in the major ver
 
 * [General](#general)
   * [New Configuration Defaults](#new-configuration-defaults)
-  * [SourceMaps](#sourcemaps)
-  * [`dist-custom-elements` Type Declarations](#dist-custom-elements-type-declarations)
+    * [SourceMaps](#sourcemaps)
+    * [`dist-custom-elements` Type Declarations](#dist-custom-elements-type-declarations)
+  * [Backwards-compat Configuration Fields Deprecated](#backwards-compat-configuration-fields-deprecated)
+    * [dynamicImportShim](#dynamicimportshim)
   * [Deprecated `assetsDir` Removed from `@Component()` decorator](#deprecated-assetsdir-removed-from-component-decorator)
   * [Drop Node 12 Support](#drop-node-12-support)
   * [Strongly Typed Inputs](#strongly-typed-inputs)
@@ -66,6 +68,30 @@ export const config: Config = {
     // ...
   ],
   // ...
+};
+```
+
+#### Backwards-compat Configuration Fields Deprecated
+
+Several configuration options related to support for Safari <11, IE11, and Edge
+<19 have been marked as deprecated, and will be removed entirely in a future
+version of Stencil.
+
+##### dynamicImportShim
+
+The `extras.dynamicImportShim` option causes Stencil to include a polyfill for
+the `import()` function for use at runtime. The field is renamed to
+`__deprecated__dynamicImportShim` to indicate deprecation. To retain the
+prior behavior the new option can be set in your project's `stencil.config.ts`:
+
+```ts
+// stencil.config.ts
+import { Config } from '@stencil/core';
+
+export const config: Config = {
+  extras: {
+    __deprecated__dynamicImportShim: true
+  }
 };
 ```
 

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -82,7 +82,7 @@ version of Stencil.
 
 The `extras.dynamicImportShim` option causes Stencil to include a polyfill for
 the [dynamic `import()`
-function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import)
+function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import)
 for use at runtime. The field is renamed to `__deprecated__dynamicImportShim`
 to indicate deprecation. To retain the prior behavior the new option can be
 set in your project's `stencil.config.ts`:

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -15,7 +15,8 @@ This is a comprehensive list of the breaking changes introduced in the major ver
     * [SourceMaps](#sourcemaps)
     * [`dist-custom-elements` Type Declarations](#dist-custom-elements-type-declarations)
   * [Backwards-compat Configuration Fields Deprecated](#backwards-compat-configuration-fields-deprecated)
-    * [dynamicImportShim](#dynamicimportshim)
+  * [Legacy Browser Support Fields Deprecated](#legacy-browser-support-fields-deprecated)
+    * [`dynamicImportShim`](#dynamicimportshim)
   * [Deprecated `assetsDir` Removed from `@Component()` decorator](#deprecated-assetsdir-removed-from-component-decorator)
   * [Drop Node 12 Support](#drop-node-12-support)
   * [Strongly Typed Inputs](#strongly-typed-inputs)
@@ -71,18 +72,20 @@ export const config: Config = {
 };
 ```
 
-#### Backwards-compat Configuration Fields Deprecated
+#### Legacy Browser Support Fields Deprecated
 
 Several configuration options related to support for Safari <11, IE11, and Edge
 <19 have been marked as deprecated, and will be removed entirely in a future
 version of Stencil.
 
-##### dynamicImportShim
+##### `dynamicImportShim`
 
 The `extras.dynamicImportShim` option causes Stencil to include a polyfill for
-the `import()` function for use at runtime. The field is renamed to
-`__deprecated__dynamicImportShim` to indicate deprecation. To retain the
-prior behavior the new option can be set in your project's `stencil.config.ts`:
+the [dynamic `import()`
+function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import)
+for use at runtime. The field is renamed to `__deprecated__dynamicImportShim`
+to indicate deprecation. To retain the prior behavior the new option can be
+set in your project's `stencil.config.ts`:
 
 ```ts
 // stencil.config.ts

--- a/src/app-data/index.ts
+++ b/src/app-data/index.ts
@@ -76,6 +76,7 @@ export const BUILD: BuildConditionals = {
   constructableCSS: true,
   cmpShouldUpdate: true,
   devTools: false,
+  // TODO(STENCIL-661): Remove code related to the dynamic import shim
   dynamicImportShim: false,
   shadowDelegatesFocus: true,
   initializeNextTick: false,

--- a/src/client/client-patch-browser.ts
+++ b/src/client/client-patch-browser.ts
@@ -34,6 +34,7 @@ export const patchBrowser = (): Promise<d.CustomElementsDefineOptions> => {
 
   // @ts-ignore
   const scriptElm =
+    // TODO(STENCIL-661): Remove code related to the dynamic import shim
     BUILD.scriptDataOpts || BUILD.safari10 || BUILD.dynamicImportShim
       ? Array.from(doc.querySelectorAll('script')).find(
           (s) =>
@@ -61,15 +62,18 @@ export const patchBrowser = (): Promise<d.CustomElementsDefineOptions> => {
 
   if (!BUILD.safari10 && importMeta !== '') {
     opts.resourcesUrl = new URL('.', importMeta).href;
+    // TODO(STENCIL-661): Remove code related to the dynamic import shim
   } else if (BUILD.dynamicImportShim || BUILD.safari10) {
     opts.resourcesUrl = new URL(
       '.',
       new URL(scriptElm.getAttribute('data-resources-url') || scriptElm.src, win.location.href)
     ).href;
+    // TODO(STENCIL-661): Remove code related to the dynamic import shim
     if (BUILD.dynamicImportShim) {
       patchDynamicImport(opts.resourcesUrl, scriptElm);
     }
 
+    // TODO(STENCIL-661): Remove code related to the dynamic import shim
     if (BUILD.dynamicImportShim && !win.customElements) {
       // module support, but no custom elements support (Old Edge)
       // @ts-ignore
@@ -79,6 +83,7 @@ export const patchBrowser = (): Promise<d.CustomElementsDefineOptions> => {
   return promiseResolve(opts);
 };
 
+// TODO(STENCIL-661): Remove code related to the dynamic import shim
 const patchDynamicImport = (base: string, orgScriptElm: HTMLScriptElement) => {
   const importFunctionName = getDynamicImportFunction(NAMESPACE);
   try {

--- a/src/compiler/app-core/app-data.ts
+++ b/src/compiler/app-core/app-data.ts
@@ -149,7 +149,8 @@ export const updateBuildConditionals = (config: Config, b: BuildConditionals) =>
   b.appendChildSlotFix = config.extras.appendChildSlotFix;
   b.slotChildNodesFix = config.extras.slotChildNodesFix;
   b.cloneNodeFix = config.extras.cloneNodeFix;
-  b.dynamicImportShim = config.extras.dynamicImportShim;
+  // TODO(STENCIL-661): Remove code related to the dynamic import shim
+  b.dynamicImportShim = config.extras.__deprecated__dynamicImportShim;
   b.lifecycleDOMEvents = !!(b.isDebug || config._isTesting || config.extras.lifecycleDOMEvents);
   b.safari10 = config.extras.safari10;
   b.scopedSlotTextContentFix = !!config.extras.scopedSlotTextContentFix;

--- a/src/compiler/bundle/core-resolve-plugin.ts
+++ b/src/compiler/bundle/core-resolve-plugin.ts
@@ -132,7 +132,8 @@ export const Build = {
     },
 
     resolveImportMeta(prop, { format }) {
-      if (config.extras.dynamicImportShim && prop === 'url' && format === 'es') {
+      // TODO(STENCIL-661): Remove code related to the dynamic import shim
+      if (config.extras.__deprecated__dynamicImportShim && prop === 'url' && format === 'es') {
         return '""';
       }
       return null;

--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -355,7 +355,8 @@ describe('validation', () => {
     expect(config.extras.appendChildSlotFix).toBe(false);
     expect(config.extras.cloneNodeFix).toBe(false);
     expect(config.extras.cssVarsShim).toBe(false);
-    expect(config.extras.dynamicImportShim).toBe(false);
+    // TODO(STENCIL-661): Remove code related to the dynamic import shim
+    expect(config.extras.__deprecated__dynamicImportShim).toBe(false);
     expect(config.extras.lifecycleDOMEvents).toBe(false);
     expect(config.extras.safari10).toBe(false);
     expect(config.extras.scriptDataOpts).toBe(false);

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -72,7 +72,8 @@ export const validateConfig = (
   validatedConfig.extras.appendChildSlotFix = !!validatedConfig.extras.appendChildSlotFix;
   validatedConfig.extras.cloneNodeFix = !!validatedConfig.extras.cloneNodeFix;
   validatedConfig.extras.cssVarsShim = !!validatedConfig.extras.cssVarsShim;
-  validatedConfig.extras.dynamicImportShim = !!validatedConfig.extras.dynamicImportShim;
+  // TODO(STENCIL-661): Remove code related to the dynamic import shim
+  validatedConfig.extras.__deprecated__dynamicImportShim = !!validatedConfig.extras.__deprecated__dynamicImportShim;
   validatedConfig.extras.lifecycleDOMEvents = !!validatedConfig.extras.lifecycleDOMEvents;
   validatedConfig.extras.safari10 = !!validatedConfig.extras.safari10;
   validatedConfig.extras.scriptDataOpts = !!validatedConfig.extras.scriptDataOpts;

--- a/src/compiler/output-targets/dist-hydrate-script/hydrate-build-conditionals.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/hydrate-build-conditionals.ts
@@ -29,6 +29,7 @@ export const getHydrateBuildConditionals = (cmps: d.ComponentCompilerMeta[]) => 
   build.hydratedAttribute = false;
   build.hydratedClass = true;
   build.scriptDataOpts = false;
+  // TODO(STENCIL-661): Remove code related to the dynamic import shim
   build.dynamicImportShim = false;
   build.attachStyles = true;
 

--- a/src/compiler/output-targets/dist-lazy/generate-esm-browser.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-esm-browser.ts
@@ -24,7 +24,8 @@ export const generateEsmBrowser = async (
       preferConst: true,
       sourcemap: config.sourceMap,
     };
-    if (config.extras.dynamicImportShim) {
+    // TODO(STENCIL-661): Remove code related to the dynamic import shim
+    if (config.extras.__deprecated__dynamicImportShim) {
       // for Edge 16-18
       esmOpts.dynamicImportFunction = getDynamicImportFunction(config.fsNamespace);
     }

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -175,6 +175,7 @@ export interface BuildConditionals extends Partial<BuildFeatures> {
   slotChildNodesFix?: boolean;
   scopedSlotTextContentFix?: boolean;
   cloneNodeFix?: boolean;
+  // TODO(STENCIL-661): Remove code related to the dynamic import shim
   dynamicImportShim?: boolean;
   hydratedAttribute?: boolean;
   hydratedClass?: boolean;

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -275,8 +275,10 @@ export interface ConfigExtras {
 
   // TODO(STENCIL-661): Remove code related to the dynamic import shim
   /**
-   * Dynamic `import()` shim. This is only needed for Edge 18 and below, and Firefox 67
-   * and below. Defaults to `false`.
+   * Dynamic `import()` shim. This is only needed for Edge 18 and below, and
+  * Firefox 67 and below. Defaults to `false`.
+   * @deprecated Since Stencil v3.0.0. IE 11, Edge <= 18, and old Safari
+   * versions are no longer supported.
    */
   __deprecated__dynamicImportShim?: boolean;
 

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -273,11 +273,12 @@ export interface ConfigExtras {
    */
   cssVarsShim?: boolean;
 
+  // TODO(STENCIL-661): Remove code related to the dynamic import shim
   /**
    * Dynamic `import()` shim. This is only needed for Edge 18 and below, and Firefox 67
    * and below. Defaults to `false`.
    */
-  dynamicImportShim?: boolean;
+  __deprecated__dynamicImportShim?: boolean;
 
   /**
    * Experimental flag. Projects that use a Stencil library built using the `dist` output target may have trouble lazily

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -276,7 +276,7 @@ export interface ConfigExtras {
   // TODO(STENCIL-661): Remove code related to the dynamic import shim
   /**
    * Dynamic `import()` shim. This is only needed for Edge 18 and below, and
-  * Firefox 67 and below. Defaults to `false`.
+   * Firefox 67 and below. Defaults to `false`.
    * @deprecated Since Stencil v3.0.0. IE 11, Edge <= 18, and old Safari
    * versions are no longer supported.
    */

--- a/src/testing/reset-build-conditionals.ts
+++ b/src/testing/reset-build-conditionals.ts
@@ -38,6 +38,7 @@ export function resetBuildConditionals(b: d.BuildConditionals) {
   b.invisiblePrehydration = true;
   b.appendChildSlotFix = false;
   b.cloneNodeFix = false;
+  // TODO(STENCIL-661): Remove code related to the dynamic import shim
   b.dynamicImportShim = false;
   b.hotModuleReplacement = false;
   b.safari10 = false;

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -159,6 +159,7 @@ export const hasDependency = (buildCtx: d.BuildCtx, depName: string): boolean =>
   return getDependencies(buildCtx).includes(depName);
 };
 
+// TODO(STENCIL-661): Remove code related to the dynamic import shim
 export const getDynamicImportFunction = (namespace: string) => `__sc_import_${namespace.replace(/\s|-/g, '_')}`;
 
 export const readPackageJson = async (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {


### PR DESCRIPTION
This marks the config field as deprecated and also adds TODO comments for STENCIL-661, the ticket for removing the code itself.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

We have support for a shim of `import()` which we'd like to remove at some point in the future.

## What is the new behavior?

The `dynamicImportShim` is now marked as deprecated, preparing the ground for us to remove it entirely later (and delete the code that implements the shim and so on).

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
