### PR TITLE
chore(repo): update renovate schedule

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -97,11 +97,13 @@
       matchPackagePrefixes: ['@typescript-eslint'],
       groupName: 'TypeScript-ESLint',
       // these packages can be released often, let's look at them every week
+      // Note: Timezone for the schedule is specified as UTC
       schedule: ["before 11am on monday"]
     },
     {
       matchPackageNames: ['eslint-plugin-jsdoc'],
       // this package can be released often, let's look at it every week
+      // Note: Timezone for the schedule is specified as UTC
       schedule: ["before 11am on monday"]
     }
   ],

--- a/renovate.json5
+++ b/renovate.json5
@@ -102,7 +102,7 @@
     {
       matchPackageNames: ['eslint-plugin-jsdoc'],
       // this package can be released often, let's look at it every week
-//      schedule: ["before 11am on monday"]
+      schedule: ["before 11am on monday"]
     }
   ],
   // Never rebase the branch or update it unless manually requested to avoid noisy PR emails

--- a/renovate.json5
+++ b/renovate.json5
@@ -102,7 +102,7 @@
     {
       matchPackageNames: ['eslint-plugin-jsdoc'],
       // this package can be released often, let's look at it every week
-      schedule: ["before 11am on monday"]
+//      schedule: ["before 11am on monday"]
     }
   ],
   // Never rebase the branch or update it unless manually requested to avoid noisy PR emails

--- a/renovate.json5
+++ b/renovate.json5
@@ -107,6 +107,8 @@
   ],
   // Never rebase the branch or update it unless manually requested to avoid noisy PR emails
   rebaseWhen: 'never',
+  // Note: Timezone for the schedule is specified as UTC
+  schedule: ['every weekday before 11am'],
   /**
    * Ensure semantic commits are enabled for commits + PR titles.
    *

--- a/renovate.json5
+++ b/renovate.json5
@@ -97,12 +97,12 @@
       matchPackagePrefixes: ['@typescript-eslint'],
       groupName: 'TypeScript-ESLint',
       // these packages can be released often, let's look at them every week
-      schedule: ["before 7am on monday"]
+      schedule: ["before 11am on monday"]
     },
     {
       matchPackageNames: ['eslint-plugin-jsdoc'],
       // this package can be released often, let's look at it every week
-      schedule: ["before 7am on monday"]
+      schedule: ["before 11am on monday"]
     }
   ],
   // Never rebase the branch or update it unless manually requested to avoid noisy PR emails


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See "New Behavior" below
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the schedule that renovate runs at. previously, it
was set to create pull requests at 7 am (utc) until https://github.com/ionic-team/stencil/pull/4324.
this was problematic, as it would only allow renovate to create pull
requests at 7 am. with the new schedule, pull requests may be created
before 11am utc on any weekday. this equates to:
- 10 pm to 7 AM (eastern)
- 9 pm to 6 am (central)
- 8 pm to 5 am (mountain)
- 7 pm to 4 am (western)

by having an 11 hour period to open pull request outside of working
hours, the hope is that prs will be created without spamming the team
throughout the day

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

N/A - we'll have to merge it and see how it goes 😬 
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
