### PR TITLE
chore(ci): temporarily install specific @types/babel__traverse

### DIFF
--- a/.github/workflows/test-component-starter.yml
+++ b/.github/workflows/test-component-starter.yml
@@ -58,6 +58,12 @@ jobs:
         working-directory: ./tmp-component-starter
         shell: bash
 
+      - name: Install Working @types/babel__traverse
+        # TODO(STENCIL-794): remove this once a new version of the library is available
+        run: npm i -D -E @types/babel__traverse@7.18.3
+        working-directory: ./tmp-component-starter
+        shell: bash
+
       - name: Build Starter Project
         run: npm run build
         working-directory: ./tmp-component-starter


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
See new behavior section

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
this commit adds a temporary pinning of `@types/babel__traverse` to the ci workflow to get it to pass again. with v7.18.4 of the library, a change was introduced that does not type check properly. reverting to using 7.18.3 (where this library is a sub-dependency of jest packages) is a temporary workaround.

this was chosen instead of pinning the library in the component starter, as we have no way to educate/inform folks that the pin is no longer necessary.

dependabot/renovate was not updated in this commit. the hope is that we either:
1) revert this this week
2) don't have to apply it (if fixed in the next few hours)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

CI begins to pass again 🎉 
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
