### PR TITLE
refactor(runtime): document Promise-based queueing in dispatchHooks

### DIFF
--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -106,12 +106,12 @@ const dispatchHooks = (hostRef: d.HostRef, isInitialLoad: boolean): Promise<void
  * of functions to be called.
  *
  * The queue is ordered on the basis of the first argument. If it's
- * `undefined`, then nothing is on the queue yet, so the provided funcion can be
- * called synchronously (although note that this function may return a `Promise`).
- * The idea is that then the return value of that enqueueing operation is kept
- * around, so that if it was a `Promise` then subsequent functions can be
- * enqueued by calling this function again with that `Promise` as the first
- * argument.
+ * `undefined`, then nothing is on the queue yet, so the provided function can
+ * be called synchronously (although note that this function may return a
+ * `Promise`). The idea is that then the return value of that enqueueing
+ * operation is kept around, so that if it was a `Promise` then subsequent
+ * functions can be enqueued by calling this function again with that `Promise`
+ * as the first argument.
  *
  * @param maybePromise either a `Promise` which should resolve before the next function is called or an 'empty' sentinel
  * @param fn a function to enqueue

--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -117,13 +117,8 @@ const dispatchHooks = (hostRef: d.HostRef, isInitialLoad: boolean): Promise<void
  * @param fn a function to enqueue
  * @returns either a `Promise` or the return value of the provided function
  */
