### PR TITLE
refactor(compiler): remove redundant function call

### DIFF
--- a/src/compiler/transformers/add-component-meta-proxy.ts
+++ b/src/compiler/transformers/add-component-meta-proxy.ts
@@ -10,13 +10,9 @@ export const addModuleMetadataProxies = (tsSourceFile: ts.SourceFile, moduleFile
 
   addCoreRuntimeApi(moduleFile, RUNTIME_APIS.proxyCustomElement);
 
-  statements.push(...moduleFile.cmps.map(addComponentMetadataProxy));
+  statements.push(...moduleFile.cmps.map(createComponentMetadataProxy));
 
   return ts.factory.updateSourceFile(tsSourceFile, statements);
-};
-
-const addComponentMetadataProxy = (compilerMeta: d.ComponentCompilerMeta) => {
-  return ts.factory.createExpressionStatement(createComponentMetadataProxy(compilerMeta));
 };
 
 /**
@@ -26,23 +22,25 @@ const addComponentMetadataProxy = (compilerMeta: d.ComponentCompilerMeta) => {
  * ```
  * where
  * - `PROXY_CUSTOM_ELEMENT` is a Stencil internal identifier that will be replaced with the name of the actual function
- * name at compile name
+ * name at compile time
  * - `ComponentClassName` is the name Stencil component's class
  * - `Metadata` is the compiler metadata associated with the Stencil component
  *
  * @param compilerMeta compiler metadata associated with the component to be wrapped in a proxy
  * @returns the generated call expression
  */
-export const createComponentMetadataProxy = (compilerMeta: d.ComponentCompilerMeta): ts.CallExpression => {
+const createComponentMetadataProxy = (compilerMeta: d.ComponentCompilerMeta): ts.ExpressionStatement => {
   const compactMeta: d.ComponentRuntimeMetaCompact = formatComponentRuntimeMeta(compilerMeta, true);
 
   const literalCmpClassName = ts.factory.createIdentifier(compilerMeta.componentClassName);
   const literalMeta = convertValueToLiteral(compactMeta);
 
-  return ts.factory.createCallExpression(
-    ts.factory.createIdentifier(PROXY_CUSTOM_ELEMENT),
-    [],
-    [literalCmpClassName, literalMeta]
+  return ts.factory.createExpressionStatement(
+    ts.factory.createCallExpression(
+      ts.factory.createIdentifier(PROXY_CUSTOM_ELEMENT),
+      [],
+      [literalCmpClassName, literalMeta]
+    )
   );
 };
 
@@ -56,7 +54,7 @@ export const createComponentMetadataProxy = (compilerMeta: d.ComponentCompilerMe
  *
  * where
  * - `PROXY_CUSTOM_ELEMENT` is a Stencil internal identifier that will be
- *   replaced with the name of the actual function name at compile name
+ *   replaced with the name of the actual function name at compile time
  * - `Clazz` is a class expression to be proxied
  * - `Metadata` is the compiler metadata associated with the Stencil component
  *


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [x] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit combines two pre-existing functions,
`addComponentMetadataProxy` and `createComponentMetadataProxy`. the former is removed, and the creation of an expr statement is moved into the latter.

`createComponentMetadataProxy` is no longer needlessly exported, as it is currently not part of the stencil public api, nor is it directly under test

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Unit tests continue to pass
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

This work was originally a part of https://github.com/ionic-team/stencil/pull/4200, as I had been considering a fix that changed some of the code in _this_ pull request. I decided to go another route, and felt these changes didn't necessarily belong in #4200
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
