### PR TITLE
chore(release): update build id, version generation

### DIFF
--- a/scripts/utils/test/options.spec.ts
+++ b/scripts/utils/test/options.spec.ts
@@ -5,6 +5,18 @@ import * as Vermoji from '../vermoji';
 describe('release options', () => {
   describe('getOptions', () => {
     const ROOT_DIR = './';
+    // Friday, February 24, 2023 2:42:09.123 PM, GMT
+    const FAKE_SYSTEM_TIME_MS = 1677249729123;
+    const FAKE_SYSTEM_TIME_S = FAKE_SYSTEM_TIME_MS.toString(10).slice(0, -3);
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(FAKE_SYSTEM_TIME_MS);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
 
     it('returns the correct default value', () => {
       const buildOpts = getOptions(ROOT_DIR);
@@ -58,8 +70,7 @@ describe('release options', () => {
         const { buildId } = getOptions(ROOT_DIR);
 
         expect(buildId).toBeDefined();
-        // Expect a Date of the format yyyyMMddHHmmss
-        expect(buildId).toMatch(/\d{14}/);
+        expect(buildId).toBe(FAKE_SYSTEM_TIME_S);
       });
 
       it('uses the provided the buildId', () => {
@@ -76,8 +87,8 @@ describe('release options', () => {
         const { version } = getOptions(ROOT_DIR);
 
         expect(version).toBeDefined();
-        // Expect a version string with the format 0.0.0-dev-yyyyMMddHHmmss
-        expect(version).toMatch(/0\.0\.0-dev\.\d{14}/);
+        // Expect a version string with the format 0.0.0-dev-[EPOCH_TIME]-[GIT_SHA_7_CHARS]
+        expect(version).toMatch(new RegExp(`\\d+\\.\\d+\\.\\d+-dev.${FAKE_SYSTEM_TIME_S}.\\w{7}`));
       });
 
       it('uses the provided the version', () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->
## PR Train 🚂 

This PR requires the following PR(s) to be approved first:
- https://github.com/ionic-team/stencil/pull/4097

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Local Stencil builds (aka "Dev Builds") have some metadata associated with them that I think could be more valuable in terms of getting development builds into the hands of Stencil Users, the Ionic Framework, etc.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
this commit changes the method used by the release scripts to generate
the build id and version number for "development builds", where a
"development build" is considered a build of stencil performed outside
using the `npm run release.*` scripts. this includes running `npm run
build` locally and in ci.

build id generation has changed from a date format 'yyyyMMddHHmmss', to
be epoch time in seconds. this allows us to easily convert the build
time to a human readable time if needed, with the added benefits of
easier de/serialization and a more compact representation. there exists
no place in the stencil codebase where this value is compared today, and
given this change only applies to dev builds, we can safely make this
change without breaking stencil or downstream consmers.

version generation has changed from '0.0.0-dev.BUILD_ID` to use the
current version stored in stencil's `package.json` as a base (so that it
is easily identifiable the stable version of stencil a build derives
from, the new build id, and a seven character sha to pinpoint the base
commit of the development build.

this commit is motivated by an effort to get development builds working
in a github actions ci environment. we wish to have this information
generated by stencil, rather than the ci process, such that commands
like `npx stencil info` returns the same version info as what's
published to the npm registry

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

I tested three pathways here. 
1. With none of these changes applied
2. With these changes applied, I built this branch (`npm ci && npm run clean && npm run build && npm pack`) and installed it in a local branch, then ran `npx stencil info` to validate these changes showed up
3. With these change applied, I ran `npm run release.prepare -- --any-branch --dry-run` to validate that these changes _wouldn't_ be found when going through the `npm run release.*` scripts

A screen shot of the output for all three steps (in that order) can be seen here:
![Screenshot 2023-02-24 at 1 46 03 PM](https://user-images.githubusercontent.com/1930213/221269303-e5390442-c6cd-46bf-b8c8-27204050fa42.png)

When running `npm run release.prepare`, I also looked at the diff of changes that were prepared for us to validate that new dev info didn't leak in:
```diff
diff --git a/CHANGELOG.md b/CHANGELOG.md
index bdc05224c..a9c4ae004 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 🐆 [3.0.2-dryrun](https://github.com/ionic-team/stencil/compare/v3.0.1...v3.0.2-dryrun) (2023-02-24)
+
+
+
 ## 🍒 [3.0.1](https://github.com/ionic-team/stencil/compare/v3.0.0...v3.0.1) (2023-02-13)
 
 
diff --git a/NOTICE.md b/NOTICE.md
index 1a8ce5033..6b4733c37 100644
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -2979,7 +2979,7 @@ Author: [Terkel Gjervig](https://terkel.com)
 
 License: MIT
 
-Author: [JS Foundation and other contributors](https://github.com/jquery/sizzle/blob/2.3.9/AUTHORS.txt)
+Author: [JS Foundation and other contributors](https://github.com/jquery/sizzle/blob/2.3.10/AUTHORS.txt)
 
 Homepage: https://sizzlejs.com
 
diff --git a/package-lock.json b/package-lock.json
index f9c1ede4d..cb27818cb 100644
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stencil/core",
-  "version": "3.0.1",
+  "version": "3.0.2-dryrun",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stencil/core",
-      "version": "3.0.1",
+      "version": "3.0.2-dryrun",
       "license": "MIT",
       "bin": {
         "stencil": "bin/stencil"
diff --git a/package.json b/package.json
index 1259f6250..4d9c98b89 100644
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/core",
-  "version": "3.0.1",
+  "version": "3.0.2-dryrun",
   "license": "MIT",
   "main": "./internal/stencil-core/index.cjs",
   "module": "./internal/stencil-core/index.js",

```

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
This commit does not allow CI to take advantage of an `npm run release.*` script. There's quite a bit more work/refactoring to do in order to get that working. This commit does not change anything with respect to CI either. It strictly updates how we generate these two pieces of metadata
