### PR TITLE
chore(build): build the CLI module with esbuild

### DIFF
--- a/.github/workflows/build-esbuild.yml
+++ b/.github/workflows/build-esbuild.yml
@@ -1,0 +1,41 @@
+name: Build Stencil with Esbuild
+
+on:
+  workflow_call:
+  # Make this a reusable workflow, no value needed
+  # https://docs.github.com/en/actions/using-workflows/reusing-workflows
+
+jobs:
+  build_core:
+    name: Core
+    runs-on: 'ubuntu-22.04'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        with:
+          # the pull_request_target event will consider the HEAD of `main` to be the SHA to use.
+          # attempt to use the SHA associated with a pull request and fallback to HEAD of `main`
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.number) || '' }}
+          persist-credentials: false
+
+      - name: Get Core Dependencies
+        uses: ./.github/workflows/actions/get-core-dependencies
+
+      - name: Core Build
+        run: npm run build.esbuild -- --ci
+        shell: bash
+
+      - name: Validate Build
+        run: npm run test.dist
+        shell: bash
+
+      - name: Validate Testing
+        run: npm run test.testing
+        shell: bash
+
+      - name: Upload Build Artifacts
+        uses: ./.github/workflows/actions/upload-archive
+        with:
+          name: stencil-core-esbuild
+          output: stencil-core-build.zip
+          paths: build cli compiler dev-server internal mock-doc scripts/build screenshot sys testing

--- a/.github/workflows/main-esbuild.yml
+++ b/.github/workflows/main-esbuild.yml
@@ -1,11 +1,9 @@
-name: CI
+name: esbuild CI
 
 on:
-  merge_group:
   push:
     branches:
       - 'main'
-      - 'stencil/v4-dev'
   pull_request:
     branches:
       - '**'
@@ -17,43 +15,39 @@ concurrency:
 jobs:
   build_core:
     name: Build
-    uses: ./.github/workflows/build.yml
-
-  lint_and_format:
-    name: Lint and Format
-    uses: ./.github/workflows/lint-and-format.yml
+    uses: ./.github/workflows/build-esbuild.yml
 
   analysis_tests:
-    name: Analysis Tests
+    name: Analysis Tests (Esbuild)
     needs: [build_core]
     uses: ./.github/workflows/test-analysis.yml
     with:
-      build_name: stencil-core
+      build_name: stencil-core-esbuild
 
   bundler_tests:
-    name: Bundler Tests
+    name: Bundler Tests (Esbuild)
     needs: [build_core]
     uses: ./.github/workflows/test-bundlers.yml
     with:
-      build_name: stencil-core
+      build_name: stencil-core-esbuild
 
   component_starter_tests:
-    name: Component Starter Smoke Test
+    name: Component Starter Smoke Test (Esbuild)
     needs: [build_core]
     uses: ./.github/workflows/test-component-starter.yml
     with:
-      build_name: stencil-core
+      build_name: stencil-core-esbuild
 
   e2e_tests:
-    name: E2E Tests
+    name: E2E Tests (Esbuild)
     needs: [build_core]
     uses: ./.github/workflows/test-e2e.yml
     with:
-      build_name: stencil-core
+      build_name: stencil-core-esbuild
 
   unit_tests:
-    name: Unit Tests
+    name: Unit Tests (Esbuild)
     needs: [build_core]
     uses: ./.github/workflows/test-unit.yml
     with:
-      build_name: stencil-core
+      build_name: stencil-core-esbuild

--- a/.github/workflows/test-analysis.yml
+++ b/.github/workflows/test-analysis.yml
@@ -4,6 +4,11 @@ on:
   workflow_call:
     # Make this a reusable workflow, no value needed
     # https://docs.github.com/en/actions/using-workflows/reusing-workflows
+    inputs:
+      build_name:
+        description: Name for the build, used to resolve the correct build artifact
+        required: true
+        type: string
 
 jobs:
   analysis_test:
@@ -30,7 +35,7 @@ jobs:
       - name: Download Build Archive
         uses: ./.github/workflows/actions/download-archive
         with:
-          name: stencil-core
+          name: ${{ inputs.build_name }}
           path: .
           filename: stencil-core-build.zip
 

--- a/.github/workflows/test-bundlers.yml
+++ b/.github/workflows/test-bundlers.yml
@@ -4,6 +4,11 @@ on:
   workflow_call:
     # Make this a reusable workflow, no value needed
     # https://docs.github.com/en/actions/using-workflows/reusing-workflows
