### PR TITLE
chore(compiler): remove safari10 extras flag

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -25,6 +25,11 @@ the [dynamic `import()`
 function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import)
 for use at runtime. For Stencil v4.0.0 this field and corresponding behavior has been removed.
 
+##### `__deprecated__safari10`
+
+If `extras.__deprecated__safari10` is set to `true` the Stencil runtime will patch ES module
+support for Safari 10. In Stencil v4.0.0 this field and corresponding behavior has been removed.
+
 ## Stencil v3.0.0
 
 * [General](#general)

--- a/src/app-data/index.ts
+++ b/src/app-data/index.ts
@@ -63,8 +63,6 @@ export const BUILD: BuildConditionals = {
   cloneNodeFix: false,
   hydratedAttribute: false,
   hydratedClass: true,
-  // TODO(STENCIL-663): Remove code related to deprecated `safari10` field.
-  safari10: false,
   scriptDataOpts: false,
   scopedSlotTextContentFix: false,
   // TODO(STENCIL-662): Remove code related to deprecated shadowDomShim field

--- a/src/compiler/app-core/app-data.ts
+++ b/src/compiler/app-core/app-data.ts
@@ -150,8 +150,6 @@ export const updateBuildConditionals = (config: Config, b: BuildConditionals) =>
   b.slotChildNodesFix = config.extras.slotChildNodesFix;
   b.cloneNodeFix = config.extras.cloneNodeFix;
   b.lifecycleDOMEvents = !!(b.isDebug || config._isTesting || config.extras.lifecycleDOMEvents);
-  // TODO(STENCIL-663): Remove code related to deprecated `safari10` field.
-  b.safari10 = config.extras.__deprecated__safari10;
   b.scopedSlotTextContentFix = !!config.extras.scopedSlotTextContentFix;
   b.scriptDataOpts = config.extras.scriptDataOpts;
   // TODO(STENCIL-662): Remove code related to deprecated shadowDomShim field

--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -390,8 +390,6 @@ describe('validation', () => {
     // TODO(STENCIL-659): Remove code implementing the CSS variable shim
     expect(config.extras.__deprecated__cssVarsShim).toBe(false);
     expect(config.extras.lifecycleDOMEvents).toBe(false);
-    // TODO(STENCIL-663): Remove code related to deprecated `safari10` field.
-    expect(config.extras.__deprecated__safari10).toBe(false);
     expect(config.extras.scriptDataOpts).toBe(false);
     // TODO(STENCIL-662): Remove code related to deprecated shadowDomShim field
     expect(config.extras.__deprecated__shadowDomShim).toBe(false);

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -107,8 +107,6 @@ export const validateConfig = (
   // TODO(STENCIL-659): Remove code implementing the CSS variable shim
   validatedConfig.extras.__deprecated__cssVarsShim = !!validatedConfig.extras.__deprecated__cssVarsShim;
   validatedConfig.extras.lifecycleDOMEvents = !!validatedConfig.extras.lifecycleDOMEvents;
-  // TODO(STENCIL-663): Remove code related to deprecated `safari10` field.
-  validatedConfig.extras.__deprecated__safari10 = !!validatedConfig.extras.__deprecated__safari10;
   validatedConfig.extras.scriptDataOpts = !!validatedConfig.extras.scriptDataOpts;
   // TODO(STENCIL-662): Remove code related to deprecated shadowDomShim field
   validatedConfig.extras.__deprecated__shadowDomShim = !!validatedConfig.extras.__deprecated__shadowDomShim;

--- a/src/compiler/optimize/optimize-js.ts
+++ b/src/compiler/optimize/optimize-js.ts
@@ -13,12 +13,7 @@ export const optimizeJs = async (inputOpts: OptimizeJsInput) => {
 
   try {
     const prettyOutput = !!inputOpts.pretty;
-    const config: Config = {
-      extras: {
-        // TODO(STENCIL-663): Remove code related to deprecated `safari10` field.
-        __deprecated__safari10: true,
-      },
-    };
+    const config: Config = {};
     const sourceTarget = inputOpts.target === 'es5' ? 'es5' : 'latest';
     const minifyOpts = getTerserOptions(config, sourceTarget, prettyOutput);
 

--- a/src/compiler/optimize/optimize-module.ts
+++ b/src/compiler/optimize/optimize-module.ts
@@ -128,8 +128,7 @@ export const optimizeModule = async (
 export const getTerserOptions = (config: Config, sourceTarget: SourceTarget, prettyOutput: boolean): MinifyOptions => {
   const opts: MinifyOptions = {
     ie8: false,
-    // TODO(STENCIL-663): Remove code related to deprecated `safari10` field.
-    safari10: !!config.extras.__deprecated__safari10,
+    safari10: false,
     format: {},
     sourceMap: config.sourceMap,
   };

--- a/src/compiler/output-targets/dist-hydrate-script/generate-hydrate-app.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/generate-hydrate-app.ts
@@ -137,8 +137,6 @@ const getHydrateBuildConditionals = (config: d.ValidatedConfig, cmps: d.Componen
   build.cloneNodeFix = false;
   build.appendChildSlotFix = false;
   build.slotChildNodesFix = false;
-  // TODO(STENCIL-663): Remove code related to deprecated `safari10` field.
-  build.safari10 = false;
   // TODO(STENCIL-662): Remove code related to deprecated shadowDomShim field
   build.shadowDomShim = false;
 

--- a/src/compiler/output-targets/dist-hydrate-script/hydrate-build-conditionals.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/hydrate-build-conditionals.ts
@@ -27,8 +27,6 @@ export const getHydrateBuildConditionals = (cmps: d.ComponentCompilerMeta[]) => 
   build.cssAnnotations = true;
   // TODO(STENCIL-662): Remove code related to deprecated shadowDomShim field
   build.shadowDomShim = true;
-  // TODO(STENCIL-663): Remove code related to deprecated `safari10` field.
-  build.safari10 = false;
   build.hydratedAttribute = false;
   build.hydratedClass = true;
   build.scriptDataOpts = false;

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -180,8 +180,6 @@ export interface BuildConditionals extends Partial<BuildFeatures> {
   hydratedAttribute?: boolean;
   hydratedClass?: boolean;
   initializeNextTick?: boolean;
-  // TODO(STENCIL-663): Remove code related to deprecated `safari10` field.
-  safari10?: boolean;
   scriptDataOpts?: boolean;
   // TODO(STENCIL-662): Remove code related to deprecated shadowDomShim field
   shadowDomShim?: boolean;

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -311,17 +311,6 @@ export interface ConfigExtras {
    */
   lifecycleDOMEvents?: boolean;
 
-  // TODO(STENCIL-663): Remove code related to deprecated `safari10` field.
-  /**
-   * Safari 10 supports ES modules with `<script type="module">`, however, it did not implement
-   * `<script nomodule>`. When set to `true`, the runtime will patch support for Safari 10
-   * due to its lack of `nomodule` support.
-   * Defaults to `false`.
-   *
-   * @deprecated Since Stencil v3.0.0, Safari 10 is no longer supported.
-   */
-  __deprecated__safari10?: boolean;
-
   /**
    * It is possible to assign data to the actual `<script>` element's `data-opts` property,
    * which then gets passed to Stencil's initial bootstrap. This feature is only required

--- a/src/testing/reset-build-conditionals.ts
+++ b/src/testing/reset-build-conditionals.ts
@@ -49,8 +49,6 @@ export function resetBuildConditionals(b: d.BuildConditionals) {
   b.appendChildSlotFix = false;
   b.cloneNodeFix = false;
   b.hotModuleReplacement = false;
-  // TODO(STENCIL-663): Remove code related to deprecated `safari10` field.
-  b.safari10 = false;
   b.scriptDataOpts = false;
   b.scopedSlotTextContentFix = false;
   b.slotChildNodesFix = false;

--- a/src/testing/spec-page.ts
+++ b/src/testing/spec-page.ts
@@ -135,8 +135,6 @@ export async function newSpecPage(opts: NewSpecPageOptions): Promise<SpecPage> {
   BUILD.cloneNodeFix = false;
   // TODO(STENCIL-662): Remove code related to deprecated shadowDomShim field
   BUILD.shadowDomShim = false;
-  // TODO(STENCIL-663): Remove code related to deprecated `safari10` field.
-  BUILD.safari10 = false;
   BUILD.attachStyles = !!opts.attachStyles;
 
   if (typeof opts.url === 'string') {

--- a/test/jest-spec-runner/stencil.config.ts
+++ b/test/jest-spec-runner/stencil.config.ts
@@ -10,7 +10,6 @@ export const config: Config = {
   hydratedFlag: null,
   extras: {
     cssVarsShim: false,
-    safari10: false,
     scriptDataOpts: false,
     shadowDomShim: false,
   },

--- a/test/karma/stencil.config.ts
+++ b/test/karma/stencil.config.ts
@@ -33,7 +33,6 @@ export const config: Config = {
     cloneNodeFix: true,
     cssVarsShim: true,
     lifecycleDOMEvents: true,
-    safari10: true,
     scopedSlotTextContentFix: true,
     scriptDataOpts: true,
     shadowDomShim: true,

--- a/test/todo-app/stencil.config.ts
+++ b/test/todo-app/stencil.config.ts
@@ -12,7 +12,6 @@ export const config: Config = {
   hydratedFlag: null,
   extras: {
     cssVarsShim: false,
-    safari10: false,
     scriptDataOpts: false,
     shadowDomShim: false,
   },


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

Remove the safari10 extras option that was marked as deprecated in v3. This builds upon #4420 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
