### PR TITLE
chore(config): add `hydratedFlag` to ValidatedConfig

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -132,6 +132,7 @@ export const runTask = async (
   const strictConfig: ValidatedConfig = {
     ...config,
     flags: createConfigFlags(config.flags ?? { task }),
+    hydratedFlag: undefined,
     logger,
     outputTargets: config.outputTargets ?? [],
     rootDir: config.rootDir ?? '/',

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -132,7 +132,7 @@ export const runTask = async (
   const strictConfig: ValidatedConfig = {
     ...config,
     flags: createConfigFlags(config.flags ?? { task }),
-    hydratedFlag: undefined,
+    hydratedFlag: config.hydratedFlag ?? null,
     logger,
     outputTargets: config.outputTargets ?? [],
     rootDir: config.rootDir ?? '/',

--- a/src/compiler/config/test/validate-hydrated.spec.ts
+++ b/src/compiler/config/test/validate-hydrated.spec.ts
@@ -18,7 +18,7 @@ describe('validate-hydrated', () => {
       // this test explicitly checks for a bad value in the stencil.config file, hence the type assertion
       (inputConfig.hydratedFlag as any) = badValue;
       const actual = validateHydrated(inputConfig);
-      expect(actual).toBeUndefined();
+      expect(actual).toBeNull();
     });
 
     it.each([[], true])('returns a default value when hydratedFlag=%s', (badValue) => {

--- a/src/compiler/config/test/validate-service-worker.spec.ts
+++ b/src/compiler/config/test/validate-service-worker.spec.ts
@@ -14,6 +14,7 @@ describe('validateServiceWorker', () => {
     config = {
       fsNamespace: 'app',
       rootDir: '/',
+      hydratedFlag: undefined,
       sys: mockCompilerSystem(),
       devMode: false,
       flags: createConfigFlags(),

--- a/src/compiler/config/test/validate-service-worker.spec.ts
+++ b/src/compiler/config/test/validate-service-worker.spec.ts
@@ -14,7 +14,7 @@ describe('validateServiceWorker', () => {
     config = {
       fsNamespace: 'app',
       rootDir: '/',
-      hydratedFlag: undefined,
+      hydratedFlag: null,
       sys: mockCompilerSystem(),
       devMode: false,
       flags: createConfigFlags(),

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -52,12 +52,12 @@ export const validateConfig = (
     ...config,
     // flags _should_ be JSON safe
     flags: JSON.parse(JSON.stringify(config.flags || {})),
+    hydratedFlag: validateHydrated(config),
     logger,
     outputTargets: config.outputTargets ?? [],
     rootDir: typeof config.rootDir === 'string' ? config.rootDir : '/',
     sys: config.sys ?? bootstrapConfig.sys ?? createSystem({ logger }),
     testing: config.testing ?? {},
-    hydratedFlag: validateHydrated(config),
   };
 
   // default devMode false

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -57,6 +57,7 @@ export const validateConfig = (
     rootDir: typeof config.rootDir === 'string' ? config.rootDir : '/',
     sys: config.sys ?? bootstrapConfig.sys ?? createSystem({ logger }),
     testing: config.testing ?? {},
+    hydratedFlag: validateHydrated(config),
   };
 
   // default devMode false
@@ -149,9 +150,6 @@ export const validateConfig = (
 
   // testing
   validateTesting(validatedConfig, diagnostics);
-
-  // hydrate flag
-  validatedConfig.hydratedFlag = validateHydrated(validatedConfig);
 
   // bundles
   if (Array.isArray(validatedConfig.bundles)) {

--- a/src/compiler/config/validate-hydrated.ts
+++ b/src/compiler/config/validate-hydrated.ts
@@ -3,7 +3,8 @@ import { isString } from '@utils';
 import { HydratedFlag, UnvalidatedConfig } from '../../declarations';
 
 /**
- * Check the provided `.hydratedFlag` prop and return a properly-validated value.
+ * Validate the `.hydratedFlag` property on the supplied config object and
+ * return a properly-validated value.
  *
  * @param config the configuration we're examining
  * @returns a suitable value for the hydratedFlag property

--- a/src/compiler/config/validate-hydrated.ts
+++ b/src/compiler/config/validate-hydrated.ts
@@ -9,22 +9,22 @@ import { HydratedFlag, UnvalidatedConfig } from '../../declarations';
  * @param config the configuration we're examining
  * @returns a suitable value for the hydratedFlag property
  */
-export const validateHydrated = (config: UnvalidatedConfig): HydratedFlag | undefined => {
+export const validateHydrated = (config: UnvalidatedConfig): HydratedFlag | null => {
   /**
    * If `config.hydratedFlag` is set to `null` that is an explicit signal that we
    * should _not_ create a default configuration when validating and should instead
-   * just return `undefined`. It may also have been set to `false`; this is an invalid
+   * just return `null`. It may also have been set to `false`; this is an invalid
    * value as far as the type system is concerned, but users may ignore this.
    *
    * See {@link HydratedFlag} for more details.
    */
   if (config.hydratedFlag === null || (config.hydratedFlag as unknown as boolean) === false) {
-    return undefined;
+    return null;
   }
 
   // Here we start building up a default config since `.hydratedFlag` wasn't set to
   // `null` on the provided config.
-  const hydratedFlag: HydratedFlag = { ...config.hydratedFlag };
+  const hydratedFlag: HydratedFlag = { ...(config.hydratedFlag ?? {}) };
 
   if (!isString(hydratedFlag.name) || hydratedFlag.property === '') {
     hydratedFlag.name = `hydrated`;

--- a/src/compiler/sys/config.ts
+++ b/src/compiler/sys/config.ts
@@ -14,6 +14,7 @@ export const getConfig = (userConfig: d.Config): d.ValidatedConfig => {
     rootDir: userConfig.rootDir ?? '/',
     sys: userConfig.sys ?? createSystem({ logger }),
     testing: userConfig ?? {},
+    hydratedFlag: undefined,
   };
 
   setPlatformPath(config.sys.platformPath);

--- a/src/compiler/sys/config.ts
+++ b/src/compiler/sys/config.ts
@@ -9,12 +9,12 @@ export const getConfig = (userConfig: d.Config): d.ValidatedConfig => {
   const config: d.ValidatedConfig = {
     ...userConfig,
     flags: createConfigFlags(userConfig.flags ?? {}),
+    hydratedFlag: userConfig.hydratedFlag ?? null,
     logger,
     outputTargets: userConfig.outputTargets ?? [],
     rootDir: userConfig.rootDir ?? '/',
     sys: userConfig.sys ?? createSystem({ logger }),
     testing: userConfig ?? {},
-    hydratedFlag: userConfig.hydratedFlag ?? null,
   };
 
   setPlatformPath(config.sys.platformPath);

--- a/src/compiler/sys/config.ts
+++ b/src/compiler/sys/config.ts
@@ -14,7 +14,7 @@ export const getConfig = (userConfig: d.Config): d.ValidatedConfig => {
     rootDir: userConfig.rootDir ?? '/',
     sys: userConfig.sys ?? createSystem({ logger }),
     testing: userConfig ?? {},
-    hydratedFlag: undefined,
+    hydratedFlag: userConfig.hydratedFlag ?? null,
   };
 
   setPlatformPath(config.sys.platformPath);

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -173,7 +173,7 @@ export interface StencilConfig {
    * type of CSS properties and values are assigned before and after hydrating. This config
    * can also be used to not include the hydrated flag at all by setting it to `null`.
    */
-  hydratedFlag?: HydratedFlag;
+  hydratedFlag?: HydratedFlag | undefined;
 
   /**
    * Ionic prefers to hide all components prior to hydration with a style tag appended
@@ -424,7 +424,7 @@ type RequireFields<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 /**
  * Fields in {@link Config} to make required for {@link ValidatedConfig}
  */
-type StrictConfigFields = 'flags' | 'logger' | 'outputTargets' | 'rootDir' | 'sys' | 'testing';
+type StrictConfigFields = 'flags' | 'logger' | 'outputTargets' | 'rootDir' | 'sys' | 'testing' | 'hydratedFlag';
 
 /**
  * A version of {@link Config} that makes certain fields required. This type represents a valid configuration entity.

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -424,7 +424,7 @@ type RequireFields<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 /**
  * Fields in {@link Config} to make required for {@link ValidatedConfig}
  */
-type StrictConfigFields = 'flags' | 'logger' | 'outputTargets' | 'rootDir' | 'sys' | 'testing' | 'hydratedFlag';
+type StrictConfigFields = 'flags' | 'hydratedFlag' | 'logger' | 'outputTargets' | 'rootDir' | 'sys' | 'testing';
 
 /**
  * A version of {@link Config} that makes certain fields required. This type represents a valid configuration entity.

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -173,7 +173,7 @@ export interface StencilConfig {
    * type of CSS properties and values are assigned before and after hydrating. This config
    * can also be used to not include the hydrated flag at all by setting it to `null`.
    */
-  hydratedFlag?: HydratedFlag | undefined;
+  hydratedFlag?: HydratedFlag | null;
 
   /**
    * Ionic prefers to hide all components prior to hydration with a style tag appended

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -39,7 +39,7 @@ export function mockValidatedConfig(overrides: Partial<ValidatedConfig> = {}): V
     rootDir: path.resolve('/'),
     sys: createTestingSystem(),
     testing: {},
-    hydratedFlag: undefined,
+    hydratedFlag: null,
     ...overrides,
   };
 }

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -34,12 +34,12 @@ export function mockValidatedConfig(overrides: Partial<ValidatedConfig> = {}): V
   return {
     ...baseConfig,
     flags: createConfigFlags(),
+    hydratedFlag: null,
     logger: mockLogger(),
     outputTargets: baseConfig.outputTargets ?? [],
     rootDir: path.resolve('/'),
     sys: createTestingSystem(),
     testing: {},
-    hydratedFlag: null,
     ...overrides,
   };
 }

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -39,6 +39,7 @@ export function mockValidatedConfig(overrides: Partial<ValidatedConfig> = {}): V
     rootDir: path.resolve('/'),
     sys: createTestingSystem(),
     testing: {},
+    hydratedFlag: undefined,
     ...overrides,
   };
 }


### PR DESCRIPTION
This adds the `hydratedFlag` property to the `ValidatedConfig` object, meaning that the field must be present.

Note that this required a change to use null to signify a missing hydrateflag.
this is because when we are building the `ValidatedConfig` type we do
the following:

```ts
type RequireFields<T, K extends keyof T> = T & { [P in K]-?: T[P] };
```

If there is a type `P` in `K extends keyof T` where the type of `T[P]` is
`Foo | undefined` then unfortunately when we do `[P in K]-?: T[P]` we'll
set the output type to just `Foo`, so the type returned by
`RequireFields` for the field in question won't be unioned with `undefined`,
which was previously what we were doing here to try to signify a missing
`HydratedFlag` value.

Instead we can just use `null` which makes it through the `-?` bit.



## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?

This should just fix a few SNC errors.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

It technically introduces one small change in a public type signature, from `HydratedFlag` to `HydratedFlag | null`. This could be grounds for making this change in v3.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
