### PR TITLE
chore(compiler): add debug statements for file watching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1270,9 +1270,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.3.1.tgz",
-      "integrity": "sha512-WTFVqWY7ipI+CsJRb6vEddYJ/lMl2bHYP5BjFDBM9JMKPjJNT4psXz6DLuJpi3EkG80Q0ef5Azzv3gKu9MvMUg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.3.2.tgz",
+      "integrity": "sha512-YAwrqy68PskkCDnSsv0afR8l8u90KhodcIFXCage5NLAoeWm0STGmtVugLBp2wc5PnhnCapCKkMjp9fYjvJl2g==",
       "dev": true,
       "dependencies": {
         "debug": "4.3.4",
@@ -8849,24 +8849,24 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "19.8.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.8.2.tgz",
-      "integrity": "sha512-LPdNVYMR6ddp4YS3GK1bqKsasCJj1aZjt9dNOKcnzKezuMoishlHY6bCnFLjTc34iqnGzIrJp07TQ9M+aML2+g==",
+      "version": "19.8.3",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.8.3.tgz",
+      "integrity": "sha512-sKtt3aDRAcWuemeEtRaJqWKRlQ72OyKVcxX3Ur3KyFUEEzb2sEHpFc2mBlTMPmzOiNg5dB4dnxfelV9/xypJrA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "0.3.1",
+        "@puppeteer/browsers": "0.3.2",
         "cosmiconfig": "8.1.3",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.8.1"
+        "puppeteer-core": "19.8.3"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.8.1.tgz",
-      "integrity": "sha512-7yPMzusYRvJ/laLaMFIQ01E9WakKkJJXLsMAymH6y5EKqYe5hhn68/SbvF+1YJMb843GftU7gT86Fw8y5jkn3w==",
+      "version": "19.8.3",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.8.3.tgz",
+      "integrity": "sha512-+gPT43K3trUIr+7+tNjCg95vMgM9RkFIeeyck3SXUTBpGkrf6sxfWckncqY8MnzHfRcyapvztKNmqvJ+Ngukyg==",
       "dev": true,
       "dependencies": {
         "chromium-bidi": "0.4.6",
@@ -11756,9 +11756,9 @@
       }
     },
     "@puppeteer/browsers": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.3.1.tgz",
-      "integrity": "sha512-WTFVqWY7ipI+CsJRb6vEddYJ/lMl2bHYP5BjFDBM9JMKPjJNT4psXz6DLuJpi3EkG80Q0ef5Azzv3gKu9MvMUg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.3.2.tgz",
+      "integrity": "sha512-YAwrqy68PskkCDnSsv0afR8l8u90KhodcIFXCage5NLAoeWm0STGmtVugLBp2wc5PnhnCapCKkMjp9fYjvJl2g==",
       "dev": true,
       "requires": {
         "debug": "4.3.4",
@@ -17470,23 +17470,23 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "19.8.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.8.2.tgz",
-      "integrity": "sha512-LPdNVYMR6ddp4YS3GK1bqKsasCJj1aZjt9dNOKcnzKezuMoishlHY6bCnFLjTc34iqnGzIrJp07TQ9M+aML2+g==",
+      "version": "19.8.3",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.8.3.tgz",
+      "integrity": "sha512-sKtt3aDRAcWuemeEtRaJqWKRlQ72OyKVcxX3Ur3KyFUEEzb2sEHpFc2mBlTMPmzOiNg5dB4dnxfelV9/xypJrA==",
       "dev": true,
       "requires": {
-        "@puppeteer/browsers": "0.3.1",
+        "@puppeteer/browsers": "0.3.2",
         "cosmiconfig": "8.1.3",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.8.1"
+        "puppeteer-core": "19.8.3"
       }
     },
     "puppeteer-core": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.8.1.tgz",
