### PR TITLE
chore(compiler): add JSDoc to ts-config module

### DIFF
--- a/src/compiler/transpile/ts-config.ts
+++ b/src/compiler/transpile/ts-config.ts
@@ -3,9 +3,28 @@ import ts from 'typescript';
 import type * as d from '../../declarations';
 import { isOutputTargetDistTypes } from '../output-targets/output-utils';
 
-export const getTsOptionsToExtend = (config: d.ValidatedConfig) => {
+/**
+ * Derive a {@link ts.CompilerOptions} object from the options currently set
+ * on the user-supplied configuration object.
+ *
+ * Some of these options (like the `module` setting) are hardcoded here, but
+ * the following are derived from the configuration object:
+ *
+ * - if one of the output targets requires type declaration output (i.e. the
+ *   {@link d.OutputTargetDistCustomElements.generateTypeDeclarations} option
+ *   is set to `true`) then we'll set `declaration: true`
+ * - the `outDir` is set to the configured cache directory
+ * - the `sourceMap` and `inlineSources` options are set based on the user's
+ *   {@link d.Config.sourceMap} configuration
+ *
+ * @param config the current user-supplied configuration
+ * @returns an object containing TypeScript compiler options
+ */
+export const getTsOptionsToExtend = (config: d.ValidatedConfig): ts.CompilerOptions => {
   const tsOptions: ts.CompilerOptions = {
     experimentalDecorators: true,
+    // if the `DIST_TYPES` output target is present then we'd like to emit
+    // declaration files
     declaration: config.outputTargets.some(isOutputTargetDistTypes),
     module: ts.ModuleKind.ESNext,
     moduleResolution: ts.ModuleResolutionKind.NodeJs,

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -244,6 +244,9 @@ export interface StencilConfig {
    * is updated, it will not trigger a re-run of tests.
    */
   watchIgnoredRegex?: RegExp | RegExp[];
+  /**
+   * Set whether unused dependencies should be excluded from the built output.
+   */
   excludeUnusedDependencies?: boolean;
   stencilCoreResolvedId?: string;
 }


### PR DESCRIPTION
This adds a JSDoc comment to the `getTsOptionsToExtend` function is `src/compiler/transpile/ts-config.ts`, previously it was not documented.

This also documents the purpose of the `excludeUnusedDependencies` config parameter.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?

This documents a previously-undocumented function.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

no logic changes, just docs.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
