### PR TITLE
chore(ci): create initial workflow for prod releases

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -1,0 +1,38 @@
+name: 'Stencil Production Release (TEST)'
+
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: choice
+        description: Which version should be published?
+        options:
+          - prerelease
+          - prepatch
+          - preminor
+          - premajor
+          - patch
+          - minor
+          - major
+      tag:
+        required: true
+        type: choice
+        description: Which npm tag should this be published to?
+        options:
+          - dev
+          - latest
+
+jobs:
+  release-stencil-production-build:
+    name: Publish Production Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo GH Input
+        run: |
+          echo "I do not use these values yet!"
+          echo "Version: ${{ inputs.version }}"
+          echo "Tag: ${{ inputs.tag }}"
+        shell: bash
+

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -1,7 +1,6 @@
 name: 'Stencil Production Release (TEST)'
 
 on:
-  push:
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -34,4 +34,3 @@ jobs:
           echo "Version: ${{ inputs.version }}"
           echo "Tag: ${{ inputs.tag }}"
         shell: bash
-


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

stencil is manually published. this commit does not enable prod releases, but moves the needle forward.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit creates the stub workflow for ci-based stencil releases. it is limited in it's functionality in that it accepts a named semver version and tag from the github, and echoes the input back to the user.

the motivation for this stub workflow (i.e. land it in `main`) is that the release workflow will require the following steps:
1. generate changelog, bump versions in package.json + package-lock.json
2. commit changes in git, push them to github
3. publish tags to git and npm

when testing a more fleshed version of this workflow out, it's possible to bump versions, commit to a test branch, and push that test branch to github. however, we cannot kick off this workflow via the workflow_dispatch event without having the workflow in the primary branch (`main`) first. getting this stubbed workflow into the project will enable the commit+push aspect of testing.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I put  a 'push' event on this workflow to force it through CI to verify that GH could read/parse it properly. The output will show empty values (since the workflow wasn't run thru the GH UI) - https://github.com/ionic-team/stencil/actions/runs/4638611979/jobs/8208576046. I removed that event after this ran

I have a more fleshed out version of this workflow running in a work-in-progress branch:
- https://github.com/ionic-team/stencil/compare/rwaskiewicz/ci-publish-step-new?expand=1
- https://github.com/ionic-team/stencil/actions/runs/4638416005/jobs/8208225585
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
