### PR TITLE
chore(renovate): add minimatch to ignore list

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -93,6 +93,11 @@
       matchPackageNames: ['glob'],
       allowedVersions: '<9.0.0',
     },
+    // TODO(STENCIL-716): remove this once Stencil drops support for Node 14
+    {
+      matchPackageNames: ['minimatch'],
+      allowedVersions: '<6.0.0',
+    },
     {
       matchPackagePrefixes: ['@typescript-eslint'],
       groupName: 'TypeScript-ESLint',


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Renovate will try to upgrade us to the latest version of minimatch, which we cannot support in Stencil v3 due to Node support constraints
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit is created in direct response to https://github.com/ionic-team/stencil/pull/4346. in #4346, renovate attempted to bump minimatch from v5->9. this led to build (in ci) to fail. to try to get stencil on a slightly newer version of the project, rwaskiewicz attempted to upgrade the patckage from v5->6, hoping that at least one major version increment was possible.

however, in minimatch v6, default exports for commonjs modules have changed. stencil is reliant on `@types/glob@8`, which assumes that the default export found in `minimatch@5` will be present (and type checking fails). unfortunately, we are pinned to our current version of glob (and its typings, whether they come from definitely typed or natively in newer versions of the package) due to the fact that stencil must continue to support node 14 (which newer versions of glob does not).

rather than complicate our type checking setup (or turning library checking off completely), we temporarily add minimatch to the ignore list for renovate.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

N/A
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
