### PR TITLE
fix(compiler): only create one class member when transforming `@Element()` decorators

### DIFF
--- a/src/compiler/transformers/component-lazy/lazy-element-getter.ts
+++ b/src/compiler/transformers/component-lazy/lazy-element-getter.ts
@@ -14,20 +14,35 @@ export const addLazyElementGetter = (
   if (cmp.elementRef) {
     addCoreRuntimeApi(moduleFile, RUNTIME_APIS.getElement);
 
-    classMembers.push(
-      ts.factory.createGetAccessorDeclaration(
-        undefined,
-        cmp.elementRef,
-        [],
-        undefined,
-        ts.factory.createBlock([
-          ts.factory.createReturnStatement(
-            ts.factory.createCallExpression(ts.factory.createIdentifier(GET_ELEMENT), undefined, [
-              ts.factory.createThis(),
-            ])
-          ),
-        ])
-      )
+    // Create the getter that will be used in the transformed class declaration
+    const getter = ts.factory.createGetAccessorDeclaration(
+      undefined,
+      cmp.elementRef,
+      [],
+      undefined,
+      ts.factory.createBlock([
+        ts.factory.createReturnStatement(
+          ts.factory.createCallExpression(ts.factory.createIdentifier(GET_ELEMENT), undefined, [
+            ts.factory.createThis(),
+          ])
+        ),
+      ])
     );
+
+    // Find the index in the class members array that correlates with the element
+    // ref identifier we have
+    const index = classMembers.findIndex(
+      (member) =>
+        member.kind === ts.SyntaxKind.PropertyDeclaration && (member.name as any)?.escapedText === cmp.elementRef
+    );
+
+    // Index should never not be a valid integer, but we'll be safe just in case.
+    // If the index is valid, we'll overwrite the existing class member with the getter
+    // so we don't create multiple members with the same identifier
+    if (index >= 0) {
+      classMembers[index] = getter;
+    } else {
+      classMembers.push(getter);
+    }
   }
 };

--- a/src/compiler/transformers/component-native/native-element-getter.ts
+++ b/src/compiler/transformers/component-native/native-element-getter.ts
@@ -7,14 +7,30 @@ export const addNativeElementGetter = (classMembers: ts.ClassElement[], cmp: d.C
   // is transformed into:
   // get element() { return this; }
   if (cmp.elementRef) {
-    classMembers.push(
-      ts.factory.createGetAccessorDeclaration(
-        undefined,
-        cmp.elementRef,
-        [],
-        undefined,
-        ts.factory.createBlock([ts.factory.createReturnStatement(ts.factory.createThis())])
-      )
+    // Create the getter that will be used in the transformed class declaration
+    const getter = ts.factory.createGetAccessorDeclaration(
+      undefined,
+      cmp.elementRef,
+      [],
+      undefined,
+      ts.factory.createBlock([ts.factory.createReturnStatement(ts.factory.createThis())])
     );
+
+    ts.SyntaxKind.AmpersandToken;
+    // Find the index in the class members array that correlates with the element
+    // ref identifier we have
+    const index = classMembers.findIndex(
+      (member) =>
+        member.kind === ts.SyntaxKind.PropertyDeclaration && (member.name as any)?.escapedText === cmp.elementRef
+    );
+
+    // Index should never not be a valid integer, but we'll be safe just in case.
+    // If the index is valid, we'll overwrite the existing class member with the getter
+    // so we don't create multiple members with the same identifier
+    if (index >= 0) {
+      classMembers[index] = getter;
+    } else {
+      classMembers.push(getter);
+    }
   }
 };

--- a/src/compiler/transformers/test/lazy-component.spec.ts
+++ b/src/compiler/transformers/test/lazy-component.spec.ts
@@ -33,4 +33,33 @@ describe('lazy-component', () => {
     expect(t.outputText).toContain(`import { registerInstance as __stencil_registerInstance } from "@stencil/core"`);
     expect(t.outputText).toContain(`__stencil_registerInstance(this, hostRef)`);
   });
+
+  it('adds a getter for an @Element() reference', () => {
+    const compilerCtx = mockCompilerCtx();
+    const transformOpts: d.TransformOptions = {
+      coreImportPath: '@stencil/core',
+      componentExport: 'lazy',
+      componentMetadata: null,
+      currentDirectory: '/',
+      proxy: null,
+      style: 'static',
+      styleImportData: null,
+    };
+
+    const code = `
+      @Component({
+        tag: 'cmp-a'
+      })
+      export class CmpA {
+        @Element() el: HtmlElement;
+      }
+    `;
+
+    const transformer = lazyComponentTransform(compilerCtx, transformOpts);
+
+    const t = transpileModule(code, null, compilerCtx, [], [transformer]);
+
+    expect(t.outputText).toContain(`get el() { return __stencil_getElement(this); } };`);
+    expect(t.outputText).not.toContain(`el;`);
+  });
 });

--- a/src/compiler/transformers/test/native-constructor.spec.ts
+++ b/src/compiler/transformers/test/native-constructor.spec.ts
@@ -67,5 +67,23 @@ describe('nativeComponentTransform', () => {
       );
       expect(transpiledModule.outputText).toContain(`this.__attachShadow()`);
     });
+
+    it('adds a getter for an @Element() reference', () => {
+      const code = `
+        @Component({
+          tag: 'cmp-a'
+        })
+        export class CmpA {
+          @Element() el: HtmlElement;
+        }
+      `;
+
+      const transformer = nativeComponentTransform(compilerCtx, transformOpts);
+
+      const transpiledModule = transpileModule(code, null, compilerCtx, [], [transformer]);
+
+      expect(transpiledModule.outputText).toContain(`get el() { return this; }`);
+      expect(transpiledModule.outputText).not.toContain(`el;`);
+    });
   });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Use of the `@Element()` decorator when targeting ES2023 will result in two class members being created on the class declaration: a getter and a class field.

GitHub Issue Number: Fixes: #4528 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

With this change, Stencil will only create the getter for grabbing the element reference. This change was made to both the lazy and native transformers.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Unit & e2e tests continue to pass.

Manual testing can be done for the lazy build using the reproduction in the associated issue and a local build of this branch.
Testing of the native build was done using a local lerna project with a Stencil component library and consuming application that leveraged the `dist-custom-elements` output.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

I also made sure to test this change in a component that also used at least one other decorator that gets transformed (`@State()` or `@Prop()`)
