### PR TITLE
chore(snc): fix SNC errors stemming from `src/compiler/cache.ts`

### DIFF
--- a/src/compiler/build/test/build-stats.spec.ts
+++ b/src/compiler/build/test/build-stats.spec.ts
@@ -1,16 +1,17 @@
 import type * as d from '@stencil/core/declarations';
-import { mockBuildCtx, mockCompilerCtx, mockConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
 import { result } from '@utils';
 
 import { generateBuildResults } from '../build-results';
 import { generateBuildStats } from '../build-stats';
 
 describe('generateBuildStats', () => {
-  const config = mockConfig();
+  let config: d.ValidatedConfig;
   let compilerCtx: d.CompilerCtx;
   let buildCtx: d.BuildCtx;
 
   beforeEach(() => {
+    config = mockValidatedConfig();
     compilerCtx = mockCompilerCtx(config);
     buildCtx = mockBuildCtx(config, compilerCtx);
   });

--- a/src/compiler/style/test/css-imports.spec.ts
+++ b/src/compiler/style/test/css-imports.spec.ts
@@ -1,5 +1,5 @@
 import type * as d from '@stencil/core/declarations';
-import { mockBuildCtx, mockCompilerCtx, mockConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
 import { buildError, normalizePath } from '@utils';
 import path from 'path';
 
@@ -16,13 +16,13 @@ describe('css-imports', () => {
   const root = path.resolve('/');
   let compilerCtx: d.CompilerCtx;
   let buildCtx: d.BuildCtx;
-  let config: d.Config;
+  let config: d.ValidatedConfig;
   let readFileMock: jest.SpyInstance<Promise<string>, [string, FsReadOptions?]>;
 
   beforeEach(() => {
+    config = mockValidatedConfig();
     compilerCtx = mockCompilerCtx(config);
     buildCtx = mockBuildCtx(config, compilerCtx);
-    config = mockConfig();
     readFileMock = jest.spyOn(compilerCtx.fs, 'readFile');
   });
 

--- a/src/compiler/style/test/optimize-css.spec.ts
+++ b/src/compiler/style/test/optimize-css.spec.ts
@@ -1,12 +1,12 @@
 import type * as d from '@stencil/core/declarations';
-import { mockCompilerCtx, mockConfig } from '@stencil/core/testing';
+import { mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
 import os from 'os';
 import path from 'path';
 
 import { optimizeCss } from '../optimize-css';
 
 describe('optimizeCss', () => {
-  let config: d.Config;
+  let config: d.ValidatedConfig;
   let compilerCtx: d.CompilerCtx;
   let diagnostics: d.Diagnostic[];
 
@@ -15,7 +15,7 @@ describe('optimizeCss', () => {
   jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
 
   beforeEach(() => {
-    config = mockConfig({ maxConcurrentWorkers: 0, minifyCss: true });
+    config = mockValidatedConfig({ maxConcurrentWorkers: 0, minifyCss: true });
     compilerCtx = mockCompilerCtx(config);
     diagnostics = [];
   });

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -410,7 +410,7 @@ export interface BundleModuleOutput {
 }
 
 export interface Cache {
-  get(key: string): Promise<string>;
+  get(key: string): Promise<string | null>;
   put(key: string, value: string): Promise<boolean>;
   has(key: string): Promise<boolean>;
   createKey(domain: string, ...args: any[]): Promise<string>;


### PR DESCRIPTION
This just fixes a few SNC errors that stem from code in `src/compiler/cache.ts`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Testing

I think that if unit tests and CI is all passing then we're probably good here
