### PR TITLE
chore(ci): update workflows for merge queue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build Stencil
 
 on:
+  merge_group:
   workflow_call:
   # Make this a reusable workflow, no value needed
   # https://docs.github.com/en/actions/using-workflows/reusing-workflows

--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -1,6 +1,7 @@
 name: Lint and Format Stencil (Check)
 
 on:
+  merge_group:
   workflow_call:
     # Make this a reusable workflow, no value needed
     # https://docs.github.com/en/actions/using-workflows/reusing-workflows

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  merge_group:
   push:
     branches:
       - 'main'

--- a/.github/workflows/test-analysis.yml
+++ b/.github/workflows/test-analysis.yml
@@ -1,6 +1,7 @@
 name: Analysis Tests
 
 on:
+  merge_group:
   workflow_call:
     # Make this a reusable workflow, no value needed
     # https://docs.github.com/en/actions/using-workflows/reusing-workflows

--- a/.github/workflows/test-browserstack.yml
+++ b/.github/workflows/test-browserstack.yml
@@ -1,6 +1,7 @@
 name: BrowserStack Tests
 
 on:
+  merge_group:
   pull_request_target:
     branches:
       - 'main'

--- a/.github/workflows/test-bundlers.yml
+++ b/.github/workflows/test-bundlers.yml
@@ -1,6 +1,7 @@
 name: Bundler Tests
 
 on:
+  merge_group:
   workflow_call:
     # Make this a reusable workflow, no value needed
     # https://docs.github.com/en/actions/using-workflows/reusing-workflows

--- a/.github/workflows/test-component-starter.yml
+++ b/.github/workflows/test-component-starter.yml
@@ -1,6 +1,7 @@
 name: Component Starter Smoke Test
 
 on:
+  merge_group:
   workflow_call:
     # Make this a reusable workflow, no value needed
     # https://docs.github.com/en/actions/using-workflows/reusing-workflows

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,6 +1,7 @@
 name: E2E Tests
 
 on:
+  merge_group:
   workflow_call:
     # Make this a reusable workflow, no value needed
     # https://docs.github.com/en/actions/using-workflows/reusing-workflows

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -1,6 +1,7 @@
 name: Unit Tests
 
 on:
+  merge_group:
   workflow_call:
     # Make this a reusable workflow, no value needed
     # https://docs.github.com/en/actions/using-workflows/reusing-workflows


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates all workflows whose status is reported to gate on `main` to include the `merge_group` event trigger. the github documentation[1] states:

> If your repository uses GitHub Actions to perform required checks on
> pull requests in your repository, you need to update the workflows
> to include the merge_group event as an additional trigger. Otherwise,
> status checks will not be triggered when you add a pull request to a
> merge queue. The merge will fail as the required status check will
> not be reported.

it's not abundantly clear if this is needed for reusable workflows explicitly. `merge_group` is added in this commit to avoid the need to configure this feature via multiple prs

[1]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing


No way to test 😢 
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
