### PR TITLE
chore(ci): run ci against stencil/v4-dev on push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'stencil/v4-dev'
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/test-browserstack.yml
+++ b/.github/workflows/test-browserstack.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'stencil/v4-dev'
 
 env:
   BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSER_STACK_ACCESS_KEY }}


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates our ci workflow to run against the `stencil/v4-dev` branch when the aforementioned branch is pushed to


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

N/A
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
