### PR TITLE
fix(runtime): prevent null data-opts access

### DIFF
--- a/src/client/client-patch-browser.ts
+++ b/src/client/client-patch-browser.ts
@@ -46,7 +46,7 @@ export const patchBrowser = (): Promise<d.CustomElementsDefineOptions> => {
         )
       : null;
   const importMeta = import.meta.url;
-  const opts = BUILD.scriptDataOpts ? (scriptElm as any)['data-opts'] || {} : {};
+  const opts = BUILD.scriptDataOpts ? ((scriptElm as any) || {})['data-opts'] || {} : {};
 
   // TODO(STENCIL-663): Remove code related to deprecated `safari10` field.
   if (BUILD.safari10 && 'onbeforeload' in scriptElm && !history.scrollRestoration /* IS_ESM_BUILD */) {


### PR DESCRIPTION
Hey team, this is a very simple fix for [issue 2431](https://github.com/ionic-team/stencil/issues/2431). I was running into the same thing when trying to directly require ionic.cjs.js in my project. 