### PR TITLE
fix handling of host attributes

### DIFF
--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -1261,6 +1261,10 @@ export interface EventEmitterData<T = any> {
   composed?: boolean;
 }
 
+/**
+ * An interface extending `HTMLElement` which describes the fields added onto
+ * host HTML elements by the Stencil runtime.
+ */
 export interface HostElement extends HTMLElement {
   // web component APIs
   connectedCallback?: () => void;
@@ -1755,12 +1759,18 @@ export interface PlatformRuntime {
   $nonce$?: string | null;
   jmp: (c: Function) => any;
   raf: (c: FrameRequestCallback) => number;
+  /**
+   * A wrapper for AddEventListener
+   */
   ael: (
     el: EventTarget,
     eventName: string,
     listener: EventListenerOrEventListenerObject,
     options: boolean | AddEventListenerOptions,
   ) => void;
+  /**
+   * A wrapper for `RemoveEventListener`
+   */
   rel: (
     el: EventTarget,
     eventName: string,

--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -499,7 +499,7 @@ export interface QueueApi {
 /**
  * Host
  */
-interface HostAttributes {
+export interface HostAttributes {
   class?: string | { [className: string]: boolean };
   style?: { [key: string]: string | undefined };
   ref?: (el: HTMLElement | null) => void;

--- a/src/runtime/vdom/set-accessor.ts
+++ b/src/runtime/vdom/set-accessor.ts
@@ -13,6 +13,21 @@ import { isComplexType } from '@utils';
 
 import { VNODE_FLAGS, XLINK_NS } from '../runtime-constants';
 
+/**
+ * When running a VDom render set properties present on a VDom node onto the
+ * corresponding HTML element.
+ *
+ * Note that this function has special functionality for the `class`,
+ * `style`, `key`, and `ref` attributes, as well as event handlers (like
+ * `onClick`, etc). All others are just passed through as-is.
+ *
+ * @param elm the HTMLElement onto which attributes should be set
+ * @param memberName the name of the attribute to set
+ * @param oldValue the old value for the attribute
+ * @param newValue the new value for the attribute
+ * @param isSvg whether we're in an svg context or not
+ * @param flags bitflags for Vdom variables
+ */
 export const setAccessor = (
   elm: HTMLElement,
   memberName: string,

--- a/test/karma/test-app/components.d.ts
+++ b/test/karma/test-app/components.d.ts
@@ -124,6 +124,8 @@ export namespace Components {
     }
     interface FactoryJsx {
     }
+    interface HostAttrOverride {
+    }
     interface ImageImport {
     }
     interface InitCssRoot {
@@ -625,6 +627,12 @@ declare global {
     var HTMLFactoryJsxElement: {
         prototype: HTMLFactoryJsxElement;
         new (): HTMLFactoryJsxElement;
+    };
+    interface HTMLHostAttrOverrideElement extends Components.HostAttrOverride, HTMLStencilElement {
+    }
+    var HTMLHostAttrOverrideElement: {
+        prototype: HTMLHostAttrOverrideElement;
+        new (): HTMLHostAttrOverrideElement;
     };
     interface HTMLImageImportElement extends Components.ImageImport, HTMLStencilElement {
     }
@@ -1210,6 +1218,7 @@ declare global {
         "external-import-b": HTMLExternalImportBElement;
         "external-import-c": HTMLExternalImportCElement;
         "factory-jsx": HTMLFactoryJsxElement;
+        "host-attr-override": HTMLHostAttrOverrideElement;
         "image-import": HTMLImageImportElement;
         "init-css-root": HTMLInitCssRootElement;
         "input-basic-root": HTMLInputBasicRootElement;
@@ -1415,6 +1424,8 @@ declare namespace LocalJSX {
     interface ExternalImportC {
     }
     interface FactoryJsx {
+    }
+    interface HostAttrOverride {
     }
     interface ImageImport {
     }
@@ -1682,6 +1693,7 @@ declare namespace LocalJSX {
         "external-import-b": ExternalImportB;
         "external-import-c": ExternalImportC;
         "factory-jsx": FactoryJsx;
+        "host-attr-override": HostAttrOverride;
         "image-import": ImageImport;
         "init-css-root": InitCssRoot;
         "input-basic-root": InputBasicRoot;
@@ -1821,6 +1833,7 @@ declare module "@stencil/core" {
             "external-import-b": LocalJSX.ExternalImportB & JSXBase.HTMLAttributes<HTMLExternalImportBElement>;
             "external-import-c": LocalJSX.ExternalImportC & JSXBase.HTMLAttributes<HTMLExternalImportCElement>;
             "factory-jsx": LocalJSX.FactoryJsx & JSXBase.HTMLAttributes<HTMLFactoryJsxElement>;
+            "host-attr-override": LocalJSX.HostAttrOverride & JSXBase.HTMLAttributes<HTMLHostAttrOverrideElement>;
             "image-import": LocalJSX.ImageImport & JSXBase.HTMLAttributes<HTMLImageImportElement>;
             "init-css-root": LocalJSX.InitCssRoot & JSXBase.HTMLAttributes<HTMLInitCssRootElement>;
             "input-basic-root": LocalJSX.InputBasicRoot & JSXBase.HTMLAttributes<HTMLInputBasicRootElement>;

--- a/test/karma/test-app/host-attr-override/host-attr-override.tsx
+++ b/test/karma/test-app/host-attr-override/host-attr-override.tsx
@@ -1,0 +1,15 @@
+import { Component, Host, h } from '@stencil/core';
+
+@Component({
+  tag: 'host-attr-override',
+  shadow: true,
+})
+export class HostAttrOverride {
+  render() {
+    return (
+      <Host class="default" role="header">
+        <slot></slot>
+      </Host>
+    );
+  }
+}

--- a/test/karma/test-app/host-attr-override/index.html
+++ b/test/karma/test-app/host-attr-override/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf8">
+<script src="./build/testapp.esm.js" type="module"></script>
+<script src="./build/testapp.js" nomodule></script>
+
+<host-attr-override class="override"></host-attr-override>
+<host-attr-override class="with-role" role="another-role"></host-attr-override>

--- a/test/karma/test-app/host-attr-override/karma.spec.ts
+++ b/test/karma/test-app/host-attr-override/karma.spec.ts
@@ -1,0 +1,19 @@
+import { setupDomTests } from '../util';
+
+describe('host attribute overrides', function () {
+  const { setupDom, tearDownDom } = setupDomTests(document);
+  let app: HTMLElement;
+
+  beforeEach(async () => {
+    app = await setupDom('/host-attr-override/index.html');
+  });
+  afterEach(tearDownDom);
+
+  it('should merge class set in HTML with that on the Host', async () => {
+    expect(app.querySelector('.default.override')).not.toBeNull();
+  });
+
+  it('should override non-class attributes', () => {
+    expect(app.querySelector('.with-role').getAttribute('role')).toBe('another-role');
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?

This adds a runtime check for attributes set on the host element instance ('from outside') before the attributes set on the `Host` component ('from inside') are set on it, to allow developers to, for instance, override a `role` attribute set on `Host` (see #3052 for instance)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Testing

I have a reproduction case up here: https://github.com/alicewriteswrongs/stencil-host-override

If you build that project with this branch of Stencil you should see that the `role` set on the custom element in HTML wins out over the value set on the `Host` element.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
