### PR TITLE
fix(test): support importing from ES modules in spec tests

### DIFF
--- a/scripts/bundles/helpers/jest/jest-preset.js
+++ b/scripts/bundles/helpers/jest/jest-preset.js
@@ -31,7 +31,7 @@ module.exports = {
   testPathIgnorePatterns: ['/.cache', '/.stencil', '/.vscode', '/dist', '/node_modules', '/www'],
   testRegex: '(/__tests__/.*|\\.?(test|spec))\\.' + moduleExtensionRegexp + '$',
   transform: {
-    '^.+\\.(ts|tsx|jsx|css)$': path.join(testingDir, 'jest-preprocessor.js'),
+    '^.+\\.(ts|tsx|jsx|css|mjs)$': path.join(testingDir, 'jest-preprocessor.js'),
   },
   watchPathIgnorePatterns: ['^.+\\.d\\.ts$'],
 };

--- a/src/compiler/transpile/transpile-module.ts
+++ b/src/compiler/transpile/transpile-module.ts
@@ -88,9 +88,11 @@ export const transpileModule = (
       return normalizePath(fileName) === normalizePath(sourceFilePath) ? sourceFile : undefined;
     },
     writeFile: (name, text) => {
-      if (name.endsWith('.js.map')) {
+      if (name.endsWith('.js.map') || name.endsWith('.mjs.map')) {
         results.map = text;
-      } else if (name.endsWith('.js')) {
+      } else if (name.endsWith('.js') || name.endsWith('.mjs')) {
+        // if the source file is an ES module w/ `.mjs` extension then
+        // TypeScript will output a `.mjs` file
         results.code = text;
       }
     },


### PR DESCRIPTION
This adds support for importing from ES modules (w/ the `.mjs` extension) in spec tests by ensuring that

1. files with such an extension are passed to the jest preprocessor (which then runs them through typescript)
2. our typescript helper for string-to-strong transpilation will emit `.mjs` files instead of just dropping them on the floor

Together these changes will allow running specs which import `.mjs` files.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

closes #3251

See that issue for details, but in any Stencil version >2.14.0 spec tests will error if any file imports from an ES module with the `.mjs` extension.

This just makes a few small tweaks to ensure that such files are properly transpiled and included!


## What is the new behavior?

`.mjs` files should be usable within spec tests.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

You could try this out in the reproduction case on the linked issue.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
