### PR TITLE
chore(config): mark appendChildSlotFix as deprecated

### DIFF
--- a/src/app-data/index.ts
+++ b/src/app-data/index.ts
@@ -59,6 +59,7 @@ export const BUILD: BuildConditionals = {
   lazyLoad: false,
   profile: false,
   slotRelocation: true,
+  // TODO(STENCIL-664): Remove code related to deprecated appendChildSlotFix field
   appendChildSlotFix: false,
   cloneNodeFix: false,
   hydratedAttribute: false,

--- a/src/compiler/app-core/app-data.ts
+++ b/src/compiler/app-core/app-data.ts
@@ -146,7 +146,8 @@ export const updateBuildConditionals = (config: Config, b: BuildConditionals) =>
   b.constructableCSS = !b.hotModuleReplacement || !!config._isTesting;
   b.asyncLoading = !!(b.asyncLoading || b.lazyLoad || b.taskQueue || b.initializeNextTick);
   b.cssAnnotations = true;
-  b.appendChildSlotFix = config.extras.appendChildSlotFix;
+  // TODO(STENCIL-664): Remove code related to deprecated appendChildSlotFix field
+  b.appendChildSlotFix = config.extras.__deprecated__appendChildSlotFix;
   b.slotChildNodesFix = config.extras.slotChildNodesFix;
   b.cloneNodeFix = config.extras.cloneNodeFix;
   b.dynamicImportShim = config.extras.dynamicImportShim;

--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -352,7 +352,8 @@ describe('validation', () => {
 
   it('should set extras defaults', () => {
     const { config } = validateConfig(userConfig, bootstrapConfig);
-    expect(config.extras.appendChildSlotFix).toBe(false);
+    // TODO(STENCIL-664): Remove code related to deprecated appendChildSlotFix field
+    expect(config.extras.__deprecated__appendChildSlotFix).toBe(false);
     expect(config.extras.cloneNodeFix).toBe(false);
     expect(config.extras.cssVarsShim).toBe(false);
     expect(config.extras.dynamicImportShim).toBe(false);

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -69,7 +69,8 @@ export const validateConfig = (
   }
 
   validatedConfig.extras = validatedConfig.extras || {};
-  validatedConfig.extras.appendChildSlotFix = !!validatedConfig.extras.appendChildSlotFix;
+  // TODO(STENCIL-664): Remove code related to deprecated appendChildSlotFix field
+  validatedConfig.extras.__deprecated__appendChildSlotFix = !!validatedConfig.extras.__deprecated__appendChildSlotFix;
   validatedConfig.extras.cloneNodeFix = !!validatedConfig.extras.cloneNodeFix;
   validatedConfig.extras.cssVarsShim = !!validatedConfig.extras.cssVarsShim;
   validatedConfig.extras.dynamicImportShim = !!validatedConfig.extras.dynamicImportShim;

--- a/src/compiler/output-targets/dist-hydrate-script/generate-hydrate-app.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/generate-hydrate-app.ts
@@ -134,6 +134,7 @@ const getHydrateBuildConditionals = (config: d.ValidatedConfig, cmps: d.Componen
   build.devTools = false;
   build.hotModuleReplacement = false;
   build.cloneNodeFix = false;
+  // TODO(STENCIL-664): Remove code related to deprecated appendChildSlotFix field
   build.appendChildSlotFix = false;
   build.slotChildNodesFix = false;
   build.safari10 = false;

--- a/src/compiler/output-targets/dist-hydrate-script/hydrate-build-conditionals.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/hydrate-build-conditionals.ts
@@ -20,6 +20,7 @@ export const getHydrateBuildConditionals = (cmps: d.ComponentCompilerMeta[]) => 
   build.member = true;
   build.constructableCSS = false;
   build.asyncLoading = true;
+  // TODO(STENCIL-664): Remove code related to deprecated appendChildSlotFix field
   build.appendChildSlotFix = false;
   build.slotChildNodesFix = false;
   build.cloneNodeFix = false;

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -171,6 +171,7 @@ export interface BuildConditionals extends Partial<BuildFeatures> {
   profile?: boolean;
   cssVarShim?: boolean;
   constructableCSS?: boolean;
+  // TODO(STENCIL-664): Remove code related to deprecated appendChildSlotFix field
   appendChildSlotFix?: boolean;
   slotChildNodesFix?: boolean;
   scopedSlotTextContentFix?: boolean;

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -249,14 +249,17 @@ export interface StencilConfig {
 }
 
 export interface ConfigExtras {
+  // TODO(STENCIL-664): Remove code related to deprecated appendChildSlotFix field
   /**
    * By default, the slot polyfill does not update `appendChild()` so that it appends
    * new child nodes into the correct child slot like how shadow dom works. This is an opt-in
    * polyfill for those who need it when using `element.appendChild(node)` and expecting the
    * child to be appended in the same location shadow dom would. This is not required for
    * IE11 or Edge 18, but can be enabled if the app is using `appendChild()`. Defaults to `false`.
+   *
+   * @deprecated Since Stencil v3.0.0, browsers requiring this are longer supported.
    */
-  appendChildSlotFix?: boolean;
+  __deprecated__appendChildSlotFix?: boolean;
 
   /**
    * By default, the runtime does not polyfill `cloneNode()` when cloning a component

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -137,6 +137,7 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
         patchCloneNode(HostElement.prototype);
       }
 
+      // TODO(STENCIL-664): Remove code related to deprecated appendChildSlotFix field
       if (BUILD.appendChildSlotFix) {
         patchSlotAppendChild(HostElement.prototype);
       }

--- a/src/runtime/dom-extras.ts
+++ b/src/runtime/dom-extras.ts
@@ -36,6 +36,7 @@ export const patchCloneNode = (HostElementPrototype: any) => {
         slotted = (srcNode.childNodes[i] as any)['s-nr'];
         nonStencilNode = stencilPrivates.every((privateField) => !(srcNode.childNodes[i] as any)[privateField]);
         if (slotted) {
+          // TODO(STENCIL-664): Remove code related to deprecated appendChildSlotFix field
           if (BUILD.appendChildSlotFix && (clonedNode as any).__appendChild) {
             (clonedNode as any).__appendChild(slotted.cloneNode(true));
           } else {
@@ -51,6 +52,7 @@ export const patchCloneNode = (HostElementPrototype: any) => {
   };
 };
 
+// TODO(STENCIL-664): Remove code related to deprecated appendChildSlotFix field
 export const patchSlotAppendChild = (HostElementPrototype: any) => {
   HostElementPrototype.__appendChild = HostElementPrototype.appendChild;
   HostElementPrototype.appendChild = function (this: d.RenderNode, newChild: d.RenderNode) {

--- a/src/testing/reset-build-conditionals.ts
+++ b/src/testing/reset-build-conditionals.ts
@@ -36,6 +36,7 @@ export function resetBuildConditionals(b: d.BuildConditionals) {
   b.hydratedAttribute = false;
   b.hydratedClass = true;
   b.invisiblePrehydration = true;
+  // TODO(STENCIL-664): Remove code related to deprecated appendChildSlotFix field
   b.appendChildSlotFix = false;
   b.cloneNodeFix = false;
   b.dynamicImportShim = false;


### PR DESCRIPTION
This marks `extras.appendChildSlotFix` on the Stencil config as deprecated, paving the way to remove the code for it later on. This also adds TODO comments around the codebase nothing code which should be removed when we remove the field entirely.

BREAKING CHANGES: The `appendChildSlotFix` field on `config.extras` is deprecated, since support for the browsers which require this fix has been dropped.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?

This field (`appendChildSlotFix`) is marked as deprecated.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