-      "integrity": "sha512-7yPMzusYRvJ/laLaMFIQ01E9WakKkJJXLsMAymH6y5EKqYe5hhn68/SbvF+1YJMb843GftU7gT86Fw8y5jkn3w==",
+      "version": "19.8.3",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.8.3.tgz",
+      "integrity": "sha512-+gPT43K3trUIr+7+tNjCg95vMgM9RkFIeeyck3SXUTBpGkrf6sxfWckncqY8MnzHfRcyapvztKNmqvJ+Ngukyg==",
       "dev": true,
       "requires": {
         "chromium-bidi": "0.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1936,15 +1936,15 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.0.tgz",
-      "integrity": "sha512-itag0qpN6q2UMM6Xgk6xoHa0D0/P+M17THnr4SVgqn9Rgam5k/He33MA7/D7QoJcdMxHFyX7U9imaBonAX/6qA==",
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.1.tgz",
+      "integrity": "sha512-1MeobQkQ9tztuleT3v72XmY0XuKXVXusAhryoLuU5YZ+mXoYKZP9SQ7Flulh1NX4DTjpGTc2b/eMu4u7M7dhnQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.57.0",
-        "@typescript-eslint/type-utils": "5.57.0",
-        "@typescript-eslint/utils": "5.57.0",
+        "@typescript-eslint/scope-manager": "5.57.1",
+        "@typescript-eslint/type-utils": "5.57.1",
+        "@typescript-eslint/utils": "5.57.1",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
@@ -1967,6 +1967,53 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.1.tgz",
+      "integrity": "sha512-N/RrBwEUKMIYxSKl0oDK5sFVHd6VI7p9K5MyUlVYAY6dyNb/wHUqndkTd3XhpGlXgnQsBkRZuu4f9kAHghvgPw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.57.1",
+        "@typescript-eslint/visitor-keys": "5.57.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.1.tgz",
+      "integrity": "sha512-bSs4LOgyV3bJ08F5RDqO2KXqg3WAdwHCu06zOqcQ6vqbTJizyBhuh1o1ImC69X4bV2g1OJxbH71PJqiO7Y1RuA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.1.tgz",
+      "integrity": "sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.57.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -2014,13 +2061,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.57.0.tgz",
-      "integrity": "sha512-kxXoq9zOTbvqzLbdNKy1yFrxLC6GDJFE2Yuo3KqSwTmDOFjUGeWSakgoXT864WcK5/NAJkkONCiKb1ddsqhLXQ==",
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.57.1.tgz",
+      "integrity": "sha512-/RIPQyx60Pt6ga86hKXesXkJ2WOS4UemFrmmq/7eOyiYjYv/MUSHPlkhU6k9T9W1ytnTJueqASW+wOmW4KrViw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.57.0",
-        "@typescript-eslint/utils": "5.57.0",
+        "@typescript-eslint/typescript-estree": "5.57.1",
+        "@typescript-eslint/utils": "5.57.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -2038,6 +2085,63 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.1.tgz",
+      "integrity": "sha512-bSs4LOgyV3bJ08F5RDqO2KXqg3WAdwHCu06zOqcQ6vqbTJizyBhuh1o1ImC69X4bV2g1OJxbH71PJqiO7Y1RuA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.1.tgz",
+      "integrity": "sha512-A2MZqD8gNT0qHKbk2wRspg7cHbCDCk2tcqt6ScCFLr5Ru8cn+TCfM786DjPhqwseiS+PrYwcXht5ztpEQ6TFTw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.57.1",
+        "@typescript-eslint/visitor-keys": "5.57.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.1.tgz",
+      "integrity": "sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.57.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/types": {
@@ -2081,17 +2185,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.57.0.tgz",
-      "integrity": "sha512-ps/4WohXV7C+LTSgAL5CApxvxbMkl9B9AUZRtnEFonpIxZDIT7wC1xfvuJONMidrkB9scs4zhtRyIwHh4+18kw==",
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.57.1.tgz",
+      "integrity": "sha512-kN6vzzf9NkEtawECqze6v99LtmDiUJCVpvieTFA1uL7/jDghiJGubGZ5csicYHU1Xoqb3oH/R5cN5df6W41Nfg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.57.0",
-        "@typescript-eslint/types": "5.57.0",
-        "@typescript-eslint/typescript-estree": "5.57.0",
+        "@typescript-eslint/scope-manager": "5.57.1",
+        "@typescript-eslint/types": "5.57.1",
+        "@typescript-eslint/typescript-estree": "5.57.1",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       },
@@ -2104,6 +2208,80 @@
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.1.tgz",
+      "integrity": "sha512-N/RrBwEUKMIYxSKl0oDK5sFVHd6VI7p9K5MyUlVYAY6dyNb/wHUqndkTd3XhpGlXgnQsBkRZuu4f9kAHghvgPw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.57.1",
+        "@typescript-eslint/visitor-keys": "5.57.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.1.tgz",
+      "integrity": "sha512-bSs4LOgyV3bJ08F5RDqO2KXqg3WAdwHCu06zOqcQ6vqbTJizyBhuh1o1ImC69X4bV2g1OJxbH71PJqiO7Y1RuA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.1.tgz",
+      "integrity": "sha512-A2MZqD8gNT0qHKbk2wRspg7cHbCDCk2tcqt6ScCFLr5Ru8cn+TCfM786DjPhqwseiS+PrYwcXht5ztpEQ6TFTw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.57.1",
+        "@typescript-eslint/visitor-keys": "5.57.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.1.tgz",
+      "integrity": "sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.57.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -12325,21 +12503,49 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.0.tgz",
-      "integrity": "sha512-itag0qpN6q2UMM6Xgk6xoHa0D0/P+M17THnr4SVgqn9Rgam5k/He33MA7/D7QoJcdMxHFyX7U9imaBonAX/6qA==",
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.1.tgz",
+      "integrity": "sha512-1MeobQkQ9tztuleT3v72XmY0XuKXVXusAhryoLuU5YZ+mXoYKZP9SQ7Flulh1NX4DTjpGTc2b/eMu4u7M7dhnQ==",
       "dev": true,
       "requires": {
         "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.57.0",
-        "@typescript-eslint/type-utils": "5.57.0",
-        "@typescript-eslint/utils": "5.57.0",
+        "@typescript-eslint/scope-manager": "5.57.1",
+        "@typescript-eslint/type-utils": "5.57.1",
+        "@typescript-eslint/utils": "5.57.1",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.57.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.1.tgz",
+          "integrity": "sha512-N/RrBwEUKMIYxSKl0oDK5sFVHd6VI7p9K5MyUlVYAY6dyNb/wHUqndkTd3XhpGlXgnQsBkRZuu4f9kAHghvgPw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.57.1",
+            "@typescript-eslint/visitor-keys": "5.57.1"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.57.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.1.tgz",
+          "integrity": "sha512-bSs4LOgyV3bJ08F5RDqO2KXqg3WAdwHCu06zOqcQ6vqbTJizyBhuh1o1ImC69X4bV2g1OJxbH71PJqiO7Y1RuA==",
+          "dev": true
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.57.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.1.tgz",
+          "integrity": "sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.57.1",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        }
       }
     },
     "@typescript-eslint/parser": {
@@ -12365,15 +12571,48 @@
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.57.0.tgz",
-      "integrity": "sha512-kxXoq9zOTbvqzLbdNKy1yFrxLC6GDJFE2Yuo3KqSwTmDOFjUGeWSakgoXT864WcK5/NAJkkONCiKb1ddsqhLXQ==",
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.57.1.tgz",
+      "integrity": "sha512-/RIPQyx60Pt6ga86hKXesXkJ2WOS4UemFrmmq/7eOyiYjYv/MUSHPlkhU6k9T9W1ytnTJueqASW+wOmW4KrViw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.57.0",
-        "@typescript-eslint/utils": "5.57.0",
+        "@typescript-eslint/typescript-estree": "5.57.1",
+        "@typescript-eslint/utils": "5.57.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/types": {
+          "version": "5.57.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.1.tgz",
+          "integrity": "sha512-bSs4LOgyV3bJ08F5RDqO2KXqg3WAdwHCu06zOqcQ6vqbTJizyBhuh1o1ImC69X4bV2g1OJxbH71PJqiO7Y1RuA==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.57.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.1.tgz",
+          "integrity": "sha512-A2MZqD8gNT0qHKbk2wRspg7cHbCDCk2tcqt6ScCFLr5Ru8cn+TCfM786DjPhqwseiS+PrYwcXht5ztpEQ6TFTw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.57.1",
+            "@typescript-eslint/visitor-keys": "5.57.1",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.57.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.1.tgz",
+          "integrity": "sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.57.1",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        }
       }
     },
     "@typescript-eslint/types": {
@@ -12398,19 +12637,62 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.57.0.tgz",
-      "integrity": "sha512-ps/4WohXV7C+LTSgAL5CApxvxbMkl9B9AUZRtnEFonpIxZDIT7wC1xfvuJONMidrkB9scs4zhtRyIwHh4+18kw==",
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.57.1.tgz",
+      "integrity": "sha512-kN6vzzf9NkEtawECqze6v99LtmDiUJCVpvieTFA1uL7/jDghiJGubGZ5csicYHU1Xoqb3oH/R5cN5df6W41Nfg==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.57.0",
-        "@typescript-eslint/types": "5.57.0",
-        "@typescript-eslint/typescript-estree": "5.57.0",
+        "@typescript-eslint/scope-manager": "5.57.1",
+        "@typescript-eslint/types": "5.57.1",
+        "@typescript-eslint/typescript-estree": "5.57.1",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.57.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.1.tgz",
+          "integrity": "sha512-N/RrBwEUKMIYxSKl0oDK5sFVHd6VI7p9K5MyUlVYAY6dyNb/wHUqndkTd3XhpGlXgnQsBkRZuu4f9kAHghvgPw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.57.1",
+            "@typescript-eslint/visitor-keys": "5.57.1"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.57.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.1.tgz",
+          "integrity": "sha512-bSs4LOgyV3bJ08F5RDqO2KXqg3WAdwHCu06zOqcQ6vqbTJizyBhuh1o1ImC69X4bV2g1OJxbH71PJqiO7Y1RuA==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.57.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.1.tgz",
+          "integrity": "sha512-A2MZqD8gNT0qHKbk2wRspg7cHbCDCk2tcqt6ScCFLr5Ru8cn+TCfM786DjPhqwseiS+PrYwcXht5ztpEQ6TFTw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.57.1",
+            "@typescript-eslint/visitor-keys": "5.57.1",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.57.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.1.tgz",
+          "integrity": "sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.57.1",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        }
       }
     },
     "@typescript-eslint/visitor-keys": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1969,62 +1969,15 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.1.tgz",
