### PR TITLE
chore(repo): change slack links to discord links

### DIFF
--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -7,7 +7,7 @@ closeAndLock:
     - label: 'ionitron: support'
       message: >
         Thanks for the issue! This issue appears to be a support request. We use this issue tracker exclusively for
-        bug reports and feature requests. Please use our [slack channel](https://stencil-worldwide.slack.com/)
+        bug reports and feature requests. Please use our [Discord server](https://chat.stenciljs.com)
         for questions about Stencil.
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please see our [Contributor Code of Conduct](https://github.com/ionic-team/stenc
 
 ## Creating an Issue
 
-* If you have a question about using Stencil, please ask in the [Stencil Worldwide Slack](https://stencil-worldwide.slack.com/) group.
+* If you have a question about using Stencil, please ask in the [Stencil Discord server](https://chat.stenciljs.com).
 
 * It is required that you clearly describe the steps necessary to reproduce the issue you are running into. Although we would love to help our users as much as possible, diagnosing issues without clear reproduction steps is extremely time-consuming and simply not sustainable.
 

--- a/readme.md
+++ b/readme.md
@@ -38,8 +38,8 @@
   <span> · </span>
   <a href="https://ionicframework.com/blog/tag/stencil/">Blog</a>
   <br />
-  Community: 
-  <a href="https://stencil-worldwide.slack.com">Slack</a>
+  Community:
+  <a href="https://chat.stenciljs.com">Discord</a>
   <span> · </span>
   <a href="https://forum.ionicframework.com/c/stencil/21/">Forums</a>
   <span> · </span>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The links point to the Slack community.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- [Stencil is now using Discord instead of Slack](https://twitter.com/stenciljs/status/1658561079767887873). The links now point to the Discord server.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Tested that the new link takes you to the Discord.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
