### PR TITLE
Use posix paths for type imports

### DIFF
--- a/src/compiler/output-targets/dist-custom-elements/custom-elements-types.ts
+++ b/src/compiler/output-targets/dist-custom-elements/custom-elements-types.ts
@@ -1,5 +1,5 @@
 import { dashToPascalCase, isOutputTargetDistCustomElements, normalizePath } from '@utils';
-import { dirname, join, relative } from 'path';
+import { dirname, join, posix } from 'path';
 
 import type * as d from '../../../declarations';
 
@@ -48,7 +48,7 @@ const generateCustomElementsTypesOutput = async (
   // the path where we're going to write the typedef for the whole dist-custom-elements output
   const customElementsDtsPath = join(outputTarget.dir!, 'index.d.ts');
   // the directory where types for the individual components are written
-  const componentsTypeDirectoryRelPath = relative(outputTarget.dir!, typesDir);
+  const componentsTypeDirectoryRelPath = posix.relative(outputTarget.dir!, typesDir);
 
   const components = buildCtx.components.filter((m) => !m.isCollectionDependency);
 
@@ -71,8 +71,8 @@ const generateCustomElementsTypesOutput = async (
             // - get the relative path to the component's source file from the source directory
             // - join that relative path to the relative path from the `index.d.ts` file to the
             //   directory where typedefs are saved
-            const componentSourceRelPath = relative(config.srcDir, component.sourceFilePath).replace(/\.tsx$/, '');
-            const componentDTSPath = join(componentsTypeDirectoryRelPath, componentSourceRelPath);
+            const componentSourceRelPath = posix.relative(config.srcDir, component.sourceFilePath).replace(/\.tsx$/, '');
+            const componentDTSPath = posix.join(componentsTypeDirectoryRelPath, componentSourceRelPath);
 
             const defineFunctionExportName = `defineCustomElement${exportName}`;
             // Get the path to the sibling typedef file for the current component
@@ -205,7 +205,7 @@ const generateCustomElementType = (componentsDtsRelPath: string, cmp: d.Componen
  * @returns the relative path from the provided `fromPath` to the `dtsPath`
  */
 const relDts = (fromPath: string, dtsPath: string): string => {
-  dtsPath = relative(fromPath, dtsPath);
+  dtsPath = posix.relative(fromPath, dtsPath);
   if (!dtsPath.startsWith('.')) {
     dtsPath = '.' + dtsPath;
   }

--- a/src/compiler/output-targets/test/custom-elements-types.spec.ts
+++ b/src/compiler/output-targets/test/custom-elements-types.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '@stencil/core/testing';
 import { DIST_CUSTOM_ELEMENTS } from '@utils';
 import path from 'path';
-import { join, relative } from 'path';
+import { join } from 'path';
 
 import type * as d from '../../../declarations';
 import { stubComponentCompilerMeta } from '../../types/tests/ComponentCompilerMeta.stub';
@@ -62,17 +62,11 @@ describe('Custom Elements Typedef generation', () => {
 
     await generateCustomElementsTypes(config, compilerCtx, buildCtx, 'types_dir');
 
-    const componentsTypeDirectoryPath = relative('my-best-dir', join('types_dir', 'components'));
-
     const expectedTypedefOutput = [
       '/* TestApp custom elements */',
-      `export { StubCmp as MyComponent } from '${join(componentsTypeDirectoryPath, 'my-component', 'my-component')}';`,
+      `export { StubCmp as MyComponent } from '../types_dir/components/my-component/my-component';`,
       `export { defineCustomElement as defineCustomElementMyComponent } from './my-component';`,
-      `export { MyBestComponent as MyBestComponent } from '${join(
-        componentsTypeDirectoryPath,
-        'the-other-component',
-        'my-real-best-component'
-      )}';`,
+      `export { MyBestComponent as MyBestComponent } from '../types_dir/components/the-other-component/my-real-best-component';`,
       `export { defineCustomElement as defineCustomElementMyBestComponent } from './my-best-component';`,
       '',
       '/**',


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
Stencil 4.0.1 on Windows generates type imports with Windows paths instead of posix paths.

GitHub Issue Number: #4543


## What is the new behavior?
Type imports now use posix paths


## Does this introduce a breaking change?

- [ ] Yes
- [X] No


## Testing

Updated tests to hard-code expected output, decoupling them from the running platform.


