### PR TITLE
chore(release): separate prompts from release tasks

### DIFF
--- a/scripts/prompts.ts
+++ b/scripts/prompts.ts
@@ -2,7 +2,13 @@ import color from 'ansi-colors';
 import inquirer from 'inquirer';
 
 import { BuildOptions } from './utils/options';
-import { getNewVersion, isValidVersionInput, prettyVersionDiff, SEMVER_INCREMENTS } from './utils/release-utils';
+import {
+  getNewVersion,
+  isPrereleaseVersion,
+  isValidVersionInput,
+  prettyVersionDiff,
+  SEMVER_INCREMENTS,
+} from './utils/release-utils';
 
 /**
  * A type describing the answers to prompts for preparing a release
@@ -81,6 +87,118 @@ export async function promptPrepareRelease(opts: BuildOptions): Promise<PrepareR
   let answers: PrepareReleasePromptAnswers;
   try {
     answers = await inquirer.prompt<PrepareReleasePromptAnswers>(prompts);
+  } catch (err: any) {
+    console.log('\n', color.red(err), '\n');
+    process.exit(0);
+  }
+  return answers;
+}
+
+/**
+ * A type describing the answers to prompts for performing a release
+ */
+export type ReleasePromptAnswers = {
+  /**
+   * If `true`, run release preparation steps
+   */
+  confirm: boolean;
+  /**
+   * A one-time password, provided by a developer's authenticator application
+   */
+  otp: string;
+  /**
+   * A user specified tag to push to the npm registry. If provided, this overrider {@link ReleasePromptAnswers#tag}
+   */
+  specifiedTag?: string;
+  /**
+   * The tag to push to the npm registry. This is _not_ the tag pushed to GitHub
+   */
+  tag?: string;
+};
+
+/**
+ * Prompts a developer to answer questions regarding how a release of Stencil should be performed
+ * @param opts build options containing the metadata needed to publish a new version of Stencil
+ */
+export async function promptRelease(opts: BuildOptions): Promise<ReleasePromptAnswers> {
+  const pkg = opts.packageJson;
+
+  const { execa } = await import('execa');
+
+  const prompts: inquirer.QuestionCollection<ReleasePromptAnswers> = [
+    {
+      type: 'list',
+      name: 'tag',
+      message: 'How should this pre-release version be tagged in npm?',
+      when: () => isPrereleaseVersion(opts.version),
+      choices: () =>
+        execa('npm', ['view', '--json', pkg.name, 'dist-tags']).then(({ stdout }) => {
+          const existingPrereleaseTags = Object.keys(JSON.parse(stdout))
+            .filter((tag) => tag !== 'latest')
+            .map((tag) => {
+              return {
+                name: tag,
+                value: tag,
+              };
+            });
+
+          if (existingPrereleaseTags.length === 0) {
+            existingPrereleaseTags.push({
+              name: 'next',
+              value: 'next',
+            });
+          }
+
+          return existingPrereleaseTags.concat([
+            new inquirer.Separator() as any,
+            {
+              name: 'Other (specify)',
+              value: null,
+            },
+          ]);
+        }),
+    },
+    {
+      type: 'input',
+      // this name is intentionally different from 'tag' above. if they collide, this input prompt will not run.
+      name: 'specifiedTag',
+      message: 'Specify Tag',
+      when: (answers: any) => !pkg.private && isPrereleaseVersion(opts.version) && !answers.tag,
+      validate: (input: any) => {
+        if (input.length === 0) {
+          return 'Please specify a tag, for example, `next` or `3.0.0-alpha.0`.';
+        } else if (input.toLowerCase() === 'latest') {
+          return "It's not possible to publish pre-releases under the `latest` tag. Please specify something else, for example, `next` or `3.0.0-alpha.0`.";
+        }
+        return true;
+      },
+    },
+    {
+      type: 'confirm',
+      name: 'confirm',
+      message: (answers: any) => {
+        opts.tag = answers.tag ?? answers.specifiedTag;
+        const tagPart = opts.tag ? ` and tag this release in npm as ${color.yellow(opts.tag)}` : '';
+        return `Will publish ${opts.vermoji}  ${color.yellow(opts.version)}${tagPart}. Continue?`;
+      },
+    },
+    {
+      type: 'input',
+      name: 'otp',
+      message: 'Enter OTP:',
+      validate: (input: any) => {
+        if (input.length !== 6) {
+          return 'Please enter a valid one-time password.';
+        }
+        return true;
+      },
+    },
+  ];
+
+  let answers: ReleasePromptAnswers;
+  try {
+    answers = await inquirer.prompt<ReleasePromptAnswers>(prompts);
+    opts.otp = answers.otp;
   } catch (err: any) {
     console.log('\n', color.red(err), '\n');
     process.exit(0);

--- a/scripts/utils/options.ts
+++ b/scripts/utils/options.ts
@@ -193,7 +193,7 @@ export interface BuildOptions {
   parse5Verion?: string;
   sizzleVersion?: string;
   terserVersion?: string;
-  otp?: '';
+  otp?: string;
 }
 
 /**


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

We're in the process of enabling CI-based deployments. Today, this is a manual process that (at a high level), requires two steps:
1. Preparing the release - where we bump the version, generate the changelog, run the tests, etc.
2. Run the release - publish the commit to GitHub, push tags to GH+NPM, create a GH release, etc.

As a part of allowing publishes to occur in CI, those two steps need to be combined. However, the second step ('Run the release') requires a user to answer a few prompts in a terminal window. This limits our options for code reuse when we programmatically prepare a release.

This commit assumes that https://github.com/ionic-team/stencil/pull/4172 has landed, which solve the same problem for the pre-release step

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit separates the existing prompts (questions asked to an
engineer during the release process) that expect an interactive
terminal to be available. this is the second step that we'll take
in order to enable ci to publish stencil, rather than it being a manual
process. the motivation behind this change is that we would like to
reuse the existing release logic. however, in order to do so, we
must separate the prompting (which won't be available in ci) from the
necessary logic to initiate a release.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

1. Unit tests pass
2. `npm run release.prepare -- --any-branch --dry-run`, then `npm run release -- --any-branch-dry-run` will test _most_ of the functionality on this branch. The version validation, git checks (tag, that the local branch is clean/has an upstream) will be skipped due to the `dry-run` flag. Running this, one should observe that the changelog, package.json, and package-lock.json all get bumped. Nothing will get pushed to NPM/github

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

### Workflow isn't Optimal

The steps in 'release' aren't "optimal"/a little confusing. I've added tests to add some clarification, but these scripts were written with mutating arguments in mind. I did not attempt to "fix" all of these in one PR. The focus here is to separaterelease prompts from the `release` function, so that we can do both that cleanup and get CI publishes one step closer to a reality

### Why not use `np`?

When we're writing tests for something like our release scripts over several hack days, it's a valid question to ask. The Stencil prod build pipeline relies on switching a lot of generated values out of the bundle. While I think it _could_ be feasible with `np`, I held off for two reasons:
1. To better understand the pre-existing steps we have. Otherwise, I wouldn't know what I was replacing `np` with 😆 
2. To avoid shoehorning our process into `np` prematurely. I'm preferring running the steps we run today (locally) in CI (eventually, that's the general plan), over a whole new pipeline. Once dev/nightly/prod are online and we have all their use cases accounted for, we can reconsider.
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