+    inputs:
+      build_name:
+        description: Name for the build, used to resolve the correct build artifact
+        required: true
+        type: string
 
 jobs:
   bundler_tests:
@@ -19,7 +24,7 @@ jobs:
       - name: Download Build Archive
         uses: ./.github/workflows/actions/download-archive
         with:
-          name: stencil-core
+          name: ${{ inputs.build_name }}
           path: .
           filename: stencil-core-build.zip
 

--- a/.github/workflows/test-component-starter.yml
+++ b/.github/workflows/test-component-starter.yml
@@ -4,6 +4,11 @@ on:
   workflow_call:
     # Make this a reusable workflow, no value needed
     # https://docs.github.com/en/actions/using-workflows/reusing-workflows
+    inputs:
+      build_name:
+        description: Name for the build, used to resolve the correct build artifact
+        required: true
+        type: string
 
 jobs:
   analysis_test:
@@ -39,7 +44,7 @@ jobs:
       - name: Download Build Archive
         uses: ./.github/workflows/actions/download-archive
         with:
-          name: stencil-core
+          name: ${{ inputs.build_name }}
           path: ./stencil-pack-destination
           filename: stencil-core-build.zip
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -4,6 +4,11 @@ on:
   workflow_call:
     # Make this a reusable workflow, no value needed
     # https://docs.github.com/en/actions/using-workflows/reusing-workflows
+    inputs:
+      build_name:
+        description: Name for the build, used to resolve the correct build artifact
+        required: true
+        type: string
 
 jobs:
   e2e_test:
@@ -30,7 +35,7 @@ jobs:
       - name: Download Build Archive
         uses: ./.github/workflows/actions/download-archive
         with:
-          name: stencil-core
+          name: ${{ inputs.build_name }}
           path: .
           filename: stencil-core-build.zip
 

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -4,6 +4,11 @@ on:
   workflow_call:
     # Make this a reusable workflow, no value needed
     # https://docs.github.com/en/actions/using-workflows/reusing-workflows
+    inputs:
+      build_name:
+        description: Name for the build, used to resolve the correct build artifact
+        required: true
+        type: string
 
 jobs:
   unit_test:
@@ -31,7 +36,7 @@ jobs:
       - name: Download Build Archive
         uses: ./.github/workflows/actions/download-archive
         with:
-          name: stencil-core
+          name: ${{ inputs.build_name }}
           path: .
           filename: stencil-core-build.zip
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "conventional-changelog-cli": "^4.0.0",
         "cspell": "^7.0.1",
         "dts-bundle-generator": "~8.0.0",
