### PR TITLE
chore(repo): use new output nomenclature for workflows 

### DIFF
--- a/.github/workflows/tech-debt-burndown.yml
+++ b/.github/workflows/tech-debt-burndown.yml
@@ -10,9 +10,6 @@ on:
   pull_request_target:
     branches:
       - '**'
-  pull_request:
-    branches:
-      - '**'
 
 jobs:
   strict_null_check: # TODO(STENCIL-446): Remove this workflow once `strictNullChecks` is enabled


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Our tech debt burndown job uses the `set-output` syntax. `set-output` was deprecated on 2022.10.11, in
favor of a new syntax - https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/. starting 2023.05.31, `set-output` is intended to be disabled.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates all workflows using the "old" output nomenclature to
use the newer variant.  applying this commit will allow the tech debt burndown to continue to function as
expected.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

- Tables/markdown in the bot-driven report is rendered correctly (I temporarily added a "pull_request" trigger to the workflow to test this)
- We no longer see the following message in runs of the tech debt burndown job (screenshot taken from another PR's run):
![Screenshot 2023-05-11 at 8 56 06 AM](https://github.com/ionic-team/stencil/assets/1930213/7c76530b-a627-4e9f-a754-347782df0769)

## Other information

I was under the impression we could perhaps remove the sanitizing of newlines and the like. That proved to be wrong 😆 
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
