### PR TITLE
chore(compiler): remove dynamicImportShim

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -4,9 +4,26 @@ This is a comprehensive list of the breaking changes introduced in the major ver
 
 ## Versions
 
+- [Stencil 4.x](#stencil-v400)
 - [Stencil 3.x](#stencil-v300)
 - [Stencil 2.x](#stencil-two)
 - [Stencil 1.x](#stencil-one)
+
+## Stencil v4.0.0
+
+- [General](#general)
+  - [Legacy Browser Support Fields Removed](#legacy-browser-support-fields-removed)
+
+### General
+
+#### Legacy Browser Support Fields Removed
+
+##### `__deprecated__dynamicImportShim`
+
+The `extras.__deprecated__dynamicImportShim` option causes Stencil to include a polyfill for
+the [dynamic `import()`
+function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import)
+for use at runtime. For Stencil v4.0.0 this field and corresponding behavior has been removed.
 
 ## Stencil v3.0.0
 

--- a/src/app-data/index.ts
+++ b/src/app-data/index.ts
@@ -79,8 +79,6 @@ export const BUILD: BuildConditionals = {
   constructableCSS: true,
   cmpShouldUpdate: true,
   devTools: false,
-  // TODO(STENCIL-661): Remove code related to the dynamic import shim
-  dynamicImportShim: false,
   shadowDelegatesFocus: true,
   initializeNextTick: false,
   asyncLoading: false,

--- a/src/compiler/app-core/app-data.ts
+++ b/src/compiler/app-core/app-data.ts
@@ -149,8 +149,6 @@ export const updateBuildConditionals = (config: Config, b: BuildConditionals) =>
   b.appendChildSlotFix = config.extras.appendChildSlotFix;
   b.slotChildNodesFix = config.extras.slotChildNodesFix;
   b.cloneNodeFix = config.extras.cloneNodeFix;
-  // TODO(STENCIL-661): Remove code related to the dynamic import shim
-  b.dynamicImportShim = config.extras.__deprecated__dynamicImportShim;
   b.lifecycleDOMEvents = !!(b.isDebug || config._isTesting || config.extras.lifecycleDOMEvents);
   // TODO(STENCIL-663): Remove code related to deprecated `safari10` field.
   b.safari10 = config.extras.__deprecated__safari10;

--- a/src/compiler/bundle/core-resolve-plugin.ts
+++ b/src/compiler/bundle/core-resolve-plugin.ts
@@ -130,14 +130,6 @@ export const Build = {
       }
       return null;
     },
-
-    resolveImportMeta(prop, { format }) {
-      // TODO(STENCIL-661): Remove code related to the dynamic import shim
-      if (config.extras.__deprecated__dynamicImportShim && prop === 'url' && format === 'es') {
-        return '""';
-      }
-      return null;
-    },
   };
 };
 

--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -389,8 +389,6 @@ describe('validation', () => {
     expect(config.extras.cloneNodeFix).toBe(false);
     // TODO(STENCIL-659): Remove code implementing the CSS variable shim
     expect(config.extras.__deprecated__cssVarsShim).toBe(false);
-    // TODO(STENCIL-661): Remove code related to the dynamic import shim
-    expect(config.extras.__deprecated__dynamicImportShim).toBe(false);
     expect(config.extras.lifecycleDOMEvents).toBe(false);
     // TODO(STENCIL-663): Remove code related to deprecated `safari10` field.
     expect(config.extras.__deprecated__safari10).toBe(false);

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -106,8 +106,6 @@ export const validateConfig = (
   validatedConfig.extras.cloneNodeFix = !!validatedConfig.extras.cloneNodeFix;
   // TODO(STENCIL-659): Remove code implementing the CSS variable shim
   validatedConfig.extras.__deprecated__cssVarsShim = !!validatedConfig.extras.__deprecated__cssVarsShim;
-  // TODO(STENCIL-661): Remove code related to the dynamic import shim
-  validatedConfig.extras.__deprecated__dynamicImportShim = !!validatedConfig.extras.__deprecated__dynamicImportShim;
   validatedConfig.extras.lifecycleDOMEvents = !!validatedConfig.extras.lifecycleDOMEvents;
   // TODO(STENCIL-663): Remove code related to deprecated `safari10` field.
   validatedConfig.extras.__deprecated__safari10 = !!validatedConfig.extras.__deprecated__safari10;

--- a/src/compiler/output-targets/dist-hydrate-script/hydrate-build-conditionals.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/hydrate-build-conditionals.ts
@@ -32,8 +32,6 @@ export const getHydrateBuildConditionals = (cmps: d.ComponentCompilerMeta[]) => 
   build.hydratedAttribute = false;
   build.hydratedClass = true;
   build.scriptDataOpts = false;
-  // TODO(STENCIL-661): Remove code related to the dynamic import shim
-  build.dynamicImportShim = false;
   build.attachStyles = true;
 
   return build;

--- a/src/compiler/output-targets/dist-lazy/generate-esm-browser.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-esm-browser.ts
@@ -1,4 +1,4 @@
-import { generatePreamble, getDynamicImportFunction } from '@utils';
+import { generatePreamble } from '@utils';
 import type { OutputOptions, RollupBuild } from 'rollup';
 
 import type * as d from '../../../declarations';
@@ -24,11 +24,7 @@ export const generateEsmBrowser = async (
       preferConst: true,
       sourcemap: config.sourceMap,
     };
-    // TODO(STENCIL-661): Remove code related to the dynamic import shim
-    if (config.extras.__deprecated__dynamicImportShim) {
-      // for Edge 16-18
-      esmOpts.dynamicImportFunction = getDynamicImportFunction(config.fsNamespace);
-    }
+
     const output = await generateRollupOutput(rollupBuild, esmOpts, config, buildCtx.entryModules);
 
     if (output != null) {

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -177,8 +177,6 @@ export interface BuildConditionals extends Partial<BuildFeatures> {
   slotChildNodesFix?: boolean;
   scopedSlotTextContentFix?: boolean;
   cloneNodeFix?: boolean;
-  // TODO(STENCIL-661): Remove code related to the dynamic import shim
-  dynamicImportShim?: boolean;
   hydratedAttribute?: boolean;
   hydratedClass?: boolean;
   initializeNextTick?: boolean;

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -288,15 +288,6 @@ export interface ConfigExtras {
    */
   __deprecated__cssVarsShim?: boolean;
 
-  // TODO(STENCIL-661): Remove code related to the dynamic import shim
-  /**
-   * Dynamic `import()` shim. This is only needed for Edge 18 and below, and
-   * Firefox 67 and below. Defaults to `false`.
-   * @deprecated Since Stencil v3.0.0. IE 11, Edge <= 18, and old Safari
-   * versions are no longer supported.
-   */
-  __deprecated__dynamicImportShim?: boolean;
-
   /**
    * Experimental flag. Projects that use a Stencil library built using the `dist` output target may have trouble lazily
    * loading components when using a bundler such as Vite or Parcel. Setting this flag to `true` will change how Stencil

--- a/src/testing/reset-build-conditionals.ts
+++ b/src/testing/reset-build-conditionals.ts
@@ -48,8 +48,6 @@ export function resetBuildConditionals(b: d.BuildConditionals) {
   b.invisiblePrehydration = true;
   b.appendChildSlotFix = false;
   b.cloneNodeFix = false;
-  // TODO(STENCIL-661): Remove code related to the dynamic import shim
-  b.dynamicImportShim = false;
   b.hotModuleReplacement = false;
   // TODO(STENCIL-663): Remove code related to deprecated `safari10` field.
   b.safari10 = false;

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -155,9 +155,6 @@ export const hasDependency = (buildCtx: d.BuildCtx, depName: string): boolean =>
   return getDependencies(buildCtx).includes(depName);
 };
 
-// TODO(STENCIL-661): Remove code related to the dynamic import shim
-export const getDynamicImportFunction = (namespace: string) => `__sc_import_${namespace.replace(/\s|-/g, '_')}`;
-
 export const readPackageJson = async (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
   try {
     const pkgJson = await compilerCtx.fs.readFile(config.packageJsonFilePath);

--- a/test/jest-spec-runner/stencil.config.ts
+++ b/test/jest-spec-runner/stencil.config.ts
@@ -10,7 +10,6 @@ export const config: Config = {
   hydratedFlag: null,
   extras: {
     cssVarsShim: false,
-    dynamicImportShim: false,
     safari10: false,
     scriptDataOpts: false,
     shadowDomShim: false,

--- a/test/karma/stencil.config.ts
+++ b/test/karma/stencil.config.ts
@@ -1,5 +1,5 @@
-import nodePolyfills from 'rollup-plugin-node-polyfills';
 import { sass } from '@stencil/sass';
+import nodePolyfills from 'rollup-plugin-node-polyfills';
 
 const { CUSTOM_ELEMENTS_OUT_DIR, DIST_OUT_DIR, TEST_OUTPUT_DIR, WWW_OUT_DIR } = require('./constants');
 import { Config } from '../../internal';
@@ -32,7 +32,6 @@ export const config: Config = {
     appendChildSlotFix: true,
     cloneNodeFix: true,
     cssVarsShim: true,
-    dynamicImportShim: true,
     lifecycleDOMEvents: true,
     safari10: true,
     scopedSlotTextContentFix: true,

--- a/test/todo-app/stencil.config.ts
+++ b/test/todo-app/stencil.config.ts
@@ -12,7 +12,6 @@ export const config: Config = {
   hydratedFlag: null,
   extras: {
     cssVarsShim: false,
-    dynamicImportShim: false,
     safari10: false,
     scriptDataOpts: false,
     shadowDomShim: false,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

Remove the dynamic import shim that was marked as deprecated in v3. This is a precursor to #4421 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
