### PR TITLE
chore(release): eliminate return argument usage

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -2,7 +2,7 @@ import color from 'ansi-colors';
 import fs from 'fs-extra';
 import { join } from 'path';
 
-import { PrepareReleasePromptAnswers, promptPrepareRelease, promptRelease, ReleasePromptAnswers } from './prompts';
+import { promptPrepareRelease, promptRelease } from './prompts';
 import { runReleaseTasks } from './release-tasks';
 import { BuildOptions, getOptions } from './utils/options';
 
@@ -21,8 +21,18 @@ export async function release(rootDir: string, args: ReadonlyArray<string>): Pro
       isPublishRelease: false,
       isProd: true,
     });
-    const answers = await promptPrepareRelease(opts);
-    return prepareRelease(opts, args, releaseDataPath, answers);
+
+    const responses = await promptPrepareRelease(opts);
+    opts.version = responses.versionToUse;
+
+    if (!responses.confirm) {
+      console.log(`\n${color.bold.magenta('Publish preparation cancelled by user')}\n`);
+      return;
+    }
+
+    fs.writeJsonSync(releaseDataPath, opts, { spaces: 2 });
+    await prepareRelease(opts, args);
+    return;
   }
 
   if (args.includes('--publish')) {
@@ -35,8 +45,16 @@ export async function release(rootDir: string, args: ReadonlyArray<string>): Pro
       isPublishRelease: true,
       isProd: true,
     });
-    const answers = await promptRelease(opts);
-    return publishRelease(opts, args, answers);
+    const responses = await promptRelease(opts);
+    opts.otp = responses.otp;
+    opts.tag = responses.npmTag;
+
+    if (!responses.confirm) {
+      console.log(`\n${color.bold.magenta('Publish cancelled by user')}\n`);
+      return;
+    }
+
+    return publishRelease(opts, args);
   }
 }
 
@@ -44,31 +62,16 @@ export async function release(rootDir: string, args: ReadonlyArray<string>): Pro
  * Prepares a release of Stencil
  * @param opts build options containing the metadata needed to release a new version of Stencil
  * @param args stringified arguments used to influence the release steps that are taken
- * @param releaseDataPath the fully qualified path of `release-data.json` to write to disk during this step
- * @param answers a collection of answers to previously answered prompts regarding details of the release
  */
