### PR TITLE
chore(ci): merge queue fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: Build Stencil
 
 on:
-  merge_group:
   workflow_call:
   # Make this a reusable workflow, no value needed
   # https://docs.github.com/en/actions/using-workflows/reusing-workflows

--- a/.github/workflows/test-analysis.yml
+++ b/.github/workflows/test-analysis.yml
@@ -1,7 +1,6 @@
 name: Analysis Tests
 
 on:
-  merge_group:
   workflow_call:
     # Make this a reusable workflow, no value needed
     # https://docs.github.com/en/actions/using-workflows/reusing-workflows

--- a/.github/workflows/test-bundlers.yml
+++ b/.github/workflows/test-bundlers.yml
@@ -1,7 +1,6 @@
 name: Bundler Tests
 
 on:
-  merge_group:
   workflow_call:
     # Make this a reusable workflow, no value needed
     # https://docs.github.com/en/actions/using-workflows/reusing-workflows

--- a/.github/workflows/test-component-starter.yml
+++ b/.github/workflows/test-component-starter.yml
@@ -1,7 +1,6 @@
 name: Component Starter Smoke Test
 
 on:
-  merge_group:
   workflow_call:
     # Make this a reusable workflow, no value needed
     # https://docs.github.com/en/actions/using-workflows/reusing-workflows

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,7 +1,6 @@
 name: E2E Tests
 
 on:
-  merge_group:
   workflow_call:
     # Make this a reusable workflow, no value needed
     # https://docs.github.com/en/actions/using-workflows/reusing-workflows

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -1,7 +1,6 @@
 name: Unit Tests
 
 on:
-  merge_group:
   workflow_call:
     # Make this a reusable workflow, no value needed
     # https://docs.github.com/en/actions/using-workflows/reusing-workflows


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Our merge queues are running certain tasks 2x

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit removes the `merge_group` event trigger from our reusable workflows. it turns out this is _not_ needed, as the `merge_group` in our `main.yml` properly propagates to all reusable workflows.

when these were applied, each workflow would be run 2x - once from `main.yml` and once independently. the latter would always fail, as they didn't have any notion of order to run in (so they'd often fail if there was no pre-built stencil artifact).


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

N/A, sadly
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