-      "integrity": "sha512-N/RrBwEUKMIYxSKl0oDK5sFVHd6VI7p9K5MyUlVYAY6dyNb/wHUqndkTd3XhpGlXgnQsBkRZuu4f9kAHghvgPw==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.57.1",
-        "@typescript-eslint/visitor-keys": "5.57.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
-      "version": "5.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.1.tgz",
-      "integrity": "sha512-bSs4LOgyV3bJ08F5RDqO2KXqg3WAdwHCu06zOqcQ6vqbTJizyBhuh1o1ImC69X4bV2g1OJxbH71PJqiO7Y1RuA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.1.tgz",
-      "integrity": "sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.57.1",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.0.tgz",
-      "integrity": "sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==",
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.1.tgz",
+      "integrity": "sha512-hlA0BLeVSA/wBPKdPGxoVr9Pp6GutGoY380FEhbVi0Ph4WNe8kLvqIRx76RSQt1lynZKfrXKs0/XeEk4zZycuA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.57.0",
-        "@typescript-eslint/types": "5.57.0",
-        "@typescript-eslint/typescript-estree": "5.57.0",
+        "@typescript-eslint/scope-manager": "5.57.1",
+        "@typescript-eslint/types": "5.57.1",
+        "@typescript-eslint/typescript-estree": "5.57.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2044,13 +1997,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.0.tgz",
-      "integrity": "sha512-NANBNOQvllPlizl9LatX8+MHi7bx7WGIWYjPHDmQe5Si/0YEYfxSljJpoTyTWFTgRy3X8gLYSE4xQ2U+aCozSw==",
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.1.tgz",
+      "integrity": "sha512-N/RrBwEUKMIYxSKl0oDK5sFVHd6VI7p9K5MyUlVYAY6dyNb/wHUqndkTd3XhpGlXgnQsBkRZuu4f9kAHghvgPw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.57.0",
-        "@typescript-eslint/visitor-keys": "5.57.0"
+        "@typescript-eslint/types": "5.57.1",
+        "@typescript-eslint/visitor-keys": "5.57.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2087,7 +2040,7 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+    "node_modules/@typescript-eslint/types": {
       "version": "5.57.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.1.tgz",
       "integrity": "sha512-bSs4LOgyV3bJ08F5RDqO2KXqg3WAdwHCu06zOqcQ6vqbTJizyBhuh1o1ImC69X4bV2g1OJxbH71PJqiO7Y1RuA==",
