### PR TITLE
feat(testing): add support for transforming path aliases in spec tests

### DIFF
--- a/src/compiler/sys/typescript/typescript-sys.ts
+++ b/src/compiler/sys/typescript/typescript-sys.ts
@@ -12,7 +12,7 @@ import { patchTypeScriptResolveModule } from './typescript-resolve-module';
 export const patchTsSystemFileSystem = (
   config: d.Config,
   compilerSys: d.CompilerSystem,
-  inMemoryFs: InMemoryFileSystem | null,
+  inMemoryFs: InMemoryFileSystem,
   tsSys: ts.System
 ): ts.System => {
   const realpath = (path: string) => {

--- a/src/compiler/sys/typescript/typescript-sys.ts
+++ b/src/compiler/sys/typescript/typescript-sys.ts
@@ -55,6 +55,8 @@ export const patchTsSystemFileSystem = (
   };
 
   tsSys.directoryExists = (p) => {
+    // At present the typing for `inMemoryFs` in this function is not accurate
+    // TODO(STENCIL-728): fix typing of `inMemoryFs` parameter in `patchTypescript`, related functions
     if (inMemoryFs) {
       const s = inMemoryFs.statSync(p);
       return s.isDirectory;
@@ -73,6 +75,8 @@ export const patchTsSystemFileSystem = (
       filePath = getTypescriptPathFromUrl(config, tsSys.getExecutingFilePath(), p);
     }
 
+    // At present the typing for `inMemoryFs` in this function is not accurate
+    // TODO(STENCIL-728): fix typing of `inMemoryFs` parameter in `patchTypescript`, related functions
     if (inMemoryFs) {
       const s = inMemoryFs.statSync(filePath);
       return !!(s && s.isFile);
@@ -89,6 +93,8 @@ export const patchTsSystemFileSystem = (
   tsSys.getDirectories = (p) => {
     const items = compilerSys.readDirSync(p);
     return items.filter((itemPath) => {
+      // At present the typing for `inMemoryFs` in this function is not accurate
+      // TODO(STENCIL-728): fix typing of `inMemoryFs` parameter in `patchTypescript`, related functions
       if (inMemoryFs) {
         const s = inMemoryFs.statSync(itemPath);
         return !!(s && s.exists && s.isDirectory);
@@ -123,6 +129,8 @@ export const patchTsSystemFileSystem = (
       filePath = getTypescriptPathFromUrl(config, tsSys.getExecutingFilePath(), p);
     }
 
+    // At present the typing for `inMemoryFs` in this function is not accurate
+    // TODO(STENCIL-728): fix typing of `inMemoryFs` parameter in `patchTypescript`, related functions
     let content = inMemoryFs
       ? inMemoryFs.readFileSync(filePath, { useCache: isUrl })
       : compilerSys.readFileSync(filePath);
@@ -141,6 +149,8 @@ export const patchTsSystemFileSystem = (
     return content;
   };
 
+  // At present the typing for `inMemoryFs` in this function is not accurate
+  // TODO(STENCIL-728): fix typing of `inMemoryFs` parameter in `patchTypescript`, related functions
   tsSys.writeFile = (p, data) => (inMemoryFs ? inMemoryFs.writeFile(p, data) : compilerSys.writeFile(p, data));
 
   return tsSys;

--- a/src/compiler/transformers/rewrite-aliased-paths.ts
+++ b/src/compiler/transformers/rewrite-aliased-paths.ts
@@ -168,8 +168,8 @@ function rewriteAliasedImport(
     retrieveTsModifiers(node),
     node.importClause,
     transformCtx.factory.createStringLiteral(
-      // if the importeee is a sibling file of the importer then `relative`
-      // will produce a something confusing result. We use `dirname` to get the
+      // if the importee is a sibling file of the importer then `relative`
+      // will produce a somewhat confusing result. We use `dirname` to get the
       // directory of the importer, so for example, assume we have two files
       // `foo/bar.ts` and `foo/baz.ts` like so:
       //
@@ -194,7 +194,7 @@ function rewriteAliasedImport(
       // import paths we're only concerned with `paths` aliases that should be
       // transformed to relative imports anyway, we check to see if the new
       // `importPath` starts with `'.'`, and add `'./'` if it doesn't, since
-      // otherwise nodejs will interpret `bar` as a module name, not a relative
+      // otherwise Node will interpret `bar` as a module name, not a relative
       // path.
       importPath.startsWith('.') ? importPath : './' + importPath
     ),

--- a/src/compiler/transformers/rewrite-aliased-paths.ts
+++ b/src/compiler/transformers/rewrite-aliased-paths.ts
@@ -167,7 +167,37 @@ function rewriteAliasedImport(
     node,
     retrieveTsModifiers(node),
     node.importClause,
-    transformCtx.factory.createStringLiteral(importPath),
+    transformCtx.factory.createStringLiteral(
+      // if the importeee is a sibling file of the importer then `relative`
+      // will produce a something confusing result. We use `dirname` to get the
+      // directory of the importer, so for example, assume we have two files
+      // `foo/bar.ts` and `foo/baz.ts` like so:
+      //
+      // ```
+      // foo
+      // ├── bar.ts
+      // └── baz.ts
+      // ```
+      //
+      // then if `baz.ts` imports a symbol from `bar.ts` we'll call
+      // `relative(fromdir, to)` like so:
+      //
+      // ```ts
+      // relative(dirname("foo/baz.ts"), "foo/bar.ts")
+      // // equivalently
+      // relative("foo", "foo/bar.ts")
+      // ```
+      //
+      // you'd think that in this case `relative` would return `'./bar.ts'` as
+      // a correct relative path to `bar.ts` from the `foo` directory, but
+      // actually in this case it returns just `bar.ts`. So since when updating
+      // import paths we're only concerned with `paths` aliases that should be
+      // transformed to relative imports anyway, we check to see if the new
+      // `importPath` starts with `'.'`, and add `'./'` if it doesn't, since
+      // otherwise nodejs will interpret `bar` as a module name, not a relative
+      // path.
+      importPath.startsWith('.') ? importPath : './' + importPath
+    ),
     node.assertClause
   );
 }

--- a/src/compiler/transformers/rewrite-aliased-paths.ts
+++ b/src/compiler/transformers/rewrite-aliased-paths.ts
@@ -168,8 +168,8 @@ function rewriteAliasedImport(
     retrieveTsModifiers(node),
     node.importClause,
     transformCtx.factory.createStringLiteral(
-      // if the importee is a sibling file of the importer then `relative`
-      // will produce a somewhat confusing result. We use `dirname` to get the
+      // if the importee is a sibling file of the importer then `relative` will
+      // produce a somewhat confusing result. We use `dirname` to get the
       // directory of the importer, so for example, assume we have two files
       // `foo/bar.ts` and `foo/baz.ts` like so:
       //
@@ -198,8 +198,8 @@ function rewriteAliasedImport(
       // path.
       //
       // Note also that any relative paths as module specifiers which _don't_
-      // need to be transformed (e.g. `'./foo'`) we've already handled on line
-      // 141, above.
+      // need to be transformed (e.g. `'./foo'`) have already been handled
+      // above.
       importPath.startsWith('.') ? importPath : './' + importPath
     ),
     node.assertClause

--- a/src/compiler/transformers/rewrite-aliased-paths.ts
+++ b/src/compiler/transformers/rewrite-aliased-paths.ts
@@ -196,6 +196,10 @@ function rewriteAliasedImport(
       // `importPath` starts with `'.'`, and add `'./'` if it doesn't, since
       // otherwise Node will interpret `bar` as a module name, not a relative
       // path.
+      //
+      // Note also that any relative paths as module specifiers which _don't_
+      // need to be transformed (e.g. `'./foo'`) we've already handled on line
+      // 141, above.
       importPath.startsWith('.') ? importPath : './' + importPath
     ),
     node.assertClause

--- a/src/compiler/transformers/test/rewrite-aliased-paths.spec.ts
+++ b/src/compiler/transformers/test/rewrite-aliased-paths.spec.ts
@@ -15,9 +15,10 @@ import { transpileModule } from './transpile';
  * transpiles the provided code.
  *
  * @param component the string of a component
+ * @param inputFileName an optional filename to use for the input file
  * @returns the tranpiled module
  */
-async function pathTransformTranspile(component: string) {
+async function pathTransformTranspile(component: string, inputFileName = 'module.tsx') {
   const compilerContext: CompilerCtx = mockCompilerCtx();
   const config = mockValidatedConfig();
 
@@ -37,8 +38,6 @@ async function pathTransformTranspile(component: string) {
   await compilerContext.fs.writeFile(path.join(config.rootDir, 'name/space.ts'), 'export const foo = x => x');
   await compilerContext.fs.writeFile(path.join(config.rootDir, 'name/space/subdir.ts'), 'export const bar = x => x;');
 
-  const inputFileName = normalizePath(path.join(config.rootDir, 'module.tsx'));
-
   return transpileModule(
     component,
     null,
@@ -47,7 +46,7 @@ async function pathTransformTranspile(component: string) {
     [],
     [rewriteAliasedDTSImportPaths],
     mockPathsConfig,
-    inputFileName
+    normalizePath(path.join(config.rootDir, inputFileName))
   );
 }
 
@@ -142,6 +141,35 @@ describe('rewrite alias module paths transform', () => {
 
     expect(t.declarationOutputText).toBe(
       'import { Foo } from "./name/space/subdir";import { Bar } from "./name/space";export declare function fooUtil(foo: Foo): Bar;'
+    );
+  });
+
+  it('should correctly rewrite sibling paths', async () => {
+    const t = await pathTransformTranspile(
+      `
+      import { foo } from "@namespace";
+      export class CmpA {
+        render() {
+          return <some-cmp>{ foo("bar") }</some-cmp>
+        }
+      }
+    `,
+      'name/component.tsx'
+    );
+
+    // with the import filename passed to `pathTransformTranspile` the file
+    // layout during this test looks like this:
+    //
+    // ```
+    // name
+    // ├── space.ts
+    // └── component.tsx
+    // ```
+    //
+    // we need to test that the relative path from `name/component.tsx` to
+    // `name/space.ts` is resolved correctly as `'./space'`.
+    expect(t.outputText).toBe(
+      'import { foo } from "./space";export class CmpA { render() { return h("some-cmp", null, foo("bar")); }}'
     );
   });
 });

--- a/src/compiler/transformers/test/rewrite-aliased-paths.spec.ts
+++ b/src/compiler/transformers/test/rewrite-aliased-paths.spec.ts
@@ -172,4 +172,34 @@ describe('rewrite alias module paths transform', () => {
       'import { foo } from "./space";export class CmpA { render() { return h("some-cmp", null, foo("bar")); }}'
     );
   });
+
+  it('should correctly rewrite nested sibling paths', async () => {
+    const t = await pathTransformTranspile(
+      `
+      import { foo } from "@namespace/subdir";
+      export class CmpA {
+        render() {
+          return <some-cmp>{ foo("bar") }</some-cmp>
+        }
+      }
+    `,
+      'name/component.tsx'
+    );
+
+    // with the import filename passed to `pathTransformTranspile` the file
+    // layout during this test looks like this:
+    //
+    // ```
+    // name
+    // ├── component.tsx
+    // └── space
+    //     └── subdir.ts
+    // ```
+    //
+    // we need to test that the relative path from `name/component.tsx` to
+    // `name/space/subdir.ts` is resolved correctly as `'./space/subdir'`.
+    expect(t.outputText).toBe(
+      'import { foo } from "./space/subdir";export class CmpA { render() { return h("some-cmp", null, foo("bar")); }}'
+    );
+  });
 });

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -2300,7 +2300,10 @@ export interface E2EProcessEnv {
   __STENCIL_PUPPETEER_VERSION__?: number;
   __STENCIL_DEFAULT_TIMEOUT__?: string;
 
-  __STENCIL_TRANSPILE_PATHS__?: boolean;
+  /**
+   * Property for injecting transformAliasedImportPaths into the Jest context
+   */
+  __STENCIL_TRANSPILE_PATHS__?: 'true' | 'false';
 }
 
 export interface AnyHTMLElement extends HTMLElement {

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -2299,6 +2299,8 @@ export interface E2EProcessEnv {
   __STENCIL_PUPPETEER_MODULE__?: string;
   __STENCIL_PUPPETEER_VERSION__?: number;
   __STENCIL_DEFAULT_TIMEOUT__?: string;
+
+  __STENCIL_TRANSPILE_PATHS__?: boolean;
 }
 
 export interface AnyHTMLElement extends HTMLElement {

--- a/src/testing/jest/jest-runner.ts
+++ b/src/testing/jest/jest-runner.ts
@@ -13,7 +13,7 @@ export async function runJest(config: d.ValidatedConfig, env: d.E2EProcessEnv) {
     const emulateConfigs = getEmulateConfigs(config.testing, config.flags);
     env.__STENCIL_EMULATE_CONFIGS__ = JSON.stringify(emulateConfigs);
     env.__STENCIL_ENV__ = JSON.stringify(config.env);
-    env.__STENCIL_TRANSPILE_PATHS__ = !!config.transformAliasedImportPaths;
+    env.__STENCIL_TRANSPILE_PATHS__ = config.transformAliasedImportPaths ? 'true' : 'false';
 
     if (config.flags.ci || config.flags.e2e) {
       env.__STENCIL_DEFAULT_TIMEOUT__ = '30000';

--- a/src/testing/jest/jest-runner.ts
+++ b/src/testing/jest/jest-runner.ts
@@ -13,6 +13,7 @@ export async function runJest(config: d.ValidatedConfig, env: d.E2EProcessEnv) {
     const emulateConfigs = getEmulateConfigs(config.testing, config.flags);
     env.__STENCIL_EMULATE_CONFIGS__ = JSON.stringify(emulateConfigs);
     env.__STENCIL_ENV__ = JSON.stringify(config.env);
+    env.__STENCIL_TRANSPILE_PATHS__ = !!config.transformAliasedImportPaths;
 
     if (config.flags.ci || config.flags.e2e) {
       env.__STENCIL_DEFAULT_TIMEOUT__ = '30000';

--- a/src/testing/test-transpile.ts
+++ b/src/testing/test-transpile.ts
@@ -15,7 +15,7 @@ export function transpile(input: string, opts: TranspileOptions = {}): Transpile
     style: null,
     styleImportData: 'queryparams',
     target: 'es2015', // default to es2015
-    transformAliasedImportPaths: !!process.env.__STENCIL_TRANSPILE_PATHS__,
+    transformAliasedImportPaths: parseStencilTranspilePaths(process.env.__STENCIL_TRANSPILE_PATHS__),
   };
 
   try {
@@ -27,4 +27,14 @@ export function transpile(input: string, opts: TranspileOptions = {}): Transpile
   } catch (e) {}
 
   return transpileSync(input, opts);
+}
+
+/**
+ * Turn a value which we assert can be 'true' or 'false' to a boolean.
+ *
+ * @param stencilTranspilePaths a value to 'parse'
+ * @returns a boolean
+ */
+function parseStencilTranspilePaths(stencilTranspilePaths: string) {
+  return stencilTranspilePaths === "true" ? true : false
 }

--- a/src/testing/test-transpile.ts
+++ b/src/testing/test-transpile.ts
@@ -15,6 +15,7 @@ export function transpile(input: string, opts: TranspileOptions = {}): Transpile
     style: null,
     styleImportData: 'queryparams',
     target: 'es2015', // default to es2015
+    transformAliasedImportPaths: !!process.env.__STENCIL_TRANSPILE_PATHS__,
   };
 
   try {

--- a/src/testing/test-transpile.ts
+++ b/src/testing/test-transpile.ts
@@ -36,5 +36,5 @@ export function transpile(input: string, opts: TranspileOptions = {}): Transpile
  * @returns a boolean
  */
 function parseStencilTranspilePaths(stencilTranspilePaths: string) {
-  return stencilTranspilePaths === "true" ? true : false
+  return stencilTranspilePaths === 'true' ? true : false;
 }

--- a/src/testing/test-transpile.ts
+++ b/src/testing/test-transpile.ts
@@ -35,6 +35,6 @@ export function transpile(input: string, opts: TranspileOptions = {}): Transpile
  * @param stencilTranspilePaths a value to 'parse'
  * @returns a boolean
  */
-function parseStencilTranspilePaths(stencilTranspilePaths: string) {
+function parseStencilTranspilePaths(stencilTranspilePaths: string): boolean {
   return stencilTranspilePaths === 'true' ? true : false;
 }


### PR DESCRIPTION
This adds support for transforming path aliases in spec tests, using the transformer which was added in #4042. Adding such support also revealed a bug with the existing path transformer, notably that it did not produce a valid path for sibling modules. See the diff for a comment explaining the details.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

Imports from modules aliases with `paths` in `tsconfig.json` don't work in spec tests.

GitHub Issue Number: fixes #3826


## What is the new behavior?

They do! This change reads the `transformAliasedImportPaths` option from the Stencil config and, if it is set to true, will transform such aliased modules to relative paths when the transpiler is being run by Jest. If the user does not set that config value to `true` then things should be as they are.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

There is a reproduction case here: https://github.com/liamdebeasi/blank-stencil-repro/tree/tsconfig-test

Confirm that it breaks:

- as-is
- with this change but without the `transformAliasImportPaths` option set to `true`

and confirm that if you set that option to `true` it will all work correctly. To test the sibling path problem mentioned in a comment on the PR you can apply the following change:

```diff
diff --git a/src/utils/utils.spec.ts b/src/utils/utils.spec.ts
index 81ff970..a7e2938 100644
--- a/src/utils/utils.spec.ts
+++ b/src/utils/utils.spec.ts
@@ -1,4 +1,4 @@
-import { format } from './utils';
+import { format } from '@utils/utils';
 
 describe('format', () => {
   it('returns empty string for no names defined', () => {
```

## Other information


