### PR TITLE
fix(compiler): normalize recommended `collection` path for `package.json` validation

### DIFF
--- a/src/compiler/types/tests/validate-package-json.spec.ts
+++ b/src/compiler/types/tests/validate-package-json.spec.ts
@@ -99,9 +99,30 @@ describe('validate-package-json', () => {
   });
 
   describe('collection', () => {
-    it('should error when missing collection property', async () => {
+    it('should produce a warning when missing collection property', async () => {
       v.validateCollection(config, compilerCtx, buildCtx, collectionOutputTarget);
+
       expect(buildCtx.diagnostics[0].messageText).toMatch(/package.json "collection" property is required/);
+      expect(buildCtx.diagnostics[0].level).toBe('warn');
+    });
+
+    it('should produce a warning if the supplied path does not match the recommended path', () => {
+      buildCtx.packageJson.collection = 'bad/path';
+
+      v.validateCollection(config, compilerCtx, buildCtx, collectionOutputTarget);
+
+      expect(buildCtx.diagnostics[0].messageText).toBe(
+        `package.json "collection" property is required when generating a distribution and must be set to: dist/collection/collection-manifest.json`
+      );
+      expect(buildCtx.diagnostics[0].level).toBe('warn');
+    });
+
+    it('should not produce a warning if the normalized paths are the same', () => {
+      buildCtx.packageJson.collection = './dist/collection/collection-manifest.json';
+
+      v.validateCollection(config, compilerCtx, buildCtx, collectionOutputTarget);
+
+      expect(buildCtx.diagnostics.length).toEqual(0);
     });
   });
 });

--- a/src/compiler/types/tests/validate-package-json.spec.ts
+++ b/src/compiler/types/tests/validate-package-json.spec.ts
@@ -1,5 +1,6 @@
 import type * as d from '@stencil/core/declarations';
 import { mockBuildCtx, mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { normalizePath } from '@utils';
 import path from 'path';
 
 import * as v from '../validate-build-package-json';
@@ -112,7 +113,10 @@ describe('validate-package-json', () => {
       v.validateCollection(config, compilerCtx, buildCtx, collectionOutputTarget);
 
       expect(buildCtx.diagnostics[0].messageText).toBe(
-        `package.json "collection" property is required when generating a distribution and must be set to: dist/collection/collection-manifest.json`
+        `package.json "collection" property is required when generating a distribution and must be set to: ${normalizePath(
+          'dist/collection/collection-manifest.json',
+          false
+        )}`
       );
       expect(buildCtx.diagnostics[0].level).toBe('warn');
     });

--- a/src/compiler/types/validate-build-package-json.ts
+++ b/src/compiler/types/validate-build-package-json.ts
@@ -149,11 +149,11 @@ export const validateCollection = (
   outputTarget: d.OutputTargetDistCollection
 ) => {
   if (outputTarget.collectionDir) {
-    const collectionRel = join(relative(config.rootDir, outputTarget.collectionDir), COLLECTION_MANIFEST_FILE_NAME);
-    if (
-      !buildCtx.packageJson.collection ||
-      normalizePath(buildCtx.packageJson.collection) !== normalizePath(collectionRel)
-    ) {
+    const collectionRel = normalizePath(
+      join(relative(config.rootDir, outputTarget.collectionDir), COLLECTION_MANIFEST_FILE_NAME),
+      false
+    );
+    if (!buildCtx.packageJson.collection || normalizePath(buildCtx.packageJson.collection, false) !== collectionRel) {
       const msg = `package.json "collection" property is required when generating a distribution and must be set to: ${collectionRel}`;
       packageJsonWarn(config, compilerCtx, buildCtx, msg, `"collection"`);
     }

--- a/src/compiler/types/validate-build-package-json.ts
+++ b/src/compiler/types/validate-build-package-json.ts
@@ -150,7 +150,10 @@ export const validateCollection = (
 ) => {
   if (outputTarget.collectionDir) {
     const collectionRel = join(relative(config.rootDir, outputTarget.collectionDir), COLLECTION_MANIFEST_FILE_NAME);
-    if (!buildCtx.packageJson.collection || normalizePath(buildCtx.packageJson.collection) !== collectionRel) {
+    if (
+      !buildCtx.packageJson.collection ||
+      normalizePath(buildCtx.packageJson.collection) !== normalizePath(collectionRel)
+    ) {
       const msg = `package.json "collection" property is required when generating a distribution and must be set to: ${collectionRel}`;
       packageJsonWarn(config, compilerCtx, buildCtx, msg, `"collection"`);
     }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `package.json` validation for the `collection` field does not use a normalized path for the comparison. This can result in a warning message to set the field to the value that already exists (can be seen by using the stock Stencil component starter)

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The recommended path gets normalized for the string comparison of the existing path and recommended path.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Tested using the component starter.
1. Create a new Stencil project, run `npm i` and `npm run build`. Notice the warning message related to the `collection` field recommends setting the value that already exists in the `package.json`
2. Build and pack this branch. Install in the starter project
3. Run `npm run build` and notice the warning message no longer appears.
4. You can also change the `collection` field in the `package.json` to a relative path like `./dist/collection/collection-manifest.json` and get no warning.
5. Changing the `collection` field to something like `collection/collection-manifest.json` will correctly throw a warning.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
