### PR TITLE
test(delegatesFocus): skip delegatesfocus test

### DIFF
--- a/test/karma/test-app/delegates-focus/karma.spec.ts
+++ b/test/karma/test-app/delegates-focus/karma.spec.ts
@@ -9,7 +9,8 @@ describe('delegates-focus', function () {
   });
   afterEach(tearDownDom);
 
-  it('should delegate focus', async () => {
+  // TODO(STENCIL-862): Re-enable this test
+  xit('should delegate focus', async () => {
     const button = app.querySelector('button');
     const delegateFocusElm = app.querySelector('delegates-focus');
     const noDelegateFocusElm = app.querySelector('no-delegates-focus');
@@ -21,7 +22,7 @@ describe('delegates-focus', function () {
     expect(noDelegateFocusStyles1.borderColor).toBe('rgb(255, 0, 0)');
 
     button.click();
-    await waitForChanges();
+    await waitForChanges(1000);
 
     const delegateFocusStyles2 = window.getComputedStyle(delegateFocusElm);
     expect(delegateFocusStyles2.borderColor).toBe('rgb(0, 0, 255)');


### PR DESCRIPTION
starting on 2023.06.12, browserstack started to use microsoft edge 114.0.1823.37. a test that had previously passed began to fail. the test that is skipped in this commit is that test. we were unable to reproduce this locally on macos and windows with the latest version of edge (114.0.1823.42). the hope is that browserstack will move to a newer version of edge in the next day or so to render this change obsolete

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
