### PR TITLE
append style tag at the end of head tag

### DIFF
--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -81,7 +81,7 @@ export const addStyle = (
             styleElm.setAttribute(HYDRATED_STYLE_ID, scopeId);
           }
 
-          styleContainerNode.insertBefore(styleElm, styleContainerNode.querySelector('link'));
+          styleContainerNode.insertBefore(styleElm, null);
         }
 
         if (appliedStyles) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
NextJS has bug where it unmounts/delete injected tags in the `<head>` tag, specifically if the injected tag in before the

`<meta name="next-head-count" content="3">`

https://github.com/vercel/next.js/issues/39143
https://github.com/vercel/next.js/issues/11012

if there is a `<link>` tag present in the `<head>` tag and is before the `<meta name="next-head-count">`, StencilJS would inject the `<style>` tags before the `<link>` tag.

When NextJS rehydrates, it will delete the injected StencilJS `<style>` tag.

https://github.com/vercel/next.js/issues/39143 has a sample project to reproduce the issue:  https://github.com/electather/nextjs-image-bug

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Instead of injecting the `<style>` tag before a `<link>` tag, it is now injects as the last child of `<head>` tag.

This is also the existing behavior when the DOM has no `<link>` tag present.


## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

I don't know. I am not sure why there is specific code to insert `<style>` tags before `<link>` tag in the DOM

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
Using the linked project above:

Screenshot of the DOM before NextJS rehydrates the `<head>` tag (StencilJS injected `<style>` tag is present):

<img width="448" alt="Screen Shot 2022-12-10 at 6 41 41 AM" src="https://user-images.githubusercontent.com/285941/206853278-e5cc0227-474c-4429-a472-b5ad50cae758.png">

Screenshot of the DOM after NextJS rehydrates the `<head>` tag (StencilJS injected `<style>` tag is gone):

<img width="485" alt="Screen Shot 2022-12-10 at 6 41 53 AM" src="https://user-images.githubusercontent.com/285941/206853300-6c648d72-f219-4b44-b8d2-4df808c83f2d.png">

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
