### PR TITLE
fixes version test to account for additional semver cases

### DIFF
--- a/scripts/utils/test/options.spec.ts
+++ b/scripts/utils/test/options.spec.ts
@@ -88,10 +88,10 @@ describe('release options', () => {
 
         expect(version).toBeDefined();
         // Expect a version string with the format 0.0.0-dev-[EPOCH_TIME]-[GIT_SHA_7_CHARS]
-        expect(version).toMatch(new RegExp(`\\d+\\.\\d+\\.\\d+-dev.${FAKE_SYSTEM_TIME_S}.\\w{7}`));
+        expect(version).toMatch(new RegExp(`\\d+\\.\\d+\\.\\d+(-(.{1,}))?-dev.${FAKE_SYSTEM_TIME_S}.\\w{7}`));
       });
 
-      it('uses the provided the version', () => {
+      it('uses the provided version', () => {
         const expectedVersion = '3.0.0-dev-1234';
         const { version } = getOptions(ROOT_DIR, { version: expectedVersion });
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

Fixes the version unit test regex to account for additional semver formats like (x.x.x-beta.x or x.x.x-rc.x)

You can see an example of current failure [here](https://github.com/ionic-team/stencil/actions/runs/5127673615/jobs/9223620629?pr=4440)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