-function enqueue(maybePromise: Promise<void> | undefined, fn: () => Promise<void>): Promise<void> | undefined {
-  if (maybePromise instanceof Promise) {
-    return maybePromise.then(fn);
-  } else {
-    return fn();
-  }
-}
+const enqueue = (maybePromise: Promise<void> | undefined, fn: () => Promise<void>): Promise<void> | undefined =>
+  maybePromise instanceof Promise ? maybePromise.then(fn) : fn();
 
 const updateComponent = async (hostRef: d.HostRef, instance: any, isInitialLoad: boolean) => {
   const elm = hostRef.$hostElement$ as d.RenderNode;

--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -47,9 +47,9 @@ const dispatchHooks = (hostRef: d.HostRef, isInitialLoad: boolean): Promise<void
   const endSchedule = createTime('scheduleUpdate', hostRef.$cmpMeta$.$tagName$);
   const instance = BUILD.lazyLoad ? hostRef.$lazyInstance$ : elm;
 
-  // We're going to use this variable together with {@link enqueue} to implement a
+  // We're going to use this variable together with `enqueue` to implement a
   // little promise-based queue. We start out with it `undefined`. When we add
-  // the first function to the queue we'll set the this variable to be that
+  // the first function to the queue we'll set this variable to be that
   // function's return value. When we attempt to add subsequent values to the
   // queue we'll check that value and, if it was a `Promise`, we'll then chain
   // the new function off of that `Promise` using `.then()`. This will give our

--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -32,12 +32,35 @@ export const scheduleUpdate = (hostRef: d.HostRef, isInitialLoad: boolean) => {
   return BUILD.taskQueue ? writeTask(dispatch) : dispatch();
 };
 
-const dispatchHooks = (hostRef: d.HostRef, isInitialLoad: boolean) => {
+/**
+ * Dispatch initial-render and update lifecycle hooks, enqueuing calls to
+ * component lifecycle methods like `componentWillLoad` as well as
+ * {@link updateComponent}, which will kick off the virtual DOM re-render.
+ *
+ * @param hostRef a reference to a host DOM node
+ * @param isInitialLoad whether we're on the initial load or not
+ * @returns an empty Promise which is used to enqueue a series of operations for
+ * the component
+ */
+const dispatchHooks = (hostRef: d.HostRef, isInitialLoad: boolean): Promise<void> => {
   const elm = hostRef.$hostElement$;
   const endSchedule = createTime('scheduleUpdate', hostRef.$cmpMeta$.$tagName$);
-  const instance = BUILD.lazyLoad ? hostRef.$lazyInstance$ : (elm as any);
+  const instance = BUILD.lazyLoad ? hostRef.$lazyInstance$ : elm;
 
-  let promise: Promise<void>;
+  // We're going to use this variable together with {@link enqueue} to implement a
+  // little promise-based queue. We start out with it `undefined`. When we add
+  // the first function to the queue we'll set the this variable to be that
+  // function's return value. When we attempt to add subsequent values to the
+  // queue we'll check that value and, if it was a `Promise`, we'll then chain
+  // the new function off of that `Promise` using `.then()`. This will give our
+  // queue two nice properties:
+  //
+  // 1. If all functions added to the queue are synchronous they'll be called
+  //    synchronously right away.
+  // 2. If all functions added to the queue are asynchronous they'll all be
+  //    called in order after `dispatchHooks` exits.
+  let maybePromise: Promise<void> | undefined;
+
   if (isInitialLoad) {
     if (BUILD.lazyLoad && BUILD.hostListener) {
       hostRef.$flags$ |= HOST_FLAGS.isListenReady;
@@ -48,27 +71,61 @@ const dispatchHooks = (hostRef: d.HostRef, isInitialLoad: boolean) => {
     }
     emitLifecycleEvent(elm, 'componentWillLoad');
     if (BUILD.cmpWillLoad) {
-      promise = safeCall(instance, 'componentWillLoad');
+      // If `componentWillLoad` returns a `Promise` then we want to wait on
+      // whatever's going on in that `Promise` before we launch into
+      // rendering the component, doing other lifecycle stuff, etc. So
+      // in that case we assign the returned promise to the variable we
+      // declared above to hold a possible 'queueing' Promise
+      maybePromise = safeCall(instance, 'componentWillLoad');
     }
   } else {
     emitLifecycleEvent(elm, 'componentWillUpdate');
 
     if (BUILD.cmpWillUpdate) {
-      promise = safeCall(instance, 'componentWillUpdate');
+      // Like `componentWillLoad` above, we allow Stencil component
+      // authors to return a `Promise` from this lifecycle callback, and
+      // we specify that our runtime will wait for that `Promise` to
+      // resolve before the component re-renders. So if the method
+      // returns a `Promise` we need to keep it around!
+      maybePromise = safeCall(instance, 'componentWillUpdate');
     }
   }
 
   emitLifecycleEvent(elm, 'componentWillRender');
   if (BUILD.cmpWillRender) {
-    promise = then(promise, () => safeCall(instance, 'componentWillRender'));
+    maybePromise = enqueue(maybePromise, () => safeCall(instance, 'componentWillRender'));
   }
 
   endSchedule();
-  return then(promise, () => updateComponent(hostRef, instance, isInitialLoad));
+
+  return enqueue(maybePromise, () => updateComponent(hostRef, instance, isInitialLoad));
 };
 
+/**
+ * This function uses a Promise to implement a simple first-in, first-out queue
+ * of functions to be called.
+ *
+ * The queue is ordered on the basis of the first argument. If it's
+ * `undefined`, then nothing is on the queue yet, so the provided funcion can be
+ * called synchronously (although note that this function may return a `Promise`).
+ * The idea is that then the return value of that enqueueing operation is kept
+ * around, so that if it was a `Promise` then subsequent functions can be
+ * enqueued by calling this function again with that `Promise` as the first
+ * argument.
+ *
+ * @param maybePromise either a `Promise` which should resolve before the next function is called or an 'empty' sentinel
+ * @param fn a function to enqueue
+ * @returns either a `Promise` or the return value of the provided function
+ */
+function enqueue(maybePromise: Promise<void> | undefined, fn: () => Promise<void>): Promise<void> | undefined {
+  if (maybePromise instanceof Promise) {
+    return maybePromise.then(fn);
+  } else {
+    return fn();
+  }
+}
+
 const updateComponent = async (hostRef: d.HostRef, instance: any, isInitialLoad: boolean) => {
-  // updateComponent
   const elm = hostRef.$hostElement$ as d.RenderNode;
   const endUpdate = createTime('update', hostRef.$cmpMeta$.$tagName$);
   const rc = elm['s-rc'];
@@ -314,10 +371,6 @@ export const safeCall = (instance: any, method: string, arg?: any) => {
     }
   }
   return undefined;
-};
-
-const then = (promise: Promise<any>, thenFn: () => any) => {
-  return promise && promise.then ? promise.then(thenFn) : thenFn();
 };
 
 const emitLifecycleEvent = (elm: EventTarget, lifecycleName: string) => {


### PR DESCRIPTION
This documents and slightly simplifies code which uses `Promise.then` to enqueue a series of rerendering-related actions which need to take place when a component gets updated. In particular, the previous implementation used a helper function called `then` which was a) `any`-typed and b) not necessary.

This also adds JSDoc to `dispatchHooks` and some explanatory inline comments.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?

This shouldn't change anything about how components are rendered, but is basically just a small simplification of a bit of code I read through recently and found confusing.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
