### PR TITLE
chore(ci): retry flaky tests

### DIFF
--- a/.github/workflows/test-browserstack.yml
+++ b/.github/workflows/test-browserstack.yml
@@ -89,7 +89,11 @@ jobs:
           local-identifier: random
 
       - name: Run Karma Tests
-        run: npm run test.karma.prod
+        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # v2.8.3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          command: npm run test.karma.prod
 
       - name: Stop BrowserStack
         uses: browserstack/github-actions/setup-local@master

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: npm run test.end-to-end1 -- --ci
+          command: npm run test.end-to-end -- --ci
 
       - name: Check Git Context
         uses: ./.github/workflows/actions/check-git-context

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: npm run test.end-to-end -- --ci
+          command: npm run test.end-to-end1 -- --ci
 
       - name: Check Git Context
         uses: ./.github/workflows/actions/check-git-context

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -35,8 +35,11 @@ jobs:
           filename: stencil-core-build.zip
 
       - name: End-to-End Tests
-        run: npm run test.end-to-end -- --ci
-        shell: bash
+        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # v2.8.3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: npm run test.end-to-end -- --ci
 
       - name: Check Git Context
         uses: ./.github/workflows/actions/check-git-context


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There are a few flaky CI jobs that, when they fail, cause pain in the development cycle due to waiting for CI to pass.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit wraps the e2e and browserstack tests in the
`nick-fields/retry` action. the goal of this is to provide a temporary &
quick fix for these two test commands, which are flaky (i.e. they may
fail due to reasons outside of changes made in a given commit).

both are configured to try each command three times. should the command
file three times, the job is marked as a failure. this differs from
today's behavior, in that a job is marked as a failure on one.

each is given a timeout configuration that is approximated based on how
long each job often takes (with a little additional padding to account
for additional logic to pull + start the retry action).

in applying this commit, there is a potential for a harmful impact on
the ci pipeline. the current/active browserstack job (which we cannot
parallelize further at this time) will continue to run while retrying.
this will block other jobs. the impact is that rather than blocking jobs
for a time period MTF (mean time to failure), we will block for
max_attempts (3) * MTF. worst case scenario, where MTF <
timeout_minutes, we may block for 3 * 15 = 45 minutes


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
The commit ['intentional fail'](https://github.com/ionic-team/stencil/pull/4321/commits/e2698711baefd0b153f277659daa9d5254858e97) purposely breaks the e2e test workflow, so that we can see what a failure/retry cycle might look like:

![Screenshot 2023-04-27 at 1 04 34 PM](https://user-images.githubusercontent.com/1930213/234936902-ab89f1c2-a8f6-4f8b-800c-6421f4e7eff5.png)

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Browserstack
Changes won't apply to this job until we merge the code [since we use `pull_request_target` ](https://github.com/ionic-team/stencil/blob/2c03eca75bdf6aba9e520d115b8f66f2ccdbe0be/.github/workflows/test-browserstack.yml#L4)

### Audit
I've tried to audit this action's code the best I can. I was able to verify:
- The tarball associated with [the GH release](https://github.com/nick-fields/retry/releases/tag/v2.8.3) matches `main@HEAD` ([SHA](https://github.com/nick-fields/retry/commit/943e742917ac94714d2f408a0e8320f2d1fcafcd)) 
- Building the project locally does not change the contents of `dist`
- [This action (no logs available)](https://github.com/nick-fields/retry/actions/runs/3804413215) appears to have generated the release (as best I can tell)
- Read through the TS source code, nothing egregiously scary jumps out at me