### PR TITLE
test(validate-testing): evaluate property checks 

### DIFF
--- a/src/compiler/config/test/validate-testing.spec.ts
+++ b/src/compiler/config/test/validate-testing.spec.ts
@@ -632,7 +632,7 @@ describe('validateTesting', () => {
       expect(config.testing.waitBeforeScreenshot).toBe(waitBeforeScreenshot);
     });
 
-    it('creates an error the value provided is negative', () => {
+    it('creates an error if the value provided is negative', () => {
       const waitBeforeScreenshot = -1;
       userConfig.flags = { ...flags, e2e: true };
       userConfig.testing = {

--- a/src/compiler/config/test/validate-testing.spec.ts
+++ b/src/compiler/config/test/validate-testing.spec.ts
@@ -82,10 +82,45 @@ describe('validateTesting', () => {
     });
   });
 
+  describe('browserWaitUntil', () => {
+    it('sets the default to "load" if no value is provided', () => {
+      userConfig.flags = { ...flags, e2e: true };
+      userConfig.testing = {};
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.browserWaitUntil).toBe('load');
+    });
+
+    it('does not override a provided value', () => {
+      userConfig.flags = { ...flags, e2e: true };
+      userConfig.testing = {
+        browserWaitUntil: 'domcontentloaded',
+      };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.browserWaitUntil).toBe('domcontentloaded');
+    });
+  });
+
   describe('browserArgs', () => {
+    it('does not add duplicate default fields', () => {
+      userConfig.flags = { ...flags, e2e: true };
+      userConfig.testing = {
+        browserArgs: ['--unique', '--font-render-hinting=medium'],
+      };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.browserArgs).toEqual(['--unique', '--font-render-hinting=medium', '--incognito']);
+    });
+
     it('adds default browser args', () => {
       userConfig.flags = { ...flags, e2e: true };
+
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
       expect(config.testing.browserArgs).toEqual(['--font-render-hinting=medium', '--incognito']);
     });
 
@@ -102,10 +137,54 @@ describe('validateTesting', () => {
     });
   });
 
