### PR TITLE
fix(rollup-config): deprecate BundlingConfig#namedExports

### DIFF
--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1526,7 +1526,12 @@ export interface CopyTask {
   keepDirStructure?: boolean;
 }
 
+// TODO(STENCIL-882): Remove this interface [BREAKING_CHANGE]
 export interface BundlingConfig {
+  /**
+   * @deprecated the `namedExports` field is no longer honored by `@rollup/plugin-commonjs` and is not used by Stencil.
+   * This field can be safely removed from your Stencil configuration file.
+   */
   namedExports?: {
     [key: string]: string[];
   };


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`namedExports`, a property on Stencil's `commonjs` configuration, is no longer honored by the rollup commonjs plugin

GitHub Issue Number: Fixes: #2523


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit deprecates the `namedExports` field on the `BundlingConfig` interface. `@rollup/plugin-commonjs` no longer honors this field as of https://github.com/rollup/plugins/commit/5d2dcf433aaa65d7ebf93d210cac67011fefe29f.

STENCIL-867

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Deprecation is now picked up in editors:
![Screenshot 2023-06-30 at 10 23 20 AM](https://github.com/ionic-team/stencil/assets/1930213/36c0b68e-92bc-4c61-8acd-16a6c9c81d1d)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
