### PR TITLE
add support for node 20

### DIFF
--- a/.github/workflows/test-analysis.yml
+++ b/.github/workflows/test-analysis.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['14', '16', '18']
+        node: ['14', '16', '18', '20']
         os: ['ubuntu-20.04', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-component-starter.yml
+++ b/.github/workflows/test-component-starter.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['14', '16', '18']
+        node: ['14', '16', '18', '20']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['14', '16', '18']
+        node: ['14', '16', '18', '20']
         os: ['ubuntu-20.04', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['14', '16', '18']
+        node: ['14', '16', '18', '20']
         os: ['ubuntu-20.04', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@types/inquirer": "^7.3.1",
         "@types/jest": "^27.0.3",
         "@types/listr": "^0.14.4",
-        "@types/node": "^18.14.0",
+        "@types/node": "^20.1.1",
         "@types/pixelmatch": "^5.2.4",
         "@types/pngjs": "^6.0.1",
         "@types/prompts": "^2.0.9",
@@ -1812,9 +1812,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.16.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.8.tgz",
-      "integrity": "sha512-p0iAXcfWCOTCBbsExHIDFCfwsqFwBTgETJveKMT+Ci3LY9YqQCI91F5S+TB20+aRCXpcWfvx5Qr5EccnwCm2NA==",
+      "version": "20.1.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.5.tgz",
+      "integrity": "sha512-IvGD1CD/nego63ySR7vrAKEX3AJTcmrAN2kn+/sDNLi1Ff5kBzDeEdqWDplK+0HAEoLYej137Sk0cUU8OLOlMg==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -12166,9 +12166,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.16.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.8.tgz",
-      "integrity": "sha512-p0iAXcfWCOTCBbsExHIDFCfwsqFwBTgETJveKMT+Ci3LY9YqQCI91F5S+TB20+aRCXpcWfvx5Qr5EccnwCm2NA==",
+      "version": "20.1.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.5.tgz",
+      "integrity": "sha512-IvGD1CD/nego63ySR7vrAKEX3AJTcmrAN2kn+/sDNLi1Ff5kBzDeEdqWDplK+0HAEoLYej137Sk0cUU8OLOlMg==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@types/inquirer": "^7.3.1",
     "@types/jest": "^27.0.3",
     "@types/listr": "^0.14.4",
-    "@types/node": "^18.14.0",
+    "@types/node": "^20.1.1",
     "@types/pixelmatch": "^5.2.4",
     "@types/pngjs": "^6.0.1",
     "@types/prompts": "^2.0.9",
@@ -149,7 +149,7 @@
   ],
   "prettier": "@ionic/prettier-config",
   "volta": {
-    "node": "18.16.0",
+    "node": "20.1.0",
     "npm": "9.6.6"
   }
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -55,7 +55,7 @@
   packageRules: [
     {
       matchPackageNames: ['@types/node'],
-      allowedVersions: '<19.0.0',
+      allowedVersions: '<21.0.0',
     },
     {
       // TODO(STENCIL-710): Increment this value as a part of updating TypeScript

--- a/src/utils/test/util.spec.ts
+++ b/src/utils/test/util.spec.ts
@@ -158,7 +158,7 @@ describe('util', () => {
       const expectedDiagnostic: d.Diagnostic = stubDiagnostic({
         absFilePath: mockPackageJsonPath,
         header: 'Error Parsing JSON',
-        messageText: 'Unexpected string in JSON at position 13', // due to missing colon in input
+        messageText: expect.stringMatching(/.*in JSON at position 13$/),
         type: 'build',
       });
 


### PR DESCRIPTION
This adds support for node 20 by

- adding it to the node version matrix for CI tests
- bumping the version we specify via Volta in `package.json`
- bumping the version of `@types/node`
- editing the renovate configuration to allow for newer versions of `@types/node`


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
