### PR TITLE
fix(compiler): reorder tsconfig#path transforms 

### DIFF
--- a/src/compiler/bundle/bundle-interface.ts
+++ b/src/compiler/bundle/bundle-interface.ts
@@ -18,7 +18,11 @@ export interface BundleOptions {
    */
   externalRuntime?: boolean;
   platform: 'client' | 'hydrate' | 'worker';
-  customTransformers?: TransformerFactory<SourceFile>[];
+  /**
+   * A collection of TypeScript transformation factories to apply during the "before" stage of the TypeScript
+   * compilation pipeline (before built-in .js transformations)
+   */
+  customBeforeTransformers?: TransformerFactory<SourceFile>[];
   /**
    * This is equivalent to the Rollup `input` configuration option. It's
    * an object mapping names to entry points which tells Rollup to bundle

--- a/src/compiler/bundle/typescript-plugin.ts
+++ b/src/compiler/bundle/typescript-plugin.ts
@@ -57,7 +57,9 @@ export const typescriptPlugin = (compilerCtx: d.CompilerCtx, bundleOpts: BundleO
           const tsResult = ts.transpileModule(mod.staticSourceFileText, {
             compilerOptions: config.tsCompilerOptions,
             fileName: mod.sourceFilePath,
-            transformers: { before: bundleOpts.customTransformers },
+            transformers: {
+              before: bundleOpts.customBeforeTransformers ?? [],
+            },
           });
           const sourceMap: d.SourceMap = tsResult.sourceMapText ? JSON.parse(tsResult.sourceMapText) : null;
           return { code: tsResult.outputText, map: sourceMap };

--- a/src/compiler/output-targets/dist-hydrate-script/bundle-hydrate-factory.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/bundle-hydrate-factory.ts
@@ -1,4 +1,5 @@
 import { loadRollupDiagnostics } from '@utils';
+import * as ts from 'typescript';
 
 import type * as d from '../../../declarations';
 import type { BundleOptions } from '../../bundle/bundle-interface';
@@ -6,6 +7,7 @@ import { bundleOutput } from '../../bundle/bundle-output';
 import { STENCIL_INTERNAL_HYDRATE_ID } from '../../bundle/entry-alias-ids';
 import { hydrateComponentTransform } from '../../transformers/component-hydrate/tranform-to-hydrate-component';
 import { removeCollectionImports } from '../../transformers/remove-collection-imports';
+import { rewriteAliasedSourceFileImportPaths } from '../../transformers/rewrite-aliased-paths';
 import { updateStencilCoreImports } from '../../transformers/update-stencil-core-import';
 import { getHydrateBuildConditionals } from './hydrate-build-conditionals';
 
@@ -21,7 +23,7 @@ export const bundleHydrateFactory = async (
       id: 'hydrate',
       platform: 'hydrate',
       conditionals: getHydrateBuildConditionals(buildCtx.components),
-      customTransformers: getHydrateCustomTransformer(config, compilerCtx),
+      customBeforeTransformers: getCustomBeforeTransformers(config, compilerCtx),
       inlineDynamicImports: true,
       inputs: {
         '@app-factory-entry': '@app-factory-entry',
@@ -43,7 +45,19 @@ export const bundleHydrateFactory = async (
   return undefined;
 };
 
-const getHydrateCustomTransformer = (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx) => {
+/**
+ * Generate a collection of transformations that are to be applied as a part of the `before` step in the TypeScript
+ * compilation process.
+ #
+ * @param config the Stencil configuration associated with the current build
+ * @param compilerCtx the current compiler context
+ * @returns a collection of transformations that should be applied to the source code, intended for the `before` part
+ * of the pipeline
+ */
+const getCustomBeforeTransformers = (
+  config: d.ValidatedConfig,
+  compilerCtx: d.CompilerCtx
+): ts.TransformerFactory<ts.SourceFile>[] => {
   const transformOpts: d.TransformOptions = {
     coreImportPath: STENCIL_INTERNAL_HYDRATE_ID,
     componentExport: null,
@@ -53,10 +67,15 @@ const getHydrateCustomTransformer = (config: d.ValidatedConfig, compilerCtx: d.C
     style: 'static',
     styleImportData: 'queryparams',
   };
+  const customBeforeTransformers = [updateStencilCoreImports(transformOpts.coreImportPath)];
 
-  return [
-    updateStencilCoreImports(transformOpts.coreImportPath),
+  if (config.transformAliasedImportPaths) {
+    customBeforeTransformers.push(rewriteAliasedSourceFileImportPaths);
+  }
+
+  customBeforeTransformers.push(
     hydrateComponentTransform(compilerCtx, transformOpts),
-    removeCollectionImports(compilerCtx),
-  ];
+    removeCollectionImports(compilerCtx)
+  );
+  return customBeforeTransformers;
 };

--- a/src/compiler/transpile/run-program.ts
+++ b/src/compiler/transpile/run-program.ts
@@ -6,10 +6,7 @@ import type * as d from '../../declarations';
 import { updateComponentBuildConditionals } from '../app-core/app-data';
 import { resolveComponentDependencies } from '../entries/resolve-component-dependencies';
 import { convertDecoratorsToStatic } from '../transformers/decorators-to-static/convert-decorators';
-import {
-  rewriteAliasedDTSImportPaths,
-  rewriteAliasedSourceFileImportPaths,
-} from '../transformers/rewrite-aliased-paths';
+import { rewriteAliasedDTSImportPaths } from '../transformers/rewrite-aliased-paths';
 import { updateModule } from '../transformers/static-to-meta/parse-static';
 import { generateAppTypes } from '../types/generate-app-types';
 import { updateStencilTypesImports } from '../types/stencil-types';
@@ -67,19 +64,20 @@ export const runTsProgram = async (
   };
 
   if (config.transformAliasedImportPaths) {
-    transformers.before.push(rewriteAliasedSourceFileImportPaths);
-    // TypeScript handles the generation of JS and `.d.ts` files through
-    // different pipelines. One (possibly surprising) consequence of this is
-    // that if you modify a source file using a transforming it will not
-    // automatically result in changes to the corresponding `.d.ts` file.
-    // Instead, if you want to, for instance, rewrite some import specifiers in
-    // both the source file _and_ its typedef you'll need to run a transformer
-    // for both of them.
-    //
-    // See here: https://github.com/itsdouges/typescript-transformer-handbook#transforms
-    // and here: https://github.com/microsoft/TypeScript/pull/23946
-    //
-    // This quirk is not terribly well documented unfortunately.
+    /**
+     * Generate a collection of transformations that are to be applied as a part of the `afterDeclarations` step in the
+     * TypeScript compilation process.
+     *
+     * TypeScript handles the generation of JS and `.d.ts` files through different pipelines. One (possibly surprising)
+     * consequence of this is that if you modify a source file using a transformer, it will not automatically result in
+     * changes to the corresponding `.d.ts` file. Instead, if you want to, for instance, rewrite some import specifiers
+     * in both the source file _and_ its typedef you'll need to run a transformer for both of them.
+     *
+     * See here: https://github.com/itsdouges/typescript-transformer-handbook#transforms
+     * and here: https://github.com/microsoft/TypeScript/pull/23946
+     *
+     * This quirk is not terribly well documented, unfortunately.
+     */
     transformers.afterDeclarations.push(rewriteAliasedDTSImportPaths);
   }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In very specific circumstances, Stencil might not detect the correct `h` and `Host` functions as a result of transforming import paths specified in `tsconfig.json#paths` (see testing section).

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit reorders the transformations run for rewriting paths to
modules in import statements.

previously, modules in import statements would be rewritten based on
the contents of `tsconfig.json#paths` before any other transformation
was run. this would conflict with the `updateStencilCoreImports`
transformation if `@stencil/core` (or any of its valid subpaths) were
listed in `tsconfig.json#paths`. this would cause the wrong versions of
helpers such as `h` and `Host` to be picked up when a project used the
`--prerender` flag on a component that imported either of the above
helpers (the `lazy` output target version would be inlined to the output
rather than the `hydrate` version).

this commit removes the transformation `run-program` and places it
(conditionally) in the "before" transformers list _after_ stencil
imports are transformed. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I generated a dev build of this branch - `@stencil/core@3.4.0-dev.1687377141.615ce97`

### Locally

The underlying issue can be reproduced by using https://github.com/rwaskiewicz/transform-import-paths

this reproduction expects that the location of a built stencil compiler to exist at `~/workspaces/stencil/bin/stencil`.
if your local stencil exists at `~/dev/username/projects/stencil`, update occurences of `~/workspaces` with the parent directory of your stencil repo.

this project contains `build` and `build-local` scripts.
the former will run a build against your local stencil project, the latter against the version of stencil installed by npm.
when running without this PR built locally, we expect both to fail.
once this PR is built, `build` ought to work, while `build-local` continues to fail
if `npm i @stencil/core@3.4.0-dev.1687377141.615ce97` is run, `build-local` will pass

likewise, without building this pr, `npm run prerender` will fail.
upon building it, `npm run prerender` will pass

### Ionic Framework

Ionic Framework already [uses the `transformAliasedImportPaths`](https://github.com/ionic-team/ionic-framework/blob/f29c66aee20573b9aab30811b46b689c49d29524/core/stencil.config.ts#L220) and [has a few `paths` in `tsconfig.json` set](https://github.com/ionic-team/ionic-framework/blob/f29c66aee20573b9aab30811b46b689c49d29524/core/tsconfig.json#L30-L33). With that in mind, the test here is that existing aliasing doesn't break when we exercise the entirety of the CI pipeline in Framework.

I created a temporary branch in the Ionic Framework repo that would run the `stencil-nightly` job with my dev build. Specifically, I applied this patch:
```diff
diff --git a/.github/workflows/stencil-nightly.yml b/.github/workflows/stencil-nightly.yml                                                                                     
index 404cb22e5b..c82f0e092a 100644                                                                                                                                            
--- a/.github/workflows/stencil-nightly.yml                                                                                                                                    
+++ b/.github/workflows/stencil-nightly.yml                                                                                                                                    
@@ -24,7 +24,7 @@ jobs:                                                                                                                                                        
       - uses: actions/checkout@v3                                                                                                                                             
       - uses: ./.github/workflows/actions/build-core-stencil-prerelease                                                                                                       
         with:                                                                                                                                                                 
-          stencil-version: nightly                                                                                                                                            
+          stencil-version: 3.4.0-dev.1687377141.615ce97                                                                                                                       
                                                                                                                                                                               
   test-core-clean-build:                                                                                                                                                      
     needs: [build-core-with-stencil-nightly]                                                                                                                                  
```
and manually kicked off the workflow (using my branch).

The results of that build [can be found here](https://github.com/ionic-team/ionic-framework/actions/runs/5338399217/jobs/9675723302)

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

There are 2 small refactors in this PR:
1. this commit renames the `BundleOptions#customTransfomers` field to
`customBeforeTransformers` as to clarify the usage of the transformers
placed in the collection assoicated with this field
2. JSDoc was added to the `BundleOptions` fields for transformers