@@ -2100,7 +2053,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+    "node_modules/@typescript-eslint/typescript-estree": {
       "version": "5.57.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.1.tgz",
       "integrity": "sha512-A2MZqD8gNT0qHKbk2wRspg7cHbCDCk2tcqt6ScCFLr5Ru8cn+TCfM786DjPhqwseiS+PrYwcXht5ztpEQ6TFTw==",
@@ -2108,63 +2061,6 @@
       "dependencies": {
         "@typescript-eslint/types": "5.57.1",
         "@typescript-eslint/visitor-keys": "5.57.1",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.1.tgz",
-      "integrity": "sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.57.1",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.0.tgz",
-      "integrity": "sha512-mxsod+aZRSyLT+jiqHw1KK6xrANm19/+VFALVFP5qa/aiJnlP38qpyaTd0fEKhWvQk6YeNZ5LGwI1pDpBRBhtQ==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.0.tgz",
-      "integrity": "sha512-LTzQ23TV82KpO8HPnWuxM2V7ieXW8O142I7hQTxWIHDcCEIjtkat6H96PFkYBQqGFLW/G/eVVOB9Z8rcvdY/Vw==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.57.0",
-        "@typescript-eslint/visitor-keys": "5.57.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2210,87 +2106,13 @@
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.1.tgz",
-      "integrity": "sha512-N/RrBwEUKMIYxSKl0oDK5sFVHd6VI7p9K5MyUlVYAY6dyNb/wHUqndkTd3XhpGlXgnQsBkRZuu4f9kAHghvgPw==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.57.1",
-        "@typescript-eslint/visitor-keys": "5.57.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-      "version": "5.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.1.tgz",
-      "integrity": "sha512-bSs4LOgyV3bJ08F5RDqO2KXqg3WAdwHCu06zOqcQ6vqbTJizyBhuh1o1ImC69X4bV2g1OJxbH71PJqiO7Y1RuA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.1.tgz",
-      "integrity": "sha512-A2MZqD8gNT0qHKbk2wRspg7cHbCDCk2tcqt6ScCFLr5Ru8cn+TCfM786DjPhqwseiS+PrYwcXht5ztpEQ6TFTw==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.57.1",
-        "@typescript-eslint/visitor-keys": "5.57.1",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+    "node_modules/@typescript-eslint/visitor-keys": {
       "version": "5.57.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.1.tgz",
       "integrity": "sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "5.57.1",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.0.tgz",
-      "integrity": "sha512-ery2g3k0hv5BLiKpPuwYt9KBkAp2ugT6VvyShXdLOkax895EC55sP0Tx5L0fZaQueiK3fBLvHVvEl3jFS5ia+g==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.57.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -12518,56 +12340,28 @@
         "natural-compare-lite": "^1.4.0",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/scope-manager": {
-          "version": "5.57.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.1.tgz",
-          "integrity": "sha512-N/RrBwEUKMIYxSKl0oDK5sFVHd6VI7p9K5MyUlVYAY6dyNb/wHUqndkTd3XhpGlXgnQsBkRZuu4f9kAHghvgPw==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.57.1",
-            "@typescript-eslint/visitor-keys": "5.57.1"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "5.57.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.1.tgz",
-          "integrity": "sha512-bSs4LOgyV3bJ08F5RDqO2KXqg3WAdwHCu06zOqcQ6vqbTJizyBhuh1o1ImC69X4bV2g1OJxbH71PJqiO7Y1RuA==",
-          "dev": true
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.57.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.1.tgz",
-          "integrity": "sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.57.1",
-            "eslint-visitor-keys": "^3.3.0"
-          }
-        }
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.0.tgz",
-      "integrity": "sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==",
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.1.tgz",
+      "integrity": "sha512-hlA0BLeVSA/wBPKdPGxoVr9Pp6GutGoY380FEhbVi0Ph4WNe8kLvqIRx76RSQt1lynZKfrXKs0/XeEk4zZycuA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.57.0",
-        "@typescript-eslint/types": "5.57.0",
-        "@typescript-eslint/typescript-estree": "5.57.0",
+        "@typescript-eslint/scope-manager": "5.57.1",
+        "@typescript-eslint/types": "5.57.1",
+        "@typescript-eslint/typescript-estree": "5.57.1",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.0.tgz",
-      "integrity": "sha512-NANBNOQvllPlizl9LatX8+MHi7bx7WGIWYjPHDmQe5Si/0YEYfxSljJpoTyTWFTgRy3X8gLYSE4xQ2U+aCozSw==",
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.1.tgz",
+      "integrity": "sha512-N/RrBwEUKMIYxSKl0oDK5sFVHd6VI7p9K5MyUlVYAY6dyNb/wHUqndkTd3XhpGlXgnQsBkRZuu4f9kAHghvgPw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.57.0",
-        "@typescript-eslint/visitor-keys": "5.57.0"
+        "@typescript-eslint/types": "5.57.1",
+        "@typescript-eslint/visitor-keys": "5.57.1"
       }
     },
     "@typescript-eslint/type-utils": {
@@ -12580,55 +12374,22 @@
         "@typescript-eslint/utils": "5.57.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/types": {
-          "version": "5.57.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.1.tgz",
-          "integrity": "sha512-bSs4LOgyV3bJ08F5RDqO2KXqg3WAdwHCu06zOqcQ6vqbTJizyBhuh1o1ImC69X4bV2g1OJxbH71PJqiO7Y1RuA==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.57.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.1.tgz",
-          "integrity": "sha512-A2MZqD8gNT0qHKbk2wRspg7cHbCDCk2tcqt6ScCFLr5Ru8cn+TCfM786DjPhqwseiS+PrYwcXht5ztpEQ6TFTw==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.57.1",
-            "@typescript-eslint/visitor-keys": "5.57.1",
-            "debug": "^4.3.4",
-            "globby": "^11.1.0",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.7",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.57.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.1.tgz",
-          "integrity": "sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.57.1",
-            "eslint-visitor-keys": "^3.3.0"
-          }
-        }
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.0.tgz",
-      "integrity": "sha512-mxsod+aZRSyLT+jiqHw1KK6xrANm19/+VFALVFP5qa/aiJnlP38qpyaTd0fEKhWvQk6YeNZ5LGwI1pDpBRBhtQ==",
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.1.tgz",
+      "integrity": "sha512-bSs4LOgyV3bJ08F5RDqO2KXqg3WAdwHCu06zOqcQ6vqbTJizyBhuh1o1ImC69X4bV2g1OJxbH71PJqiO7Y1RuA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.0.tgz",
-      "integrity": "sha512-LTzQ23TV82KpO8HPnWuxM2V7ieXW8O142I7hQTxWIHDcCEIjtkat6H96PFkYBQqGFLW/G/eVVOB9Z8rcvdY/Vw==",
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.1.tgz",
+      "integrity": "sha512-A2MZqD8gNT0qHKbk2wRspg7cHbCDCk2tcqt6ScCFLr5Ru8cn+TCfM786DjPhqwseiS+PrYwcXht5ztpEQ6TFTw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.57.0",
-        "@typescript-eslint/visitor-keys": "5.57.0",
+        "@typescript-eslint/types": "5.57.1",
+        "@typescript-eslint/visitor-keys": "5.57.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -12650,58 +12411,15 @@
         "@typescript-eslint/typescript-estree": "5.57.1",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