-async function prepareRelease(
-  opts: BuildOptions,
-  args: ReadonlyArray<string>,
-  releaseDataPath: string,
-  answers: PrepareReleasePromptAnswers
-): Promise<void> {
-  if (!answers.confirm) {
-    // the dev said 'no' to the release, return
-    return;
-  }
-
+async function prepareRelease(opts: BuildOptions, args: ReadonlyArray<string>): Promise<void> {
   const pkg = opts.packageJson;
   const oldVersion = opts.packageJson.version;
   console.log(
     `\nPrepare to publish ${opts.vermoji}  ${color.bold.magenta(pkg.name)} ${color.dim(`(currently ${oldVersion})`)}\n`
   );
 
-  opts.version = answers.version ?? answers.specifiedVersion;
   try {
-    // write `release-data.json`
-    fs.writeJsonSync(releaseDataPath, opts, { spaces: 2 });
-    return runReleaseTasks(opts, args);
+    await runReleaseTasks(opts, args);
   } catch (err: any) {
     console.log('\n', color.red(err), '\n');
     process.exit(0);
@@ -79,18 +82,8 @@ async function prepareRelease(
  * Initiates publishing a Stencil release.
  * @param opts build options containing the metadata needed to publish a new version of Stencil
  * @param args stringified arguments used to influence the steps that are taken
- * @param answers a collection of answers to previously answered prompts regarding details of the release
  */
-async function publishRelease(
-  opts: BuildOptions,
-  args: ReadonlyArray<string>,
-  answers: ReleasePromptAnswers
-): Promise<void> {
-  if (!answers.confirm) {
-    // the dev said 'no' to the release, return
-    return;
-  }
-
+async function publishRelease(opts: BuildOptions, args: ReadonlyArray<string>): Promise<void> {
   const pkg = opts.packageJson;
   if (opts.version !== pkg.version) {
     throw new Error('Prepare release data and package.json versions do not match. Try re-running release prepare.');

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -86,7 +86,9 @@ async function prepareRelease(opts: BuildOptions, args: ReadonlyArray<string>): 
 async function publishRelease(opts: BuildOptions, args: ReadonlyArray<string>): Promise<void> {
   const pkg = opts.packageJson;
   if (opts.version !== pkg.version) {
-    throw new Error('Prepare release data and package.json versions do not match. Try re-running release prepare.');
+    throw new Error(
+      `Prepare release data (${opts.version}) and package.json (${pkg.version}) versions do not match. Try re-running release prepare.`
+    );
   }
 
   console.log(`\nPublish ${opts.vermoji}  ${color.bold.magenta(pkg.name)} ${color.yellow(`${opts.version}`)}\n`);

--- a/scripts/test/prompts.spec.ts
+++ b/scripts/test/prompts.spec.ts
@@ -1,0 +1,34 @@
+import {
+  determineAnsweredTagToUse,
+  determineAnsweredVersionToUse,
+  PrepareReleasePromptAnswers,
+  ReleasePromptAnswers,
+} from '../prompts';
+
+describe('determineAnsweredVersionToUse', () => {
+  it.each<[PrepareReleasePromptAnswers, string]>([
+    [{ version: '1.0.0', specifiedVersion: '2.0.0', confirm: true }, '1.0.0'],
+    [{ version: '1.0.0', confirm: true }, '1.0.0'],
+    [{ specifiedVersion: '2.0.0', confirm: true }, '2.0.0'],
+    [{ version: '', specifiedVersion: '', confirm: true }, 'UNKNOWN'],
+    [{ version: '', confirm: true }, 'UNKNOWN'],
+    [{ specifiedVersion: '', confirm: true }, 'UNKNOWN'],
+    [{ confirm: true }, 'UNKNOWN'],
+  ])('%s returns "%s"', (answers, expected) => {
+    expect(determineAnsweredVersionToUse(answers)).toBe(expected);
+  });
+});
+
+describe('determineAnsweredTagToUse', () => {
+  it.each<[ReleasePromptAnswers, string]>([
+    [{ tag: '1.0.0', specifiedTag: '2.0.0', confirm: true, otp: '' }, '1.0.0'],
+    [{ tag: '1.0.0', confirm: true, otp: '' }, '1.0.0'],
+    [{ specifiedTag: '2.0.0', confirm: true, otp: '' }, '2.0.0'],
+    [{ tag: '', specifiedTag: '', confirm: true, otp: '' }, 'UNKNOWN'],
+    [{ tag: '', confirm: true, otp: '' }, 'UNKNOWN'],
+    [{ specifiedTag: '', confirm: true, otp: '' }, 'UNKNOWN'],
+    [{ confirm: true, otp: '' }, 'UNKNOWN'],
+  ])('%s returns "%s"', (answers, expected) => {
+    expect(determineAnsweredTagToUse(answers)).toBe(expected);
+  });
+});

--- a/scripts/test/release.spec.ts
+++ b/scripts/test/release.spec.ts
@@ -59,7 +59,7 @@ describe('release()', () => {
       promptPrepareReleaseSpy = jest.spyOn(Prompts, 'promptPrepareRelease');
       promptPrepareReleaseSpy.mockResolvedValue({
         confirm: true,
-        version: '0.0.1',
+        versionToUse: '0.0.1',
       });
     });
 
@@ -91,7 +91,7 @@ describe('release()', () => {
     it('returns early when confirm is falsy', async () => {
       promptPrepareReleaseSpy.mockResolvedValue({
         confirm: false,
-        version: '0.0.1',
+        versionToUse: '0.0.1',
       });
 
       await release(rootDir, [prepareFlag]);
@@ -107,23 +107,6 @@ describe('release()', () => {
         {
           packageJson: stubPackageData(),
           version: '0.0.1',
-        },
-        [prepareFlag]
-      );
-    });
-
-    it('invokes runReleaseTasks with a specified version when version is not set', async () => {
-      promptPrepareReleaseSpy.mockResolvedValue({
-        confirm: true,
-        specifiedVersion: '0.0.2',
-      });
-
-      await release(rootDir, [prepareFlag]);
-      expect(runReleaseTasksSpy).toHaveBeenCalledTimes(1);
-      expect(runReleaseTasksSpy).toHaveBeenCalledWith(
-        {
-          packageJson: stubPackageData(),
-          version: '0.0.2',
         },
         [prepareFlag]
       );
@@ -164,8 +147,8 @@ describe('release()', () => {
       promptReleaseSpy = jest.spyOn(Prompts, 'promptRelease');
       promptReleaseSpy.mockResolvedValue({
         confirm: true,
-        tag: 'testing',
-        // six characters long (correct length), but a very fake OTP
+        npmTag: 'testing',
+        // six characters long (i.e. correct length), but a very fake OTP
         otp: 'abcOtp',
       });
     });
@@ -197,8 +180,8 @@ describe('release()', () => {
     it('returns early when confirm is falsy', async () => {
       promptReleaseSpy.mockResolvedValue({
         confirm: false,
-        tag: 'testing',
-        // six characters long (correct length), but a very fake OTP
+        npmTag: 'testing',
+        // six characters long (i.e. correct length), but a very fake OTP
         otp: 'abcOtp',
       });
 
@@ -225,9 +208,11 @@ describe('release()', () => {
       expect(runReleaseTasksSpy).toHaveBeenCalledTimes(1);
       expect(runReleaseTasksSpy).toHaveBeenCalledWith(
         {
+          otp: 'abcOtp',
           packageJson: stubPackageData({
             version: '0.1.0',
           }),
+          tag: 'testing',
           version: '0.1.0',
         },
         [publishFlag]

--- a/scripts/test/release.spec.ts
+++ b/scripts/test/release.spec.ts
@@ -199,7 +199,7 @@ describe('release()', () => {
       });
 
       await expect(release(rootDir, [publishFlag])).rejects.toThrow(
-        'Prepare release data and package.json versions do not match. Try re-running release prepare.'
+        'Prepare release data (0.1.1) and package.json (0.1.0) versions do not match. Try re-running release prepare.'
       );
     });
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We currently mutate an argument to our prompting functions when preparing/performing a release.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit eliminates return parameter usage in the release scripts. with this commit, the `opts` argument provided to the prepare-release and release prompting functions shall no longer be mutated by either of them.

to accomplish this, two new types are introduced - `NormalizedPrepareResponses` and `NormalizedReleaseResponses`. both types are intended to be returned by their respective prompting functions and serve as the source of truth when their is user choice (e.g. semver version to use, npm tag) involved with a release. to further this goal, new utility functions have been created to provide a single source of truth for this decision logic. tests for these helpers are included, as it's not exactly intuitive that a `tag` will always take precedence over 'specifiedTag`.

this commit does not however, eliminate all mutation. it only moves it out of the prompting stage of the release process, and into the primary release script section.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Check out this branch and perform the following:
### Release Preparation
1. Run `npm run release.prepare -- --any-branch --dry-run` to evaluate that the release preparation scripts run as intended 
    - `--any-branch` is needed bc we're not on `main` 
    - `--dry-run` is needed to skip checks related to being on `main` and ensuring `main` is in sync with GitHub. It will still perform npm install, building, and validation of the build
2. select '3.2.1-0' when prompted for a version - this version should appear in `CHANGELOG.md`, `package.json`, and `package-lock.json` after the script runs.
3. `git reset --hard`
4. Run `npm run release.prepare -- --any-branch --dry-run` again, this time, specify a version ('3.2.1-1') - this version should appear in `CHANGELOG.md`, `package.json`, and `package-lock.json` after the script runs. Do not remove these changes, as we'll use them in the next section.

### Release
 ⚠️ These steps must be followed closely, otherwise we risk a release getting out into the wild ⚠️ 
1. Run `npm run release -- --any-branch --dry-run` to evaluate that the release preparation scripts run as intended 
    - `--any-branch` is needed bc we're not on `main` 
    - `--dry-run` is needed to skip the actual release
    - Select 'dev' as the tag (just in case)
    - Use 'hello!' as your OTP (just in case)
2. Your browser will open a GitHub Release form. The publish did _not_ occur, this step does not get skipped on `--dry-run`. Verify the version number in the form

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The `prompt.ts` code for preparing a release and performing a release are getting a bit long. I'm gonna follow up on a comment Tanner had with a PR to split `prompts.ts` into two