### PR TITLE
chore(snc): fix some SNC errors in src/compiler/plugin/plugin.ts

### DIFF
--- a/src/compiler/plugin/plugin.ts
+++ b/src/compiler/plugin/plugin.ts
@@ -6,7 +6,7 @@ import { PluginCtx, PluginTransformResults } from '../../declarations';
 import { parseCssImports } from '../style/css-imports';
 
 export const runPluginResolveId = async (pluginCtx: PluginCtx, importee: string) => {
-  for (const plugin of pluginCtx.config.plugins) {
+  for (const plugin of pluginCtx.config?.plugins ?? []) {
     if (isFunction(plugin.resolveId)) {
       try {
         const results = plugin.resolveId(importee, null, pluginCtx);
@@ -32,7 +32,7 @@ export const runPluginResolveId = async (pluginCtx: PluginCtx, importee: string)
 };
 
 export const runPluginLoad = async (pluginCtx: PluginCtx, id: string) => {
-  for (const plugin of pluginCtx.config.plugins) {
+  for (const plugin of pluginCtx.config?.plugins ?? []) {
     if (isFunction(plugin.load)) {
       try {
         const results = plugin.load(id, pluginCtx);
@@ -63,7 +63,7 @@ export const runPluginTransforms = async (
   buildCtx: d.BuildCtx,
   id: string,
   cmp?: d.ComponentCompilerMeta
-) => {
+): Promise<PluginTransformResults | null> => {
   const pluginCtx: PluginCtx = {
     config: config,
     sys: config.sys,
@@ -81,10 +81,11 @@ export const runPluginTransforms = async (
     return null;
   }
 
-  const transformResults: PluginTransformResults = {
+  const transformResults = {
     code: sourceText,
     id: id,
-  };
+    dependencies: [] as string[],
+  } satisfies PluginTransformResults;
 
   const isRawCssFile = transformResults.id.toLowerCase().endsWith('.css');
   const shouldParseCssDocs = cmp != null && config.outputTargets.some(isOutputTargetDocs);
@@ -113,7 +114,7 @@ export const runPluginTransforms = async (
     }
   }
 
-  for (const plugin of pluginCtx.config.plugins) {
+  for (const plugin of pluginCtx.config?.plugins ?? []) {
     if (isFunction(plugin.transform)) {
       try {
         let pluginTransformResults: PluginTransformResults | string;
@@ -184,7 +185,7 @@ export const runPluginTransforms = async (
 };
 
 export const runPluginTransformsEsmImports = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   code: string,
@@ -198,13 +199,13 @@ export const runPluginTransformsEsmImports = async (
     diagnostics: [],
   };
 
-  const transformResults: PluginTransformResults = {
+  const transformResults = {
     code,
     id,
-    map: null,
-    diagnostics: [],
-    dependencies: [],
-  };
+    map: undefined as string | undefined,
+    diagnostics: [] as d.Diagnostic[],
+    dependencies: [] as string[],
+  } satisfies PluginTransformResults;
 
   const isRawCssFile = id.toLowerCase().endsWith('.css');
   if (isRawCssFile) {
@@ -218,7 +219,7 @@ export const runPluginTransformsEsmImports = async (
     }
   }
 
-  for (const plugin of pluginCtx.config.plugins) {
+  for (const plugin of pluginCtx.config?.plugins ?? []) {
     if (isFunction(plugin.transform)) {
       try {
         let pluginTransformResults: PluginTransformResults | string;


### PR DESCRIPTION
This just fixes some SNC errors in `src/compiler/plugin/plugin.ts`, mainly by switching a few type annotations to instead use the `satisfies` operator and also adding some null property access checks w/ the nullish coalescing operator.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
