### PR TITLE
fix(compiler): ensure rollup outputs a single file for hydrateFactory

### DIFF
--- a/src/compiler/output-targets/dist-hydrate-script/generate-hydrate-app.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/generate-hydrate-app.ts
@@ -90,6 +90,7 @@ const generateHydrateFactory = async (config: d.ValidatedConfig, compilerCtx: d.
           intro: HYDRATE_FACTORY_INTRO,
           outro: HYDRATE_FACTORY_OUTRO,
           preferConst: false,
+          inlineDynamicImports: true,
         });
 
         if (!buildCtx.hasError && rollupOutput != null && Array.isArray(rollupOutput.output)) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When [generating a hydrateFactory](https://github.com/ionic-team/stencil/blob/main/src/compiler/output-targets/dist-hydrate-script/generate-hydrate-app.ts#L86), rollup may split the output into multiple files. As Stencil [only outputs the content of the first file](https://github.com/ionic-team/stencil/blob/main/src/compiler/output-targets/dist-hydrate-script/generate-hydrate-app.ts#L96) this results in a broken hydrate script. 

`/dist/hydrate/index.js`

```js
// ...
var _appFactoryEntry = require('./@app-factory-entry-5119d8cd.js');
require('punycode');


exports.hydrateApp = _appFactoryEntry.hydrateApp;
// ...
```


When running `stencil build --prerender`:

```
[39:02.7]  prerendering failed in 64 ms
[ ERROR ]  Hydrate Error
           Error: Cannot find module './@app-factory-entry-5119d8cd.js' Require
```

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

By using the [inlinedynamicimports](https://rollupjs.org/configuration-options/#output-inlinedynamicimports) option, rollup bundles to hydrate factory to a single file, and hydrate, `--prerender` work as expected.  

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Tested with `yarn link` against failing project.

## Other information

To reproduce:

1. Clone [Event Store Design System](https://github.com/EventStore/Design-System)

```
git clone git@github.com:EventStore/Design-System.git
```

2. Checkout `update-stencil` branch

```
git checkout update-stencil
```

3. Install dependencies

```
corepack enable
yarn
```

4. Attempt to build documentation site

```
yarn docs
```

5. Observe failure.

6. If you want to observe more directly, you can edit `node_modules/@stencil/core/compiler/stencil.js` on line `58112` to log `rollupOutput`, and see that there are multiple files.

7. Using this PR, build a new version of stencil and link the build:

```
yarn link ~/path/to/stencil
```

8. re-run docs build

```
yarn docs
```

9. Observe success :tada: 