### PR TITLE
docs(runtime): add JSDoc to and rename `callNodeRefs`

### DIFF
--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -249,7 +249,7 @@ const removeVnodes = (vnodes: d.VNode[], startIdx: number, endIdx: number, vnode
   for (; startIdx <= endIdx; ++startIdx) {
     if ((vnode = vnodes[startIdx])) {
       elm = vnode.$elm$;
-      callNodeRefs(vnode);
+      nullifyVNodeRefs(vnode);
 
       if (BUILD.slotRelocation) {
         // we're removing this element
@@ -778,10 +778,17 @@ const isNodeLocatedInSlot = (nodeToRelocate: d.RenderNode, slotNameAttr: string)
   return slotNameAttr === '';
 };
 
-export const callNodeRefs = (vNode: d.VNode) => {
+/**
+ * 'Nullify' any VDom `ref` callbacks on a VDom node or its children by
+ * calling them with `null`. This signals that the DOM element corresponding to
+ * the VDom node has been removed from the DOM.
+ *
+ * @param vNode a virtual DOM node
+ */
+export const nullifyVNodeRefs = (vNode: d.VNode) => {
   if (BUILD.vdomRef) {
     vNode.$attrs$ && vNode.$attrs$.ref && vNode.$attrs$.ref(null);
-    vNode.$children$ && vNode.$children$.map(callNodeRefs);
+    vNode.$children$ && vNode.$children$.map(nullifyVNodeRefs);
   }
 };
 


### PR DESCRIPTION
This is a really small change that I meant to do before, I think when I added a bunch of JSDoc to this file in #3931 but I realized reading through this recently that this function had a not-great name and I thought hey, let's rename that! And that's the story of this PR 📖

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?

None, renaming and documentation change only.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
