### PR TITLE
fix(runtime): issue with update-component and patched Promise

### DIFF
--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -118,7 +118,21 @@ const dispatchHooks = (hostRef: d.HostRef, isInitialLoad: boolean): Promise<void
  * @returns either a `Promise` or the return value of the provided function
  */
 const enqueue = (maybePromise: Promise<void> | undefined, fn: () => Promise<void>): Promise<void> | undefined =>
-  maybePromise instanceof Promise ? maybePromise.then(fn) : fn();
+  isPromisey(maybePromise) ? maybePromise.then(fn) : fn();
+
+/**
+ * Check that a value is a `Promise`. To check, we first see if the value is an
+ * instance of the `Promise` global. In a few circumstances, in particular if
+ * the global has been overwritten, this is could be misleading, so we also do
+ * a little 'duck typing' check to see if the `.then` property of the value is
+ * defined and a function.
+ *
+ * @param maybePromise it might be a promise!
+ * @returns whether it is or not
+ */
+const isPromisey = (maybePromise: Promise<void> | unknown): maybePromise is Promise<void> =>
+  maybePromise instanceof Promise ||
+  (maybePromise && (maybePromise as any).then && typeof (maybePromise as Promise<void>).then === 'function');
 
 const updateComponent = async (hostRef: d.HostRef, instance: any, isInitialLoad: boolean) => {
   const elm = hostRef.$hostElement$ as d.RenderNode;


### PR DESCRIPTION
This fixes an issue with a check used in `updateComponent` to enqueue asynchronous updates (implemented with async functions) to components. In particular, if the global `Promise` object is patched such that it is not equal to the native `Promise` object returned by, for instance, an `async` function, which will return the native, unpatched object even if `window.Promise` has been overwritten.

A previous change in #4250 made a change such that we did a check like this:

```ts
maybePromise instanceof Promise
```

The problem is that if `maybePromise` is the return value of an async function, like

```ts
const foo = await something();
```

and `window.Promise` has been overwritten then this check will unfortunately fail unexpectedly.

The fix is just to first check `instanceof` and then add a duck-type-ey fallback as well.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## Testing

Check out the reproduction case linked in #4459. Without this fix it will log `1,3,2` in the console, and with it, `1,2,3`.
