### PR TITLE
feat(compiler): add flag for auto exporting custom types

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -137,6 +137,7 @@ export const runTask = async (
     rootDir: config.rootDir ?? '/',
     sys: sys ?? config.sys ?? coreCompiler.createSystem({ logger }),
     testing: config.testing ?? {},
+    autoExportCustomTypes: config.autoExportCustomTypes ?? true,
   };
 
   switch (task) {

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -131,13 +131,13 @@ export const runTask = async (
   const logger = config.logger ?? createLogger();
   const strictConfig: ValidatedConfig = {
     ...config,
+    autoExportCustomTypes: config.autoExportCustomTypes ?? true,
     flags: createConfigFlags(config.flags ?? { task }),
     logger,
     outputTargets: config.outputTargets ?? [],
     rootDir: config.rootDir ?? '/',
     sys: sys ?? config.sys ?? coreCompiler.createSystem({ logger }),
     testing: config.testing ?? {},
-    autoExportCustomTypes: config.autoExportCustomTypes ?? true,
   };
 
   switch (task) {

--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -447,4 +447,17 @@ describe('validation', () => {
       expect(config.buildDist).toBe(config.buildEs5);
     });
   });
+
+  describe('autoExportCustomTypes', () => {
+    it('should default to true', () => {
+      const { config } = validateConfig(userConfig, bootstrapConfig);
+      expect(config.autoExportCustomTypes).toBe(true);
+    });
+
+    it.each([true, false])('should respect the user input value when %s', (autoExportCustomTypes) => {
+      userConfig.autoExportCustomTypes = autoExportCustomTypes;
+      const { config } = validateConfig(userConfig, bootstrapConfig);
+      expect(config.autoExportCustomTypes).toBe(autoExportCustomTypes);
+    });
+  });
 });

