### PR TITLE
chore(v2): port dev build infrastructure

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -39,6 +39,11 @@ This workflow is responsible for building Stencil and validating the resultant a
 This workflow is responsible for validating that the code adheres to the Stencil team's formatting configuration before
 a pull request is merged.
 
+### Dev Release (`release-dev.yml`)
+
+This workflow initiates a developer build of Stencil from the `main` branch.
+It is intended to be manually invoked by a member of the Stencil team.
+
 ### Test Analysis (`test-analysis.yml`)
 
 This workflow is responsible for running the Stencil analysis testing suite.

--- a/.github/workflows/actions/publish-npm/action.yml
+++ b/.github/workflows/actions/publish-npm/action.yml
@@ -1,0 +1,38 @@
+name: 'Release'
+description: 'Releases Stencil Core'
+inputs:
+  version:
+    description: 'The type of version to release.'
+  tag:
+    description: 'The tag to publish to on NPM.'
+  token:
+    description: 'The NPM authentication token required to publish.'
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout Code
+      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+
+    - name: Get Core Dependencies
+      uses: ./.github/workflows/actions/get-core-dependencies
+
+    - name: Download Build Archive
+      uses: ./.github/workflows/actions/download-archive
+      with:
+        name: stencil-core
+        path: .
+        filename: stencil-core-build.zip
+
+    - name: Set Version
+      run: npm version --no-git-tag-version ${{ inputs.version }}
+      shell: bash
+
+    - name: Prepare NPM Token
+      run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+      shell: bash
+      env:
+        NPM_TOKEN: ${{ inputs.token }}
+
+    - name: Publish to NPM
+      run: npm publish --tag ${{ inputs.tag }}
+      shell: bash

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,0 +1,61 @@
+name: 'Stencil Dev Release'
+
+on:
+  workflow_dispatch:
+    # Make this a reusable workflow, no value needed
+    # https://docs.github.com/en/actions/using-workflows/reusing-workflows
+
+jobs:
+  build_core:
+    name: Build
+    uses: ./.github/workflows/build.yml
+
+  get-dev-version:
+    name: Get Dev Build Version
+    needs: [build_core]
+    runs-on: ubuntu-20.04
+    outputs:
+      dev-version: ${{ steps.get-dev-version.outputs.DEV_VERSION }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+
+      - name: Get Core Dependencies
+        uses: ./.github/workflows/actions/get-core-dependencies
+
+      - name: Download Build Archive
+        uses: ./.github/workflows/actions/download-archive
+        with:
+          name: stencil-core
+          path: .
+          filename: stencil-core-build.zip
+
+      - name: Get Version
+        id: get-dev-version
+        run: |
+          # A unique string to publish Stencil under
+          # e.g. "3.0.1-dev.1677185104.7c87e34"
+          #
+          # Pull this value from the compiled artifacts
+          DEV_VERSION=$(./bin/stencil version)
+
+          echo "Using version $DEV_VERSION"
+
+          # store a key/value pair in GITHUB_OUTPUT
+          # e.g. "DEV_VERSION=3.0.1-dev.1677185104.7c87e34"
+          echo "DEV_VERSION=$DEV_VERSION" >> $GITHUB_OUTPUT
+
+        shell: bash
+
+  release-stencil-dev-build:
+    name: Publish Dev Build
+    needs: [get-dev-version, build_core]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: ./.github/workflows/actions/publish-npm
+        with:
+          tag: dev
+          version: ${{ needs.get-dev-version.outputs.dev-version }}
+          token: ${{ secrets.NPM_TOKEN }}

--- a/scripts/utils/test/options.spec.ts
+++ b/scripts/utils/test/options.spec.ts
@@ -5,6 +5,18 @@ import * as Vermoji from '../vermoji';
 describe('release options', () => {
   describe('getOptions', () => {
     const ROOT_DIR = './';
+    // Friday, February 24, 2023 2:42:09.123 PM, GMT
+    const FAKE_SYSTEM_TIME_MS = 1677249729123;
+    const FAKE_SYSTEM_TIME_S = FAKE_SYSTEM_TIME_MS.toString(10).slice(0, -3);
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(FAKE_SYSTEM_TIME_MS);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
 
     it('returns the correct default value', () => {
       const buildOpts = getOptions(ROOT_DIR);
@@ -58,8 +70,7 @@ describe('release options', () => {
         const { buildId } = getOptions(ROOT_DIR);
 
         expect(buildId).toBeDefined();
-        // Expect a Date of the format yyyyMMddHHmmss
-        expect(buildId).toMatch(/\d{14}/);
+        expect(buildId).toBe(FAKE_SYSTEM_TIME_S);
       });
 
       it('uses the provided the buildId', () => {
@@ -76,8 +87,8 @@ describe('release options', () => {
         const { version } = getOptions(ROOT_DIR);
 
         expect(version).toBeDefined();
-        // Expect a version string with the format 0.0.0-dev-yyyyMMddHHmmss
-        expect(version).toMatch(/0\.0\.0-dev\.\d{14}/);
+        // Expect a version string with the format 0.0.0-dev-[EPOCH_TIME]-[GIT_SHA_7_CHARS]
+        expect(version).toMatch(new RegExp(`\\d+\\.\\d+\\.\\d+-dev.${FAKE_SYSTEM_TIME_S}.\\w{7}`));
       });
 
       it('uses the provided the version', () => {

--- a/scripts/utils/test/options.spec.ts
+++ b/scripts/utils/test/options.spec.ts
@@ -1,0 +1,141 @@
+import { path } from '../../../compiler';
+import { BuildOptions, getOptions } from '../options';
+import * as Vermoji from '../vermoji';
+
+describe('release options', () => {
+  describe('getOptions', () => {
+    const ROOT_DIR = './';
+
+    it('returns the correct default value', () => {
+      const buildOpts = getOptions(ROOT_DIR);
+
+      // some paths exist in the expected object that are not normalized, so we store the OS-specific separator in a
+      // variable in order to call `join()` with it
+      const separator = path.sep;
+
+      expect(buildOpts).toEqual<BuildOptions>({
+        buildDir: 'build',
+        // More focused tests for `buildId` can be found in another testing suite in this file
+        buildId: expect.any(String),
+        bundleHelpersDir: ['scripts', 'bundles', 'helpers'].join(separator),
+        changelogPath: 'CHANGELOG.md',
+        ghRepoName: 'stencil',
+        ghRepoOrg: 'ionic-team',
+        isCI: false,
+        isProd: false,
+        isPublishRelease: false,
+        nodeModulesDir: 'node_modules',
+        output: {
+          cliDir: 'cli',
+          compilerDir: 'compiler',
+          devServerDir: 'dev-server',
+          internalDir: 'internal',
+          mockDocDir: 'mock-doc',
+          screenshotDir: 'screenshot',
+          sysNodeDir: ['sys', 'node'].join(separator),
+          testingDir: 'testing',
+        },
+        // reads in package.json, skip it verifying it
+        packageJson: expect.any(Object),
+        packageJsonPath: 'package.json',
+        packageLockJsonPath: 'package-lock.json',
+        rootDir: ROOT_DIR,
+        scriptsBuildDir: ['scripts', 'build'].join(separator),
+        scriptsBundlesDir: ['scripts', 'bundles'].join(separator),
+        scriptsDir: 'scripts',
+        srcDir: 'src',
+        tag: 'dev',
+        typescriptDir: ['node_modules', 'typescript'].join(separator),
+        typescriptLibDir: ['node_modules', 'typescript', 'lib'].join(separator),
+        vermoji: '💎',
+        // More focused tests for `version` can be found in another testing suite in this file
+        version: expect.any(String),
+      });
+    });
+
+    describe('buildId', () => {
+      it('defaults the buildId if none is provided', () => {
+        const { buildId } = getOptions(ROOT_DIR);
+
+        expect(buildId).toBeDefined();
+        // Expect a Date of the format yyyyMMddHHmmss
+        expect(buildId).toMatch(/\d{14}/);
+      });
+
+      it('uses the provided the buildId', () => {
+        const expectedBuildId = 'test-build-id';
+        const { buildId } = getOptions(ROOT_DIR, { buildId: expectedBuildId });
+
+        expect(buildId).toBeDefined();
+        expect(buildId).toBe(expectedBuildId);
+      });
+    });
+
+    describe('version', () => {
+      it('defaults the version if none is provided', () => {
+        const { version } = getOptions(ROOT_DIR);
+
+        expect(version).toBeDefined();
+        // Expect a version string with the format 0.0.0-dev-yyyyMMddHHmmss
+        expect(version).toMatch(/0\.0\.0-dev\.\d{14}/);
+      });
+
+      it('uses the provided the version', () => {
+        const expectedVersion = '3.0.0-dev-1234';
+        const { version } = getOptions(ROOT_DIR, { version: expectedVersion });
+
+        expect(version).toBeDefined();
+        expect(version).toBe(expectedVersion);
+      });
+    });
+
+    describe('publish + prod check', () => {
+      it("throws an error if 'isPublishRelease' is set, but Stencil is not built for 'isProd'", () => {
+        expect(() => getOptions(ROOT_DIR, { isProd: false, isPublishRelease: true })).toThrow(
+          'release must also be a prod build'
+        );
+      });
+
+      it.each<Partial<BuildOptions>>([
+        { isProd: false },
+        { isPublishRelease: false },
+        { isProd: false, isPublishRelease: false },
+        { isProd: true, isPublishRelease: false },
+        { isProd: true, isPublishRelease: true },
+      ])("does not throw an error for other combinations of 'isPublishRelease' and 'isProd'", (buildOpts) => {
+        expect(() => getOptions(ROOT_DIR, buildOpts)).not.toThrow();
+      });
+    });
+
+    describe('vermoji', () => {
+      let getVermojiSpy: jest.SpyInstance<ReturnType<typeof Vermoji.getVermoji>, Parameters<typeof Vermoji.getVermoji>>;
+
+      beforeEach(() => {
+        getVermojiSpy = jest.spyOn(Vermoji, 'getVermoji');
+        getVermojiSpy.mockImplementation((_changelogPath) => '🧀');
+      });
+
+      afterEach(() => {
+        getVermojiSpy.mockRestore();
+      });
+
+      it('defaults to 💎 for non-prod builds', () => {
+        expect(getOptions(ROOT_DIR).vermoji).toBe('💎');
+      });
+
+      it.each<Partial<BuildOptions>>([
+        { isProd: true, vermoji: '🦄' },
+        { isProd: false, vermoji: '🦄' },
+      ])("uses the provided vermoji, regardless of 'isProd'", () => {
+        const expectedVermoji = '🦄';
+        const { vermoji } = getOptions(ROOT_DIR, { vermoji: expectedVermoji });
+        expect(vermoji).toEqual('🦄');
+      });
+
+      it('picks a new vermoji when none is provided for prod builds', () => {
+        const { vermoji } = getOptions(ROOT_DIR, { isProd: true });
+        expect(vermoji).toEqual('🧀');
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR adds the following commits from the `main` (v3) branch to the `v2-maintenance` branch:
- [test(release): add getOptions coverage](https://github.com/ionic-team/stencil/commit/e6668ac3862a516e67049d807b232a5f46997079) - [https://github.com/ionic-team/stencil/commit/e6668ac3862a516e67049d807b232a5f46997079](https://github.com/ionic-team/stencil/commit/e6668ac3862a516e67049d807b232a5f46997079)
- [chore(release): update build id, version generation](https://github.com/ionic-team/stencil/commit/aa9ddba5927f5d2abf7589270cdc9e303f261591) - [https://github.com/ionic-team/stencil/commit/aa9ddba5927f5d2abf7589270cdc9e303f261591](https://github.com/ionic-team/stencil/commit/aa9ddba5927f5d2abf7589270cdc9e303f261591)
- [chore(ci): publish dev builds in ci](https://github.com/ionic-team/stencil/commit/da60c539bae55aa1fa935441c7ab438af55300a6) - [https://github.com/ionic-team/stencil/commit/da60c539bae55aa1fa935441c7ab438af55300a6](https://github.com/ionic-team/stencil/commit/da60c539bae55aa1fa935441c7ab438af55300a6) 


This has been done strictly via `git cherry-pick`, like so (taken from `history` in my terminal):
```
git checkout -b rwaskiewicz/v2/port-dev-build
git cherry-pick e6668ac3862a516e67049d807b232a5f46997079
git cherry-pick aa9ddba5927f5d2abf7589270cdc9e303f261591
git cherry-pick da60c539bae55aa1fa935441c7ab438af55300a6
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

I tested two pathways here. 
1. With these changes applied, I built this branch (`npm ci && npm run clean && npm run build && npm pack`) and installed it in a local branch, then ran `npx stencil info` to validate these changes showed up
```
npx stencil info

      System: node 18.14.2
    Platform: darwin (22.2.0)
   CPU Model: Apple M1 (8 cpus)
    Compiler: /private/tmp/ws-monday/node_modules/@stencil/core/compiler/stencil.js
       Build: 1678715653
     Stencil: 3.1.0-dev.1678715653.182e990 💙
  TypeScript: 4.9.5
      Rollup: 2.42.3
      Parse5: 7.1.2
      Sizzle: 2.42.3
      Terser: 5.16.5
```
2. With these change applied, I ran `npm run release.prepare -- --any-branch --dry-run` to validate that these changes _wouldn't_ be found when going through the `npm run release.*` scripts


## Other information

I intend to rebase this PR and merge it as three separate commits, I just created one PR to make the review easier
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

We'll have to run browserstack tests locally, since it doesn't quite run on v2-maintenance ATM (until https://github.com/ionic-team/stencil/pull/4158 lands)
