### PR TITLE
fix(runtime): add autocomplete to textarea

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1257,6 +1257,8 @@ export namespace JSXBase {
   }
 
   export interface TextareaHTMLAttributes<T> extends HTMLAttributes<T> {
+    autoComplete?: string;
+    autocomplete?: string;
     autoFocus?: boolean;
     autofocus?: boolean | string;
     cols?: number;


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Using 'autoComplete' attributes causes type errors like so:
<img width="412" alt="Screenshot 2023-06-07 at 5 36 48 PM" src="https://github.com/ionic-team/stencil/assets/1930213/3a225b82-bfd8-46fe-8d87-f37b5c68feb7">

GitHub Issue Number: https://github.com/ionic-team/stencil/issues/2882


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

we accept 'on' or 'off' for the attribute

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I spun up a component library `npm init stencil component attr-test` and added the text-area elements you see in the screenshot above. I then built + packed this library, and installed it. After installing it, type errors only occur on invalid values:
<img width="412" alt="Screenshot 2023-06-07 at 5 37 08 PM" src="https://github.com/ionic-team/stencil/assets/1930213/d8235c0a-3e1b-432a-bbac-b24358b926ea">

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
