### PR TITLE
chore(snc): remove snc violations from parse-props.spec

### DIFF
--- a/src/compiler/transformers/test/parse-props.spec.ts
+++ b/src/compiler/transformers/test/parse-props.spec.ts
@@ -28,10 +28,10 @@ describe('parse props', () => {
       },
     });
 
-    expect(t.property.attribute).toBe('val');
-    expect(t.property.type).toBe('string');
-    expect(t.property.optional).toBe(true);
-    expect(t.cmp.hasProp).toBe(true);
+    expect(t.property?.attribute).toBe('val');
+    expect(t.property?.type).toBe('string');
+    expect(t.property?.optional).toBe(true);
+    expect(t.cmp?.hasProp).toBe(true);
   });
 
   it('prop required', () => {
@@ -60,7 +60,7 @@ describe('parse props', () => {
         type: 'string',
       },
     });
-    expect(t.property.required).toBe(true);
+    expect(t.property?.required).toBe(true);
   });
 
   it('prop mutable', () => {
@@ -90,7 +90,7 @@ describe('parse props', () => {
         type: 'string',
       },
     });
-    expect(t.property.mutable).toBe(true);
+    expect(t.property?.mutable).toBe(true);
   });
 
   it('prop reflectAttr', () => {
@@ -119,8 +119,8 @@ describe('parse props', () => {
         type: 'string',
       },
     });
-    expect(t.property.reflect).toBe(true);
-    expect(t.cmp.hasReflect).toBe(true);
+    expect(t.property?.reflect).toBe(true);
+    expect(t.cmp?.hasReflect).toBe(true);
   });
 
   it('prop array', () => {
@@ -147,9 +147,9 @@ describe('parse props', () => {
         type: 'unknown',
       },
     });
-    expect(t.property.type).toBe('unknown');
-    expect(t.property.attribute).toBe(undefined);
-    expect(t.property.reflect).toBe(false);
+    expect(t.property?.type).toBe('unknown');
+    expect(t.property?.attribute).toBe(undefined);
+    expect(t.property?.reflect).toBe(false);
   });
 
   it('prop object', () => {
@@ -182,9 +182,9 @@ describe('parse props', () => {
         type: 'any',
       },
     });
-    expect(t.property.type).toBe('any');
-    expect(t.property.attribute).toBe('val');
-    expect(t.property.reflect).toBe(false);
+    expect(t.property?.type).toBe('any');
+    expect(t.property?.attribute).toBe('val');
+    expect(t.property?.reflect).toBe(false);
   });
 
   it('prop multiword', () => {
@@ -214,8 +214,8 @@ describe('parse props', () => {
         type: 'string',
       },
     });
-    expect(t.property.name).toBe('multiWord');
-    expect(t.property.attribute).toBe('multi-word');
+    expect(t.property?.name).toBe('multiWord');
+    expect(t.property?.attribute).toBe('multi-word');
   });
 
   it('prop w/ string type', () => {
@@ -244,8 +244,8 @@ describe('parse props', () => {
         type: 'string',
       },
     });
-    expect(t.property.type).toBe('string');
-    expect(t.property.attribute).toBe('val');
+    expect(t.property?.type).toBe('string');
+    expect(t.property?.attribute).toBe('val');
   });
 
   it('prop w/ number type', () => {
@@ -274,8 +274,8 @@ describe('parse props', () => {
         type: 'number',
       },
     });
-    expect(t.property.type).toBe('number');
-    expect(t.property.attribute).toBe('val');
+    expect(t.property?.type).toBe('number');
+    expect(t.property?.attribute).toBe('val');
   });
 
   it('prop w/ boolean type', () => {
@@ -304,8 +304,8 @@ describe('parse props', () => {
         type: 'boolean',
       },
     });
-    expect(t.property.type).toBe('boolean');
-    expect(t.property.attribute).toBe('val');
+    expect(t.property?.type).toBe('boolean');
+    expect(t.property?.attribute).toBe('val');
   });
 
   it('prop w/ any type', () => {
@@ -334,8 +334,8 @@ describe('parse props', () => {
         type: 'any',
       },
     });
-    expect(t.property.type).toBe('any');
-    expect(t.property.attribute).toBe('val');
+    expect(t.property?.type).toBe('any');
+    expect(t.property?.attribute).toBe('val');
   });
 
   it('prop w/ inferred string type', () => {
@@ -365,8 +365,8 @@ describe('parse props', () => {
         type: 'string',
       },
     });
-    expect(t.property.type).toBe('string');
-    expect(t.property.attribute).toBe('val');
+    expect(t.property?.type).toBe('string');
+    expect(t.property?.attribute).toBe('val');
   });
 
   it('prop w/ inferred number type', () => {
@@ -396,8 +396,8 @@ describe('parse props', () => {
         type: 'number',
       },
     });
-    expect(t.property.type).toBe('number');
-    expect(t.property.attribute).toBe('val');
+    expect(t.property?.type).toBe('number');
+    expect(t.property?.attribute).toBe('val');
   });
 
   it('prop w/ inferred boolean type', () => {
@@ -427,8 +427,8 @@ describe('parse props', () => {
         type: 'boolean',
       },
     });
-    expect(t.property.type).toBe('boolean');
-    expect(t.property.attribute).toBe('val');
+    expect(t.property?.type).toBe('boolean');
+    expect(t.property?.attribute).toBe('val');
   });
 
   it('prop w/ inferred any type from null', () => {
@@ -459,7 +459,7 @@ describe('parse props', () => {
         type: 'any',
       },
     });
-    expect(t.property.type).toBe('any');
-    expect(t.property.attribute).toBe('val');
+    expect(t.property?.type).toBe('any');
+    expect(t.property?.attribute).toBe('val');
   });
 });


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the test for prop parsing via `transpileModule` to account for the fact that returned fields may be `undefined`


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Unit tests continue to pass
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