+        "esbuild": "^0.19.4",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-jest": "^27.0.4",
@@ -1164,6 +1165,358 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.4.tgz",
+      "integrity": "sha512-uBIbiYMeSsy2U0XQoOGVVcpIktjLMEKa7ryz2RLr7L/vTnANNEsPVAh4xOv7ondGz6ac1zVb0F8Jx20rQikffQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.4.tgz",
+      "integrity": "sha512-mRsi2vJsk4Bx/AFsNBqOH2fqedxn5L/moT58xgg51DjX1la64Z3Npicut2VbhvDFO26qjWtPMsVxCd80YTFVeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.4.tgz",
+      "integrity": "sha512-4iPufZ1TMOD3oBlGFqHXBpa3KFT46aLl6Vy7gwed0ZSYgHaZ/mihbYb4t7Z9etjkC9Al3ZYIoOaHrU60gcMy7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.4.tgz",
+      "integrity": "sha512-Lviw8EzxsVQKpbS+rSt6/6zjn9ashUZ7Tbuvc2YENgRl0yZTktGlachZ9KMJUsVjZEGFVu336kl5lBgDN6PmpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.4.tgz",
+      "integrity": "sha512-YHbSFlLgDwglFn0lAO3Zsdrife9jcQXQhgRp77YiTDja23FrC2uwnhXMNkAucthsf+Psr7sTwYEryxz6FPAVqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.4.tgz",
+      "integrity": "sha512-vz59ijyrTG22Hshaj620e5yhs2dU1WJy723ofc+KUgxVCM6zxQESmWdMuVmUzxtGqtj5heHyB44PjV/HKsEmuQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.4.tgz",
+      "integrity": "sha512-3sRbQ6W5kAiVQRBWREGJNd1YE7OgzS0AmOGjDmX/qZZecq8NFlQsQH0IfXjjmD0XtUYqr64e0EKNFjMUlPL3Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.4.tgz",
+      "integrity": "sha512-z/4ArqOo9EImzTi4b6Vq+pthLnepFzJ92BnofU1jgNlcVb+UqynVFdoXMCFreTK7FdhqAzH0vmdwW5373Hm9pg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.4.tgz",
+      "integrity": "sha512-ZWmWORaPbsPwmyu7eIEATFlaqm0QGt+joRE9sKcnVUG3oBbr/KYdNE2TnkzdQwX6EDRdg/x8Q4EZQTXoClUqqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.4.tgz",
+      "integrity": "sha512-EGc4vYM7i1GRUIMqRZNCTzJh25MHePYsnQfKDexD8uPTCm9mK56NIL04LUfX2aaJ+C9vyEp2fJ7jbqFEYgO9lQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.4.tgz",
+      "integrity": "sha512-WVhIKO26kmm8lPmNrUikxSpXcgd6HDog0cx12BUfA2PkmURHSgx9G6vA19lrlQOMw+UjMZ+l3PpbtzffCxFDRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.4.tgz",
+      "integrity": "sha512-keYY+Hlj5w86hNp5JJPuZNbvW4jql7c1eXdBUHIJGTeN/+0QFutU3GrS+c27L+NTmzi73yhtojHk+lr2+502Mw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.4.tgz",
+      "integrity": "sha512-tQ92n0WMXyEsCH4m32S21fND8VxNiVazUbU4IUGVXQpWiaAxOBvtOtbEt3cXIV3GEBydYsY8pyeRMJx9kn3rvw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.4.tgz",
+      "integrity": "sha512-tRRBey6fG9tqGH6V75xH3lFPpj9E8BH+N+zjSUCnFOX93kEzqS0WdyJHkta/mmJHn7MBaa++9P4ARiU4ykjhig==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.4.tgz",
+      "integrity": "sha512-152aLpQqKZYhThiJ+uAM4PcuLCAOxDsCekIbnGzPKVBRUDlgaaAfaUl5NYkB1hgY6WN4sPkejxKlANgVcGl9Qg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.4.tgz",
+      "integrity": "sha512-Mi4aNA3rz1BNFtB7aGadMD0MavmzuuXNTaYL6/uiYIs08U7YMPETpgNn5oue3ICr+inKwItOwSsJDYkrE9ekVg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.4.tgz",
+      "integrity": "sha512-9+Wxx1i5N/CYo505CTT7T+ix4lVzEdz0uCoYGxM5JDVlP2YdDC1Bdz+Khv6IbqmisT0Si928eAxbmGkcbiuM/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.4.tgz",
+      "integrity": "sha512-MFsHleM5/rWRW9EivFssop+OulYVUoVcqkyOkjiynKBCGBj9Lihl7kh9IzrreDyXa4sNkquei5/DTP4uCk25xw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.4.tgz",
+      "integrity": "sha512-6Xq8SpK46yLvrGxjp6HftkDwPP49puU4OF0hEL4dTxqCbfx09LyrbUj/D7tmIRMj5D5FCUPksBbxyQhp8tmHzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.4.tgz",
+      "integrity": "sha512-PkIl7Jq4mP6ke7QKwyg4fD4Xvn8PXisagV/+HntWoDEdmerB2LTukRZg728Yd1Fj+LuEX75t/hKXE2Ppk8Hh1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.4.tgz",
+      "integrity": "sha512-ga676Hnvw7/ycdKB53qPusvsKdwrWzEyJ+AtItHGoARszIqvjffTwaaW3b2L6l90i7MO9i+dlAW415INuRhSGg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.4.tgz",
+      "integrity": "sha512-HP0GDNla1T3ZL8Ko/SHAS2GgtjOg+VmWnnYLhuTksr++EnduYB0f3Y2LzHsUwb2iQ13JGoY6G3R8h6Du/WG6uA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -5426,6 +5779,43 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.2.1.tgz",
       "integrity": "sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==",
       "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.4.tgz",