-  describe('testPathIgnorePatterns', () => {
-    it('set default testPathIgnorePatterns', () => {
-      userConfig.flags = { ...flags, e2e: true };
+  describe('screenshotConnector', () => {
+    it('assigns the screenshotConnector value from the provided flags', () => {
+      userConfig.flags = { ...flags, e2e: true, screenshotConnector: path.join(ROOT, 'mock', 'path') };
+      userConfig.testing = { screenshotConnector: path.join(ROOT, 'another', 'mock', 'path') };
+
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.screenshotConnector).toBe(path.join(ROOT, 'mock', 'path'));
+    });
+
+    it("uses the config's root dir to make the screenshotConnector path absolute", () => {
+      userConfig.flags = { ...flags, e2e: true, screenshotConnector: path.join('mock', 'path') };
+      userConfig.testing = { screenshotConnector: path.join('another', 'mock', 'path') };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.screenshotConnector).toBe(path.join(ROOT, 'User', 'some', 'path', 'mock', 'path'));
+    });
+
+    it('sets screenshotConnector if a non-string is provided', () => {
+      userConfig.flags = { ...flags, e2e: true };
+      // the nature of this test is to evaluate a non-string, hence the type assertion
+      userConfig.testing = { screenshotConnector: true as unknown as string };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.screenshotConnector).toBe(path.join('screenshot', 'local-connector.js'));
+    });
+  });
+
+  describe('testPathIgnorePatterns', () => {
+    it('does not alter a provided testPathIgnorePatterns', () => {
+      userConfig.flags = { ...flags, e2e: true };
+
+      const mockPath1 = path.join('this', 'is', 'a', 'mock', 'path');
+      const mockPath2 = path.join('this', 'is', 'another', 'mock', 'path');
+      userConfig.testing = { testPathIgnorePatterns: [mockPath1, mockPath2] };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.testPathIgnorePatterns).toEqual([mockPath1, mockPath2]);
+    });
+
+    it('sets the default testPathIgnorePatterns if not array is provided', () => {
+      userConfig.flags = { ...flags, e2e: true };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
       expect(config.testing.testPathIgnorePatterns).toEqual([
         path.join(ROOT, 'User', 'some', 'path', '.vscode'),
         path.join(ROOT, 'User', 'some', 'path', '.stencil'),
@@ -114,14 +193,16 @@ describe('validateTesting', () => {
       ]);
     });
 
-    it('set default testPathIgnorePatterns with custom outputTargets', () => {
+    it('sets the default testPathIgnorePatterns with custom outputTargets', () => {
       userConfig.flags = { ...flags, e2e: true };
       userConfig.outputTargets = [
         { type: 'dist', dir: 'dist-folder' },
         { type: 'www', dir: 'www-folder' },
         { type: 'docs-readme', dir: 'docs' },
       ];
+
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
       expect(config.testing.testPathIgnorePatterns).toEqual([
         path.join(ROOT, 'User', 'some', 'path', '.vscode'),
         path.join(ROOT, 'User', 'some', 'path', '.stencil'),
@@ -132,29 +213,251 @@ describe('validateTesting', () => {
     });
   });
 
+  describe('preset', () => {
+    it.each([null, true])("uses stencil's default preset if a non-string (%s) is provided", (nonStringPreset) => {
+      userConfig.flags = { ...flags, e2e: true };
+      userConfig.testing = {
+        // the nature of this test requires a non-string value, hence the type assertion
+        preset: nonStringPreset as unknown as string,
+      };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      // 'testing' is the internal directory where `jest-preset.js` can be found
+      expect(config.testing.preset).toEqual('testing');
+    });
+
+    it('forces a provided preset path to be absolute', () => {
+      userConfig.flags = { ...flags, e2e: true };
+      userConfig.testing = {
+        preset: path.join('mock', 'path'),
+      };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.preset).toEqual(path.join(ROOT, 'User', 'some', 'path', 'mock', 'path'));
+    });
+
+    it('does not change an already absolute preset path', () => {
+      userConfig.flags = { ...flags, e2e: true };
+
+      const presetPath = path.join(ROOT, 'mock', 'path');
+      userConfig.testing = {
+        preset: presetPath,
+      };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.preset).toEqual(presetPath);
+    });
+  });
+
+  describe('setupFilesAfterEnv', () => {
+    it.each([null, true])('forces a non-array (%s) of setup files to a default', (nonSetupFiles) => {
+      userConfig.flags = { ...flags, e2e: true };
+      userConfig.testing = {
+        // the nature of this test requires a non-string value, hence the type assertion
+        setupFilesAfterEnv: nonSetupFiles as unknown as string[],
+      };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      // 'testing' is the internal directory where the default setup file can be found
+      expect(config.testing.setupFilesAfterEnv).toEqual([path.join('testing', 'jest-setuptestframework.js')]);
+    });
+
+    it.each([[[]], [['mock-setup-file.js']]])(
+      "prepends stencil's default file to an array: %s",
+      (setupFilesAfterEnv) => {
+        userConfig.flags = { ...flags, e2e: true };
+        userConfig.testing = {
+          setupFilesAfterEnv: [...setupFilesAfterEnv],
+        };
+
+        const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+        expect(config.testing.setupFilesAfterEnv).toEqual([
+          // 'testing' is the internal directory where the default setup file can be found
+          path.join('testing', 'jest-setuptestframework.js'),
+          ...setupFilesAfterEnv,
+        ]);
+      }
+    );
+  });
+
   describe('testEnvironment', () => {
-    it('set relative testEnvironment to absolute', () => {
+    it('sets a relative testEnvironment to absolute', () => {
       userConfig.flags = { ...flags, e2e: true };
       userConfig.testing = {
         testEnvironment: './rel-path.js',
       };
+
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
       expect(path.isAbsolute(config.testing.testEnvironment)).toBe(true);
       expect(path.basename(config.testing.testEnvironment)).toEqual('rel-path.js');
     });
 
-    it('set node module testEnvironment', () => {
+    it('allows a node module testEnvironment', () => {
       userConfig.flags = { ...flags, e2e: true };
       userConfig.testing = {
         testEnvironment: 'jsdom',
       };
+
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
       expect(config.testing.testEnvironment).toEqual('jsdom');
     });
 
-    it('do nothing for empty testEnvironment', () => {
+    it('does nothing for an empty testEnvironment', () => {
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
       expect(config.testing.testEnvironment).toBeUndefined();
+    });
+  });
+
+  describe('allowableMismatchedPixels', () => {
+    it.each([0, 123])('does nothing is a non-negative number (%s) is provided', (pixelCount) => {
+      userConfig.flags = { ...flags, e2e: true };
+      userConfig.testing = {
+        allowableMismatchedPixels: pixelCount,
+      };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.allowableMismatchedPixels).toBe(pixelCount);
+    });
+
+    it('creates an error if a negative number is provided', () => {
+      const pixelCount = -1;
+      userConfig.flags = { ...flags, e2e: true };
+      userConfig.testing = {
+        allowableMismatchedPixels: pixelCount,
+      };
+
+      const { config, diagnostics } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.allowableMismatchedPixels).toBe(pixelCount);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]).toEqual({
+        absFilePath: null,
+        header: 'Build Error',
+        level: 'error',
+        lines: [],
+        messageText: 'allowableMismatchedPixels must be a value that is 0 or greater',
+        relFilePath: null,
+        type: 'build',
+      });
+    });
+
+    it.each([true, null])('defaults to a reasonable value if a non-number (%s) is provided', (pixelCount) => {
+      userConfig.flags = { ...flags, e2e: true };
+      userConfig.testing = {
+        // the nature of this test requires using a non-number, hence th type assertion
+        allowableMismatchedPixels: pixelCount as unknown as number,
+      };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.allowableMismatchedPixels).toBe(100);
+    });
+  });
+
+  describe('allowableMismatchedRatio', () => {
+    it.each([-0, 0, 0.5, 1.0])(
+      'does nothing if a value between 0 and 1 is provided (%s)',
+      (allowableMismatchedRatio) => {
+        userConfig.flags = { ...flags, e2e: true };
+        userConfig.testing = {
+          allowableMismatchedRatio,
+        };
+
+        const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+        expect(config.testing.allowableMismatchedRatio).toBe(allowableMismatchedRatio);
+      }
+    );
+
+    it.each([-1, -0.1, 1.1, 2])(
+      'creates an error if a number outside 0 and 1 is provided (%s)',
+      (allowableMismatchedRatio) => {
+        userConfig.flags = { ...flags, e2e: true };
+        userConfig.testing = {
+          allowableMismatchedRatio,
+        };
+
+        const { config, diagnostics } = validateConfig(userConfig, mockLoadConfigInit());
+
+        expect(config.testing.allowableMismatchedRatio).toBe(allowableMismatchedRatio);
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0]).toEqual({
+          absFilePath: null,
+          header: 'Build Error',
+          level: 'error',
+          lines: [],
+          messageText: 'allowableMismatchedRatio must be a value ranging from 0 to 1',
+          relFilePath: null,
+          type: 'build',
+        });
+      }
+    );
+
+    it.each([true, null])('does nothing when a non-number (%s) is provided', (allowableMismatchedRatio) => {
+      userConfig.flags = { ...flags, e2e: true };
+      userConfig.testing = {
+        // the nature of this test requires using a non-number, hence th type assertion
+        allowableMismatchedRatio: allowableMismatchedRatio as unknown as number,
+      };
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+      expect(config.testing.allowableMismatchedRatio).toBe(allowableMismatchedRatio);
+    });
+  });
+
+  describe('pixelmatchThreshold', () => {
+    it.each([-0, 0, 0.5, 1.0])('does nothing if a value between 0 and 1 is provided (%s)', (pixelmatchThreshold) => {
+      userConfig.flags = { ...flags, e2e: true };
+      userConfig.testing = {
+        pixelmatchThreshold,
+      };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.pixelmatchThreshold).toBe(pixelmatchThreshold);
+    });
+
+    it.each([-0.1, -1, 1.1, 2])(
+      'creates an error if a number outside 0 and 1 is provided (%s)',
+      (pixelmatchThreshold) => {
+        userConfig.flags = { ...flags, e2e: true };
+        userConfig.testing = {
+          pixelmatchThreshold,
+        };
+
+        const { config, diagnostics } = validateConfig(userConfig, mockLoadConfigInit());
+
+        expect(config.testing.pixelmatchThreshold).toBe(pixelmatchThreshold);
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0]).toEqual({
+          absFilePath: null,
+          header: 'Build Error',
+          level: 'error',
+          lines: [],
+          messageText: 'pixelmatchThreshold must be a value ranging from 0 to 1',
+          relFilePath: null,
+          type: 'build',
+        });
+      }
+    );
+
+    it.each([true, null])('defaults to a reasonable value if a non-number (%s) is provided', (pixelmatchThreshold) => {
+      userConfig.flags = { ...flags, e2e: true };
+      userConfig.testing = {
+        // the nature of this test requires using a non-number, hence th type assertion
+        pixelmatchThreshold: pixelmatchThreshold as unknown as number,
+      };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.allowableMismatchedPixels).toBe(100);
     });
   });
 
@@ -262,6 +565,153 @@ describe('validateTesting', () => {
       ])(`doesn't match the file '%s'`, (filename) => {
         expect(testRegex.test(filename)).toBe(false);
       });
+    });
+  });
+
+  describe('testMatch', () => {
+    it('removes testRegex from the config when testMatch is an array', () => {
+      userConfig.flags = { ...flags, e2e: true };
+      userConfig.testing = {
+        testMatch: ['mockMatcher'],
+      };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.testMatch).toEqual(['mockMatcher']);
+      expect(config.testing.testRegex).toBeUndefined();
+    });
+
+    it('removes testMatch from the config when testRegex is a string', () => {
+      userConfig.flags = { ...flags, e2e: true };
+      userConfig.testing = {
+        testMatch: undefined,
+        testRegex: '/regexStr/',
+      };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.testMatch).toBeUndefined();
+      expect(config.testing.testRegex).toBe('/regexStr/');
+    });
+  });
+
+  describe('runner', () => {
+    it('does nothing if the runner property is a string', () => {
+      userConfig.flags = { ...flags, e2e: true };
+      userConfig.testing = {
+        runner: 'my-runner.js',
+      };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.runner).toEqual('my-runner.js');
+    });
+
+    it('sets the runner if a non-string value is provided', () => {
+      userConfig.flags = { ...flags, e2e: true };
+      userConfig.testing = {
+        runner: undefined,
+      };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      // 'testing' is the internal directory where the default runner file can be found
+      expect(config.testing.runner).toEqual(path.join('testing', 'jest-runner.js'));
+    });
+  });
+
+  describe('waitBeforeScreenshot', () => {
+    it.each([-0, 0, 0.5, 1.0])('does nothing for a non-negative value (%s)', (waitBeforeScreenshot) => {
+      userConfig.flags = { ...flags, e2e: true };
+      userConfig.testing = {
+        waitBeforeScreenshot,
+      };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.waitBeforeScreenshot).toBe(waitBeforeScreenshot);
+    });
+
+    it('creates an error the value provided is negative', () => {
+      const waitBeforeScreenshot = -1;
+      userConfig.flags = { ...flags, e2e: true };
+      userConfig.testing = {
+        waitBeforeScreenshot,
+      };
+
+      const { config, diagnostics } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.waitBeforeScreenshot).toBe(waitBeforeScreenshot);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]).toEqual({
+        absFilePath: null,
+        header: 'Build Error',
+        level: 'error',
+        lines: [],
+        messageText: 'waitBeforeScreenshot must be a value that is 0 or greater',
+        relFilePath: null,
+        type: 'build',
+      });
+    });
+
+    it.each([true, null])('defaults to a reasonable value if a non-number (%s) is provided', (waitBeforeScreenshot) => {
+      userConfig.flags = { ...flags, e2e: true };
+      userConfig.testing = {
+        // the nature of this test requires using a non-number, hence th type assertion
+        pixelmatchThreshold: waitBeforeScreenshot as unknown as number,
+      };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.waitBeforeScreenshot).toBe(10);
+    });
+  });
+
+  describe('emulate', () => {
+    it.each([[undefined], [[]]])('provides a reasonable default for %s', (emulate) => {
+      userConfig.flags = { ...flags, e2e: true };
+      userConfig.testing = {
+        emulate,
+      };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.emulate).toEqual([
+        {
+          userAgent: 'default',
+          viewport: {
+            width: 600,
+            height: 600,
+            deviceScaleFactor: 1,
+            isMobile: false,
+            hasTouch: false,
+            isLandscape: false,
+          },
+        },
+      ]);
+    });
+
+    it('does nothing when a non-zero length array is provided', () => {
+      userConfig.flags = { ...flags, e2e: true };
+
+      const emulateConfig: d.EmulateConfig = {
+        userAgent: 'mockAgent',
+        viewport: {
+          width: 100,
+          height: 100,
+          deviceScaleFactor: 1,
+          isMobile: true,
+          hasTouch: true,
+          isLandscape: false,
+        },
+      };
+      userConfig.testing = {
+        emulate: [emulateConfig],
+      };
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing.emulate).toEqual([emulateConfig]);
     });
   });
 });

--- a/src/compiler/config/test/validate-testing.spec.ts
+++ b/src/compiler/config/test/validate-testing.spec.ts
@@ -657,7 +657,7 @@ describe('validateTesting', () => {
     it.each([true, null])('defaults to a reasonable value if a non-number (%s) is provided', (waitBeforeScreenshot) => {
       userConfig.flags = { ...flags, e2e: true };
       userConfig.testing = {
-        // the nature of this test requires using a non-number, hence th type assertion
+        // the nature of this test requires using a non-number, hence the type assertion
         pixelmatchThreshold: waitBeforeScreenshot as unknown as number,
       };
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Our testing config validation code is missing code coverage. As a part of exploring the refactor to start decoupling testing code from Stencil, I wanted to test these things to verify my understanding of things.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

There are 2 commits in this PR:
- the first groups existing "free standing" tests into `describe` blocks for the property they test
- adds tests for any properties we're missing

I recommend reviewing them independently, as the diffs are much nicer (IMO)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

I traced/debugged each of these (well, most of them) in a node debugger to verify they did what I claim they do

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

1. This PR depends on https://github.com/ionic-team/stencil/pull/4375, which needs to land first
