### PR TITLE
chore(cli): remove browser-specific behavior from the generate and test tasks

### DIFF
--- a/src/cli/task-generate.ts
+++ b/src/cli/task-generate.ts
@@ -1,7 +1,6 @@
 import { normalizePath, validateComponentTag } from '@utils';
 import { join, parse, relative } from 'path';
 
-import { IS_NODE_ENV } from '../compiler/sys/environment';
 import type { ValidatedConfig } from '../declarations';
 
 /**
@@ -14,11 +13,6 @@ import type { ValidatedConfig } from '../declarations';
  * @returns a void promise
  */
 export const taskGenerate = async (config: ValidatedConfig): Promise<void> => {
-  if (!IS_NODE_ENV) {
-    config.logger.error(`"generate" command is currently only implemented for a NodeJS environment`);
-    return config.sys.exit(1);
-  }
-
   if (!config.configPath) {
     config.logger.error('Please run this command in your root directory (i. e. the one containing stencil.config.ts).');
     return config.sys.exit(1);

--- a/src/cli/task-test.ts
+++ b/src/cli/task-test.ts
@@ -1,4 +1,3 @@
-import { IS_NODE_ENV } from '../compiler/sys/environment';
 import type { TestingRunOptions, ValidatedConfig } from '../declarations';
 
 /**
@@ -7,11 +6,6 @@ import type { TestingRunOptions, ValidatedConfig } from '../declarations';
  * @returns a void promise
  */
 export const taskTest = async (config: ValidatedConfig): Promise<void> => {
-  if (!IS_NODE_ENV) {
-    config.logger.error(`"test" command is currently only implemented for a NodeJS environment`);
-    return config.sys.exit(1);
-  }
-
   config.buildDocs = false;
   const testingRunOpts: TestingRunOptions = {
     e2e: !!config.flags.e2e,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

You should be able to use the generation task as normal!


