### PR TITLE
chore(v4): post-rebase fixups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,8 +81,8 @@
         "ws": "8.13.0"
       },
       "engines": {
-        "node": ">=14.10.0",
-        "npm": ">=6.0.0"
+        "node": ">=16.0.0",
+        "npm": ">=7.10.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/test/docs-json/docs.d.ts
+++ b/test/docs-json/docs.d.ts
@@ -16,49 +16,157 @@ import { ComponentCompilerEventComplexType, ComponentCompilerMethodComplexType, 
  * target (see {@link JsonDocs.typeLibrary}).
  */
 export type JsonDocsTypeLibrary = Record<string, ComponentCompilerReferencedType>;
+/**
+ * A container for JSDoc metadata for a project
+ */
 export interface JsonDocs {
+    /**
+     * The metadata for the JSDocs for each component in a Stencil project
+     */
     components: JsonDocsComponent[];
+    /**
+     * The timestamp at which the metadata was generated, in the format YYYY-MM-DDThh:mm:ss
+     */
     timestamp: string;
     compiler: {
+        /**
+         * The name of the compiler that generated the metadata
+         */
         name: string;
+        /**
+         * The version of the Stencil compiler that generated the metadata
+         */
         version: string;
+        /**
+         * The version of TypeScript that was used to generate the metadata
+         */
         typescriptVersion: string;
     };
     typeLibrary: JsonDocsTypeLibrary;
 }
+/**
+ * Container for JSDoc metadata for a single Stencil component
+ */
 export interface JsonDocsComponent {
+    /**
+     * The directory containing the Stencil component, minus the file name.
+     *
+     * @example /workspaces/stencil-project/src/components/my-component
+     */
     dirPath?: string;
+    /**
+     * The name of the file containing the Stencil component, with no path
+     *
+     * @example my-component.tsx
+     */
     fileName?: string;
+    /**
+     * The full path of the file containing the Stencil component
+     *
+     * @example /workspaces/stencil-project/src/components/my-component/my-component.tsx
+     */
     filePath?: string;
+    /**
+     * The path to the component's `readme.md` file, including the filename
+     *
+     * @example /workspaces/stencil-project/src/components/my-component/readme.md
+     */
     readmePath?: string;
+    /**
+     * The path to the component's `usage` directory
+     *
+     * @example /workspaces/stencil-project/src/components/my-component/usage/
+     */
     usagesDir?: string;
+    /**
+     * The encapsulation strategy for a component
+     */
     encapsulation: 'shadow' | 'scoped' | 'none';
+    /**
+     * The tag name for the component, for use in HTML
+     */
     tag: string;
+    /**
+     * The contents of a component's `readme.md` that are user generated.
+     *
+     * Auto-generated contents are not stored in this reference.
+     */
     readme: string;
+    /**
+     * The description of a Stencil component, found in the JSDoc that sits above the component's declaration
+     */
     docs: string;
+    /**
+     * JSDoc tags found in the JSDoc comment written atop a component's declaration
+     */
     docsTags: JsonDocsTag[];
     /**
      * The text from the class-level JSDoc for a Stencil component, if present.
      */
     overview?: string;
+    /**
+     * A mapping of usage example file names to their contents for the component.
+     */
     usage: JsonDocsUsage;
+    /**
+     * Array of metadata for a component's `@Prop`s
+     */
     props: JsonDocsProp[];
+    /**
+     * Array of metadata for a component's `@Method`s
+     */
     methods: JsonDocsMethod[];
+    /**
+     * Array of metadata for a component's `@Event`s
+     */
     events: JsonDocsEvent[];
+    /**
+     * Array of metadata for a component's `@Listen` handlers
+     */
     listeners: JsonDocsListener[];
+    /**
+     * Array of metadata for a component's CSS styling information
+     */
     styles: JsonDocsStyle[];
+    /**
+     * Array of component Slot information, generated from `@slot` tags
+     */
     slots: JsonDocsSlot[];
+    /**
+     * Array of component Parts information, generate from `@part` tags
+     */
     parts: JsonDocsPart[];
+    /**
+     * Array of metadata describing where the current component is used
+     */
     dependents: string[];
+    /**
+     * Array of metadata listing the components which are used in current component
+     */
     dependencies: string[];
+    /**
+     * Describes a tree of components coupling
+     */
     dependencyGraph: JsonDocsDependencyGraph;
+    /**
+     * A deprecation reason/description found following a `@deprecated` tag
+     */
     deprecation?: string;
 }
 export interface JsonDocsDependencyGraph {
     [tagName: string]: string[];
 }
+/**
+ * A descriptor for a single JSDoc tag found in a block comment
+ */
 export interface JsonDocsTag {
+    /**
+     * The tag name (immediately following the '@')
+     */
     name: string;
+    /**
+     * The description that immediately follows the tag name
+     */
     text?: string;
 }
 export interface JsonDocsValue {
@@ -88,22 +196,65 @@ export interface JsonDocsValue {
 export interface JsonDocsUsage {
     [key: string]: string;
 }
+/**
+ * An intermediate representation of a `@Prop` decorated member's JSDoc
+ */
 export interface JsonDocsProp {
+    /**
+     * the name of the prop
+     */
     name: string;
     complexType?: ComponentCompilerPropertyComplexType;
+    /**
+     * the type of the prop, in terms of the TypeScript type system (as opposed to JavaScript's or HTML's)
+     */
     type: string;
+    /**
+     * `true` if the prop was configured as "mutable" where it was declared, `false` otherwise
+     */
     mutable: boolean;
     /**
      * The name of the attribute that is exposed to configure a compiled web component
      */
     attr?: string;
+    /**
+     * `true` if the prop was configured to "reflect" back to HTML where it (the prop) was declared, `false` otherwise
+     */
     reflectToAttr: boolean;
+    /**
+     * the JSDoc description text associated with the prop
+     */
     docs: string;
+    /**
+     * JSDoc tags associated with the prop
+     */
     docsTags: JsonDocsTag[];
+    /**
+     * The default value of the prop
+     */
     default?: string;
+    /**
+     * Deprecation text associated with the prop. This is the text that immediately follows a `@deprecated` tag
+     */
     deprecation?: string;
     values: JsonDocsValue[];
+    /**
+     * `true` if a component is declared with a '?', `false` otherwise
+     *
+     * @example
+     * ```tsx
+     * @Prop() componentProps?: any;
+     * ```
+     */
     optional: boolean;
+    /**
+     * `true` if a component is declared with a '!', `false` otherwise
+     *
+     * @example
+     * ```tsx
+     * @Prop() componentProps!: any;
+     * ```
+     */
     required: boolean;
 }
 export interface JsonDocsMethod {
@@ -147,12 +298,35 @@ export interface JsonDocsListener {
     capture: boolean;
     passive: boolean;
 }
+/**
+ * A descriptor for a slot
+ *
+ * Objects of this type are translated from the JSDoc tag, `@slot`
+ */
 export interface JsonDocsSlot {
+    /**
+     * The name of the slot. Defaults to an empty string for an unnamed slot.
+     */
     name: string;
+    /**
+     * A textual description of the slot.
+     */
     docs: string;
 }
+/**
+ * A descriptor of a CSS Shadow Part
+ *
+ * Objects of this type are translated from the JSDoc tag, `@part`, or the 'part'
+ * attribute on a component in TSX
+ */
 export interface JsonDocsPart {
+    /**
+     * The name of the Shadow part
+     */
     name: string;
+    /**
+     * A textual description of the Shadow part.
+     */
     docs: string;
 }
 export interface StyleDoc {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

**DO NOT SQUASH**

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When we rebased `stencil/v4-dev` against `main`, I found two small issues:
1. we hadn't propagated `engines` changes back to `package-lock.json`
2. due to two separate efforts, one in `main` and one in `stencil/v4-dev`, we had an out of date `.d.ts` generated file as a result of the rebase

the latter is causing CI to fail, but I figured why not just knock 2 out now and merge them as 2 distinct commits?

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit propagates the changes to the `engines` field that were made
to `package.json` in https://github.com/ionic-team/stencil/pull/4472

 this commit propagates jsdoc changes that were landed in
https://github.com/ionic-team/stencil/pull/3683 into the `main` branch.
`stencil/v4-dev` did not include these changes initially, so when we
rebased `stencil/v4-dev` atop of `main`, ci for v4 began to fail due to
a dirty git context

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Tested the analysis stuff locally

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

**DO NOT SQUASH**