### PR TITLE
test(validate-testing): test when no flags are provided

### DIFF
--- a/src/compiler/config/test/validate-testing.spec.ts
+++ b/src/compiler/config/test/validate-testing.spec.ts
@@ -31,6 +31,29 @@ describe('validateTesting', () => {
     ];
   });
 
+  describe('no testing flags', () => {
+    it('returns an empty testing config when no testing config nor testing flags are provided', () => {
+      userConfig.flags = { ...flags, e2e: false, spec: false };
+      delete userConfig.testing;
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing).toEqual({});
+    });
+
+    it('returns the provided testing config when neither testing flag is provided', () => {
+      const testingConfig: d.TestingConfig = {
+        bail: false,
+      };
+      userConfig.flags = { ...flags, e2e: false, spec: false };
+      userConfig.testing = testingConfig;
+
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+
+      expect(config.testing).toEqual(testingConfig);
+    });
+  });
+
   describe('browserHeadless', () => {
     describe("using 'headless' value from cli", () => {
       it.each([false, true, 'new'])('sets browserHeadless to %s', (headless) => {


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit adds tests for valdiating stencil's testing configuration when no flags are provided to the testing validation function.



## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing


Unit tests continue to pass
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

this changeset was intended to be added in
https://github.com/ionic-team/stencil/pull/4384, but for some reason was missed