### PR TITLE
chore(snc): remove in-memory-fs.spec snc violations

### DIFF
--- a/src/compiler/sys/tests/in-memory-fs.spec.ts
+++ b/src/compiler/sys/tests/in-memory-fs.spec.ts
@@ -11,17 +11,17 @@ describe(`in-memory-fs, getCommitInstructions`, () => {
   });
 
   function fsItem(item: any): FsItem {
-    const defaultItem: FsItem = {
-      exists: null,
-      fileText: null,
-      size: null,
-      mtimeMs: null,
-      isDirectory: null,
-      isFile: null,
-      queueCopyFileToDest: null,
-      queueDeleteFromDisk: null,
-      queueWriteToDisk: null,
-      useCache: null,
+    const defaultItem: Partial<FsItem> = {
+      exists: undefined,
+      fileText: undefined,
+      size: undefined,
+      mtimeMs: undefined,
+      isDirectory: undefined,
+      isFile: undefined,
+      queueCopyFileToDest: undefined,
+      queueDeleteFromDisk: undefined,
+      queueWriteToDisk: undefined,
+      useCache: undefined,
     };
     return Object.assign(defaultItem, item);
   }
@@ -40,9 +40,9 @@ describe(`in-memory-fs, getCommitInstructions`, () => {
     expect(i.filesToWrite).toEqual([]);
     expect(i.dirsToDelete).toEqual([`C:/dir1/dir2/dir3`, `C:/dir1/dir2`, `C:/dir1`]);
     expect(i.dirsToEnsure).toEqual([]);
-    expect(items.get(`C:/dir1`).queueDeleteFromDisk).toBe(false);
-    expect(items.get(`C:/dir1/dir2`).queueDeleteFromDisk).toBe(false);
-    expect(items.get(`C:/dir1/dir2/dir3`).queueDeleteFromDisk).toBe(false);
+    expect(items.get(`C:/dir1`)?.queueDeleteFromDisk).toBe(false);
+    expect(items.get(`C:/dir1/dir2`)?.queueDeleteFromDisk).toBe(false);
+    expect(items.get(`C:/dir1/dir2/dir3`)?.queueDeleteFromDisk).toBe(false);
   });
 
   it(`dirsToDelete, sort longest to shortest, unix`, () => {
@@ -59,9 +59,9 @@ describe(`in-memory-fs, getCommitInstructions`, () => {
     expect(i.filesToWrite).toEqual([]);
     expect(i.dirsToDelete).toEqual([`/dir1/dir2/dir3`, `/dir1/dir2`, `/dir1`]);
     expect(i.dirsToEnsure).toEqual([]);
-    expect(items.get(`/dir1`).queueDeleteFromDisk).toBe(false);
-    expect(items.get(`/dir1/dir2`).queueDeleteFromDisk).toBe(false);
-    expect(items.get(`/dir1/dir2/dir3`).queueDeleteFromDisk).toBe(false);
+    expect(items.get(`/dir1`)?.queueDeleteFromDisk).toBe(false);
+    expect(items.get(`/dir1/dir2`)?.queueDeleteFromDisk).toBe(false);
+    expect(items.get(`/dir1/dir2/dir3`)?.queueDeleteFromDisk).toBe(false);
   });
 
   it(`ensure dirs, sort shortest to longest, windows`, () => {
@@ -76,9 +76,9 @@ describe(`in-memory-fs, getCommitInstructions`, () => {
     expect(i.filesToWrite).toEqual([`C:/dir1/dir2/dir3/file2.js`, `C:/dir1/dir2/file1.js`]);
     expect(i.dirsToDelete).toEqual([]);
     expect(i.dirsToEnsure).toEqual([`C:/dir1`, `C:/dir1/dir2`, `C:/dir1/dir2/dir3`]);
-    expect(items.get(`C:/dir1`).queueDeleteFromDisk).toBe(false);
-    expect(items.get(`C:/dir1/dir2/file1.js`).queueDeleteFromDisk).toBe(false);
-    expect(items.get(`C:/dir1/dir2/dir3/file2.js`).queueDeleteFromDisk).toBe(false);
+    expect(items.get(`C:/dir1`)?.queueDeleteFromDisk).toBe(false);
+    expect(items.get(`C:/dir1/dir2/file1.js`)?.queueDeleteFromDisk).toBe(false);
+    expect(items.get(`C:/dir1/dir2/dir3/file2.js`)?.queueDeleteFromDisk).toBe(false);
   });
 
   it(`ensure dirs, sort shortest to longest`, () => {
@@ -91,9 +91,9 @@ describe(`in-memory-fs, getCommitInstructions`, () => {
     expect(i.filesToWrite).toEqual([`/dir1/dir2/dir3/file2.js`, `/dir1/dir2/file1.js`]);
     expect(i.dirsToDelete).toEqual([]);
     expect(i.dirsToEnsure).toEqual([`/dir1`, `/dir1/dir2`, `/dir1/dir2/dir3`]);
-    expect(items.get(`/dir1`).queueDeleteFromDisk).toBe(false);
-    expect(items.get(`/dir1/dir2/file1.js`).queueDeleteFromDisk).toBe(false);
-    expect(items.get(`/dir1/dir2/dir3/file2.js`).queueDeleteFromDisk).toBe(false);
+    expect(items.get(`/dir1`)?.queueDeleteFromDisk).toBe(false);
+    expect(items.get(`/dir1/dir2/file1.js`)?.queueDeleteFromDisk).toBe(false);
+    expect(items.get(`/dir1/dir2/dir3/file2.js`)?.queueDeleteFromDisk).toBe(false);
   });
 
   it(`do not delete a files/directory if we also want to ensure it`, () => {
@@ -104,7 +104,7 @@ describe(`in-memory-fs, getCommitInstructions`, () => {
     expect(i.filesToWrite).toEqual([`/dir1/file1.js`]);
     expect(i.dirsToDelete).toEqual([]);
     expect(i.dirsToEnsure).toEqual([`/dir1`]);
-    expect(items.get(`/dir1/file1.js`).queueWriteToDisk).toBe(false);
+    expect(items.get(`/dir1/file1.js`)?.queueWriteToDisk).toBe(false);
   });
 
   it(`queueDeleteFromDisk`, () => {
@@ -117,10 +117,10 @@ describe(`in-memory-fs, getCommitInstructions`, () => {
     expect(i.filesToWrite).toEqual([]);
     expect(i.dirsToDelete).toEqual([`/dir1`]);
     expect(i.dirsToEnsure).toEqual([]);
-    expect(items.get(`/dir1`).queueDeleteFromDisk).toBe(false);
-    expect(items.get(`/dir1/file1.js`).queueDeleteFromDisk).toBe(false);
-    expect(items.get(`/dir2/file2.js`).queueDeleteFromDisk).toBe(false);
-    expect(items.get(`/dir1`).queueDeleteFromDisk).toBe(false);
+    expect(items.get(`/dir1`)?.queueDeleteFromDisk).toBe(false);
+    expect(items.get(`/dir1/file1.js`)?.queueDeleteFromDisk).toBe(false);
+    expect(items.get(`/dir2/file2.js`)?.queueDeleteFromDisk).toBe(false);
+    expect(items.get(`/dir1`)?.queueDeleteFromDisk).toBe(false);
   });
 
   it(`write directory to disk`, () => {
@@ -130,7 +130,7 @@ describe(`in-memory-fs, getCommitInstructions`, () => {
     expect(i.filesToWrite).toEqual([]);
     expect(i.dirsToDelete).toEqual([]);
     expect(i.dirsToEnsure).toEqual([`/dir1`]);
-    expect(items.get(`/dir1`).queueWriteToDisk).toBe(false);
+    expect(items.get(`/dir1`)?.queueWriteToDisk).toBe(false);
   });
 
   it(`write file queued even if it's also queueDeleteFromDisk`, () => {
@@ -140,7 +140,7 @@ describe(`in-memory-fs, getCommitInstructions`, () => {
     expect(i.filesToWrite).toEqual([`/dir1/file1.js`]);
     expect(i.dirsToDelete).toEqual([]);
     expect(i.dirsToEnsure).toEqual([`/dir1`]);
-    expect(items.get(`/dir1/file1.js`).queueWriteToDisk).toBe(false);
+    expect(items.get(`/dir1/file1.js`)?.queueWriteToDisk).toBe(false);
   });
 
   it(`write file queued`, () => {
@@ -152,9 +152,9 @@ describe(`in-memory-fs, getCommitInstructions`, () => {
     expect(i.filesToWrite).toEqual([`/dir1/file1.js`, `/dir1/file2.js`, `/dir2/file3.js`]);
     expect(i.dirsToDelete).toEqual([]);
     expect(i.dirsToEnsure).toEqual([`/dir1`, `/dir2`]);
-    expect(items.get(`/dir1/file1.js`).queueWriteToDisk).toBe(false);
-    expect(items.get(`/dir1/file2.js`).queueWriteToDisk).toBe(false);
-    expect(items.get(`/dir2/file3.js`).queueWriteToDisk).toBe(false);
+    expect(items.get(`/dir1/file1.js`)?.queueWriteToDisk).toBe(false);
+    expect(items.get(`/dir1/file2.js`)?.queueWriteToDisk).toBe(false);
+    expect(items.get(`/dir2/file3.js`)?.queueWriteToDisk).toBe(false);
   });
 
   it(`do nothing`, () => {
@@ -423,7 +423,7 @@ describe(`in-memory-fs`, () => {
     await fs.commit();
     fs.clearCache();
 
-    let content: string;
+    let content: string = '';
     try {
       content = await fs.readFile(`/dir/file.js`);
     } catch (e) {
@@ -465,7 +465,7 @@ describe(`in-memory-fs`, () => {
     await fs.commit();
     fs.clearCache();
 
-    let content: string;
+    let content: string = '';
     try {
       content = fs.readFileSync(`/dir/file.js`);
     } catch (e) {


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit removes the `strictNullChecks` violations found in `in-memory-fs.spec.ts`. there are two types of changes found within this file:
1. `fsItem`, a helper function in the suite, has been updated to set it's default values to `undefined` to adhere to `Partial<FsItem>`, fixing assignability issues with setting each field to null
2. retrieval of entries from the `items` map use optional chaining. this was deemed safe as we are not asserting against `undefined` in any of the `get` calls in said tests
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Unit tests continue to pass
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
