### PR TITLE
refactor(compiler): remove unused parameter

### DIFF
--- a/src/compiler/transformers/component-native/native-component.ts
+++ b/src/compiler/transformers/component-native/native-component.ts
@@ -47,7 +47,7 @@ const updateNativeHostComponentMembers = (
 ) => {
   const classMembers = removeStaticMetaProperties(classNode);
 
-  updateNativeConstructor(classMembers, moduleFile, cmp, true);
+  updateNativeConstructor(classMembers, moduleFile, cmp);
   addNativeConnectedCallback(classMembers, cmp);
   addNativeElementGetter(classMembers, cmp);
   addWatchers(classMembers, cmp);

--- a/src/compiler/transformers/component-native/native-constructor.ts
+++ b/src/compiler/transformers/component-native/native-constructor.ts
@@ -12,13 +12,11 @@ import { retrieveTsModifiers } from '../transform-utils';
  * @param classMembers the class elements to modify
  * @param moduleFile the Stencil module representation of the component class
  * @param cmp the component metadata generated for the component
- * @param ensureSuper an unused argument, as its always true
  */
 export const updateNativeConstructor = (
   classMembers: ts.ClassElement[],
   moduleFile: d.Module,
-  cmp: d.ComponentCompilerMeta,
-  ensureSuper: boolean
+  cmp: d.ComponentCompilerMeta
 ): void => {
   if (cmp.isPlain) {
     return;
@@ -36,11 +34,9 @@ export const updateNativeConstructor = (
       ...addLegacyProps(moduleFile, cmp),
     ];
 
-    if (ensureSuper) {
-      const hasSuper = cstrMethod.body.statements.some((s) => s.kind === ts.SyntaxKind.SuperKeyword);
-      if (!hasSuper) {
-        statements = [createNativeConstructorSuper(), ...statements];
-      }
+    const hasSuper = cstrMethod.body.statements.some((s) => s.kind === ts.SyntaxKind.SuperKeyword);
+    if (!hasSuper) {
+      statements = [createNativeConstructorSuper(), ...statements];
     }
 
     classMembers[cstrMethodIndex] = ts.factory.updateConstructorDeclaration(
@@ -57,9 +53,7 @@ export const updateNativeConstructor = (
       ...addLegacyProps(moduleFile, cmp),
     ];
 
-    if (ensureSuper) {
-      statements = [createNativeConstructorSuper(), ...statements];
-    }
+    statements = [createNativeConstructorSuper(), ...statements];
 
     const cstrMethod = ts.factory.createConstructorDeclaration(undefined, [], ts.factory.createBlock(statements, true));
     classMembers.unshift(cstrMethod);

--- a/src/compiler/transformers/component-native/native-constructor.ts
+++ b/src/compiler/transformers/component-native/native-constructor.ts
@@ -7,8 +7,14 @@ import { addLegacyProps } from '../legacy-props';
 import { retrieveTsModifiers } from '../transform-utils';
 
 /**
- * Updates a constructor to include
- * Modifies a list of provided {@link ts.ClassElement}s in place
+ * Updates a constructor to include:
+ * - a `super()` call
+ * - function calls to initialize the component
+ * - function calls to create custom event emitters
+ * If a constructor does not exist, one will be created
+ *
+ * The constructor will be added to the provided list of {@link ts.ClassElement}s in place
+ *
  * @param classMembers the class elements to modify
  * @param moduleFile the Stencil module representation of the component class
  * @param cmp the component metadata generated for the component

--- a/src/compiler/transformers/component-native/native-constructor.ts
+++ b/src/compiler/transformers/component-native/native-constructor.ts
@@ -47,13 +47,12 @@ export const updateNativeConstructor = (
     );
   } else {
     // create a constructor()
-    let statements: ts.Statement[] = [
+    const statements: ts.Statement[] = [
+      createNativeConstructorSuper(),
       ...nativeInit(moduleFile, cmp),
       ...addCreateEvents(moduleFile, cmp),
       ...addLegacyProps(moduleFile, cmp),
     ];
-
-    statements = [createNativeConstructorSuper(), ...statements];
 
     const cstrMethod = ts.factory.createConstructorDeclaration(undefined, [], ts.factory.createBlock(statements, true));
     classMembers.unshift(cstrMethod);

--- a/src/compiler/transformers/component-native/native-constructor.ts
+++ b/src/compiler/transformers/component-native/native-constructor.ts
@@ -118,6 +118,6 @@ const nativeAttachShadowStatement = (moduleFile: d.Module): ts.ExpressionStateme
  */
 const createNativeConstructorSuper = (): ts.ExpressionStatement => {
   return ts.factory.createExpressionStatement(
-    ts.factory.createCallExpression(ts.factory.createIdentifier('super'), undefined, undefined)
+    ts.factory.createCallExpression(ts.factory.createSuper(), undefined, undefined)
   );
 };

--- a/src/compiler/transformers/component-native/native-constructor.ts
+++ b/src/compiler/transformers/component-native/native-constructor.ts
@@ -6,12 +6,20 @@ import { addCreateEvents } from '../create-event';
 import { addLegacyProps } from '../legacy-props';
 import { retrieveTsModifiers } from '../transform-utils';
 
+/**
+ * Updates a constructor to include
+ * Modifies a list of provided {@link ts.ClassElement}s in place
+ * @param classMembers the class elements to modify
+ * @param moduleFile the Stencil module representation of the component class
+ * @param cmp the component metadata generated for the component
+ * @param ensureSuper an unused argument, as its always true
+ */
 export const updateNativeConstructor = (
   classMembers: ts.ClassElement[],
   moduleFile: d.Module,
   cmp: d.ComponentCompilerMeta,
   ensureSuper: boolean
-) => {
+): void => {
   if (cmp.isPlain) {
     return;
   }
@@ -72,7 +80,13 @@ const nativeInit = (moduleFile: d.Module, cmp: d.ComponentCompilerMeta): Readonl
   return initStatements;
 };
 
-const nativeRegisterHostStatement = () => {
+/**
+ * Generate an expression statement to register a host element with its VDOM equivalent in a global element-to-vdom
+ * mapping.
+ * @returns the generated expression statement
+ */
+const nativeRegisterHostStatement = (): ts.ExpressionStatement => {
+  // Create an expression statement, `this.__registerHost();`
   return ts.factory.createExpressionStatement(
     ts.factory.createCallExpression(
       ts.factory.createPropertyAccessExpression(ts.factory.createThis(), ts.factory.createIdentifier('__registerHost')),
@@ -99,7 +113,11 @@ const nativeAttachShadowStatement = (moduleFile: d.Module): ts.ExpressionStateme
   );
 };
 
-const createNativeConstructorSuper = () => {
+/**
+ * Create an expression statement for calling `super()` for a class.
+ * @returns the generated expression statement
+ */
+const createNativeConstructorSuper = (): ts.ExpressionStatement => {
   return ts.factory.createExpressionStatement(
     ts.factory.createCallExpression(ts.factory.createIdentifier('super'), undefined, undefined)
   );

--- a/src/compiler/transformers/create-event.ts
+++ b/src/compiler/transformers/create-event.ts
@@ -6,7 +6,7 @@ import { addCoreRuntimeApi, CREATE_EVENT, RUNTIME_APIS } from './core-runtime-ap
 
 /**
  * For a Stencil component, generate the code to create custom emitted events, based on `@Event()` decorators
- * @param moduleFile the component class representation that code is being generated for
+ * @param moduleFile the 'home module' of the class for which code is being generated
  * @param cmp the component metadata associated with the provided module
  * @returns the generated event creation code
  */

--- a/src/compiler/transformers/create-event.ts
+++ b/src/compiler/transformers/create-event.ts
@@ -30,9 +30,13 @@ export const addCreateEvents = (moduleFile: d.Module, cmp: d.ComponentCompilerMe
 };
 
 /**
- * Generate a bit number encoded with event behavior information
+ * Generate a bit flag encoded with event behavior information.
+ *
+ * This function uses the provided event metadata to determine which flags are set. {@link EVENT_FLAGS} acts as the
+ * backing data structure that sets the actual bits on the returned value.
+ *
  * @param eventMeta the metadata associated with the event
- * @returns the encoded behaviors
+ * @returns the encoded event behaviors
  */
 const computeFlags = (eventMeta: d.ComponentCompilerEvent): number => {
   let flags = 0;

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -772,6 +772,13 @@ export interface ComponentCompilerFeatures {
   htmlTagNames: string[];
   htmlParts: string[];
   isUpdateable: boolean;
+  /**
+   * A plain component is one that doesn't have:
+   * - any members decorated with `@Prop()`, `@State()`, `@Element()`, `@Method()`
+   * - any methods decorated with `@Listen()`
+   * - any styles
+   * - any lifecycle methods, including `render()`
+   */
   isPlain: boolean;
   potentialCmpRefs: string[];
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`native-constructor.ts#updateNativeConstructor` is always called with its fourth formal argument
set to `true`. I came across this while working on the sourcemap race condition (STENCIL-301).
separating refactoring that out into a separate commit

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit removes an unsed parameter from `updateNativeConstructor` in
`native-constructor.ts`. the function was always called with a value of
`true` for the `hasSuper` argument. with this commit, we remove it and
the related conditionals (as the conditional always evaluated to `true`.
the bodies of the conditionals have been inlined with the rest of the
code

this commit also adds jsdoc to relevant parts of the codebase. readers should
be able to start with `updateNativeConstructor` and read all called function's
jsdoc to get a sense of what they do. however, `addLegacyProps` was not documented,
as said props are no longer support in stencil.

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
