### PR TITLE
fix(runtime): properly type color-interpolation-filter

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1444,7 +1444,7 @@ export namespace JSXBase {
     clipPathUnits?: number | string;
     'clip-rule'?: number | string;
     'color-interpolation'?: number | string;
-    'color-interpolation-filters'?: 'auto' | 's-rGB' | 'linear-rGB' | 'inherit';
+    'color-interpolation-filters'?: 'auto' | 'sRGB' | 'linearRGB';
     'color-profile'?: number | string;
     'color-rendering'?: number | string;
     contentScriptType?: number | string;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Stencil improperly types `'color-interpolation-filter'` attribute values. It causes TypeScript to error when 'sRGB' or 'linearRGB' are provided, both of which are valid.

GitHub Issue Number: Fixes: https://github.com/ionic-team/stencil/issues/3354


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->


this commit updates the typings of
`SVGAttributes#color-interpolation-filter` to match the current spec, which states the only accepted values are 'auto', 'sRGB' and 'linearRGB'.

this commit renames 's-rGB' to 'sRGB' and 'linear-rGB' to 'linearRGB'. it also removes 'inherit'.

it is believed this was done by accident in a regex-based replacement of camelCased properties to kebab-cased attributes in 667597dd
## Does this introduce a breaking change?

- [ ] Yes
- [x] No - although folks using this may see TS errors upon upgrading

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Before applying this change:
![Screenshot 2023-06-29 at 5 41 26 PM](https://github.com/ionic-team/stencil/assets/1930213/a2fafd20-7951-413c-9748-14f0692ec9fd)
After:
![Screenshot 2023-06-29 at 5 52 36 PM](https://github.com/ionic-team/stencil/assets/1930213/85a97d94-9782-4563-a4c6-f6618d50aac3)



## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
