### PR TITLE
docs(dist-lazy): add a small note noting a value will be mutated

### DIFF
--- a/src/compiler/output-targets/dist-lazy/lazy-output.ts
+++ b/src/compiler/output-targets/dist-lazy/lazy-output.ts
@@ -116,7 +116,13 @@ const getLazyCustomTransformer = (config: d.ValidatedConfig, compilerCtx: d.Comp
 };
 
 /**
- * Generate entry modules to be used by the build process by determining how modules and components are connected
+ * Generate entry modules to be used by the build process by determining how
+ * modules and components are connected
+ *
+ * **Note**: this function mutates the {@link d.BuildCtx} object that is
+ * passed in to it, assigning the generated entry modules to the `entryModules`
+ * property
+ *
  * @param config the Stencil configuration file that was provided as a part of the build step
  * @param buildCtx the current build context
  */


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
