### PR TITLE
fix(compiler): sourcemap errors for dist-custom-elements + dist-hydrate-script

### DIFF
--- a/src/compiler/transformers/component-native/native-component.ts
+++ b/src/compiler/transformers/component-native/native-component.ts
@@ -1,7 +1,8 @@
+import { DIST_CUSTOM_ELEMENTS } from '@utils';
 import ts from 'typescript';
 
 import type * as d from '../../../declarations';
-import { addCoreRuntimeApi, HTML_ELEMENT, RUNTIME_APIS } from '../core-runtime-apis';
+import { addOutputTargetCoreRuntimeApi, HTML_ELEMENT, RUNTIME_APIS } from '../core-runtime-apis';
 import { transformHostData } from '../host-data-transform';
 import { removeStaticMetaProperties } from '../remove-static-meta-properties';
 import { updateComponentClass } from '../update-component-class';
@@ -40,7 +41,7 @@ const updateNativeHostComponentHeritageClauses = (
 
   if (moduleFile.cmps.length >= 1) {
     // we'll need to import `HTMLElement` in order to extend it
-    addCoreRuntimeApi(moduleFile, RUNTIME_APIS.HTMLElement);
+    addOutputTargetCoreRuntimeApi(moduleFile, DIST_CUSTOM_ELEMENTS, RUNTIME_APIS.HTMLElement);
   }
 
   const heritageClause = ts.factory.createHeritageClause(ts.SyntaxKind.ExtendsKeyword, [

--- a/src/compiler/transformers/test/native-constructor.spec.ts
+++ b/src/compiler/transformers/test/native-constructor.spec.ts
@@ -38,7 +38,7 @@ describe('nativeComponentTransform', () => {
       const transpiledModule = transpileModule(code, null, compilerCtx, [], [transformer]);
 
       expect(transpiledModule.outputText).toContain(
-        `import { HTMLElement, defineCustomElement as __stencil_defineCustomElement, attachShadow as __stencil_attachShadow } from "@stencil/core";`
+        `import { defineCustomElement as __stencil_defineCustomElement, HTMLElement, attachShadow as __stencil_attachShadow } from "@stencil/core";`
       );
       expect(transpiledModule.outputText).toContain(`this.__attachShadow()`);
     });
@@ -63,7 +63,7 @@ describe('nativeComponentTransform', () => {
       const transpiledModule = transpileModule(code, null, compilerCtx, [], [transformer]);
 
       expect(transpiledModule.outputText).toContain(
-        `import { HTMLElement, defineCustomElement as __stencil_defineCustomElement, attachShadow as __stencil_attachShadow } from "@stencil/core";`
+        `import { defineCustomElement as __stencil_defineCustomElement, HTMLElement, attachShadow as __stencil_attachShadow } from "@stencil/core";`
       );
       expect(transpiledModule.outputText).toContain(`this.__attachShadow()`);
     });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

see 'new behavior' and https://github.com/ionic-team/stencil/issues/4260

GitHub Issue Number: Fixes: #4260


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit fixes an issue where a stencil project that use both the `dist-custom-elements` and `dist-hydrate-script` output targets would see the following error when building their project (with sourcemaps enabled):

```
[ WARN  ]  Bundling Warning SOURCEMAP_ERROR
           Error when using sourcemap for reporting an error: Can't resolve original location of error.
```

this commit resolves this error by ensuring the `HTMLElement` core runtime API used by `dist-custom-elements` no longer interferes with the generated code for `dist-hydrate-script`. this is accomplished by using the output-target-specific runtime api slots introduced in #4200. this prevents the `HTMLElement` import from polluting the sourcemaps/source used in the `dist-hydrate-script` target

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Unit tests have been updated to account for the change in the order of imports.

Pull down the reproduction case at https://github.com/rwaskiewicz/stencil-dist-hydrate-script-sourcemap-warn
1. `npm i @stencil/core@latest`
2. `npm run build`
3. Observe the following output:
```
> dist-hydrate-script-sourcemap-warn@0.0.1 build
> stencil build --docs

[58:06.7]  @stencil/core
[58:06.8]  [CURRENT_VERSION}
[58:07.6]  build, dist-hydrate-script-sourcemap-warn, prod mode, started ...
[58:07.6]  transpile started ...
[58:08.6]  transpile finished in 938 ms
[58:08.6]  generate custom elements + source maps started ...
[58:08.6]  generate hydrate app started ...
[58:08.9]  generate custom elements + source maps finished in 377 ms
[58:08.9]  generate hydrate app finished in 378 ms

[ WARN  ]  Bundling Warning SOURCEMAP_ERROR
           Error when using sourcemap for reporting an error: Can't resolve original location of error.

[58:08.9]  build finished in 1.33 s
```
4. Install the dev build: `npm i @stencil/core@4.0.1-dev.1688045194.5d2dda3`
5. `npm run build`
6. Observe that the issue no longer occurs
7. I also compared the outputs of `dist-hydrate` and `dist-custom-elements`, and found no meaningful differences between the dev build and v4.0.1

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