+      "integrity": "sha512-x7jL0tbRRpv4QUyuDMjONtWFciygUxWaUM1kMX2zWxI0X2YWOt7MSA0g4UdeSiHM8fcYVzpQhKYOycZwxTdZkA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.19.4",
+        "@esbuild/android-arm64": "0.19.4",
+        "@esbuild/android-x64": "0.19.4",
+        "@esbuild/darwin-arm64": "0.19.4",
+        "@esbuild/darwin-x64": "0.19.4",
+        "@esbuild/freebsd-arm64": "0.19.4",
+        "@esbuild/freebsd-x64": "0.19.4",
+        "@esbuild/linux-arm": "0.19.4",
+        "@esbuild/linux-arm64": "0.19.4",
+        "@esbuild/linux-ia32": "0.19.4",
+        "@esbuild/linux-loong64": "0.19.4",
+        "@esbuild/linux-mips64el": "0.19.4",
+        "@esbuild/linux-ppc64": "0.19.4",
+        "@esbuild/linux-riscv64": "0.19.4",
+        "@esbuild/linux-s390x": "0.19.4",
+        "@esbuild/linux-x64": "0.19.4",
+        "@esbuild/netbsd-x64": "0.19.4",
+        "@esbuild/openbsd-x64": "0.19.4",
+        "@esbuild/sunos-x64": "0.19.4",
+        "@esbuild/win32-arm64": "0.19.4",
+        "@esbuild/win32-ia32": "0.19.4",
+        "@esbuild/win32-x64": "0.19.4"
+      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -12347,6 +12737,160 @@
         "jsdoc-type-pratt-parser": "~4.0.0"
       }
     },
+    "@esbuild/android-arm": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.4.tgz",
+      "integrity": "sha512-uBIbiYMeSsy2U0XQoOGVVcpIktjLMEKa7ryz2RLr7L/vTnANNEsPVAh4xOv7ondGz6ac1zVb0F8Jx20rQikffQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-arm64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.4.tgz",
+      "integrity": "sha512-mRsi2vJsk4Bx/AFsNBqOH2fqedxn5L/moT58xgg51DjX1la64Z3Npicut2VbhvDFO26qjWtPMsVxCd80YTFVeg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.4.tgz",
+      "integrity": "sha512-4iPufZ1TMOD3oBlGFqHXBpa3KFT46aLl6Vy7gwed0ZSYgHaZ/mihbYb4t7Z9etjkC9Al3ZYIoOaHrU60gcMy7g==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-arm64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.4.tgz",
+      "integrity": "sha512-Lviw8EzxsVQKpbS+rSt6/6zjn9ashUZ7Tbuvc2YENgRl0yZTktGlachZ9KMJUsVjZEGFVu336kl5lBgDN6PmpA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.4.tgz",
+      "integrity": "sha512-YHbSFlLgDwglFn0lAO3Zsdrife9jcQXQhgRp77YiTDja23FrC2uwnhXMNkAucthsf+Psr7sTwYEryxz6FPAVqw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.4.tgz",
+      "integrity": "sha512-vz59ijyrTG22Hshaj620e5yhs2dU1WJy723ofc+KUgxVCM6zxQESmWdMuVmUzxtGqtj5heHyB44PjV/HKsEmuQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.4.tgz",
+      "integrity": "sha512-3sRbQ6W5kAiVQRBWREGJNd1YE7OgzS0AmOGjDmX/qZZecq8NFlQsQH0IfXjjmD0XtUYqr64e0EKNFjMUlPL3Cw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.4.tgz",
+      "integrity": "sha512-z/4ArqOo9EImzTi4b6Vq+pthLnepFzJ92BnofU1jgNlcVb+UqynVFdoXMCFreTK7FdhqAzH0vmdwW5373Hm9pg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.4.tgz",
+      "integrity": "sha512-ZWmWORaPbsPwmyu7eIEATFlaqm0QGt+joRE9sKcnVUG3oBbr/KYdNE2TnkzdQwX6EDRdg/x8Q4EZQTXoClUqqA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.4.tgz",
+      "integrity": "sha512-EGc4vYM7i1GRUIMqRZNCTzJh25MHePYsnQfKDexD8uPTCm9mK56NIL04LUfX2aaJ+C9vyEp2fJ7jbqFEYgO9lQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-loong64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.4.tgz",
+      "integrity": "sha512-WVhIKO26kmm8lPmNrUikxSpXcgd6HDog0cx12BUfA2PkmURHSgx9G6vA19lrlQOMw+UjMZ+l3PpbtzffCxFDRg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.4.tgz",
+      "integrity": "sha512-keYY+Hlj5w86hNp5JJPuZNbvW4jql7c1eXdBUHIJGTeN/+0QFutU3GrS+c27L+NTmzi73yhtojHk+lr2+502Mw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.4.tgz",
+      "integrity": "sha512-tQ92n0WMXyEsCH4m32S21fND8VxNiVazUbU4IUGVXQpWiaAxOBvtOtbEt3cXIV3GEBydYsY8pyeRMJx9kn3rvw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.4.tgz",
+      "integrity": "sha512-tRRBey6fG9tqGH6V75xH3lFPpj9E8BH+N+zjSUCnFOX93kEzqS0WdyJHkta/mmJHn7MBaa++9P4ARiU4ykjhig==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.4.tgz",
+      "integrity": "sha512-152aLpQqKZYhThiJ+uAM4PcuLCAOxDsCekIbnGzPKVBRUDlgaaAfaUl5NYkB1hgY6WN4sPkejxKlANgVcGl9Qg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.4.tgz",
+      "integrity": "sha512-Mi4aNA3rz1BNFtB7aGadMD0MavmzuuXNTaYL6/uiYIs08U7YMPETpgNn5oue3ICr+inKwItOwSsJDYkrE9ekVg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.4.tgz",
+      "integrity": "sha512-9+Wxx1i5N/CYo505CTT7T+ix4lVzEdz0uCoYGxM5JDVlP2YdDC1Bdz+Khv6IbqmisT0Si928eAxbmGkcbiuM/A==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.4.tgz",
+      "integrity": "sha512-MFsHleM5/rWRW9EivFssop+OulYVUoVcqkyOkjiynKBCGBj9Lihl7kh9IzrreDyXa4sNkquei5/DTP4uCk25xw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.4.tgz",
+      "integrity": "sha512-6Xq8SpK46yLvrGxjp6HftkDwPP49puU4OF0hEL4dTxqCbfx09LyrbUj/D7tmIRMj5D5FCUPksBbxyQhp8tmHzw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.4.tgz",
+      "integrity": "sha512-PkIl7Jq4mP6ke7QKwyg4fD4Xvn8PXisagV/+HntWoDEdmerB2LTukRZg728Yd1Fj+LuEX75t/hKXE2Ppk8Hh1w==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.4.tgz",
+      "integrity": "sha512-ga676Hnvw7/ycdKB53qPusvsKdwrWzEyJ+AtItHGoARszIqvjffTwaaW3b2L6l90i7MO9i+dlAW415INuRhSGg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.4.tgz",
+      "integrity": "sha512-HP0GDNla1T3ZL8Ko/SHAS2GgtjOg+VmWnnYLhuTksr++EnduYB0f3Y2LzHsUwb2iQ13JGoY6G3R8h6Du/WG6uA==",
+      "dev": true,
+      "optional": true
+    },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -15519,6 +16063,36 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.2.1.tgz",
       "integrity": "sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==",
       "dev": true
