### PR TITLE
chore(compiler): remove `getCurrentDirectory` from `sys/environment`

### DIFF
--- a/src/compiler/sys/environment.ts
+++ b/src/compiler/sys/environment.ts
@@ -22,5 +22,3 @@ export const HAS_WEB_WORKER = IS_BROWSER_ENV && typeof Worker === 'function';
 export const IS_FETCH_ENV = typeof fetch === 'function';
 
 export const requireFunc = IS_NODE_ENV ? require : () => {};
-
-export const getCurrentDirectory: () => string = IS_NODE_ENV ? process.cwd : () => '/';

--- a/src/compiler/sys/typescript/typescript-sys.ts
+++ b/src/compiler/sys/typescript/typescript-sys.ts
@@ -3,7 +3,7 @@ import { basename, resolve } from 'path';
 import ts from 'typescript';
 
 import type * as d from '../../../declarations';
-import { getCurrentDirectory, IS_CASE_SENSITIVE_FILE_NAMES, IS_WEB_WORKER_ENV } from '../environment';
+import { IS_CASE_SENSITIVE_FILE_NAMES, IS_WEB_WORKER_ENV } from '../environment';
 import { fetchUrlSync } from '../fetch/fetch-module-sync';
 import { InMemoryFileSystem } from '../in-memory-fs';
 import { patchTypeScriptResolveModule } from './typescript-resolve-module';
@@ -214,7 +214,7 @@ const patchTypeScriptSysMinimum = () => {
       directoryExists: () => false,
       exit: noop,
       fileExists: () => false,
-      getCurrentDirectory,
+      getCurrentDirectory: process.cwd,
       getDirectories: () => [],
       getExecutingFilePath: () => './',
       readDirectory: () => [],

--- a/src/compiler/transpile/transpile-module.ts
+++ b/src/compiler/transpile/transpile-module.ts
@@ -5,7 +5,6 @@ import ts from 'typescript';
 import type * as d from '../../declarations';
 import { BuildContext } from '../build/build-ctx';
 import { CompilerContext } from '../build/compiler-ctx';
-import { getCurrentDirectory } from '../sys/environment';
 import { lazyComponentTransform } from '../transformers/component-lazy/transform-lazy-component';
 import { nativeComponentTransform } from '../transformers/component-native/tranform-to-native-component';
 import { convertDecoratorsToStatic } from '../transformers/decorators-to-static/convert-decorators';
@@ -99,7 +98,7 @@ export const transpileModule = (
     getDefaultLibFileName: () => `lib.d.ts`,
     useCaseSensitiveFileNames: () => false,
     getCanonicalFileName: (fileName) => fileName,
-    getCurrentDirectory: () => transformOpts.currentDirectory || getCurrentDirectory(),
+    getCurrentDirectory: () => transformOpts.currentDirectory || process.cwd(),
     getNewLine: () => ts.sys.newLine || '\n',
     fileExists: (fileName) => normalizePath(fileName) === normalizePath(sourceFilePath),
     readFile: () => '',


### PR DESCRIPTION
This just removes a bit of redundant code from `src/compiler/sys/environment`, in particular the `getCurrentDirectory` function which in a node environment is just an alias for `process.cwd`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

For this I think it would be good to just make sure that a Stencil project like Framework will still build correctly and so on.
