### PR TITLE
fix(compiler): handle ts 5.0 static members

### DIFF
--- a/src/compiler/output-targets/dist-custom-elements/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements/index.ts
@@ -204,6 +204,7 @@ export const addCustomElementInputs = (
 
     if (cmp.isPlain) {
       exp.push(`export { ${importName} as ${exportName} } from '${cmp.sourceFilePath}';`);
+      // TODO(STENCIL-855): Invalid syntax generation, note the unbalanced left curly brace
       indexExports.push(`export { {${exportName} } from '${coreKey}';`);
     } else {
       // the `importName` may collide with the `exportName`, alias it just in case it does with `importAs`

--- a/src/compiler/transformers/component-lazy/lazy-component.ts
+++ b/src/compiler/transformers/component-lazy/lazy-component.ts
@@ -17,7 +17,7 @@ export const updateLazyComponentClass = (
   cmp: d.ComponentCompilerMeta
 ) => {
   const members = updateLazyComponentMembers(transformOpts, styleStatements, classNode, moduleFile, cmp);
-  return updateComponentClass(transformOpts, classNode, classNode.heritageClauses, members);
+  return updateComponentClass(transformOpts, classNode, classNode.heritageClauses, members, moduleFile);
 };
 
 const updateLazyComponentMembers = (

--- a/src/compiler/transformers/component-native/native-component.ts
+++ b/src/compiler/transformers/component-native/native-component.ts
@@ -20,7 +20,7 @@ export const updateNativeComponentClass = (
 ): ts.ClassDeclaration | ts.VariableStatement => {
   const heritageClauses = updateNativeHostComponentHeritageClauses(classNode, moduleFile);
   const members = updateNativeHostComponentMembers(transformOpts, classNode, moduleFile, cmp);
-  return updateComponentClass(transformOpts, classNode, heritageClauses, members);
+  return updateComponentClass(transformOpts, classNode, heritageClauses, members, moduleFile);
 };
 
 /**

--- a/src/compiler/transformers/component-native/proxy-custom-element-function.ts
+++ b/src/compiler/transformers/component-native/proxy-custom-element-function.ts
@@ -84,7 +84,7 @@ export const proxyCustomElement = (
             // update the variable statement containing the updated declaration list
             const updatedVariableStatement = ts.factory.updateVariableStatement(
               stmt,
-              [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+              stmt.modifiers,
               updatedDeclarationList
             );
 

--- a/src/compiler/transformers/decorators-to-static/convert-static-members.ts
+++ b/src/compiler/transformers/decorators-to-static/convert-static-members.ts
@@ -1,0 +1,18 @@
+import ts from 'typescript';
+
+/**
+ * Helper function to detect if a class element fits the following criteria:
+ * - It is a property declaration (e.g. `foo`)
+ * - It has an initializer (e.g. `foo *=1*`)
+ * - The property declaration has the `static` modifier on it (e.g. `*static* foo =1`)
+ * @param classElm the class member to test
+ * @returns true if the class member fits the above criteria, false otherwise
+ */
+export const hasStaticInitializerInClass = (classElm: ts.ClassElement): boolean => {
+  return (
+    ts.isPropertyDeclaration(classElm) &&
+    classElm.initializer !== undefined &&
+    Array.isArray(classElm.modifiers) &&
+    classElm.modifiers!.some((modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword)
+  );
+};

--- a/src/compiler/transformers/remove-static-meta-properties.ts
+++ b/src/compiler/transformers/remove-static-meta-properties.ts
@@ -24,6 +24,7 @@ export const removeStaticMetaProperties = (classNode: ts.ClassDeclaration): ts.C
   });
 };
 
+// TODO(STENCIL-856): Move these properties to constants for better type safety within the codebase
 /**
  * A list of static getter names that are specific to Stencil to exclude from a class's member list
  */
@@ -37,6 +38,7 @@ const REMOVE_STATIC_GETTERS = new Set([
   'methods',
   'states',
   'originalStyleUrls',
+  'stencilHasStaticMembersWithInit',
   'styleMode',
   'style',
   'styles',

--- a/src/compiler/transformers/static-to-meta/component.ts
+++ b/src/compiler/transformers/static-to-meta/component.ts
@@ -54,7 +54,6 @@ export const parseStaticComponentMeta = (
   const docs = serializeSymbol(typeChecker, symbol);
   const isCollectionDependency = moduleFile.isCollectionDependency;
   const encapsulation = parseStaticEncapsulation(staticMembers);
-
   const cmp: d.ComponentCompilerMeta = {
     tagName: tagName,
     excludeFromCollection: moduleFile.excludeFromCollection,
@@ -62,6 +61,7 @@ export const parseStaticComponentMeta = (
     componentClassName: cmpNode.name ? cmpNode.name.text : '',
     elementRef: parseStaticElementRef(staticMembers),
     encapsulation,
+    hasStaticInitializedMember: getStaticValue(staticMembers, 'stencilHasStaticMembersWithInit') ?? false,
     shadowDelegatesFocus: parseStaticShadowDelegatesFocus(encapsulation, staticMembers),
     properties: parseStaticProps(staticMembers),
     virtualProperties: parseVirtualProps(docs),

--- a/src/compiler/transformers/test/convert-static-members.spec.ts
+++ b/src/compiler/transformers/test/convert-static-members.spec.ts
@@ -1,0 +1,158 @@
+import ts from 'typescript';
+
+import { hasStaticInitializerInClass } from '../decorators-to-static/convert-static-members';
+
+describe('convert-static-members', () => {
+  describe('hasStaticInitializerInClass', () => {
+    it('returns true for a static property with an initializer', () => {
+      const classWithStaticMembers = ts.factory.createClassDeclaration(
+        [ts.factory.createToken(ts.SyntaxKind.ExportKeyword)],
+        ts.factory.createIdentifier('ClassWithStaticMember'),
+        undefined,
+        undefined,
+        [
+          ts.factory.createPropertyDeclaration(
+            [ts.factory.createToken(ts.SyntaxKind.StaticKeyword)],
+            ts.factory.createIdentifier('propertyName'),
+            undefined,
+            undefined,
+            ts.factory.createStringLiteral('initial value')
+          ),
+        ]
+      );
+      expect(classWithStaticMembers.members.some(hasStaticInitializerInClass)).toBe(true);
+    });
+
+    it('returns true for a private static property with an initializer', () => {
+      const classWithStaticMembers = ts.factory.createClassDeclaration(
+        [ts.factory.createToken(ts.SyntaxKind.ExportKeyword)],
+        ts.factory.createIdentifier('ClassWithStaticMember'),
+        undefined,
+        undefined,
+        [
+          ts.factory.createPropertyDeclaration(
+            [ts.factory.createToken(ts.SyntaxKind.PrivateKeyword), ts.factory.createToken(ts.SyntaxKind.StaticKeyword)],
+            ts.factory.createIdentifier('propertyName'),
+            undefined,
+            undefined,
+            ts.factory.createStringLiteral('initial value')
+          ),
+        ]
+      );
+      expect(classWithStaticMembers.members.some(hasStaticInitializerInClass)).toBe(true);
+    });
+
+    it('returns true for a static property with an initializer with multiple members', () => {
+      const classWithStaticMembers = ts.factory.createClassDeclaration(
+        [ts.factory.createToken(ts.SyntaxKind.ExportKeyword)],
+        ts.factory.createIdentifier('ClassWithStaticAndNonStaticMembers'),
+        undefined,
+        undefined,
+        [
+          ts.factory.createPropertyDeclaration(
+            undefined,
+            ts.factory.createIdentifier('nonStaticProperty'),
+            undefined,
+            undefined,
+            ts.factory.createStringLiteral('some value')
+          ),
+          ts.factory.createPropertyDeclaration(
+            [ts.factory.createToken(ts.SyntaxKind.StaticKeyword)],
+            ts.factory.createIdentifier('propertyName'),
+            undefined,
+            undefined,
+            ts.factory.createStringLiteral('initial value')
+          ),
+        ]
+      );
+      expect(classWithStaticMembers.members.some(hasStaticInitializerInClass)).toBe(true);
+    });
+
+    it('returns false for a class without any members', () => {
+      const classWithStaticMembers = ts.factory.createClassDeclaration(
+        [ts.factory.createToken(ts.SyntaxKind.ExportKeyword)],
+        ts.factory.createIdentifier('ClassWithNoMembers'),
+        undefined,
+        undefined,
+        [] // no members for this class
+      );
+      expect(classWithStaticMembers.members.some(hasStaticInitializerInClass)).toBe(false);
+    });
+
+    it('returns false for a static property without an initializer', () => {
+      const classWithStaticMembers = ts.factory.createClassDeclaration(
+        [ts.factory.createToken(ts.SyntaxKind.ExportKeyword)],
+        ts.factory.createIdentifier('ClassWithUninitializedStaticMember'),
+        undefined,
+        undefined,
+        [
+          ts.factory.createPropertyDeclaration(
+            [ts.factory.createToken(ts.SyntaxKind.StaticKeyword)],
+            ts.factory.createIdentifier('propertyName'),
+            undefined,
+            undefined,
+            undefined // the initializer is false
+          ),
+        ]
+      );
+      expect(classWithStaticMembers.members.some(hasStaticInitializerInClass)).toBe(false);
+    });
+
+    it('returns false for a private static property without an initializer', () => {
+      const classWithStaticMembers = ts.factory.createClassDeclaration(
+        [ts.factory.createToken(ts.SyntaxKind.ExportKeyword)],
+        ts.factory.createIdentifier('ClassWithUninitializedStaticMember'),
+        undefined,
+        undefined,
+        [
+          ts.factory.createPropertyDeclaration(
+            [ts.factory.createToken(ts.SyntaxKind.PrivateKeyword), ts.factory.createToken(ts.SyntaxKind.StaticKeyword)],
+            ts.factory.createIdentifier('propertyName'),
+            undefined,
+            undefined,
+            undefined // the initializer is false
+          ),
+        ]
+      );
+      expect(classWithStaticMembers.members.some(hasStaticInitializerInClass)).toBe(false);
+    });
+
+    it('returns false for a modified property with an initializer', () => {
+      const classWithStaticMembers = ts.factory.createClassDeclaration(
+        [ts.factory.createToken(ts.SyntaxKind.ExportKeyword)],
+        ts.factory.createIdentifier('ClassWithNonStaticMember'),
+        undefined,
+        undefined,
+        [
+          ts.factory.createPropertyDeclaration(
+            [ts.factory.createToken(ts.SyntaxKind.PrivateKeyword)], // the property  is declared as private
+            ts.factory.createIdentifier('propertyName'),
+            undefined,
+            undefined,
+            ts.factory.createStringLiteral('initial value')
+          ),
+        ]
+      );
+      expect(classWithStaticMembers.members.some(hasStaticInitializerInClass)).toBe(false);
+    });
+
+    it('returns false for an unmodified property with an initializer', () => {
+      const classWithStaticMembers = ts.factory.createClassDeclaration(
+        [ts.factory.createToken(ts.SyntaxKind.ExportKeyword)],
+        ts.factory.createIdentifier('ClassWithUnmodifiedMembers'),
+        undefined,
+        undefined,
+        [
+          ts.factory.createPropertyDeclaration(
+            undefined, // the property declaration has no modifiers
+            ts.factory.createIdentifier('propertyName'),
+            undefined,
+            undefined,
+            ts.factory.createStringLiteral('initial value')
+          ),
+        ]
+      );
+      expect(classWithStaticMembers.members.some(hasStaticInitializerInClass)).toBe(false);
+    });
+  });
+});

--- a/src/compiler/transformers/test/parse-members.spec.ts
+++ b/src/compiler/transformers/test/parse-members.spec.ts
@@ -1,0 +1,18 @@
+import { transpileModule } from './transpile';
+
+describe('parse static members', () => {
+  it('places a static getter on the component', () => {
+    const t = transpileModule(`
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        static myStatic = 'a value';
+
+        render() {
+          return <div>Hello, I have {CmpA.myStatic}</div>
+        }
+      }
+    `);
+
+    expect(t.outputText.includes('static get stencilHasStaticMembersWithInit() { return true; }')).toBe(true);
+  });
+});

--- a/src/compiler/transformers/test/proxy-custom-element-function.spec.ts
+++ b/src/compiler/transformers/test/proxy-custom-element-function.spec.ts
@@ -83,6 +83,19 @@ describe('proxy-custom-element-function', () => {
 
       expect(formatCode(transpiledModule.outputText)).toContain(
         formatCode(
+          `const ${componentClassName} = /*@__PURE__*/ __stencil_proxyCustomElement(class ${componentClassName} extends HTMLElement {}, true);`
+        )
+      );
+    });
+
+    it('wraps an exported class initializer in a proxyCustomElement call', () => {
+      const code = `export const ${componentClassName} = class extends HTMLElement {};`;
+
+      const transformer = proxyCustomElement(compilerCtx, transformOpts);
+      const transpiledModule = transpileModule(code, null, compilerCtx, [], [transformer]);
+
+      expect(formatCode(transpiledModule.outputText)).toContain(
+        formatCode(
           `export const ${componentClassName} = /*@__PURE__*/ __stencil_proxyCustomElement(class ${componentClassName} extends HTMLElement {}, true);`
         )
       );
@@ -97,7 +110,7 @@ describe('proxy-custom-element-function', () => {
 
         expect(formatCode(transpiledModule.outputText)).toContain(
           formatCode(
-            `export const foo = 'hello world!', ${componentClassName} = /*@__PURE__*/ __stencil_proxyCustomElement(class ${componentClassName} extends HTMLElement {}, true);`
+            `const foo = 'hello world!', ${componentClassName} = /*@__PURE__*/ __stencil_proxyCustomElement(class ${componentClassName} extends HTMLElement {}, true);`
           )
         );
       });
@@ -110,7 +123,7 @@ describe('proxy-custom-element-function', () => {
 
         expect(formatCode(transpiledModule.outputText)).toContain(
           formatCode(
-            `export const ${componentClassName} = /*@__PURE__*/ __stencil_proxyCustomElement(class ${componentClassName} extends HTMLElement {}, true), foo = 'hello world!';`
+            `const ${componentClassName} = /*@__PURE__*/ __stencil_proxyCustomElement(class ${componentClassName} extends HTMLElement {}, true), foo = 'hello world!';`
           )
         );
       });
@@ -123,7 +136,7 @@ describe('proxy-custom-element-function', () => {
 
         expect(formatCode(transpiledModule.outputText)).toContain(
           formatCode(
-            `export const foo = 'hello world!', ${componentClassName} = /*@__PURE__*/ __stencil_proxyCustomElement(class ${componentClassName} extends HTMLElement {}, true), bar = 'goodbye?';`
+            `const foo = 'hello world!', ${componentClassName} = /*@__PURE__*/ __stencil_proxyCustomElement(class ${componentClassName} extends HTMLElement {}, true), bar = 'goodbye?';`
           )
         );
       });

--- a/src/compiler/transformers/test/transpile.ts
+++ b/src/compiler/transformers/test/transpile.ts
@@ -175,11 +175,19 @@ export function transpileModule(
  */
 const prettifyTSOutput = (tsOutput: string): string => tsOutput.replace(/\s+/gm, ' ');
 
-export function getStaticGetter(output: string, prop: string) {
-  const toEvaluate = `return ${output.replace('export', '')}`;
+/**
+ * Helper function for tests that converts stringified JavaScript to a runtime value.
+ * A value from the generated JavaScript is returned based on the provided property name.
+ * @param stringifiedJs the stringified JavaScript
+ * @param propertyName the property name to pull off the generated JavaScript
+ * @returns the value associated with the provided property name. Returns undefined if an error occurs while converting
+ * the stringified JS to JavaScript, or if the property does not exist on the generated JavaScript.
+ */
+export function getStaticGetter(stringifiedJs: string, propertyName: string): string | void {
+  const toEvaluate = `return ${stringifiedJs.replace('export', '')}`;
   try {
     const Obj = new Function(toEvaluate);
-    return Obj()[prop];
+    return Obj()[propertyName];
   } catch (e) {
     console.error(e);
     console.error(toEvaluate);

--- a/src/compiler/transformers/update-component-class.ts
+++ b/src/compiler/transformers/update-component-class.ts
@@ -3,11 +3,26 @@ import ts from 'typescript';
 import type * as d from '../../declarations';
 import { retrieveTsDecorators, retrieveTsModifiers } from './transform-utils';
 
+/**
+ * Transformation helper for updating how a Stencil component class is declared.
+ *
+ * Based on the output module type (CommonJS or ESM), the behavior is slightly different:
+ * - For CommonJS, the component class is left as is
+ * - For ESM, the component class is re-written as a variable statement
+ *
+ * @param transformOpts the options provided to TypeScript + Rollup for transforming the AST node
+ * @param classNode the node in the AST pertaining to the Stencil component class to transform
+ * @param heritageClauses a collection of heritage clauses associated with the provided class node
+ * @param members a collection of members attached to the provided class node
+ * @param moduleFile the Stencil intermediate representation associated with the provided class node
+ * @returns the updated component class declaration
+ */
 export const updateComponentClass = (
   transformOpts: d.TransformOptions,
   classNode: ts.ClassDeclaration,
   heritageClauses: ts.HeritageClause[] | ts.NodeArray<ts.HeritageClause>,
-  members: ts.ClassElement[]
+  members: ts.ClassElement[],
+  moduleFile: d.Module
 ): ts.ClassDeclaration | ts.VariableStatement => {
   let classModifiers = retrieveTsModifiers(classNode)?.slice() ?? [];
 
@@ -15,7 +30,8 @@ export const updateComponentClass = (
     // CommonJS, leave component class as is
 
     if (transformOpts.componentExport === 'customelement') {
-      // remove export from class
+      // remove export from class - it may already be removed by the TypeScript compiler in certain circumstances if
+      // this transformation is run after transpilation occurs
       classModifiers = classModifiers.filter((m) => {
         return m.kind !== ts.SyntaxKind.ExportKeyword;
       });
@@ -31,25 +47,48 @@ export const updateComponentClass = (
   }
 
   // ESM with export
-  return createConstClass(transformOpts, classNode, heritageClauses, members);
+  return createConstClass(transformOpts, classNode, heritageClauses, members, moduleFile);
 };
 
+/**
+ * Rewrites a component class as a variable statement.
+ *
+ * After running this function, the following:
+ * ```ts
+ * class MyComponent {}
+ * ```
+ * is rewritten as
+ * ```ts
+ * const MyComponent = class {}
+ * ```
+ * @param transformOpts the options provided to TypeScript + Rollup for transforming the AST node
+ * @param classNode the node in the AST pertaining to the Stencil component class to transform
+ * @param heritageClauses a collection of heritage clauses associated with the provided class node
+ * @param members a collection of members attached to the provided class node
+ * @param moduleFile the Stencil intermediate representation associated with the provided class node
+ * @returns the component class, re-written as a variable statement
+ */
 const createConstClass = (
   transformOpts: d.TransformOptions,
   classNode: ts.ClassDeclaration,
   heritageClauses: ts.HeritageClause[] | ts.NodeArray<ts.HeritageClause>,
-  members: ts.ClassElement[]
-) => {
+  members: ts.ClassElement[],
+  moduleFile: d.Module
+): ts.VariableStatement => {
   const className = classNode.name;
 
   const classModifiers = (retrieveTsModifiers(classNode) ?? []).filter((m) => {
-    // remove the export
+    // remove the export - it may already be removed by the TypeScript compiler in certain circumstances if this
+    // transformation is run after transpilation occurs
     return m.kind !== ts.SyntaxKind.ExportKeyword;
   });
 
   const constModifiers: ts.Modifier[] = [];
 
-  if (transformOpts.componentExport !== 'customelement') {
+  if (
+    transformOpts.componentExport !== 'customelement' &&
+    !moduleFile.cmps.some((cmp) => cmp.hasStaticInitializedMember)
+  ) {
     constModifiers.push(ts.factory.createModifier(ts.SyntaxKind.ExportKeyword));
   }
 

--- a/src/compiler/types/tests/ComponentCompilerMeta.stub.ts
+++ b/src/compiler/types/tests/ComponentCompilerMeta.stub.ts
@@ -53,6 +53,7 @@ export const stubComponentCompilerMeta = (
   hasReflect: false,
   hasRenderFn: false,
   hasState: false,
+  hasStaticInitializedMember: false,
   hasStyle: false,
   hasVdomAttribute: false,
   hasVdomClass: false,

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -762,6 +762,7 @@ export interface ComponentCompilerFeatures {
   hasReflect: boolean;
   hasRenderFn: boolean;
   hasState: boolean;
+  hasStaticInitializedMember: boolean;
   hasStyle: boolean;
   hasVdomAttribute: boolean;
   hasVdomClass: boolean;

--- a/test/karma/test-app/components.d.ts
+++ b/test/karma/test-app/components.d.ts
@@ -318,6 +318,12 @@ export namespace Components {
     }
     interface SlottedCss {
     }
+    interface StaticMembers {
+    }
+    interface StaticMembersSeparateExport {
+    }
+    interface StaticMembersSeparateInitializer {
+    }
     interface StaticStyles {
     }
     interface StencilSibling {
@@ -1098,6 +1104,24 @@ declare global {
         prototype: HTMLSlottedCssElement;
         new (): HTMLSlottedCssElement;
     };
+    interface HTMLStaticMembersElement extends Components.StaticMembers, HTMLStencilElement {
+    }
+    var HTMLStaticMembersElement: {
+        prototype: HTMLStaticMembersElement;
+        new (): HTMLStaticMembersElement;
+    };
+    interface HTMLStaticMembersSeparateExportElement extends Components.StaticMembersSeparateExport, HTMLStencilElement {
+    }
+    var HTMLStaticMembersSeparateExportElement: {
+        prototype: HTMLStaticMembersSeparateExportElement;
+        new (): HTMLStaticMembersSeparateExportElement;
+    };
+    interface HTMLStaticMembersSeparateInitializerElement extends Components.StaticMembersSeparateInitializer, HTMLStencilElement {
+    }
+    var HTMLStaticMembersSeparateInitializerElement: {
+        prototype: HTMLStaticMembersSeparateInitializerElement;
+        new (): HTMLStaticMembersSeparateInitializerElement;
+    };
     interface HTMLStaticStylesElement extends Components.StaticStyles, HTMLStencilElement {
     }
     var HTMLStaticStylesElement: {
@@ -1258,6 +1282,9 @@ declare global {
         "slot-replace-wrapper": HTMLSlotReplaceWrapperElement;
         "slot-replace-wrapper-root": HTMLSlotReplaceWrapperRootElement;
         "slotted-css": HTMLSlottedCssElement;
+        "static-members": HTMLStaticMembersElement;
+        "static-members-separate-export": HTMLStaticMembersSeparateExportElement;
+        "static-members-separate-initializer": HTMLStaticMembersSeparateInitializerElement;
         "static-styles": HTMLStaticStylesElement;
         "stencil-sibling": HTMLStencilSiblingElement;
         "svg-attr": HTMLSvgAttrElement;
@@ -1582,6 +1609,12 @@ declare namespace LocalJSX {
     }
     interface SlottedCss {
     }
+    interface StaticMembers {
+    }
+    interface StaticMembersSeparateExport {
+    }
+    interface StaticMembersSeparateInitializer {
+    }
     interface StaticStyles {
     }
     interface StencilSibling {
@@ -1718,6 +1751,9 @@ declare namespace LocalJSX {
         "slot-replace-wrapper": SlotReplaceWrapper;
         "slot-replace-wrapper-root": SlotReplaceWrapperRoot;
         "slotted-css": SlottedCss;
+        "static-members": StaticMembers;
+        "static-members-separate-export": StaticMembersSeparateExport;
+        "static-members-separate-initializer": StaticMembersSeparateInitializer;
         "static-styles": StaticStyles;
         "stencil-sibling": StencilSibling;
         "svg-attr": SvgAttr;
@@ -1853,6 +1889,9 @@ declare module "@stencil/core" {
             "slot-replace-wrapper": LocalJSX.SlotReplaceWrapper & JSXBase.HTMLAttributes<HTMLSlotReplaceWrapperElement>;
             "slot-replace-wrapper-root": LocalJSX.SlotReplaceWrapperRoot & JSXBase.HTMLAttributes<HTMLSlotReplaceWrapperRootElement>;
             "slotted-css": LocalJSX.SlottedCss & JSXBase.HTMLAttributes<HTMLSlottedCssElement>;
+            "static-members": LocalJSX.StaticMembers & JSXBase.HTMLAttributes<HTMLStaticMembersElement>;
+            "static-members-separate-export": LocalJSX.StaticMembersSeparateExport & JSXBase.HTMLAttributes<HTMLStaticMembersSeparateExportElement>;
+            "static-members-separate-initializer": LocalJSX.StaticMembersSeparateInitializer & JSXBase.HTMLAttributes<HTMLStaticMembersSeparateInitializerElement>;
             "static-styles": LocalJSX.StaticStyles & JSXBase.HTMLAttributes<HTMLStaticStylesElement>;
             "stencil-sibling": LocalJSX.StencilSibling & JSXBase.HTMLAttributes<HTMLStencilSiblingElement>;
             "svg-attr": LocalJSX.SvgAttr & JSXBase.HTMLAttributes<HTMLSvgAttrElement>;

--- a/test/karma/test-app/static-members/README.md
+++ b/test/karma/test-app/static-members/README.md
@@ -1,0 +1,26 @@
+This test suite is focused on ensuring that component's with static class fields compiles correctly.
+With TypeScript v5.0, exported classes with static exports would be compiled as:
+```ts
+class StaticMembers {};
+StaticMembers.property = '';
+StaticMembers.anotherProperty = '';
+export { StaticMembers };
+```
+
+However, Stencil would also inject the `export` keyword in front of the class declaration, resulting in two exports:
+```ts
+export class StaticMembers {};
+StaticMembers.property = '';
+StaticMembers.anotherProperty = '';
+export { StaticMembers }; // 2 exports causes an error!
+```
+
+Which produces an error when we get to the rollup stage:
+```console
+[ ERROR ]  Rollup: Parse Error: ./test-app/static-members/cmp.tsx:35:9
+           Duplicate export 'StaticMembers' (Note that you need plugins to import files that are not JavaScript) at
+           ... (elided) ...
+```
+See: https://github.com/ionic-team/stencil/issues/4424 for more information
+See: https://www.typescriptlang.org/play?#code/KYDwDg9gTgLgBAYwDYEMDOa4GUYpgSwQFlgBbAI2CkwG8BYAKDjjVwITjCgjCpgE84AXjgAmANyMAvkA
+for a TS playground reproduction of the `export` keyword being moved around

--- a/test/karma/test-app/static-members/index.html
+++ b/test/karma/test-app/static-members/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="utf8">
+<script src="./build/testapp.esm.js" type="module"></script>
+<script src="./build/testapp.js" nomodule></script>
+
+<static-members></static-members>
+<static-members-separate-export></static-members-separate-export>
+<static-members-separate-initializer></static-members-separate-initializer>

--- a/test/karma/test-app/static-members/karma.spec.ts
+++ b/test/karma/test-app/static-members/karma.spec.ts
@@ -1,0 +1,29 @@
+import { setupDomTests } from '../util';
+
+describe('static-members', function () {
+  const { setupDom, tearDownDom } = setupDomTests(document);
+  let app: HTMLElement;
+
+  beforeEach(async () => {
+    app = await setupDom('/static-members/index.html');
+  });
+  afterEach(tearDownDom);
+
+  it('renders properly with initialized static members', async () => {
+    const cmp = app.querySelector('static-members');
+
+    expect(cmp.textContent.trim()).toBe('This is a component with static public and private members');
+  });
+
+  it('renders properly with a separate export', async () => {
+    const cmp = app.querySelector('static-members-separate-export');
+
+    expect(cmp.textContent.trim()).toBe('This is a component with static public and private members');
+  });
+
+  it('renders properly with a static member initialized outside of a class', async () => {
+    const cmp = app.querySelector('static-members-separate-initializer');
+
+    expect(cmp.textContent.trim()).toBe('This is a component with static an externally initialized member');
+  });
+});

--- a/test/karma/test-app/static-members/static-members-separate-export.tsx
+++ b/test/karma/test-app/static-members/static-members-separate-export.tsx
@@ -1,0 +1,22 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'static-members-separate-export',
+})
+class StaticMembersWithSeparateExport {
+  /**
+   * See the spec file associated with this file for the motivation for this test
+   */
+  static property = 'public';
+  private static anotherProperty = 'private';
+
+  render() {
+    return (
+      <div>
+        This is a component with static {StaticMembersWithSeparateExport.property} and{' '}
+        {StaticMembersWithSeparateExport.anotherProperty} members
+      </div>
+    );
+  }
+}
+export { StaticMembersWithSeparateExport };

--- a/test/karma/test-app/static-members/static-members-separate-initializer.tsx
+++ b/test/karma/test-app/static-members/static-members-separate-initializer.tsx
@@ -1,0 +1,15 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'static-members-separate-initializer',
+})
+export class StaticMembersWithSeparateInitializer {
+  /**
+   * See the spec file associated with this file for the motivation for this test
+   */
+  static property: string;
+  render() {
+    return <div>This is a component with static an {StaticMembersWithSeparateInitializer.property} member</div>;
+  }
+}
+StaticMembersWithSeparateInitializer.property = 'externally initialized';

--- a/test/karma/test-app/static-members/static-members.tsx
+++ b/test/karma/test-app/static-members/static-members.tsx
@@ -1,0 +1,20 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'static-members',
+})
+export class StaticMembers {
+  /**
+   * See the spec file associated with this file for the motivation for this test
+   */
+  static property = 'public';
+  private static anotherProperty = 'private';
+
+  render() {
+    return (
+      <div>
+        This is a component with static {StaticMembers.property} and {StaticMembers.anotherProperty} members
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?

A component like the following will fail to compile:
```tsx
import { Component, h } from '@stencil/core';

@Component({
  tag: 'my-component',
})
export class MyComponent {
  private static myVar = "input";

  render() {
    console.log(MyComponent.myVar);
    return (<div></div>);
  }
}
```
With the following error:
```console
[ ERROR ]  Rollup: Parse Error: <FILE_PATH>
		   Duplicate export 'MyComponent' (Note that you need plugins to
		   import files that are not JavaScript) Error parsing: <FILE_PATH>
```


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #4424


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit fixes a bug where static class members that are initialized
on a stencil component result in 2 `export` statements of a component
class being generated. as a result of 2 `ExportDeclaration`s being
created, the compilation process will fail.

this fix involves detecting initialized static members of a class before
they go through the transpilation phase, because a class can be
transformed in such a way that we lose the ability to determine if
something like the following was originally authored:
```ts
class MyComponent {
  static myVar = 1;
}
```

as a result, whether or not this static initializer exists or not is
stuffed onto the component's metadata. this allows us to store if an
additional transformation is needed or not after transpilation has
occurred. specifically, should we add an `export` keyword to a modified
class declaration in the form:
```ts
// determine if this `VariableDeclaration` needs an `export`
const MyComponent = class {}
```


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

A special build of Stencil, `@stencil/core@3.3.0-dev.1685651872.3091be9` was created using the dev release process [LOGS](https://github.com/ionic-team/stencil/actions/runs/5148994502)

### Starter Project 
- Created a local Stencil project and smoke tested locally: `npm init stencil component tmp-component-starter && cd $_ && npm i @stencil/core@3.3.0`
- Apply the following patch (`git apply starter.txt`, [starter.txt](https://github.com/ionic-team/stencil/files/11629611/starter.txt)):
```diff
diff --git a/src/components/my-component/my-component.tsx b/src/components/my-component/my-component.tsx
index 56d51d9..8deec6e 100644
--- a/src/components/my-component/my-component.tsx
+++ b/src/components/my-component/my-component.tsx
@@ -7,6 +7,7 @@ import { format } from '../../utils/utils';
   shadow: true,
 })
 export class MyComponent {
+  static MyVar = 1;
   /**
    * The first name
    */
@@ -27,6 +28,6 @@ export class MyComponent {
   }
 
   render() {
-    return <div>Hello, World! I'm {this.getText()}</div>;
+    return <div>Hello, World! I'm {this.getText()} {MyComponent.MyVar}</div>;
   }
 }
```
- `npm run build`
- Build fails since the fix is not in Stencil v3.3.0:
```console
 ERROR ]  Rollup: Parse Error: ./src/components/my-component/my-component.tsx:82:9
           Duplicate export 'MyComponent' (Note that you need plugins to import files that are not JavaScript) Error
           parsing: /private/tmp/tmp-component-starter/src/components/my-component/my-component.tsx, line: 82, column:
           9

[45:10.0]  build failed in 1.25 s
```
- `npm i @stencil/core@3.3.0-dev.1685651872.3091be9 && npm run build && npm t`
- Build Passes 🎉 Tests Fail (for a good reason) 🎉 

### Ionic Framework
- I [created a branch](https://github.com/ionic-team/ionic-framework/compare/main...rwaskiewicz/nightly-and-more) in the Ionic Framework repo that points to my special branch/release, and [was able to kick off the "nightly" build step manually to run through Framework's CI step](https://github.com/ionic-team/ionic-framework/actions/runs/5149116085)
  - The first run passes, since Framework has no static members on any of its component classes
- Apply the [following patch](https://github.com/ionic-team/ionic-framework/commit/9ef11b82a65756e3875687b6e6e69e15b4b6101c) (`git apply framework.txt`, [framework.txt](https://github.com/ionic-team/stencil/files/11629900/framework.txt)):

```diff
diff --git a/core/src/components/accordion/accordion.tsx b/core/src/components/accordion/accordion.tsx
index fd65ffcd3e..8d87f9de60 100644
--- a/core/src/components/accordion/accordion.tsx
+++ b/core/src/components/accordion/accordion.tsx
@@ -42,6 +42,7 @@ export class Accordion implements ComponentInterface {
   private contentEl: HTMLDivElement | undefined;
   private contentElWrapper: HTMLDivElement | undefined;
   private headerEl: HTMLDivElement | undefined;
+  private static MyVar = 123;
 
   private currentRaf: number | undefined;
 
@@ -146,6 +147,7 @@ export class Accordion implements ComponentInterface {
   };
 
   private getSlottedHeaderIonItem = () => {
+    console.log(Accordion.MyVar);
     const { headerEl } = this;
     if (!headerEl) {
       return;
```
- Initiate another run, [see CI pass again](https://github.com/ionic-team/ionic-framework/actions/runs/5149345350)
- [Revert the change](https://github.com/ionic-team/ionic-framework/commit/0774104fa54d026a20f9d1b9e302e724af4e37e3) where we use the special dev build for the nightly job
- Kick off one final CI run, [which fails](https://github.com/ionic-team/ionic-framework/actions/runs/5149459834)
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information


Consider a TypeScript class that:
- has a static member that is defined on the class
- is exported from the file in which it is defined
```ts
export class MyComponent {
  static myVar = 1;
}
```

[In TypeScript v4.9 and lower](https://www.typescriptlang.org/play?ts=4.9.5#code/KYDwDg9gTgLgBAYwDYEMDOa4FkCeBhCAW0gDtgT4BvAKAEg0YUYBLBOQnANRSjgF44ARgDc1AL5A) the class is transpiled as such:
```js
export class MyComponent {
}
MyComponent.myVar = 1;
```

[Starting with TypeScript v5.0](https://www.typescriptlang.org/play?ts=5.0.4#code/KYDwDg9gTgLgBAYwDYEMDOa4FkCeBhCAW0gDtgT4BvAKAEg0YUYBLBOQnANRSjgF44ARgDc1AL5A), the class is transpiled like so:
```js
class MyComponent {
}
MyComponent.myVar = 1;
export { MyComponent };
```
Where the `export` occurs separate from the class's declaration:
```diff
- export class MyComponent {
+ class MyComponent {
}
MyComponent.myVar = 1;
+ export { MyComponent };
```

Note this only occurs when both conditions above are met. The following
code snippet compiles the same using TypeScript [v4.9](https://www.typescriptlang.org/play?ts=4.9.5#code/KYDwDg9gTgLgBAYwDYEMDOa4FkCeBhCAW0gDtgT4BvAKAF8g) and [v5.0](https://www.typescriptlang.org/play?ts=5.0.4&ssl=2&ssc=2&pln=1&pc=1#code/KYDwDg9gTgLgBAYwDYEMDOa4FkCeBhCAW0gDtgT4BvAKAF8g):
```ts
export class MyComponent {
}
// transpiles to
export class MyComponent {
}
```

The difference in compilation when both conditions are met leads to a bug in
Stencil v3.3.0, the first version of the library which supports TypeScript v5.0.

Stencil made the assumption that the `export` keyword continues to be inlined
with the class declaration, rather than a new `ExportDeclaration` instance
being created. In Stencil v3.3.0, the `export` keyword is added to the generated
code:
```ts
export class MyComponent {};
MyComponent.myVar = 1;
export { MyComponent }; // 2 exports causes an error!
```
Two exports of the class (`MyComponent`) causes errors following the TypeScript
compilation step in Stencil:
```console
[ ERROR ]  Rollup: Parse Error: <FILE_PATH>
		   Duplicate export 'MyComponent' (Note that you need plugins to
		   import files that are not JavaScript) Error parsing: <FILE_PATH>
```

In an ideal world, we delegate inserting `export` to the TypeScript compiler.
However, this is not possible as the `ExportDeclaration` is _only_ created for
classes that are exported and have static members. So while removing Stencil's
`export` keyword injection will work for:
```ts
export class MyComponent {
  static myVar = 1;
}
// becomes the following on TS 5.0 if we remove Stencil's `export` injection
class MyComponent {
}
MyComponent.myVar = 1;
export { MyComponent };
```
it will not work for:
```ts
export class MyComponent {
  myVar = 1;
}
// becomes the following on TS 5.0 if we remove Stencil's `export` injection
class MyComponent {
  constructor() {
    this.myVar = 1;
  }
}
```
as `export` is removed from `MyComponent` in the compilation process. This behavior is
controlled by the [`TransformOptions#componentExport` field](https://github.com/ionic-team/stencil/blob/bd1023a67c5224cbae3e445170cb13227a5cf8fb/src/declarations/stencil-public-compiler.ts#L2683).

Import injection should only occur when neither of two aforementioned criteria are met:
- has a static member that is defined on the class
- is exported from the file in which it is defined