+    },
+    "esbuild": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.4.tgz",
+      "integrity": "sha512-x7jL0tbRRpv4QUyuDMjONtWFciygUxWaUM1kMX2zWxI0X2YWOt7MSA0g4UdeSiHM8fcYVzpQhKYOycZwxTdZkA==",
+      "dev": true,
+      "requires": {
+        "@esbuild/android-arm": "0.19.4",
+        "@esbuild/android-arm64": "0.19.4",
+        "@esbuild/android-x64": "0.19.4",
+        "@esbuild/darwin-arm64": "0.19.4",
+        "@esbuild/darwin-x64": "0.19.4",
+        "@esbuild/freebsd-arm64": "0.19.4",
+        "@esbuild/freebsd-x64": "0.19.4",
+        "@esbuild/linux-arm": "0.19.4",
+        "@esbuild/linux-arm64": "0.19.4",
+        "@esbuild/linux-ia32": "0.19.4",
+        "@esbuild/linux-loong64": "0.19.4",
+        "@esbuild/linux-mips64el": "0.19.4",
+        "@esbuild/linux-ppc64": "0.19.4",
+        "@esbuild/linux-riscv64": "0.19.4",
+        "@esbuild/linux-s390x": "0.19.4",
+        "@esbuild/linux-x64": "0.19.4",
+        "@esbuild/netbsd-x64": "0.19.4",
+        "@esbuild/openbsd-x64": "0.19.4",
+        "@esbuild/sunos-x64": "0.19.4",
+        "@esbuild/win32-arm64": "0.19.4",
+        "@esbuild/win32-ia32": "0.19.4",
+        "@esbuild/win32-x64": "0.19.4"
+      }
     },
     "escalade": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   ],
   "scripts": {
     "build": "npm run tsc.scripts && npm run tsc.prod && npm run rollup.prod.ci",
+    "build.esbuild": "npm run clean && npm run build && node scripts/build/esbuild/build.js",
+    "build.esbuild.watch": "npm run clean && npm run build && node scripts/build/esbuild/build.js --watch",
     "clean": "rm -rf build/ cli/ compiler/ dev-server/ internal/ mock-doc/ sys/ testing/ && npm run clean-scripts",
     "clean-scripts": "rm -rf scripts/build",
     "lint": "eslint 'bin/*' 'scripts/*.ts' 'scripts/**/*.ts' 'src/*.ts' 'src/**/*.ts' 'src/**/*.tsx'",
@@ -86,6 +88,7 @@
     "conventional-changelog-cli": "^4.0.0",
     "cspell": "^7.0.1",
     "dts-bundle-generator": "~8.0.0",
+    "esbuild": "^0.19.4",
     "eslint": "^8.23.1",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-jest": "^27.0.4",

--- a/scripts/esbuild/build.ts
+++ b/scripts/esbuild/build.ts
@@ -1,0 +1,15 @@
+import { getOptions } from '../utils/options';
+import { buildCli } from './cli';
+
+// the main entry point for the Esbuild-based build
+async function main() {
+  const opts = getOptions(process.cwd(), {
+    isProd: !!process.argv.includes('--prod'),
+    isCI: !!process.argv.includes('--ci'),
+    isWatch: !!process.argv.includes('--watch'),
+  });
+
+  await buildCli(opts);
+}
+
+main();

--- a/scripts/esbuild/cli.ts
+++ b/scripts/esbuild/cli.ts
@@ -1,0 +1,82 @@
+import type { BuildOptions as ESBuildOptions } from 'esbuild';
+import fs from 'fs-extra';
+import { join } from 'path';
+
+import { getBanner } from '../utils/banner';
+import { BuildOptions } from '../utils/options';
+import { writePkgJson } from '../utils/write-pkg-json';
+import { getBaseEsbuildOptions, getEsbuildAliases, getEsbuildExternalModules, runBuilds } from './util';
+
+/**
+ * Runs esbuild to bundle the `cli` submodule
+ *
+ * @param opts build options
+ * @returns a promise for this bundle's build output
+ */
+export async function buildCli(opts: BuildOptions) {
+  // clear out rollup stuff
+  await fs.emptyDir(opts.output.cliDir);
+
+  const inputDir = join(opts.srcDir, 'cli');
+  const buildDir = join(opts.buildDir, 'cli');
+
+  const outputDir = opts.output.cliDir;
+  const esmFilename = 'index.js';
+  const cjsFilename = 'index.cjs';
+
+  const dtsFilename = 'index.d.ts';
+
+  const cliAliases = getEsbuildAliases();
+
+  const external = getEsbuildExternalModules(opts, opts.output.cliDir);
+
+  const cliEsbuildOptions = {
+    ...getBaseEsbuildOptions(),
+    alias: cliAliases,
+    entryPoints: [join(inputDir, 'index.ts')],
+    external,
+    platform: 'node',
+    sourcemap: 'linked',
+  } satisfies ESBuildOptions;
+
+  // ESM build options
+  const esmOptions: ESBuildOptions = {
+    ...cliEsbuildOptions,
+    outfile: join(outputDir, esmFilename),
+    format: 'esm',
+    banner: {
+      js: getBanner(opts, `Stencil CLI`, true),
+    },
+  };
+
+  // CommonJS build options
+  const cjsContext: ESBuildOptions = {
+    ...cliEsbuildOptions,
+    outfile: join(outputDir, cjsFilename),
+    format: 'cjs',
+    banner: {
+      js: getBanner(opts, `Stencil CLI (CommonJS)`, true),
+    },
+  };
+
+  // create public d.ts
+  let dts = await fs.readFile(join(buildDir, 'public.d.ts'), 'utf8');
+  dts = dts.replace('@stencil/core/internal', '../internal/index');
+  await fs.writeFile(join(opts.output.cliDir, dtsFilename), dts);
+
+  // copy config-flags.d.ts
+  let configDts = await fs.readFile(join(buildDir, 'config-flags.d.ts'), 'utf8');
+  configDts = configDts.replace('@stencil/core/declarations', '../internal/index');
+  await fs.writeFile(join(opts.output.cliDir, 'config-flags.d.ts'), configDts);
+
+  // write cli/package.json
+  writePkgJson(opts, opts.output.cliDir, {
+    name: '@stencil/core/cli',
+    description: 'Stencil CLI.',
+    main: cjsFilename,
+    module: esmFilename,
+    types: dtsFilename,
+  });
+
+  return runBuilds([esmOptions, cjsContext], opts);
+}

--- a/scripts/esbuild/util.ts
+++ b/scripts/esbuild/util.ts
@@ -1,0 +1,124 @@
+import type { BuildOptions as ESBuildOptions, BuildResult as ESBuildResult } from 'esbuild';
+import * as esbuild from 'esbuild';
+import { join } from 'path';
+
+import { BuildOptions } from '../utils/options';
+
+/**
+ * Aliases which map the module identifiers we set in `paths` in `tsconfig.json` to
+ * bundles (built either with esbuild or with rollup).
+ *
+ * @returns a map of aliases to bundle entry points, relative to the root directory
+ */
+export function getEsbuildAliases(): Record<string, string> {
+  return {
+    // node module redirection
+    chalk: 'ansi-colors',
+
+    // mapping aliases to top-level bundle entrypoints
+    '@stencil/core/testing': './testing/index.js',
+    '@stencil/core/compiler': './compiler/stencil.js',
+    '@stencil/core/dev-server': './dev-server/index.js',
+    '@stencil/core/mock-doc': './mock-doc/index.cjs',
+    '@stencil/core/internal/testing': './internal/testing/index.js',
+
+    // mapping node.js module names to `sys/node` "cache"
+    //
+    // these allow us to bundle and ship a dependency (like `prompts`) as part
+    // of the Stencil distributable but also have our separate bundles
+    // reference the same file
+    prompts: './sys/node/prompts.js',
+  };
+}
+
+/**
+ * Node modules which should be universally marked as external
+ *
+ * Note that we should not rely on this to mark node.js built-in modules as
+ * external. Doing so will override esbuild's automatic marking of those modules
+ * as side-effect-free, which allows imports from them to be properly
+ * tree-shaken.
+ */
+const externalNodeModules = [
+  '@jest/core',
+  '@jest/reporters',
+  '@microsoft/typescript-etw',
+  'assert',
+  'buffer',
+  'child_process',
+  'console',
+  'constants',
+  'expect',
+  'fsevents',
+  'inspector',
+  'jest',
+  'jest-cli',
+  'jest-config',
+  'jest-message-id',
+  'jest-pnp-resolver',
+  'jest-runner',
+  'net',
+  'puppeteer',
+  'puppeteer-core',
+  'readline',
+  'stream',
+  'tty',
+  'url',
+  'util',
+  'vm',
+  'yargs',
+  'zlib',
+];
+
+/**
+ * Get a manifest of modules which should be marked as external for a given
+ * esbuild bundle
+ *
+ * @param opts options for the current build
+ * @param ownEntryPoint the entry point alias of the current module
+ * @returns a list of modules which should be marked as external
+ */
+export function getEsbuildExternalModules(opts: BuildOptions, ownEntryPoint: string): string[] {
+  const bundles = Object.values(opts.output);
+  const externalBundles = bundles.filter((outdir) => outdir !== ownEntryPoint).map((outdir) => join(outdir, '*'));
+
+  return [...externalNodeModules, ...externalBundles];
+}
+
+/**
+ * A helper which runs an array of esbuild, uh, _builds_
+ *
+ * This accepts an array of build configurations and will either run a synchronous
+ * build _or_ run them all in watch mode, depending on the {@link BuildOptions['isWatch']}
+ * setting.
+ *
+ * @param builds the array of outputs to build
+ * @param opts Stencil build options
+ * @returns a Promise representing the execution of the builds
+ */
+export function runBuilds(builds: ESBuildOptions[], opts: BuildOptions): Promise<(void | ESBuildResult)[]> {
+  if (opts.isWatch) {
+    return Promise.all(
+      builds.map(async (buildConfig) => {
+        const context = await esbuild.context(buildConfig);
+        return context.watch();
+      }),
+    );
+  } else {
+    return Promise.all(builds.map(esbuild.build));
+  }
+}
+
+/**
+ * Get base esbuild options which we want to always have set for all of our
+ * bundles
+ *
+ * @returns a base set of options
+ */
+export function getBaseEsbuildOptions(): ESBuildOptions {
+  return {
+    bundle: true,
+    legalComments: 'inline',
+    logLevel: 'info',
+  };
+}

--- a/scripts/utils/options.ts
+++ b/scripts/utils/options.ts
@@ -60,6 +60,7 @@ export function getOptions(rootDir: string, inputOpts: BuildOptions = {}): Build
     buildId: null,
     isProd: false,
     isCI: false,
+    isWatch: false,
     isPublishRelease: false,
     vermoji: null,
     tag: 'dev',
@@ -153,18 +154,18 @@ function getPkg(opts: BuildOptions, pkgName: string): PackageData {
 }
 
 export interface BuildOptions {
-  ghRepoOrg?: string;
+  buildDir?: string;
+  bundleHelpersDir?: string;
   ghRepoName?: string;
-  rootDir?: string;
-  srcDir?: string;
+  ghRepoOrg?: string;
   nodeModulesDir?: string;
+  rootDir?: string;
+  scriptsBuildDir?: string;
+  scriptsBundlesDir?: string;
+  scriptsDir?: string;
+  srcDir?: string;
   typescriptDir?: string;
   typescriptLibDir?: string;
-  buildDir?: string;
-  scriptsDir?: string;
-  scriptsBundlesDir?: string;
-  scriptsBuildDir?: string;
-  bundleHelpersDir?: string;
 
   output?: {
     cliDir: string;
@@ -177,23 +178,24 @@ export interface BuildOptions {
     testingDir: string;
   };
 
-  version?: string;
   buildId?: string;
+  changelogPath?: string;
+  isCI?: boolean;
   isProd?: boolean;
   isPublishRelease?: boolean;
-  isCI?: boolean;
-  vermoji?: string;
+  isWatch?: boolean;
+  otp?: string;
+  packageJson?: PackageData;
   packageJsonPath?: string;
   packageLockJsonPath?: string;
-  packageJson?: PackageData;
-  changelogPath?: string;
-  tag?: string;
-  typescriptVersion?: string;
-  rollupVersion?: string;
   parse5Version?: string;
+  rollupVersion?: string;
   sizzleVersion?: string;
+  tag?: string;
   terserVersion?: string;
-  otp?: string;
+  typescriptVersion?: string;
+  vermoji?: string;
+  version?: string;
 }
 
 /**

--- a/scripts/utils/test/options.spec.ts
+++ b/scripts/utils/test/options.spec.ts
@@ -37,6 +37,7 @@ describe('release options', () => {
         isCI: false,
         isProd: false,
         isPublishRelease: false,
+        isWatch: false,
         nodeModulesDir: 'node_modules',
         output: {
           cliDir: 'cli',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "paths": {
       "@app-data": ["src/app-data/index.ts"],
       "@app-globals": ["src/app-globals/index.ts"],
+      "@environment": ["src/compiler/sys/environment.ts"],
       "@dev-server-process": ["src/dev-server/server-process.ts"],
       "@hydrate-factory": ["src/hydrate/runner/hydrate-factory.ts"],
       "@platform": ["src/client/index.ts"],


### PR DESCRIPTION
This adds a support for building Stencil with [esbuild](https://esbuild.github.io/). This comprises:

- a new subdirectory `scripts/esbuild` which holds all the esbuild-related stuff
- support for bundling the `cli/` bundle with esbuild
- new `package.json` scripts `build.esbuild` and `build.esbuild.watch` for doing a "hybrid" build
- new CI workflows to build Stencil with esbuild and then run the existing unit and e2e test suites against the build artifact

Right now this new build / bundle setup exists parallel to the existing, rollup-based build setup. The idea is that we'll continue to use rollup for building and releasing, but we'll gradually increase the scope of the esbuild-based pipeline until it can build all of stencil. As noted above, this PR starts with just the `cli/` module.

The esbuild-based pipeline is also set up to first call the existing rollup-based build. It then deletes the `cli/` module built by rollup and replaces it with its own output.

Esbuild has a few notable differences from rollup which are relevant here:

- It can directly bundle and transform TypeScript, so we can go from TypeScript to bundled JS in one step (rather than with our Rollup pipeline, where we run `tsc` and then run Rollup on the JS emitted by `tsc`). This decreases a bit of build complexity because for instance esbuild can read the `paths` configuration in `tsconfig.json`, so we no longer need something analogous to our [alias plugin](https://github.com/ionic-team/stencil/blob/b97dadc967b1fde892cb75a544b1eecd2361b194/scripts/bundles/plugins/alias-plugin.ts) which normally brings those aliases into the Rollup build.
- It's very fast! the `cli/` module builds in about 13ms.
- It also strips documentation comments from the code, I think because it does an AST based transform and discards comments as part of parsing (or doesn't make an effort to keep them around). This results in smaller bundle sizes. It does have support for retaining [certain specially-formatted comments](https://esbuild.github.io/api/#legal-comments) which is a good thing because we use a few magic comments for Vite support.
- OOB it supports pretty much all of what we're currently doing in our Rollup-based build pipeline, so we should be able to gradually port everything over.

Once this is merged we can start using esbuild for local development and also start to port over other modules. I have a working build already for the `compiler/` directory, getting that set up for local development will really speed things up!

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

no esbuild, rollup slow


## What is the new behavior?

yes esbuild, rollup still slow!

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

I've built and packed this and then run it in several little example projects and in Framework with no problems.
