### PR TITLE
chore(snc): drop a few SNC errors from validate-output-www.spec.ts

### DIFF
--- a/src/compiler/config/test/validate-output-www.spec.ts
+++ b/src/compiler/config/test/validate-output-www.spec.ts
@@ -95,7 +95,7 @@ describe('validateOutputTargetWww', () => {
     };
     userConfig.outputTargets = [outputTarget];
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
-    const www = config.outputTargets.find(isOutputTargetWww);
+    const www = config.outputTargets.find(isOutputTargetWww) as d.OutputTargetWww;
 
     expect(www.dir).toBe(path.join(rootDir, 'www', 'docs'));
     expect(www.appDir).toBe(path.join(rootDir, 'www', 'docs'));
@@ -113,7 +113,7 @@ describe('validateOutputTargetWww', () => {
     };
     userConfig.outputTargets = [outputTarget];
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
-    const www = config.outputTargets.find(isOutputTargetWww);
+    const www = config.outputTargets.find(isOutputTargetWww) as d.OutputTargetWww;
 
     expect(www.type).toBe('www');
     expect(www.dir).toBe(path.join(rootDir, 'my-www'));
@@ -126,7 +126,7 @@ describe('validateOutputTargetWww', () => {
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
     expect(config.outputTargets).toHaveLength(5);
 
-    const outputTarget = config.outputTargets.find(isOutputTargetWww);
+    const outputTarget = config.outputTargets.find(isOutputTargetWww) as d.OutputTargetWww;
     expect(outputTarget.dir).toBe(path.join(rootDir, 'www'));
     expect(outputTarget.buildDir).toBe(path.join(rootDir, 'www', 'build'));
     expect(outputTarget.indexHtml).toBe(path.join(rootDir, 'www', 'index.html'));
@@ -142,7 +142,7 @@ describe('validateOutputTargetWww', () => {
       };
       userConfig.outputTargets = [outputTarget];
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
-      const www = config.outputTargets.find(isOutputTargetWww);
+      const www = config.outputTargets.find(isOutputTargetWww) as d.OutputTargetWww;
 
       expect(www.type).toBe('www');
       expect(www.dir).toBe(path.join(rootDir, 'my-www'));
@@ -160,7 +160,7 @@ describe('validateOutputTargetWww', () => {
       };
       userConfig.outputTargets = [outputTarget];
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
-      const www = config.outputTargets.find(isOutputTargetWww);
+      const www = config.outputTargets.find(isOutputTargetWww) as d.OutputTargetWww;
 
       expect(www.type).toBe('www');
       expect(www.dir).toBe(path.join(rootDir, 'www'));
@@ -178,7 +178,7 @@ describe('validateOutputTargetWww', () => {
       };
       userConfig.outputTargets = [outputTarget];
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
-      const www = config.outputTargets.find(isOutputTargetWww);
+      const www = config.outputTargets.find(isOutputTargetWww) as d.OutputTargetWww;
 
       expect(www.type).toBe('www');
       expect(www.dir).toBe(path.join(rootDir, 'www'));
@@ -347,7 +347,7 @@ describe('validateOutputTargetWww', () => {
       };
       userConfig.outputTargets = [hydrateOutputTarget];
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
-      const o = config.outputTargets.find(isOutputTargetHydrate);
+      const o = config.outputTargets.find(isOutputTargetHydrate) as d.OutputTargetHydrate;
       expect(o.external).toContain('lodash');
       expect(o.external).toContain('left-pad');
       expect(o.external).toContain('fs');
@@ -359,7 +359,7 @@ describe('validateOutputTargetWww', () => {
       userConfig.flags = { ...flags, prerender: true };
 
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
-      const o = config.outputTargets.find(isOutputTargetHydrate);
+      const o = config.outputTargets.find(isOutputTargetHydrate) as d.OutputTargetHydrate;
       expect(o.external).toContain('fs');
       expect(o.external).toContain('path');
       expect(o.external).toContain('crypto');


### PR DESCRIPTION
We can drop a few here by adding `as OutputTargetWww` casts in a few places.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
