### PR TITLE
chore(snc): fix SNC errors relating to `HostRef.$hostElement$`

### DIFF
--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -1730,7 +1730,7 @@ export interface HostRef {
   $ancestorComponent$?: HostElement;
   $flags$: number;
   $cmpMeta$: ComponentRuntimeMeta;
-  $hostElement$?: HostElement;
+  $hostElement$: HostElement;
   $instanceValues$?: Map<string, any>;
   $lazyInstance$?: ComponentInterface;
   $onReadyPromise$?: Promise<any>;

--- a/src/runtime/profile.ts
+++ b/src/runtime/profile.ts
@@ -2,8 +2,6 @@ import { BUILD } from '@app-data';
 import { getHostRef, win } from '@platform';
 import { HOST_FLAGS } from '@utils';
 
-import type * as d from '../declarations';
-
 let i = 0;
 
 export const createTime = (fnName: string, tagName = '') => {
@@ -44,7 +42,7 @@ const inspect = (ref: any) => {
     return undefined;
   }
   const flags = hostRef.$flags$;
-  const hostElement = hostRef.$hostElement$ as d.HostElement;
+  const hostElement = hostRef.$hostElement$;
   return {
     renderCount: hostRef.$renderCount$,
     flags: {

--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -9,7 +9,7 @@ import { PLATFORM_FLAGS } from './runtime-constants';
 import { attachStyles } from './styles';
 import { renderVdom } from './vdom/vdom-render';
 
-export const attachToAncestor = (hostRef: d.HostRef, ancestorComponent: d.HostElement) => {
+export const attachToAncestor = (hostRef: d.HostRef, ancestorComponent?: d.HostElement) => {
   if (BUILD.asyncLoading && ancestorComponent && !hostRef.$onRenderResolve$ && ancestorComponent['s-p']) {
     ancestorComponent['s-p'].push(new Promise((r) => (hostRef.$onRenderResolve$ = r)));
   }
@@ -66,7 +66,7 @@ const dispatchHooks = (hostRef: d.HostRef, isInitialLoad: boolean): Promise<void
       hostRef.$flags$ |= HOST_FLAGS.isListenReady;
       if (hostRef.$queuedListeners$) {
         hostRef.$queuedListeners$.map(([methodName, event]) => safeCall(instance, methodName, event));
-        hostRef.$queuedListeners$ = null;
+        hostRef.$queuedListeners$ = undefined;
       }
     }
     emitLifecycleEvent(elm, 'componentWillLoad');
@@ -145,7 +145,7 @@ const updateComponent = async (hostRef: d.HostRef, instance: any, isInitialLoad:
     plt.$cssShim$.updateHost(elm);
   }
   if (BUILD.isDev) {
-    hostRef.$renderCount$++;
+    hostRef.$renderCount$ = hostRef.$renderCount$ === undefined ? 1 : hostRef.$renderCount$ + 1;
     hostRef.$flags$ &= ~HOST_FLAGS.devOnRender;
   }
 
@@ -179,7 +179,7 @@ const updateComponent = async (hostRef: d.HostRef, instance: any, isInitialLoad:
   endUpdate();
 
   if (BUILD.asyncLoading) {
-    const childrenPromises = elm['s-p'];
+    const childrenPromises = elm['s-p'] ?? [];
     const postUpdate = () => postUpdateComponent(hostRef);
     if (childrenPromises.length === 0) {
       postUpdate();


### PR DESCRIPTION
This makes the `$hostElement$` property required on the `HostRef` interface. I believe this is actually in line with how this property is already used, since I can't find an instance where we create a `HostRef` without supplying a value for `$hostElement$`. Since this property is accessed a lot throughout the runtime this drops a number of SNC errors.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
