### PR TITLE
fix(compiler): address when a home module cannot be found

### DIFF
--- a/src/compiler/transformers/test/parse-props.spec.ts
+++ b/src/compiler/transformers/test/parse-props.spec.ts
@@ -34,6 +34,39 @@ describe('parse props', () => {
     expect(t.cmp?.hasProp).toBe(true);
   });
 
+  it('should correctly parse a prop with an unresolved type', () => {
+    const t = transpileModule(`
+    @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() val?: Foo;
+      }
+    `);
+    expect(getStaticGetter(t.outputText, 'properties')).toEqual({
+      val: {
+        attribute: 'val',
+        complexType: {
+          references: {
+            Foo: {
+              id: 'global::Foo',
+              location: 'global',
+            },
+          },
+          resolved: 'Foo',
+          original: 'Foo',
+        },
+        docs: {
+          text: '',
+          tags: [],
+        },
+        mutable: false,
+        optional: true,
+        reflect: false,
+        required: false,
+        type: 'any',
+      },
+    });
+  });
+
   it('prop required', () => {
     const t = transpileModule(`
     @Component({tag: 'cmp-a'})

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -519,18 +519,20 @@ const getTypeReferenceLocation = (
     const compilerHost = ts.createCompilerHost(options);
     const importHomeModule = getHomeModule(sourceFile, localImportPath, options, compilerHost, program);
 
-    const importName = namedImportBindings.elements.find((nbe) => nbe.name.getText() === typeName).name;
-    const originalTypeName = getOriginalTypeName(importName, checker);
+    if (importHomeModule) {
+      const importName = namedImportBindings.elements.find((nbe) => nbe.name.getText() === typeName).name;
+      const originalTypeName = getOriginalTypeName(importName, checker);
 
-    const typeDecl = findTypeWithName(importHomeModule, originalTypeName);
-    type = checker.getTypeAtLocation(typeDecl);
+      const typeDecl = findTypeWithName(importHomeModule, originalTypeName);
+      type = checker.getTypeAtLocation(typeDecl);
 
-    const id = addToLibrary(type, originalTypeName, checker, normalizePath(importHomeModule.fileName, false));
-    return {
-      location: 'import',
-      path: localImportPath,
-      id,
-    };
+      const id = addToLibrary(type, originalTypeName, checker, normalizePath(importHomeModule.fileName, false));
+      return {
+        location: 'import',
+        path: localImportPath,
+        id,
+      };
+    }
   }
 
   // Loop through all top level exports to find if any reference to the type for 'local' reference location


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?

A bit of the code added in #4212 incorrectly assumed a value wouldn't be falsy

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

You should be able to build and install this in framework and then run `npm run test.spec` without errors. additionally, the output from the `docs-json` output target in `docs/core.json` shouldn't change.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
