### PR TITLE
chore(config): mark `scriptDataOpts` field as deprecated

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -16,8 +16,9 @@ This is a comprehensive list of the breaking changes introduced in the major ver
     * [`dist-custom-elements` Type Declarations](#dist-custom-elements-type-declarations)
   * [Legacy Browser Support Fields Deprecated](#legacy-browser-support-fields-deprecated)
     * [`dynamicImportShim`](#dynamicimportshim)
-    * [`cssVarShim`](#cssvarshim)
+    * [`cssVarsShim`](#cssvarsshim)
     * [`shadowDomShim`](#shadowdomshim)
+    * [`scriptDataOpts`](#scriptdataopts)
   * [Deprecated `assetsDir` Removed from `@Component()` decorator](#deprecated-assetsdir-removed-from-component-decorator)
   * [Drop Node 12 Support](#drop-node-12-support)
   * [Strongly Typed Inputs](#strongly-typed-inputs)
@@ -100,9 +101,9 @@ export const config: Config = {
 };
 ```
 
-##### `cssVarShim`
+##### `cssVarsShim`
 
-`extras.cssVarShim` causes Stencil to include a polyfill for [CSS
+`extras.cssVarsShim` causes Stencil to include a polyfill for [CSS
 variables](https://developer.mozilla.org/en-US/docs/Web/CSS/--*). For Stencil
 v3.0.0 this field is renamed to `__deprecated__cssVarsShim`. To retain the
 previous behavior the new option can be set in your project's
@@ -135,6 +136,27 @@ import { Config } from '@stencil/core';
 export const config: Config = {
   extras: {
     __deprecated__shadowDomShim: true
+  }
+};
+```
+
+##### `scriptDataOpts`
+
+`extras.scriptDataOpts` causes Stencil to read the `data-opts` property from
+Stencil's host `<script>` tag and then pass that data along to the Stencil
+runtime.
+For Stencil
+v3.0.0 this field is renamed to `__deprecated__scriptDataOpts`. To retain the
+previous behavior the new option can be set in your project's
+`stencil.config.ts`:
+
+```ts
+// stencil.config.ts
+import { Config } from '@stencil/core';
+
+export const config: Config = {
+  extras: {
+    __deprecated__scriptDataOpts: true
   }
 };
 ```

--- a/src/app-data/index.ts
+++ b/src/app-data/index.ts
@@ -64,6 +64,7 @@ export const BUILD: BuildConditionals = {
   hydratedAttribute: false,
   hydratedClass: true,
   safari10: false,
+  // TODO(STENCIL-664): Remove code associated with deprecated scriptDataOpts flag
   scriptDataOpts: false,
   scopedSlotTextContentFix: false,
   // TODO(STENCIL-662): Remove code related to deprecated shadowDomShim field

--- a/src/client/client-patch-browser.ts
+++ b/src/client/client-patch-browser.ts
@@ -37,6 +37,7 @@ export const patchBrowser = (): Promise<d.CustomElementsDefineOptions> => {
   // @ts-ignore
   const scriptElm =
     // TODO(STENCIL-661): Remove code related to the dynamic import shim
+    // TODO(STENCIL-664): Remove code associated with deprecated scriptDataOpts flag
     BUILD.scriptDataOpts || BUILD.safari10 || BUILD.dynamicImportShim
       ? Array.from(doc.querySelectorAll('script')).find(
           (s) =>
@@ -45,6 +46,7 @@ export const patchBrowser = (): Promise<d.CustomElementsDefineOptions> => {
         )
       : null;
   const importMeta = import.meta.url;
+  // TODO(STENCIL-664): Remove code associated with deprecated scriptDataOpts flag
   const opts = BUILD.scriptDataOpts ? (scriptElm as any)['data-opts'] || {} : {};
 
   if (BUILD.safari10 && 'onbeforeload' in scriptElm && !history.scrollRestoration /* IS_ESM_BUILD */) {

--- a/src/compiler/app-core/app-data.ts
+++ b/src/compiler/app-core/app-data.ts
@@ -154,7 +154,8 @@ export const updateBuildConditionals = (config: Config, b: BuildConditionals) =>
   b.lifecycleDOMEvents = !!(b.isDebug || config._isTesting || config.extras.lifecycleDOMEvents);
   b.safari10 = config.extras.safari10;
   b.scopedSlotTextContentFix = !!config.extras.scopedSlotTextContentFix;
-  b.scriptDataOpts = config.extras.scriptDataOpts;
+  // TODO(STENCIL-664): Remove code associated with deprecated scriptDataOpts flag
+  b.scriptDataOpts = config.extras.__deprecated__scriptDataOpts;
   // TODO(STENCIL-662): Remove code related to deprecated shadowDomShim field
   b.shadowDomShim = config.extras.__deprecated__shadowDomShim;
   b.attachStyles = true;

--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -360,7 +360,8 @@ describe('validation', () => {
     expect(config.extras.__deprecated__dynamicImportShim).toBe(false);
     expect(config.extras.lifecycleDOMEvents).toBe(false);
     expect(config.extras.safari10).toBe(false);
-    expect(config.extras.scriptDataOpts).toBe(false);
+    // TODO(STENCIL-664): Remove code associated with deprecated scriptDataOpts flag
+    expect(config.extras.__deprecated__scriptDataOpts).toBe(false);
     // TODO(STENCIL-662): Remove code related to deprecated shadowDomShim field
     expect(config.extras.__deprecated__shadowDomShim).toBe(false);
     expect(config.extras.slotChildNodesFix).toBe(false);

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -77,7 +77,8 @@ export const validateConfig = (
   validatedConfig.extras.__deprecated__dynamicImportShim = !!validatedConfig.extras.__deprecated__dynamicImportShim;
   validatedConfig.extras.lifecycleDOMEvents = !!validatedConfig.extras.lifecycleDOMEvents;
   validatedConfig.extras.safari10 = !!validatedConfig.extras.safari10;
-  validatedConfig.extras.scriptDataOpts = !!validatedConfig.extras.scriptDataOpts;
+  // TODO(STENCIL-664): Remove code associated with deprecated scriptDataOpts flag
+  validatedConfig.extras.__deprecated__scriptDataOpts = !!validatedConfig.extras.__deprecated__scriptDataOpts;
   // TODO(STENCIL-662): Remove code related to deprecated shadowDomShim field
   validatedConfig.extras.__deprecated__shadowDomShim = !!validatedConfig.extras.__deprecated__shadowDomShim;
   validatedConfig.extras.slotChildNodesFix = !!validatedConfig.extras.slotChildNodesFix;

--- a/src/compiler/output-targets/dist-hydrate-script/hydrate-build-conditionals.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/hydrate-build-conditionals.ts
@@ -30,6 +30,7 @@ export const getHydrateBuildConditionals = (cmps: d.ComponentCompilerMeta[]) => 
   build.safari10 = false;
   build.hydratedAttribute = false;
   build.hydratedClass = true;
+  // TODO(STENCIL-664): Remove code associated with deprecated scriptDataOpts flag
   build.scriptDataOpts = false;
   // TODO(STENCIL-661): Remove code related to the dynamic import shim
   build.dynamicImportShim = false;

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -182,6 +182,7 @@ export interface BuildConditionals extends Partial<BuildFeatures> {
   hydratedClass?: boolean;
   initializeNextTick?: boolean;
   safari10?: boolean;
+  // TODO(STENCIL-664): Remove code associated with deprecated scriptDataOpts flag
   scriptDataOpts?: boolean;
   // TODO(STENCIL-662): Remove code related to deprecated shadowDomShim field
   shadowDomShim?: boolean;

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -307,12 +307,15 @@ export interface ConfigExtras {
    */
   safari10?: boolean;
 
+  // TODO(STENCIL-664): Remove code associated with deprecated scriptDataOpts flag
   /**
    * It is possible to assign data to the actual `<script>` element's `data-opts` property,
    * which then gets passed to Stencil's initial bootstrap. This feature is only required
    * for very special cases and rarely needed. Defaults to `false`.
+   *
+   * @deprecated As of Stencil 3.0.0, this field is deprecated
    */
-  scriptDataOpts?: boolean;
+  __deprecated__scriptDataOpts?: boolean;
 
   /**
    * Experimental flag to align the behavior of invoking `textContent` on a scoped component to act more like a

--- a/src/testing/reset-build-conditionals.ts
+++ b/src/testing/reset-build-conditionals.ts
@@ -42,6 +42,7 @@ export function resetBuildConditionals(b: d.BuildConditionals) {
   b.dynamicImportShim = false;
   b.hotModuleReplacement = false;
   b.safari10 = false;
+  // TODO(STENCIL-664): Remove code associated with deprecated scriptDataOpts flag
   b.scriptDataOpts = false;
   b.scopedSlotTextContentFix = false;
   b.slotChildNodesFix = false;


### PR DESCRIPTION
This marks the `extras.scriptDataOpts` field on the Stencil config as deprecated and sprinkles TODO here and there to note where we'll need to rip the related code out later.

BREAKING CHANGES: The `extras.scriptDataOpts` field is deprecated and will be removed entirely in a future version. For now, it is renamed to `__deprecated__scriptDataOpts`.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?

This marks the `scriptDataOpts` field as deprecated. hooray for deprecation!

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
