### PR TITLE
fix(compiler): re-enable build caching

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -73,7 +73,7 @@ This field should be removed from a project's Stencil configuration file (`stenc
 ### Legacy Cache Stats Config Flag Removed
 
 The `enableCacheStats` flag was used in legacy behavior for caching, but has not been used for some time. This
-flag has been removed from Stencil's API and should be removed from any projects' Stencil configs.
+flag has been removed from Stencil's API and should be removed from a project's Stencil configuration file (`stencil.config.ts`).
 
 ### Drop Node 14 Support
 

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -15,6 +15,7 @@ This is a comprehensive list of the breaking changes introduced in the major ver
   - [In Browser Compilation Support Removed](#in-browser-compilation-support-removed)
   - [Legacy Context and Connect APIs Removed](#legacy-context-and-connect-APIs-removed)
   - [Legacy Browser Support Removed](#legacy-browser-support-removed)
+  - [Legacy Cache Stats Config Flag Removed](#legacy-cache-stats-config-flag-removed)
   - [Drop Node 14 Support](#drop-node-14-support)
 
 ### General
@@ -68,6 +69,11 @@ The `extras.__deprecated__shadowDomShim` option would check whether a shim for [
 DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM)
 was needed in the current browser, and include one if so.
 This field should be removed from a project's Stencil configuration file (`stencil.config.ts`). 
+
+### Legacy Cache Stats Config Flag Removed
+
+The `enableCacheStats` flag was used in legacy behavior for caching, but has not been used for some time. This
+flag has been removed from Stencil's API and should be removed from any projects' Stencil configs.
 
 ### Drop Node 14 Support
 

--- a/src/compiler/build/write-build.ts
+++ b/src/compiler/build/write-build.ts
@@ -32,7 +32,9 @@ export const writeBuild = async (
 
     // successful write
     // kick off writing the cached file stuff
+    await compilerCtx.cache.commit();
     buildCtx.debug(`in-memory-fs: ${compilerCtx.fs.getMemoryStats()}`);
+    buildCtx.debug(`cache: ${compilerCtx.cache.getMemoryStats()}`);
 
     await outputServiceWorkers(config, buildCtx);
     await validateBuildFiles(config, compilerCtx, buildCtx);

--- a/src/compiler/cache.ts
+++ b/src/compiler/cache.ts
@@ -8,7 +8,7 @@ export class Cache implements d.Cache {
   private skip = false;
   private sys: d.CompilerSystem;
   private logger: d.Logger;
-  private cacheDir: string;
+  private buildCacheDir: string;
 
   constructor(private config: d.Config, private cacheFs: InMemoryFileSystem) {
     this.sys = config.sys;
@@ -20,7 +20,7 @@ export class Cache implements d.Cache {
       return;
     }
 
-    this.cacheDir = this.config.cacheDir;
+    this.buildCacheDir = join(this.config.cacheDir, '.build');
 
     if (!this.config.enableCache || !this.cacheFs) {
       this.config.logger.info(`cache optimizations disabled`);
@@ -28,10 +28,10 @@ export class Cache implements d.Cache {
       return;
     }
 
-    this.config.logger.debug(`cache enabled, cacheDir: ${this.cacheDir}`);
+    this.config.logger.debug(`cache enabled, cacheDir: ${this.buildCacheDir}`);
 
     try {
-      const readmeFilePath = join(this.cacheDir, '_README.log');
+      const readmeFilePath = join(this.buildCacheDir, '_README.log');
       await this.cacheFs.writeFile(readmeFilePath, CACHE_DIR_README);
     } catch (e) {
       this.logger.error(`Cache, initCacheDir: ${e}`);
@@ -126,8 +126,8 @@ export class Cache implements d.Cache {
       }
 
       const fs = this.cacheFs.sys;
-      const cachedFileNames = await fs.readDir(this.cacheDir);
-      const cachedFilePaths = cachedFileNames.map((f) => join(this.cacheDir, f));
+      const cachedFileNames = await fs.readDir(this.buildCacheDir);
+      const cachedFilePaths = cachedFileNames.map((f) => join(this.buildCacheDir, f));
 
       let totalCleared = 0;
 
@@ -153,16 +153,16 @@ export class Cache implements d.Cache {
 
   async clearDiskCache() {
     if (this.cacheFs != null) {
-      const hasAccess = await this.cacheFs.access(this.cacheDir);
+      const hasAccess = await this.cacheFs.access(this.buildCacheDir);
       if (hasAccess) {
-        await this.cacheFs.remove(this.cacheDir);
+        await this.cacheFs.remove(this.buildCacheDir);
         await this.cacheFs.commit();
       }
     }
   }
 
   private getCacheFilePath(key: string) {
-    return join(this.cacheDir, key) + '.log';
+    return join(this.buildCacheDir, key) + '.log';
   }
 
   getMemoryStats() {

--- a/src/compiler/cache.ts
+++ b/src/compiler/cache.ts
@@ -8,6 +8,7 @@ export class Cache implements d.Cache {
   private skip = false;
   private sys: d.CompilerSystem;
   private logger: d.Logger;
+  private cacheDir: string;
 
   constructor(private config: d.Config, private cacheFs: InMemoryFileSystem) {
     this.sys = config.sys;
@@ -19,16 +20,18 @@ export class Cache implements d.Cache {
       return;
     }
 
+    this.cacheDir = this.config.cacheDir;
+
     if (!this.config.enableCache || !this.cacheFs) {
       this.config.logger.info(`cache optimizations disabled`);
       this.clearDiskCache();
       return;
     }
 
-    this.config.logger.debug(`cache enabled, cacheDir: ${this.config.cacheDir}`);
+    this.config.logger.debug(`cache enabled, cacheDir: ${this.cacheDir}`);
 
     try {
-      const readmeFilePath = join(this.config.cacheDir, '_README.log');
+      const readmeFilePath = join(this.cacheDir, '_README.log');
       await this.cacheFs.writeFile(readmeFilePath, CACHE_DIR_README);
     } catch (e) {
       this.logger.error(`Cache, initCacheDir: ${e}`);
@@ -44,7 +47,7 @@ export class Cache implements d.Cache {
     if (this.failed >= MAX_FAILED) {
       if (!this.skip) {
         this.skip = true;
-        this.logger.debug(`cache had ${this.failed} failed ops, skip disk ops for remander of build`);
+        this.logger.debug(`cache had ${this.failed} failed ops, skip disk ops for remainder of build`);
       }
       return null;
     }
@@ -54,7 +57,7 @@ export class Cache implements d.Cache {
       result = await this.cacheFs.readFile(this.getCacheFilePath(key));
       this.failed = 0;
       this.skip = false;
-    } catch (e) {
+    } catch (e: unknown) {
       this.failed++;
       result = null;
     }
@@ -72,7 +75,7 @@ export class Cache implements d.Cache {
     try {
       await this.cacheFs.writeFile(this.getCacheFilePath(key), value);
       result = true;
-    } catch (e) {
+    } catch (e: unknown) {
       this.failed++;
       result = false;
     }
@@ -123,8 +126,8 @@ export class Cache implements d.Cache {
       }
 
       const fs = this.cacheFs.sys;
-      const cachedFileNames = await fs.readDir(this.config.cacheDir);
-      const cachedFilePaths = cachedFileNames.map((f) => join(this.config.cacheDir, f));
+      const cachedFileNames = await fs.readDir(this.cacheDir);
+      const cachedFilePaths = cachedFileNames.map((f) => join(this.cacheDir, f));
 
       let totalCleared = 0;
 
@@ -150,16 +153,16 @@ export class Cache implements d.Cache {
 
   async clearDiskCache() {
     if (this.cacheFs != null) {
-      const hasAccess = await this.cacheFs.access(this.config.cacheDir);
+      const hasAccess = await this.cacheFs.access(this.cacheDir);
       if (hasAccess) {
-        await this.cacheFs.remove(this.config.cacheDir);
+        await this.cacheFs.remove(this.cacheDir);
         await this.cacheFs.commit();
       }
     }
   }
 
   private getCacheFilePath(key: string) {
-    return join(this.config.cacheDir, key) + '.log';
+    return join(this.cacheDir, key) + '.log';
   }
 
   getMemoryStats() {

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -42,6 +42,32 @@ export interface StencilConfig {
    * To disable this feature, set enableCache to false.
    */
   enableCache?: boolean;
+  /**
+   * The directory where sub-directories will be created for caching when `enableCache` is set
+   * `true` or if using Stencil's Screenshot Connector.
+   *
+   * @example
+   * {
+   *   ...,
+   *   enableCache: true,
+   *   cacheDir: '.cache',
+   *   testing: {
+   *     screenshotConnector: 'connector.js'
+   *   }
+   * }
+   *
+   * Will result in the following file structure:
+   * stencil-project-root
+   * └── .cache
+   *     ├── .build <-- Where build related file caching is written
+   *     |
+   *     └── screenshot-cache.json <-- Where screenshot caching is written
+   */
+  cacheDir?: string;
+  /**
+   * @deprecated this flag is no longer used by Stencil and can be safely removed.
+   */
+  enableCacheStats?: boolean;
 
   /**
    * Stencil is traditionally used to compile many components into an app,
@@ -244,13 +270,8 @@ export interface StencilConfig {
   entryComponentsHint?: string[];
   buildDist?: boolean;
   buildLogFilePath?: string;
-  cacheDir?: string;
   devInspector?: boolean;
   devServer?: StencilDevServerConfig;
-  /**
-   * @deprecated this flag is no longer used by Stencil and can be safely removed.
-   */
-  enableCacheStats?: boolean;
   sys?: CompilerSystem;
   tsconfig?: string;
   validateTypes?: boolean;

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -46,22 +46,30 @@ export interface StencilConfig {
    * The directory where sub-directories will be created for caching when `enableCache` is set
    * `true` or if using Stencil's Screenshot Connector.
    *
+   * @default '.stencil'
+   *
    * @example
-   * {
-   *   ...,
-   *   enableCache: true,
-   *   cacheDir: '.cache',
-   *   testing: {
-   *     screenshotConnector: 'connector.js'
-   *   }
+   *
+   * A Stencil config like the following:
+   * ```ts
+   * export const config = {
+   *  ...,
+   *  enableCache: true,
+   *  cacheDir: '.cache',
+   *  testing: {
+   *    screenshotConnector: 'connector.js'
+   *  }
    * }
+   * ```
    *
    * Will result in the following file structure:
+   * ```tree
    * stencil-project-root
    * └── .cache
    *     ├── .build <-- Where build related file caching is written
    *     |
    *     └── screenshot-cache.json <-- Where screenshot caching is written
+   * ```
    */
   cacheDir?: string;
   /**

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -247,6 +247,9 @@ export interface StencilConfig {
   cacheDir?: string;
   devInspector?: boolean;
   devServer?: StencilDevServerConfig;
+  /**
+   * @deprecated this flag is no longer used by Stencil and can be safely removed.
+   */
   enableCacheStats?: boolean;
   sys?: CompilerSystem;
   tsconfig?: string;

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -72,10 +72,6 @@ export interface StencilConfig {
    * ```
    */
   cacheDir?: string;
-  /**
-   * @deprecated this flag is no longer used by Stencil and can be safely removed.
-   */
-  enableCacheStats?: boolean;
 
   /**
    * Stencil is traditionally used to compile many components into an app,

--- a/src/screenshot/connector-base.ts
+++ b/src/screenshot/connector-base.ts
@@ -42,8 +42,8 @@ export class ScreenshotConnector implements d.ScreenshotConnector {
     this.buildAuthor = opts.buildAuthor;
     this.buildUrl = opts.buildUrl;
     this.previewUrl = opts.previewUrl;
-    (this.buildTimestamp = typeof opts.buildTimestamp === 'number' ? opts.buildTimestamp : Date.now()),
-      (this.cacheDir = opts.cacheDir);
+    this.buildTimestamp = typeof opts.buildTimestamp === 'number' ? opts.buildTimestamp : Date.now();
+    this.cacheDir = opts.cacheDir;
     this.packageDir = opts.packageDir;
     this.rootDir = opts.rootDir;
     this.appNamespace = opts.appNamespace;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Caching was disabled in [this commit](https://github.com/ionic-team/stencil/commit/63595bc540db9aa85295f5a8dc8738beb2a37611#diff-a2a3c503f6a2b9ee197d01f14954b0f59a14820ed2b30cd6046e92d5d233e446). 

GitHub Issue Number: N/A

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This commit re-enables build caching and makes a few updates to not conflict with caching when using a screenshot connector.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Automated unit and e2e tests continue to pass.

Did quite a bit of manual benchmarking against Ionic framework. Results can be found [here](https://ionic-cloud.atlassian.net/browse/STENCIL-848?focusedCommentId=21008)

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

Huge thanks to @George-Payne for pointing this out and doing the work to get this moving in [his PR](#3456)!

This branch/PR was created as an easy means of porting his work over to an updated version of Stencil
