### PR TITLE
docs(docs-json): add JSDoc to things related to docs-json OT

### DIFF
--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -535,7 +535,7 @@ const getTypeReferenceLocation = (typeName: string, tsNode: ts.Node): d.Componen
  * Resolve a type annotation, using the TypeScript typechecker to convert a
  * {@link ts.Type} record to a string.
  *
- * For instance, assume there's a module `foot.ts` which exports a type `Foo`
+ * For instance, assume there's a module `foo.ts` which exports a type `Foo`
  * which looks like this:
  *
  * ```ts

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -535,18 +535,21 @@ const getTypeReferenceLocation = (typeName: string, tsNode: ts.Node): d.Componen
  * Resolve a type annotation, using the TypeScript typechecker to convert a
  * {@link ts.Type} record to a string.
  *
- * For instance, if a module `bar.ts` imports a type `Foo` from another file
+ * For instance, assume there's a module `foot.ts` which exports a type `Foo`
  * which looks like this:
  *
  * ```ts
  * // foo.ts
- * type Foo = (b: bar) => boolean;
+ * type Foo = (b: string) => boolean;
  * ```
  *
- * and then declares a type:
+ * and then a module `bar.ts` which imports `Foo` and uses it to annotate a
+ * variable declaration like so:
  *
  * ```ts
  * // bar.ts
+ * import { Foo } from './foo';
+ *
  * let foo: Foo | undefined;
  * ```
  *
@@ -555,7 +558,7 @@ const getTypeReferenceLocation = (typeName: string, tsNode: ts.Node): d.Componen
  * like:
  *
  * ```ts
- * "(b: bar) => boolean | undefined";
+ * "(b: string) => boolean | undefined";
  * ```
  *
  * @param checker a typescript typechecker

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -531,7 +531,38 @@ const getTypeReferenceLocation = (typeName: string, tsNode: ts.Node): d.Componen
   };
 };
 
-export const resolveType = (checker: ts.TypeChecker, type: ts.Type) => {
+/**
+ * Resolve a type annotation, using the TypeScript typechecker to convert a
+ * {@link ts.Type} record to a string.
+ *
+ * For instance, if a module `bar.ts` imports a type `Foo` from another file
+ * which looks like this:
+ *
+ * ```ts
+ * // foo.ts
+ * type Foo = (b: bar) => boolean;
+ * ```
+ *
+ * and then declares a type:
+ *
+ * ```ts
+ * // bar.ts
+ * let foo: Foo | undefined;
+ * ```
+ *
+ * If this function is called with the {@link ts.Type} object corresponding to
+ * the {@link ts.Node} object for the `foo` variable, it will return something
+ * like:
+ *
+ * ```ts
+ * "(b: bar) => boolean | undefined";
+ * ```
+ *
+ * @param checker a typescript typechecker
+ * @param type the type to resolve
+ * @returns a resolved, user-readable string
+ */
+export const resolveType = (checker: ts.TypeChecker, type: ts.Type): string => {
   const set = new Set<string>();
   parseDocsType(checker, type, set);
 
@@ -543,7 +574,7 @@ export const resolveType = (checker: ts.TypeChecker, type: ts.Type) => {
   }
 
   let parts = Array.from(set.keys()).sort();
-  // TODO(STENCIL-366): Get this section of code under tests that directly exercises this behavior
+  // TODO(STENCIL-366): Get this section of code under tests that directly exercise this behavior
   if (parts.length > 1) {
     parts = parts.map((p) => (p.indexOf('=>') >= 0 ? `(${p})` : p));
   }
@@ -556,6 +587,7 @@ export const resolveType = (checker: ts.TypeChecker, type: ts.Type) => {
 
 /**
  * Formats a TypeScript `Type` entity as a string
+ *
  * @param checker a reference to the TypeScript type checker
  * @param type a TypeScript `Type` entity to format
  * @returns the formatted string
@@ -567,6 +599,18 @@ export const typeToString = (checker: ts.TypeChecker, type: ts.Type): string => 
   return checker.typeToString(type, undefined, TYPE_FORMAT_FLAGS);
 };
 
+/**
+ * Parse a type into its component parts, recursively dealing with each variant
+ * if it is a union type.
+ *
+ * **Note**: this function will mutate the `parts` set, adding new strings for
+ * any types it finds.
+ *
+ * @param checker a TypeScript typechecker instance
+ * @param type a TypeScript type
+ * @param parts an out param that holds parts of the type annotation we're
+ * assembling
+ */
 export const parseDocsType = (checker: ts.TypeChecker, type: ts.Type, parts: Set<string>): void => {
   if (type.isUnion()) {
     (type as ts.UnionType).types.forEach((t) => {

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -865,7 +865,7 @@ export interface ComponentCompilerPropertyComplexType {
    * A 'resolved' type, where e.g. imported types have been resolved and inlined
    *
    * For instance, an annotation like `(foo: Foo) => string;` will be
-   * converted to `(foo: { foo: string}) => string;`.
+   * converted to `(foo: { foo: string }) => string;`.
    */
   resolved: string;
   /**

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -852,9 +852,26 @@ export interface ComponentCompilerVirtualProperty {
 
 export type ComponentCompilerPropertyType = 'any' | 'string' | 'boolean' | 'number' | 'unknown';
 
+/**
+ * Information about the type of a Stencil-implemented component property, in
+ * particular a `@Prop()` or `@Event()`.
+ */
 export interface ComponentCompilerPropertyComplexType {
+  /**
+   * The string of the original type annotation in the Stencil source code
+   */
   original: string;
+  /**
+   * A 'resolved' type, where e.g. imported types have been resolved and inlined
+   *
+   * For instance, an annotation like `(foo: Foo) => string;` will be
+   * converted to `(foo: { foo: string}) => string;`.
+   */
   resolved: string;
+  /**
+   * A record of the types which were referenced in the assorted type
+   * annotation in the original source file.
+   */
   references: ComponentCompilerTypeReferences;
 }
 

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -2044,6 +2044,12 @@ export interface OutputTargetDocsJson extends OutputTargetBase {
   type: 'docs-json';
 
   file: string;
+  /**
+   * Set an optional file path where Stencil should write a `d.ts` file to disk
+   * at build-time containing type declarations for {@link JsonDocs} and related
+   * interfaces. If this is omitted or set to `null` Stencil will not write such
+   * a file.
+   */
   typesFile?: string | null;
   strict?: boolean;
 }


### PR DESCRIPTION
This adds some JSDoc comments to interfaces and functions which relate to the docs-json output target which were previously undocumented. Some of these things aren't particularly intuitive if you don't know what they're for!

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

A good deal of functions and interfaces relating to the `docs-json` output target are not annotated or documented, and it's a bit confusing as a result to trace around and figure out what's going on.


## What is the new behavior?

A few more things are documented!

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
