### PR TITLE
chore(snc): fix a few SNC errors in `src/utils/test/util.spec.ts

### DIFF
--- a/src/utils/test/util.spec.ts
+++ b/src/utils/test/util.spec.ts
@@ -66,7 +66,7 @@ describe('util', () => {
     });
 
     it('returns false if a project has no dependencies', () => {
-      buildCtx.packageJson.dependencies = null;
+      buildCtx.packageJson.dependencies = undefined;
 
       expect(util.hasDependency(buildCtx, 'a-non-existent-pkg')).toBe(false);
     });
@@ -146,7 +146,6 @@ describe('util', () => {
     expect(util.createJsVarName('A')).toBe('a');
     expect(util.createJsVarName('    ')).toBe('');
     expect(util.createJsVarName('')).toBe('');
-    expect(util.createJsVarName(null)).toBe(null);
   });
 
   describe('parsePackageJson', () => {
@@ -226,7 +225,7 @@ interface Foo extends Components.Foo, HTMLStencilElement {`);
     interface Foo extends Components.Foo, HTMLStencilElement {`);
     });
 
-    it.each([[null], [undefined], [{ tags: [], text: '' }]])(
+    it.each<[d.CompilerJsDoc | undefined]>([[undefined], [{ tags: [], text: '' }]])(
       'does not add a doc block when docs are empty (%j)',
       (docs) => {
         expect(util.addDocBlock(str, docs)).toEqual(str);

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -142,12 +142,8 @@ function getDocBlockLines(docs: d.CompilerJsDoc): string[] {
  * @param buildCtx the current build context to query for a specific package
  * @returns a list of package names the project is dependent on
  */
-const getDependencies = (buildCtx: d.BuildCtx): ReadonlyArray<string> => {
-  if (buildCtx.packageJson != null && buildCtx.packageJson.dependencies != null) {
-    return Object.keys(buildCtx.packageJson.dependencies).filter((pkgName) => !SKIP_DEPS.includes(pkgName));
-  }
-  return [];
-};
+const getDependencies = (buildCtx: d.BuildCtx): ReadonlyArray<string> =>
+  Object.keys(buildCtx?.packageJson?.dependencies ?? {}).filter((pkgName) => !SKIP_DEPS.includes(pkgName));
 
 /**
  * Utility to determine whether a project has a dependency on a package


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
