### PR TITLE
chore(release): fix tagging behavior for prod

### DIFF
--- a/scripts/release-prompts.ts
+++ b/scripts/release-prompts.ts
@@ -147,5 +147,5 @@ export async function promptRelease(opts: BuildOptions): Promise<NormalizedRelea
  * @returns the tag to use. defaults to `null` if no tag was specified
  */
 export function determineAnsweredTagToUse(answers: ReleasePromptAnswers): string | null {
-  return answers.specifiedTag ? answers.specifiedTag : answers.tag ? answers.tag : null;
+  return answers.specifiedTag || answers.tag || null;
 }

--- a/scripts/release-prompts.ts
+++ b/scripts/release-prompts.ts
@@ -106,7 +106,7 @@ export async function promptRelease(opts: BuildOptions): Promise<NormalizedRelea
       name: 'confirm',
       message: (answers: any) => {
         const tagToUse = determineAnsweredTagToUse(answers);
-        const tagPart = ` and tag this release in npm as ${color.yellow(tagToUse)}`;
+        const tagPart = tagToUse ? ` and tag this release in npm as ${color.yellow(tagToUse)}` : '';
         return `Will publish ${opts.vermoji}  ${color.yellow(opts.version)}${tagPart}. Continue?`;
       },
     },
@@ -144,8 +144,8 @@ export async function promptRelease(opts: BuildOptions): Promise<NormalizedRelea
  * answers is to be used.
  *
  * @param answers user provided answers to pick from
- * @returns the tag to use. defaults to 'UNKNOWN' if the tag cannot be determined.
+ * @returns the tag to use. defaults to `null` if no tag was specified
  */
-export function determineAnsweredTagToUse(answers: ReleasePromptAnswers): string {
-  return answers.tag ? answers.tag : answers.specifiedTag ? answers.specifiedTag : 'UNKNOWN';
+export function determineAnsweredTagToUse(answers: ReleasePromptAnswers): string | null {
+  return answers.specifiedTag ? answers.specifiedTag : answers.tag ? answers.tag : null;
 }

--- a/scripts/test/release-prompts.spec.ts
+++ b/scripts/test/release-prompts.spec.ts
@@ -2,13 +2,15 @@ import { determineAnsweredTagToUse, ReleasePromptAnswers } from '../release-prom
 
 describe('determineAnsweredTagToUse', () => {
   it.each<[ReleasePromptAnswers, string]>([
-    [{ tag: '1.0.0', specifiedTag: '2.0.0', confirm: true, otp: '' }, '1.0.0'],
+    [{ tag: '1.0.0', specifiedTag: '2.0.0', confirm: true, otp: '' }, '2.0.0'],
     [{ tag: '1.0.0', confirm: true, otp: '' }, '1.0.0'],
     [{ specifiedTag: '2.0.0', confirm: true, otp: '' }, '2.0.0'],
-    [{ tag: '', specifiedTag: '', confirm: true, otp: '' }, 'UNKNOWN'],
-    [{ tag: '', confirm: true, otp: '' }, 'UNKNOWN'],
-    [{ specifiedTag: '', confirm: true, otp: '' }, 'UNKNOWN'],
-    [{ confirm: true, otp: '' }, 'UNKNOWN'],
+    [{ tag: undefined, specifiedTag: '2.0.0', confirm: true, otp: '' }, '2.0.0'],
+    [{ tag: null, specifiedTag: '2.0.0', confirm: true, otp: '' }, '2.0.0'],
+    [{ tag: '', specifiedTag: '', confirm: true, otp: '' }, null],
+    [{ tag: '', confirm: true, otp: '' }, null],
+    [{ specifiedTag: '', confirm: true, otp: '' }, null],
+    [{ confirm: true, otp: '' }, null],
   ])('%s returns "%s"', (answers, expected) => {
     expect(determineAnsweredTagToUse(answers)).toBe(expected);
   });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
this commit fixes a regression introduced in https://github.com/ionic-team/stencil/pull/4235. the commit made the assumption that the npm tag will always be present: https://github.com/ionic-team/stencil/commit/d19538eb33b297c14419e94b73c322a9c790c67a#diff-a8c342d5def4847ce523d42113bc62856f35e802a444ec746839c39018f62017L180-R229. when in fact that is not the case. an npm tag is assumed to be the 'latest' when it is empty. with this commit, the precedence of npm tags is updated to prefer specified tags, a valid npm tag, then null (previously a valid npm tag, a specifed tag, then 'UNKNOWN') was preferred). this allows for a specified tag to continue to take priority over a 'latest' tag, while reintroducing 'null' for the latest tag.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

To test, I compared the results of attempting to publish Stencil prior to the regression (using the git tag `v3.1.0`) as my base against this branch. I compared two use cases - selecting a pre-defined semver release type from our prompts (e.g. 'patch') and inputting the version manually 

### Using a predetermined version
![Screenshot 2023-04-11 at 5 29 54 PM](https://user-images.githubusercontent.com/1930213/231297078-1f37f53d-b4d6-486b-84c0-da479252e7e9.png)
![Screenshot 2023-04-11 at 5 44 57 PM](https://user-images.githubusercontent.com/1930213/231297235-047030f8-7651-45a2-b7df-22f61fa90d2e.png)

### Using a specified version
![Screenshot 2023-04-11 at 5 48 25 PM](https://user-images.githubusercontent.com/1930213/231297236-8f3a2773-84dc-4b09-8564-ef54678880e2.png)
![Screenshot 2023-04-11 at 6 09 34 PM](https://user-images.githubusercontent.com/1930213/231299572-d9c64292-6f97-480e-9802-bc368e18696d.png)

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