--- a/src/compiler/config/test/validate-service-worker.spec.ts
+++ b/src/compiler/config/test/validate-service-worker.spec.ts
@@ -12,15 +12,15 @@ describe('validateServiceWorker', () => {
 
   beforeEach(() => {
     config = {
-      fsNamespace: 'app',
-      rootDir: '/',
-      sys: mockCompilerSystem(),
+      autoExportCustomTypes: true,
       devMode: false,
       flags: createConfigFlags(),
+      fsNamespace: 'app',
       logger: mockLogger(),
       outputTargets: [],
+      rootDir: '/',
+      sys: mockCompilerSystem(),
       testing: {},
-      autoExportCustomTypes: true,
     };
   });
 

--- a/src/compiler/config/test/validate-service-worker.spec.ts
+++ b/src/compiler/config/test/validate-service-worker.spec.ts
@@ -20,6 +20,7 @@ describe('validateServiceWorker', () => {
       logger: mockLogger(),
       outputTargets: [],
       testing: {},
+      autoExportCustomTypes: true,
     };
   });
 

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -51,13 +51,13 @@ export const validateConfig = (
   const validatedConfig: ValidatedConfig = {
     ...config,
     // flags _should_ be JSON safe
+    autoExportCustomTypes: config.autoExportCustomTypes ?? true,
     flags: JSON.parse(JSON.stringify(config.flags || {})),
     logger,
     outputTargets: config.outputTargets ?? [],
     rootDir: typeof config.rootDir === 'string' ? config.rootDir : '/',
     sys: config.sys ?? bootstrapConfig.sys ?? createSystem({ logger }),
     testing: config.testing ?? {},
-    autoExportCustomTypes: config.autoExportCustomTypes ?? true,
   };
 
   // default devMode false

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -57,6 +57,7 @@ export const validateConfig = (
     rootDir: typeof config.rootDir === 'string' ? config.rootDir : '/',
     sys: config.sys ?? bootstrapConfig.sys ?? createSystem({ logger }),
     testing: config.testing ?? {},
+    autoExportCustomTypes: config.autoExportCustomTypes ?? true,
   };
 
   // default devMode false

--- a/src/compiler/sys/config.ts
+++ b/src/compiler/sys/config.ts
@@ -8,13 +8,13 @@ export const getConfig = (userConfig: d.Config): d.ValidatedConfig => {
   const logger = userConfig.logger ?? createLogger();
   const config: d.ValidatedConfig = {
     ...userConfig,
+    autoExportCustomTypes: userConfig.autoExportCustomTypes ?? true,
     flags: createConfigFlags(userConfig.flags ?? {}),
     logger,
     outputTargets: userConfig.outputTargets ?? [],
     rootDir: userConfig.rootDir ?? '/',
     sys: userConfig.sys ?? createSystem({ logger }),
     testing: userConfig ?? {},
-    autoExportCustomTypes: userConfig.autoExportCustomTypes ?? true,
   };
 
   setPlatformPath(config.sys.platformPath);

--- a/src/compiler/sys/config.ts
+++ b/src/compiler/sys/config.ts
@@ -14,6 +14,7 @@ export const getConfig = (userConfig: d.Config): d.ValidatedConfig => {
     rootDir: userConfig.rootDir ?? '/',
     sys: userConfig.sys ?? createSystem({ logger }),
     testing: userConfig ?? {},
+    autoExportCustomTypes: userConfig.autoExportCustomTypes ?? true,
   };
 
   setPlatformPath(config.sys.platformPath);

--- a/src/compiler/types/generate-app-types.ts
+++ b/src/compiler/types/generate-app-types.ts
@@ -115,7 +115,12 @@ const generateComponentTypesFile = (config: d.Config, buildCtx: d.BuildCtx, areT
   });
 
   // Write all import and export statements for event types
-  c.push(...expressions.map((ref) => `import ${ref}`), ...expressions.map((ref) => `export ${ref}`));
+  c.push(...expressions.map((ref) => `import ${ref}`));
+
+  // Only re-export the custom types if the option is set on the config
+  if (config.autoExportCustomTypes) {
+    c.push(...expressions.map((ref) => `export ${ref}`));
+  }
 
   c.push(`export namespace Components {`);
   c.push(...modules.map((m) => `${m.component}`));

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -436,13 +436,13 @@ type RequireFields<T, K extends keyof T> = T & { [P in K]-?: T[P] };
  * Fields in {@link Config} to make required for {@link ValidatedConfig}
  */
 type StrictConfigFields =
+  | 'autoExportCustomTypes'
   | 'flags'
   | 'logger'
   | 'outputTargets'
   | 'rootDir'
   | 'sys'
-  | 'testing'
-  | 'autoExportCustomTypes';
+  | 'testing';
 
 /**
  * A version of {@link Config} that makes certain fields required. This type represents a valid configuration entity.

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -246,6 +246,17 @@ export interface StencilConfig {
   watchIgnoredRegex?: RegExp | RegExp[];
   excludeUnusedDependencies?: boolean;
   stencilCoreResolvedId?: string;
+
+  /**
+   * @deprecated will not be supported in a future version of Stencil.
+   *
+   * When `true`, any custom types used as a part of a component `@Prop` or
+   * `@Event` will be automatically exported from the generated `components.d.ts` file
+   * in the compiled output.
+   *
+   * @default true
+   */
+  autoExportCustomTypes?: boolean;
 }
 
 export interface ConfigExtras {
@@ -424,7 +435,14 @@ type RequireFields<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 /**
  * Fields in {@link Config} to make required for {@link ValidatedConfig}
  */
-type StrictConfigFields = 'flags' | 'logger' | 'outputTargets' | 'rootDir' | 'sys' | 'testing';
+type StrictConfigFields =
+  | 'flags'
+  | 'logger'
+  | 'outputTargets'
+  | 'rootDir'
+  | 'sys'
+  | 'testing'
+  | 'autoExportCustomTypes';
 
 /**
  * A version of {@link Config} that makes certain fields required. This type represents a valid configuration entity.

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -39,6 +39,7 @@ export function mockValidatedConfig(overrides: Partial<ValidatedConfig> = {}): V
     rootDir: path.resolve('/'),
     sys: createTestingSystem(),
     testing: {},
+    autoExportCustomTypes: true,
     ...overrides,
   };
 }

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -33,13 +33,13 @@ export function mockValidatedConfig(overrides: Partial<ValidatedConfig> = {}): V
 
   return {
     ...baseConfig,
+    autoExportCustomTypes: true,
     flags: createConfigFlags(),
     logger: mockLogger(),
     outputTargets: baseConfig.outputTargets ?? [],
     rootDir: path.resolve('/'),
     sys: createTestingSystem(),
     testing: {},
-    autoExportCustomTypes: true,
     ...overrides,
   };
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally and any changes were pushed
- [X] Unit tests (`npm test`) were run locally and passed
- [X] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [X] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, Framework encounters issues migrating to Stencil V3 due to a circular type definition. This happens because the types referenced by their components live in a root `interface.d.ts` file. This file is manually maintained and exports the contents of `components.d.ts` file, which is what results in the circular dependency.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This commit adds `autoExportCustomTypes` as a config flag to control whether or not custom types used for component props/events get exported from the `components.d.ts` file. This flag defaults `true` and was immediately marked as deprecated as it was only added as an interim fix for the Ionic Framework team's migrations to Stencil V3

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

- Unit tests were added to the config validation test suite for the new field
- Tested Framework with the local build and got the same output in `components.d.ts` as V2 with the flag disabled. 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