-      },
-      "dependencies": {
-        "@typescript-eslint/scope-manager": {
-          "version": "5.57.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.1.tgz",
-          "integrity": "sha512-N/RrBwEUKMIYxSKl0oDK5sFVHd6VI7p9K5MyUlVYAY6dyNb/wHUqndkTd3XhpGlXgnQsBkRZuu4f9kAHghvgPw==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.57.1",
-            "@typescript-eslint/visitor-keys": "5.57.1"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "5.57.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.1.tgz",
-          "integrity": "sha512-bSs4LOgyV3bJ08F5RDqO2KXqg3WAdwHCu06zOqcQ6vqbTJizyBhuh1o1ImC69X4bV2g1OJxbH71PJqiO7Y1RuA==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.57.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.1.tgz",
-          "integrity": "sha512-A2MZqD8gNT0qHKbk2wRspg7cHbCDCk2tcqt6ScCFLr5Ru8cn+TCfM786DjPhqwseiS+PrYwcXht5ztpEQ6TFTw==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.57.1",
-            "@typescript-eslint/visitor-keys": "5.57.1",
-            "debug": "^4.3.4",
-            "globby": "^11.1.0",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.7",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.57.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.1.tgz",
-          "integrity": "sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.57.1",
-            "eslint-visitor-keys": "^3.3.0"
-          }
-        }
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.0.tgz",
-      "integrity": "sha512-ery2g3k0hv5BLiKpPuwYt9KBkAp2ugT6VvyShXdLOkax895EC55sP0Tx5L0fZaQueiK3fBLvHVvEl3jFS5ia+g==",
+      "version": "5.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.1.tgz",
+      "integrity": "sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/types": "5.57.1",
         "eslint-visitor-keys": "^3.3.0"
       }
     },

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -40,7 +40,7 @@ export const startupLogVersion = (logger: Logger, task: TaskCommand, coreCompile
   let startupMsg: string;
 
   if (isDevBuild) {
-    startupMsg = logger.yellow('[LOCAL DEV]');
+    startupMsg = logger.yellow(`[LOCAL DEV] v${coreCompiler.version}`);
   } else {
     startupMsg = logger.cyan(`v${coreCompiler.version}`);
   }

--- a/src/compiler/build/compiler-ctx.ts
+++ b/src/compiler/build/compiler-ctx.ts
@@ -79,6 +79,7 @@ export const getModuleLegacy = (_config: d.Config, compilerCtx: d.CompilerCtx, s
       jsFilePath: jsFilePath,
       cmps: [],
       coreRuntimeApis: [],
+      outputTargetCoreRuntimeApis: {},
       collectionName: null,
       dtsFilePath: null,
       excludeFromCollection: false,

--- a/src/compiler/build/watch-build.ts
+++ b/src/compiler/build/watch-build.ts
@@ -53,6 +53,19 @@ export const createWatchBuild = async (
     buildCtx.hasHtmlChanges = hasHtmlChanges(config, buildCtx);
     buildCtx.hasServiceWorkerChanges = hasServiceWorkerChanges(config, buildCtx);
 
+    if (config.flags.debug) {
+      config.logger.debug(`WATCH_BUILD::watchBuild::onBuild filesAdded: ${formatFilesForDebug(buildCtx.filesAdded)}`);
+      config.logger.debug(
+        `WATCH_BUILD::watchBuild::onBuild filesDeleted: ${formatFilesForDebug(buildCtx.filesDeleted)}`
+      );
+      config.logger.debug(
+        `WATCH_BUILD::watchBuild::onBuild filesUpdated: ${formatFilesForDebug(buildCtx.filesUpdated)}`
+      );
+      config.logger.debug(
+        `WATCH_BUILD::watchBuild::onBuild filesWritten: ${formatFilesForDebug(buildCtx.filesWritten)}`
+      );
+    }
+
     dirsAdded.clear();
     dirsDeleted.clear();
     filesAdded.clear();
@@ -68,6 +81,22 @@ export const createWatchBuild = async (
     if (result && !result.hasError) {
       isRebuild = true;
     }
+  };
+
+  /**
+   * Utility method for formatting a debug message that must either list a number of files, or the word 'none' if the
+   * provided list is empty
+   * @param files a list of files, the list may be empty
+   * @returns the provided list if it is not empty. otherwise, return the word 'none'
+   */
+  const formatFilesForDebug = (files: ReadonlyArray<string>): string => {
+    /**
+     * In the created message, it's important that there's no whitespace prior to the file name.
+     * Stencil's logger will split messages by whitespace according to the width of the terminal window.
+     * Since file names can be fully qualified paths (and therefore quite long), putting whitespace between a '-' and
+     * the path can lead to formatted messages where the '-' is on its own line
+     */
+    return files.length > 0 ? files.map((filename: string) => `-${filename}`).join('\n') : 'none';
   };
 
   const start = async () => {
@@ -104,7 +133,7 @@ export const createWatchBuild = async (
           break;
       }
 
-      config.logger.debug(`onFsChange ${eventKind}: ${p}`);
+      config.logger.debug(`WATCH_BUILD::fs_event_change - type=${eventKind}, path=${p}, time=${new Date().getTime()}`);
       tsWatchProgram.rebuild();
     }
   };

--- a/src/compiler/output-targets/dist-custom-elements/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements/index.ts
@@ -48,7 +48,7 @@ export const outputCustomElements = async (
     return;
   }
 
-  const bundlingEventMessage = 'generate custom elements';
+  const bundlingEventMessage = `generate custom elements${config.sourceMap ? ' + source maps' : ''}`;
   const timespan = buildCtx.createTimeSpan(`${bundlingEventMessage} started`);
 
   await Promise.all(outputTargets.map((target) => bundleCustomElements(config, compilerCtx, buildCtx, target)));

--- a/src/compiler/output-targets/output-utils.ts
+++ b/src/compiler/output-targets/output-utils.ts
@@ -61,7 +61,12 @@ export const isOutputTargetStats = (o: d.OutputTarget): o is d.OutputTargetStats
 
 export const isOutputTargetDistTypes = (o: d.OutputTarget): o is d.OutputTargetDistTypes => o.type === DIST_TYPES;
 
-export const getComponentsFromModules = (moduleFiles: d.Module[]) =>
+/**
+ * Retrieve the Stencil component compiler metadata from a collection of Stencil {@link Module}s
+ * @param moduleFiles the collection of `Module`s to retrieve the metadata from
+ * @returns the metadata, lexicographically sorted by the tag names of the components
+ */
+export const getComponentsFromModules = (moduleFiles: d.Module[]): d.ComponentCompilerMeta[] =>
   sortBy(flatOne(moduleFiles.map((m) => m.cmps)), (c: d.ComponentCompilerMeta) => c.tagName);
 
 export const COPY = 'copy';

--- a/src/compiler/transformers/add-imports.ts
+++ b/src/compiler/transformers/add-imports.ts
@@ -3,12 +3,28 @@ import ts from 'typescript';
 import type * as d from '../../declarations';
 import { createImportStatement, createRequireStatement } from './transform-utils';
 
+/**
+ * Create a new import statement, and update the provided source file with the newly created statement.
+ *
+ * The generated import statement will be placed at the beginning of the source file.
+ *
+ * The generated import statement will be either a commonjs require statement or esm import statement, based on the
+ * provided transform options.
+ *
+ * The import statement may include more than one named imports (identifiers) for the provided import path.
+ *
+ * @param transformOpts transform options configured for the current output target transpilation
+ * @param tsSourceFile the TypeScript source file that is being updated
+ * @param importFnNames a collection of named imports to add to the generated import statement
+ * @param importPath the path to the module that the collection of named imports should be imported from
+ * @returns the updated TypeScript source file
+ */
 export const addImports = (
   transformOpts: d.TransformOptions,
   tsSourceFile: ts.SourceFile,
   importFnNames: string[],
   importPath: string
-) => {
+): ts.SourceFile => {
   if (importFnNames.length === 0) {
     return tsSourceFile;
   }

--- a/src/compiler/transformers/component-native/native-component.ts
+++ b/src/compiler/transformers/component-native/native-component.ts
@@ -17,18 +17,29 @@ export const updateNativeComponentClass = (
   classNode: ts.ClassDeclaration,
   moduleFile: d.Module,
   cmp: d.ComponentCompilerMeta
-) => {
+): ts.ClassDeclaration | ts.VariableStatement => {
   const heritageClauses = updateNativeHostComponentHeritageClauses(classNode, moduleFile);
   const members = updateNativeHostComponentMembers(transformOpts, classNode, moduleFile, cmp);
   return updateComponentClass(transformOpts, classNode, heritageClauses, members);
 };
 
-const updateNativeHostComponentHeritageClauses = (classNode: ts.ClassDeclaration, moduleFile: d.Module) => {
+/**
+ * Generate a heritage clause (e.g. `extends [IDENTIFIER]`) for a Stencil component to extend `HTMLElement`
+ * @param classNode the syntax tree of the Stencil component class to update
+ * @param moduleFile the Stencil Module associated with the provided class node
+ * @returns the generated heritage clause
+ */
+const updateNativeHostComponentHeritageClauses = (
+  classNode: ts.ClassDeclaration,
+  moduleFile: d.Module
+): ts.NodeArray<ts.HeritageClause> | [ts.HeritageClause] => {
   if (classNode.heritageClauses != null && classNode.heritageClauses.length > 0) {
+    // the syntax tree has a heritage clause already, don't generate a new one
     return classNode.heritageClauses;
   }
 
   if (moduleFile.cmps.length >= 1) {
+    // we'll need to import `HTMLElement` in order to extend it
     addCoreRuntimeApi(moduleFile, RUNTIME_APIS.HTMLElement);
   }
 
@@ -44,7 +55,7 @@ const updateNativeHostComponentMembers = (
   classNode: ts.ClassDeclaration,
   moduleFile: d.Module,
   cmp: d.ComponentCompilerMeta
-) => {
+): ts.ClassElement[] => {
   const classMembers = removeStaticMetaProperties(classNode);
 
   updateNativeConstructor(classMembers, moduleFile, cmp);

--- a/src/compiler/transformers/core-runtime-apis.ts
+++ b/src/compiler/transformers/core-runtime-apis.ts
@@ -29,9 +29,41 @@ export const RUNTIME_APIS = {
   registerInstance: `registerInstance as ${REGISTER_INSTANCE}`,
 };
 
-export const addCoreRuntimeApi = (moduleFile: d.Module, coreRuntimeApi: string) => {
+/**
+ * Update a Stencil Module entity to include a {@link RUNTIME_APIS} entry if it does not already exist.
+ * This allows Stencil to keep `moduleFile` easily serializable, where this helper function treats the data structure
+ * that stores {@link Module#coreRuntimeApis} similar to a JS `Set`.
+ * @param moduleFile the Module entity to update
+ * @param coreRuntimeApi the API to add to the provided module
+ */
+export const addCoreRuntimeApi = (moduleFile: d.Module, coreRuntimeApi: string): void => {
   if (!moduleFile.coreRuntimeApis.includes(coreRuntimeApi)) {
     moduleFile.coreRuntimeApis.push(coreRuntimeApi);
+  }
+};
+
+/**
+ * Update a Stencil Module entity to include a {@link RUNTIME_APIS} entry for a specific output target, if it does not
+ * already exist.
+ * This allows Stencil to keep `moduleFile` easily serializable, where this helper function treats the data structure
+ * that stores {@link Module#outputTargetCoreRuntimeApis} similar to a JS `Set`.
+ * @param moduleFile the Module entity to update
+ * @param outputTarget the output target to assign the provided runtime api under
+ * @param coreRuntimeApi the API to add to the provided module
+ */
+export const addOutputTargetCoreRuntimeApi = (
+  moduleFile: d.Module,
+  outputTarget: d.OutputTarget['type'],
+  coreRuntimeApi: string
+): void => {
+  if (!moduleFile.outputTargetCoreRuntimeApis[outputTarget]) {
+    // no such output target-specific collection exists, create the empty collection
+    moduleFile.outputTargetCoreRuntimeApis[outputTarget] = [];
+  }
+
+  if (!moduleFile.outputTargetCoreRuntimeApis[outputTarget].includes(coreRuntimeApi)) {
+    // add the api to the collection
+    moduleFile.outputTargetCoreRuntimeApis[outputTarget].push(coreRuntimeApi);
   }
 };
 

--- a/src/compiler/transformers/remove-static-meta-properties.ts
+++ b/src/compiler/transformers/remove-static-meta-properties.ts
@@ -2,6 +2,13 @@ import ts from 'typescript';
 
 import { retrieveTsModifiers } from './transform-utils';
 
+/**
+ * Creates a new collection of class members that belong to the provided class node and that do not exist in
+ * {@link REMOVE_STATIC_GETTERS}
+ * @param classNode the class node in the syntax tree to inspect
+ * @returns a new collection of class members belonging to the provided class node, less those found in
+ * {@link REMOVE_STATIC_GETTERS}
+ */
 export const removeStaticMetaProperties = (classNode: ts.ClassDeclaration): ts.ClassElement[] => {
   if (classNode.members == null) {
     return [];
@@ -17,6 +24,9 @@ export const removeStaticMetaProperties = (classNode: ts.ClassDeclaration): ts.C
   });
 };
 
+/**
+ * A list of static getter names that are specific to Stencil to exclude from a class's member list
+ */
 const REMOVE_STATIC_GETTERS = new Set([
   'is',
   'properties',

--- a/src/compiler/transformers/test/core-runtime-apis.spec.ts
+++ b/src/compiler/transformers/test/core-runtime-apis.spec.ts
@@ -1,8 +1,9 @@
 import * as ts from 'typescript';
 
 import * as d from '../../../declarations';
+import { DIST_CUSTOM_ELEMENTS } from '../../output-targets/output-utils';
 import { createModule } from '../../transpile/transpiled-module';
-import { addCoreRuntimeApi, addLegacyApis, RUNTIME_APIS } from '../core-runtime-apis';
+import { addCoreRuntimeApi, addLegacyApis, addOutputTargetCoreRuntimeApi, RUNTIME_APIS } from '../core-runtime-apis';
 
 describe('addCoreRuntimeApi()', () => {
   let mockModule: d.Module;
@@ -37,6 +38,44 @@ describe('addCoreRuntimeApi()', () => {
     // attempt to add the api again, doing so shall not create a duplicate entry
     addCoreRuntimeApi(mockModule, RUNTIME_APIS.attachShadow);
     expect(mockModule.coreRuntimeApis).toEqual([RUNTIME_APIS.attachShadow]);
+  });
+});
+
+describe('addOutputTargetCoreRuntimeApi()', () => {
+  let mockModule: d.Module;
+
+  beforeEach(() => {
+    const sourceText = "console.log('hello world');";
+    mockModule = createModule(
+      ts.createSourceFile('mock-file.ts', sourceText, ts.ScriptTarget.ES5),
+      sourceText,
+      'mock-file.js'
+    );
+  });
+
+  it("adds new entries to a module's outputTargetCoreRuntimeApis for the specified output target", () => {
+    expect(mockModule.outputTargetCoreRuntimeApis).toBeDefined();
+    expect(Object.entries(mockModule.outputTargetCoreRuntimeApis)).toHaveLength(0);
+
+    addOutputTargetCoreRuntimeApi(mockModule, DIST_CUSTOM_ELEMENTS, RUNTIME_APIS.attachShadow);
+    expect(mockModule.outputTargetCoreRuntimeApis).toEqual({ [DIST_CUSTOM_ELEMENTS]: [RUNTIME_APIS.attachShadow] });
+
+    addOutputTargetCoreRuntimeApi(mockModule, DIST_CUSTOM_ELEMENTS, RUNTIME_APIS.createEvent);
+    expect(mockModule.outputTargetCoreRuntimeApis).toEqual({
+      [DIST_CUSTOM_ELEMENTS]: [RUNTIME_APIS.attachShadow, RUNTIME_APIS.createEvent],
+    });
+  });
+
+  it("does not allow duplicate entries in a module's outputTargetCoreRuntimeApis", () => {
+    expect(mockModule.outputTargetCoreRuntimeApis).toBeDefined();
+    expect(Object.entries(mockModule.outputTargetCoreRuntimeApis)).toHaveLength(0);
+
+    addOutputTargetCoreRuntimeApi(mockModule, DIST_CUSTOM_ELEMENTS, RUNTIME_APIS.attachShadow);
+    expect(mockModule.outputTargetCoreRuntimeApis).toEqual({ [DIST_CUSTOM_ELEMENTS]: [RUNTIME_APIS.attachShadow] });
+
+    // attempt to add the api again, doing so shall not create a duplicate entry
+    addOutputTargetCoreRuntimeApi(mockModule, DIST_CUSTOM_ELEMENTS, RUNTIME_APIS.attachShadow);
+    expect(mockModule.outputTargetCoreRuntimeApis).toEqual({ [DIST_CUSTOM_ELEMENTS]: [RUNTIME_APIS.attachShadow] });
   });
 });
 

--- a/src/compiler/transformers/test/native-constructor.spec.ts
+++ b/src/compiler/transformers/test/native-constructor.spec.ts
@@ -38,7 +38,7 @@ describe('nativeComponentTransform', () => {
       const transpiledModule = transpileModule(code, null, compilerCtx, [], [transformer]);
 
       expect(transpiledModule.outputText).toContain(
-        `import { HTMLElement, attachShadow as __stencil_attachShadow, defineCustomElement as __stencil_defineCustomElement } from "@stencil/core";`
+        `import { HTMLElement, defineCustomElement as __stencil_defineCustomElement, attachShadow as __stencil_attachShadow } from "@stencil/core";`
       );
       expect(transpiledModule.outputText).toContain(`this.__attachShadow()`);
     });
@@ -63,7 +63,7 @@ describe('nativeComponentTransform', () => {
       const transpiledModule = transpileModule(code, null, compilerCtx, [], [transformer]);
 
       expect(transpiledModule.outputText).toContain(
-        `import { HTMLElement, attachShadow as __stencil_attachShadow, defineCustomElement as __stencil_defineCustomElement } from "@stencil/core";`
+        `import { HTMLElement, defineCustomElement as __stencil_defineCustomElement, attachShadow as __stencil_attachShadow } from "@stencil/core";`
       );
       expect(transpiledModule.outputText).toContain(`this.__attachShadow()`);
     });

--- a/src/compiler/transpile/transpiled-module.ts
+++ b/src/compiler/transpile/transpiled-module.ts
@@ -3,11 +3,26 @@ import ts from 'typescript';
 
 import type * as d from '../../declarations';
 
-export const getModule = (compilerCtx: d.CompilerCtx, filePath: string) =>
+/**
+ * Helper function for retrieving a Stencil {@link Module} from the provided compiler context
+ * @param compilerCtx the compiler context to retrieve the `Module` from
+ * @param filePath the path of the file corresponding to the `Module` to lookup
+ * @returns the `Module`, or `undefined` if one cannot be found
+ */
+export const getModule = (compilerCtx: d.CompilerCtx, filePath: string): d.Module | undefined =>
   compilerCtx.moduleMap.get(normalizePath(filePath));
 
+/**
+ * Creates a {@link Module} entity with reasonable defaults
+ * @param staticSourceFile the TypeScript representation of the source file. This may not be the original
+ * representation of the file, but instead a new `SourceFile` created using the TypeScript API
+ * @param staticSourceFileText the text from the `SourceFile`. This text may originate from the original representation
+ * of the file.
+ * @param emitFilepath the path of the JavaScript file that should be emitted after transpilation
+ * @returns the created `Module`
+ */
 export const createModule = (
-  staticSourceFile: ts.SourceFile, // this is NOT the original
+  staticSourceFile: ts.SourceFile, // this may NOT be the original
   staticSourceFileText: string,
   emitFilepath: string
 ): d.Module => ({
@@ -17,6 +32,7 @@ export const createModule = (
   staticSourceFileText,
   cmps: [],
   coreRuntimeApis: [],
+  outputTargetCoreRuntimeApis: {},
   collectionName: null,
   dtsFilePath: null,
   excludeFromCollection: false,

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -18,6 +18,7 @@ import type {
   LoggerTimeSpan,
   OptimizeCssInput,
   OptimizeCssOutput,
+  OutputTarget,
   OutputTargetWww,
   PageReloadStrategy,
   PrerenderConfig,
@@ -257,6 +258,9 @@ export interface BuildCtx {
   indexBuildCount: number;
   indexDoc: Document;
   isRebuild: boolean;
+  /**
+   * A collection of Stencil's intermediate representation of components, tied to the current build
+   */
   moduleFiles: Module[];
   packageJson: PackageJsonData;
   pendingCopyTasks: Promise<CopyResults>[];
@@ -700,6 +704,9 @@ export interface CompilerCtx {
   hasSuccessfulBuild: boolean;
   isActivelyBuilding: boolean;
   lastBuildResults: CompilerBuildResults;
+  /**
+   * A mapping of a file path to a Stencil {@link Module}
+   */
   moduleMap: ModuleMap;
   nodeMap: NodeMap;
   resolvedCollections: Set<string>;
@@ -1398,6 +1405,12 @@ export interface MinifyJsResult {
   };
 }
 
+/**
+ * A mapping from a TypeScript or JavaScript source file path on disk, to a Stencil {@link Module}.
+ *
+ * It is advised that the key (path) be normalized before storing/retrieving the `Module` to avoid unnecessary lookup
+ * failures.
+ */
 export type ModuleMap = Map<string, Module>;
 
 /**
@@ -1405,12 +1418,21 @@ export type ModuleMap = Map<string, Module>;
  * various pieces of information like the classes declared within it, the path
  * to the original source file, HTML tag names defined in the file, and so on.
  *
- * Note that this gets serialized/parsed as JSON and therefore cannot be a
+ * Note that this gets serialized/parsed as JSON and therefore cannot contain a
  * `Map` or a `Set`.
  */
 export interface Module {
   cmps: ComponentCompilerMeta[];
+  /**
+   * A collection of modules that a component will need. The modules in this list must have import statements generated
+   * in order for the component to function.
+   */
   coreRuntimeApis: string[];
+  /**
+   * A collection of modules that a component will need for a specific output target. The modules in this list must
+   * have import statements generated in order for the component to function, but only for a specific output target.
+   */
+  outputTargetCoreRuntimeApis: Partial<Record<OutputTarget['type'], string[]>>;
   collectionName: string;
   dtsFilePath: string;
   excludeFromCollection: boolean;

--- a/src/sys/node/node-sys.ts
+++ b/src/sys/node/node-sys.ts
@@ -36,7 +36,7 @@ import { NodeWorkerController } from './node-worker-controller';
  */
 export function createNodeSys(c: { process?: any; logger?: Logger } = {}): CompilerSystem {
   const prcs: NodeJS.Process = c?.process ?? global.process;
-  const logger: Logger = c?.logger;
+  const logger: Logger | undefined = c?.logger;
   const destroys = new Set<() => Promise<void> | void>();
   const onInterruptsCallbacks: (() => void)[] = [];
 

--- a/src/sys/node/node-sys.ts
+++ b/src/sys/node/node-sys.ts
@@ -17,6 +17,7 @@ import type {
   CompilerSystemRealpathResults,
   CompilerSystemRemoveFileResults,
   CompilerSystemWriteFileResults,
+  Logger,
 } from '../../declarations';
 import { asyncGlob, nodeCopyTasks } from './node-copy-tasks';
 import { NodeLazyRequire } from './node-lazy-require';
@@ -30,11 +31,12 @@ import { NodeWorkerController } from './node-worker-controller';
  *
  * This takes an optional param supplying a `process` object to be used.
  *
- * @param c an optional object wrapping a `process` object
+ * @param c an optional object wrapping `process` and `logger` objects
  * @returns a node.js `CompilerSystem` object
  */
-export function createNodeSys(c: { process?: any } = {}): CompilerSystem {
+export function createNodeSys(c: { process?: any; logger?: Logger } = {}): CompilerSystem {
   const prcs: NodeJS.Process = c?.process ?? global.process;
+  const logger: Logger = c?.logger;
   const destroys = new Set<() => Promise<void> | void>();
   const onInterruptsCallbacks: (() => void)[] = [];
 
@@ -457,9 +459,12 @@ export function createNodeSys(c: { process?: any } = {}): CompilerSystem {
       sys.events = buildEvents();
 
       sys.watchDirectory = (p, callback, recursive) => {
+        logger?.debug(`NODE_SYS_DEBUG::watchDir ${p}`);
+
         const tsFileWatcher = tsSysWatchDirectory(
           p,
           (fileName) => {
+            logger?.debug(`NODE_SYS_DEBUG::watchDir:callback dir=${p} changedPath=${fileName}`);
             callback(normalizePath(fileName), 'fileUpdate');
           },
           recursive
@@ -496,6 +501,8 @@ export function createNodeSys(c: { process?: any } = {}): CompilerSystem {
        * @returns an object with a method for unhooking the file watcher from the system
        */
       sys.watchFile = (path: string, callback: CompilerFileWatcherCallback): CompilerFileWatcher => {
+        logger?.debug(`NODE_SYS_DEBUG::watchFile ${path}`);
+
         const tsFileWatcher = tsSysWatchFile(
           path,
           (fileName: string, tsEventKind: TypeScript.FileWatcherEventKind) => {

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -242,6 +242,7 @@ export function mockWindow(html: string = null) {
 export const mockModule = (mod: Partial<Module> = {}): Module => ({
   cmps: [],
   coreRuntimeApis: [],
+  outputTargetCoreRuntimeApis: {},
   collectionName: '',
   dtsFilePath: '',
   excludeFromCollection: false,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We have no debug logging for watching builds (which is why I'm adding it 😉) 
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit is a follow up to https://github.com/ionic-team/stencil/pull/4146. when debugging the file watcher, it's valuable to know what files have been perceived as added/updated/etc. for #4146, we created dev-builds with additional logging statements to help diagnose the issue. in this commit, we add more refined debugging statements that attempt to balance providing useful information while not spamming the output with logging statements.

when starting a dev server, the version of stencil has been added to the `[LOCAL DEV]`. starting with https://github.com/ionic-team/stencil/pull/4098, stencil has useful information in both dev and prod builds of the project that can is used here. this was also added to avoid a call to stencil's info task - most of the information from the info task is already provided in the output of starting of the dev server. by adding only the version here, we avoid redundant logging statements.

the watch build task has been updated to log the files changed (added, updated, deleted, written). these statements can get slightly verbose, with at least one line per category per rebuild. however, this information was immensely helpful in #4146, and was deemed worth the extra output. the output is only provided when the logging level of the stencil logger is set to "debug", and won't be enabled for normal runs of the compiler.

similar to the watch build task, additional debug-only logging was added to the node-sys watch file-related functions. debug statements in this file are not guarded with a conditional statement, as we do not have any guarantees/information around the logging level that has been set when a node-sys instance is created. in order to log correctly, an optional logger (optional as to not break the contract of this public api) has been added to the creation of node-sys. should one not be provided, debug logging will not apply.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
- Create a new Stencil project with `npm init stencil component debug-log-test`
- In that project, install a dev build of this project: `npm i @stencil/core@3.2.0-dev.1680277977.315afe6`
- For the following commands, one should _not_ see the debug output:
    - `npm run build`
    - `npm run build -- --debug`
    - `npm start`
- For `npm start -- --debug` one _should_ see the newly created debug statements
## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

There are less debug statements in this commit/pr than there were from our original logging branches. I tried to balance spewing _tons_ of info to the console with the value provided. While I think for our original logging/debugging branch that was OK (since we were trying to debug a serious issue), it's not necessarily required for _all_ debugging scenarios in Stencil