### PR TITLE
refactor(environment): remove IS_NODE_ENV and delete dead code

### DIFF
--- a/src/compiler/build/build-finish.ts
+++ b/src/compiler/build/build-finish.ts
@@ -2,7 +2,6 @@ import { isFunction, isRemoteUrl } from '@utils';
 import { relative } from 'path';
 
 import type * as d from '../../declarations';
-import { IS_NODE_ENV } from '../sys/environment';
 import { generateBuildResults } from './build-results';
 import { generateBuildStats, writeBuildStats } from './build-stats';
 
@@ -122,7 +121,7 @@ const buildDone = async (
 
   if (!config.watch) {
     compilerCtx.reset();
-    if (IS_NODE_ENV && global.gc) {
+    if (global.gc) {
       buildCtx.debug(`triggering forced gc`);
       global.gc();
       buildCtx.debug(`forced gc finished`);

--- a/src/compiler/config/load-config.ts
+++ b/src/compiler/config/load-config.ts
@@ -1,16 +1,8 @@
 import { createNodeSys } from '@sys-api-node';
 import { buildError, catchError, hasError, isString, normalizePath } from '@utils';
 import { dirname } from 'path';
-import ts from 'typescript';
 
-import type {
-  CompilerSystem,
-  Diagnostic,
-  LoadConfigInit,
-  LoadConfigResults,
-  UnvalidatedConfig,
-} from '../../declarations';
-import { IS_NODE_ENV } from '../sys/environment';
+import type { Diagnostic, LoadConfigInit, LoadConfigResults, UnvalidatedConfig } from '../../declarations';
 import { nodeRequire } from '../sys/node-require';
 import { validateTsConfig } from '../sys/typescript/typescript-config';
 import { validateConfig } from './validate-config';
@@ -55,7 +47,7 @@ export const loadConfig = async (init: LoadConfigInit = {}): Promise<LoadConfigR
     // attached to a configuration entity, validated or otherwise)
     const sys = init.sys ?? createNodeSys();
 
-    const loadedConfigFile = await loadConfigFile(sys, results.diagnostics, configPath);
+    const loadedConfigFile = await loadConfigFile(results.diagnostics, configPath);
     if (hasError(results.diagnostics)) {
       return results;
     }
@@ -116,23 +108,21 @@ export const loadConfig = async (init: LoadConfigInit = {}): Promise<LoadConfigR
 
 /**
  * Load a Stencil configuration file from disk
- * @param sys the underlying System entity to use to interact with the operating system
- * @param diagnostics a series of diagnostics used to track errors & warnings throughout the loading process. Entries
- * may be added to this list in the event of an error.
+ *
+ * @param diagnostics a series of diagnostics used to track errors & warnings
+ * throughout the loading process. Entries may be added to this list in the
+ * event of an error.
  * @param configPath the path to the configuration file to load
- * @returns an unvalidated configuration. In the event of an error, additional diagnostics may be pushed to the
- * provided `diagnostics` argument and `null` will be returned.
+ * @returns an unvalidated configuration. In the event of an error, additional
+ * diagnostics may be pushed to the provided `diagnostics` argument and `null`
+ * will be returned.
  */
-const loadConfigFile = async (
-  sys: CompilerSystem,
-  diagnostics: Diagnostic[],
-  configPath: string
-): Promise<UnvalidatedConfig | null> => {
+const loadConfigFile = async (diagnostics: Diagnostic[], configPath: string): Promise<UnvalidatedConfig | null> => {
   let config: UnvalidatedConfig | null = null;
 
   if (isString(configPath)) {
     // the passed in config was a string, so it's probably a path to the config we need to load
-    const configFileData = await evaluateConfigFile(sys, diagnostics, configPath);
+    const configFileData = await evaluateConfigFile(diagnostics, configPath);
     if (hasError(diagnostics)) {
       return config;
     }
@@ -152,73 +142,28 @@ const loadConfigFile = async (
 
 /**
  * Load the configuration file, based on the environment that Stencil is being run in
- * @param sys the underlying System entity to use to interact with the operating system
- * @param diagnostics a series of diagnostics used to track errors & warnings throughout the loading process. Entries
- * may be added to this list in the event of an error.
+ *
+ * @param diagnostics a series of diagnostics used to track errors & warnings
+ * throughout the loading process. Entries may be added to this list in the
+ * event of an error.
  * @param configFilePath the path to the configuration file to load
- * @returns an unvalidated configuration. In the event of an error, additional diagnostics may be pushed to the
- * provided `diagnostics` argument and `null` will be returned.
+ * @returns an unvalidated configuration. In the event of an error, additional
+ * diagnostics may be pushed to the provided `diagnostics` argument and `null`
+ * will be returned.
  */
 const evaluateConfigFile = async (
-  sys: CompilerSystem,
   diagnostics: Diagnostic[],
   configFilePath: string
 ): Promise<{ config?: UnvalidatedConfig } | null> => {
   let configFileData: { config?: UnvalidatedConfig } | null = null;
 
   try {
-    if (IS_NODE_ENV) {
-      const results = nodeRequire(configFilePath);
-      diagnostics.push(...results.diagnostics);
-      configFileData = results.module;
-    } else {
-      // browser environment, can't use node's require() to evaluate
-      let sourceText = await sys.readFile(configFilePath);
-      sourceText = transpileTypedConfig(diagnostics, sourceText, configFilePath);
-      if (hasError(diagnostics)) {
-        return configFileData;
-      }
-
-      const evalConfig = new Function(`const exports = {}; ${sourceText}; return exports;`);
-      configFileData = evalConfig();
-    }
+    const results = nodeRequire(configFilePath);
+    diagnostics.push(...results.diagnostics);
+    configFileData = results.module;
   } catch (e: any) {
     catchError(diagnostics, e);
   }
 
   return configFileData;
-};
-
-/**
- * Transpiles the provided TypeScript source text into JavaScript.
- *
- * This function is intended to be used on a `stencil.config.ts` file
- *
- * @param diagnostics a collection of compiler diagnostics to check as a part of the compilation process
- * @param sourceText the text to transpile
- * @param filePath the name of the file to transpile
- * @returns the transpiled text. If there are any diagnostics in the provided collection, the provided source is returned
- */
-const transpileTypedConfig = (diagnostics: Diagnostic[], sourceText: string, filePath: string): string => {
-  // let's transpile an awesome stencil.config.ts file into
-  // a boring stencil.config.js file
-  if (hasError(diagnostics)) {
-    return sourceText;
-  }
-
-  const opts: ts.TranspileOptions = {
-    fileName: filePath,
-    compilerOptions: {
-      module: ts.ModuleKind.CommonJS,
-      moduleResolution: ts.ModuleResolutionKind.NodeJs,
-      esModuleInterop: true,
-      target: ts.ScriptTarget.ES2015,
-      allowJs: true,
-    },
-    reportDiagnostics: false,
-  };
-
-  const output = ts.transpileModule(sourceText, opts);
-
-  return output.outputText;
 };

--- a/src/compiler/optimize/autoprefixer.ts
+++ b/src/compiler/optimize/autoprefixer.ts
@@ -1,7 +1,6 @@
 import { Postcss } from 'postcss';
 
 import type * as d from '../../declarations';
-import { IS_NODE_ENV } from '../sys/environment';
 
 type CssProcessor = ReturnType<Postcss>;
 let cssProcessor: CssProcessor;
@@ -22,9 +21,6 @@ export const autoprefixCss = async (cssText: string, opts: boolean | null | d.Au
     output: cssText,
     diagnostics: [],
   };
-  if (!IS_NODE_ENV) {
-    return output;
-  }
 
   try {
     const autoprefixerOpts = opts != null && typeof opts === 'object' ? opts : DEFAULT_AUTOPREFIX_OPTIONS;

--- a/src/compiler/sys/environment.ts
+++ b/src/compiler/sys/environment.ts
@@ -1,13 +1,3 @@
 export const IS_WINDOWS_ENV = process.platform === 'win32';
 
 export const IS_CASE_SENSITIVE_FILE_NAMES = !IS_WINDOWS_ENV;
-
-export const IS_BROWSER_ENV =
-  typeof location !== 'undefined' && typeof navigator !== 'undefined' && typeof XMLHttpRequest !== 'undefined';
-
-export const IS_WEB_WORKER_ENV =
-  IS_BROWSER_ENV && typeof self !== 'undefined' && typeof (self as any).importScripts === 'function';
-
-export const HAS_WEB_WORKER = IS_BROWSER_ENV && typeof Worker === 'function';
-
-export const IS_FETCH_ENV = typeof fetch === 'function';

--- a/src/compiler/sys/environment.ts
+++ b/src/compiler/sys/environment.ts
@@ -1,13 +1,4 @@
-export const IS_NODE_ENV =
-  typeof global !== 'undefined' &&
-  typeof require === 'function' &&
-  !!global.process &&
-  typeof __filename === 'string' &&
-  (!(global as any as Window).origin || typeof (global as any as Window).origin !== 'string');
-
-export const OS_PLATFORM = IS_NODE_ENV ? process.platform : '';
-
-export const IS_WINDOWS_ENV = OS_PLATFORM === 'win32';
+export const IS_WINDOWS_ENV = process.platform === 'win32';
 
 export const IS_CASE_SENSITIVE_FILE_NAMES = !IS_WINDOWS_ENV;
 

--- a/src/compiler/sys/fetch/fetch-utils.ts
+++ b/src/compiler/sys/fetch/fetch-utils.ts
@@ -46,44 +46,6 @@ export const getStencilModuleUrl = (compilerExe: string, path: string): string =
   return new URL('./' + path, stencilRootUrl).href;
 };
 
-export const getCommonDirUrl = (
-  sys: d.CompilerSystem,
-  pkgVersions: Map<string, string>,
-  dirPath: string,
-  fileName: string
-) => getNodeModuleFetchUrl(sys, pkgVersions, dirPath) + '/' + fileName;
-
-export const getNodeModuleFetchUrl = (sys: d.CompilerSystem, pkgVersions: Map<string, string>, filePath: string) => {
-  // /node_modules/lodash/package.json
-  filePath = normalizePath(filePath);
-
-  // ["node_modules", "lodash", "package.json"]
-  let pathParts = filePath.split('/').filter((p) => p.length);
-
-  const nmIndex = pathParts.lastIndexOf('node_modules');
-  if (nmIndex > -1 && nmIndex < pathParts.length - 1) {
-    pathParts = pathParts.slice(nmIndex + 1);
-  }
-
-  let moduleId = pathParts.shift();
-
-  if (moduleId.startsWith('@')) {
-    moduleId += '/' + pathParts.shift();
-  }
-
-  const path = pathParts.join('/');
-  if (moduleId === '@stencil/core') {
-    const compilerExe = sys.getCompilerExecutingPath();
-    return getStencilModuleUrl(compilerExe, path);
-  }
-
-  return sys.getRemoteModuleUrl({
-    moduleId,
-    version: pkgVersions.get(moduleId),
-    path,
-  });
-};
-
 export const skipFilePathFetch = (filePath: string) => {
   if (isTsFile(filePath) || isTsxFile(filePath)) {
     // don't bother trying to resolve  node_module packages w/ typescript files

--- a/src/compiler/sys/fetch/tests/fetch-module.spec.ts
+++ b/src/compiler/sys/fetch/tests/fetch-module.spec.ts
@@ -1,6 +1,4 @@
-import type * as d from '../../../../declarations';
-import { createSystem } from '../../stencil-sys';
-import { getNodeModuleFetchUrl, getStencilModuleUrl, skipFilePathFetch } from '../fetch-utils';
+import { getStencilModuleUrl, skipFilePathFetch } from '../fetch-utils';
 
 describe('fetch module', () => {
   let compilerExe: string;
@@ -42,93 +40,6 @@ describe('fetch module', () => {
       const m = getStencilModuleUrl(compilerExe, p);
       expect(m).toBe('http://localhost:3333/@stencil/core/package.json');
     });
-  });
-});
-
-describe('getNodeModuleFetchUrl', () => {
-  const pkgVersions = new Map<string, string>();
-  const config: d.Config = {
-    rootDir: '/my-app/',
-    sys: createSystem(),
-  };
-  const sys = config.sys;
-
-  beforeEach(() => {
-    sys.getCompilerExecutingPath = null;
-    pkgVersions.clear();
-  });
-
-  it('cdn @stencil/core', () => {
-    const filePath = '/node_modules/@stencil/core/internal/hydrate/index.mjs';
-    sys.getCompilerExecutingPath = () => 'http://localhost/stencil/core/compiler/stencil.js';
-    const url = getNodeModuleFetchUrl(sys, pkgVersions, filePath);
-    expect(url).toBe('http://localhost/stencil/core/internal/hydrate/index.mjs');
-  });
-
-  it('local @stencil/core', () => {
-    const filePath = '/node_modules/@stencil/core/package.json';
-    sys.getCompilerExecutingPath = () => 'http://cdn.stenciljs.com/npm/@stencil/core@1.2.3/compiler/stencil.js';
-    const url = getNodeModuleFetchUrl(sys, pkgVersions, filePath);
-    expect(url).toBe('http://cdn.stenciljs.com/npm/@stencil/core@1.2.3/package.json');
-  });
-
-  it('local @stencil/core, root dir', () => {
-    const filePath = '/some/dir/node_modules/@stencil/core/package.json';
-    sys.getCompilerExecutingPath = () => 'https://cdn.stenciljs.com/@stencil/core@1.2.3/compiler/stencil.js';
-    const url = getNodeModuleFetchUrl(sys, pkgVersions, filePath);
-    expect(url).toBe('https://cdn.stenciljs.com/@stencil/core@1.2.3/package.json');
-  });
-
-  it('w/ version number', () => {
-    pkgVersions.set('lodash', '1.2.3');
-    const filePath = '/node_modules/lodash/package.json';
-    const url = getNodeModuleFetchUrl(sys, pkgVersions, filePath);
-    expect(url).toBe('https://cdn.jsdelivr.net/npm/lodash@1.2.3/package.json');
-  });
-
-  it('w/ version number, root dir', () => {
-    pkgVersions.set('lodash', '1.2.3');
-    const filePath = '/some/dir/node_modules/lodash/package.json';
-    const url = getNodeModuleFetchUrl(sys, pkgVersions, filePath);
-    expect(url).toBe('https://cdn.jsdelivr.net/npm/lodash@1.2.3/package.json');
-  });
-
-  it('w/out version number', () => {
-    const filePath = '/node_modules/lodash/package.json';
-    const url = getNodeModuleFetchUrl(sys, pkgVersions, filePath);
-    expect(url).toBe('https://cdn.jsdelivr.net/npm/lodash/package.json');
-  });
-
-  it('w/out version number, root dir', () => {
-    const filePath = 'some/path/node_modules/lodash/package.json';
-    const url = getNodeModuleFetchUrl(sys, pkgVersions, filePath);
-    expect(url).toBe('https://cdn.jsdelivr.net/npm/lodash/package.json');
-  });
-
-  it('w/ scoped package', () => {
-    const filePath = '/node_modules/@ionic/core/package.json';
-    const url = getNodeModuleFetchUrl(sys, pkgVersions, filePath);
-    expect(url).toBe('https://cdn.jsdelivr.net/npm/@ionic/core/package.json');
-  });
-
-  it('w/ scoped package, rootdir', () => {
-    const filePath = '/some/dir/node_modules/@ionic/core/package.json';
-    const url = getNodeModuleFetchUrl(sys, pkgVersions, filePath);
-    expect(url).toBe('https://cdn.jsdelivr.net/npm/@ionic/core/package.json');
-  });
-
-  it('version w/ scoped package', () => {
-    pkgVersions.set('@ionic/core', '1.2.3');
-    const filePath = '/node_modules/@ionic/core/package.json';
-    const url = getNodeModuleFetchUrl(sys, pkgVersions, filePath);
-    expect(url).toBe('https://cdn.jsdelivr.net/npm/@ionic/core@1.2.3/package.json');
-  });
-
-  it('version w/ scoped package, rootdir', () => {
-    pkgVersions.set('@ionic/core', '1.2.3');
-    const filePath = '/some/path/node_modules/@ionic/core/package.json';
-    const url = getNodeModuleFetchUrl(sys, pkgVersions, filePath);
-    expect(url).toBe('https://cdn.jsdelivr.net/npm/@ionic/core@1.2.3/package.json');
   });
 });
 

--- a/src/compiler/sys/node-require.ts
+++ b/src/compiler/sys/node-require.ts
@@ -2,7 +2,6 @@ import { catchError, loadTypeScriptDiagnostic } from '@utils';
 import ts from 'typescript';
 
 import type { Diagnostic } from '../../declarations';
-import { IS_NODE_ENV } from './environment';
 
 export const nodeRequire = (id: string) => {
   const results = {
@@ -11,61 +10,59 @@ export const nodeRequire = (id: string) => {
     diagnostics: [] as Diagnostic[],
   };
 
-  if (IS_NODE_ENV) {
-    try {
-      const fs: typeof import('fs') = require('fs');
-      const path: typeof import('path') = require('path');
+  try {
+    const fs: typeof import('fs') = require('fs');
+    const path: typeof import('path') = require('path');
 
-      results.id = path.resolve(id);
+    results.id = path.resolve(id);
 
-      // ensure we cleared out node's internal require() cache for this file
-      delete require.cache[results.id];
+    // ensure we cleared out node's internal require() cache for this file
+    delete require.cache[results.id];
 
-      // let's override node's require for a second
-      // don't worry, we'll revert this when we're done
-      require.extensions['.ts'] = (module: NodeJS.Module, fileName: string) => {
-        let sourceText = fs.readFileSync(fileName, 'utf8');
+    // let's override node's require for a second
+    // don't worry, we'll revert this when we're done
+    require.extensions['.ts'] = (module: NodeJS.Module, fileName: string) => {
+      let sourceText = fs.readFileSync(fileName, 'utf8');
 
-        if (fileName.endsWith('.ts')) {
-          // looks like we've got a typed config file
-          // let's transpile it to .js quick
-          const tsResults = ts.transpileModule(sourceText, {
-            fileName,
-            compilerOptions: {
-              module: ts.ModuleKind.CommonJS,
-              moduleResolution: ts.ModuleResolutionKind.NodeJs,
-              esModuleInterop: true,
-              target: ts.ScriptTarget.ES2017,
-              allowJs: true,
-            },
-          });
-          sourceText = tsResults.outputText;
+      if (fileName.endsWith('.ts')) {
+        // looks like we've got a typed config file
+        // let's transpile it to .js quick
+        const tsResults = ts.transpileModule(sourceText, {
+          fileName,
+          compilerOptions: {
+            module: ts.ModuleKind.CommonJS,
+            moduleResolution: ts.ModuleResolutionKind.NodeJs,
+            esModuleInterop: true,
+            target: ts.ScriptTarget.ES2017,
+            allowJs: true,
+          },
+        });
+        sourceText = tsResults.outputText;
 
-          results.diagnostics.push(...tsResults.diagnostics.map(loadTypeScriptDiagnostic));
-        } else {
-          // quick hack to turn a modern es module
-          // into and old school commonjs module
-          sourceText = sourceText.replace(/export\s+\w+\s+(\w+)/gm, 'exports.$1');
-        }
+        results.diagnostics.push(...tsResults.diagnostics.map(loadTypeScriptDiagnostic));
+      } else {
+        // quick hack to turn a modern es module
+        // into and old school commonjs module
+        sourceText = sourceText.replace(/export\s+\w+\s+(\w+)/gm, 'exports.$1');
+      }
 
-        try {
-          // we need to coerce because of the requirements for the arguments to
-          // this function. It's safe enough since it's already wrapped in a
-          // `try { } catch`.
-          (module as NodeModuleWithCompile)._compile(sourceText, fileName);
-        } catch (e: any) {
-          catchError(results.diagnostics, e);
-        }
-      };
+      try {
+        // we need to coerce because of the requirements for the arguments to
+        // this function. It's safe enough since it's already wrapped in a
+        // `try { } catch`.
+        (module as NodeModuleWithCompile)._compile(sourceText, fileName);
+      } catch (e: any) {
+        catchError(results.diagnostics, e);
+      }
+    };
 
-      // let's do this!
-      results.module = require(results.id);
+    // let's do this!
+    results.module = require(results.id);
 
-      // all set, let's go ahead and reset the require back to the default
-      require.extensions['.ts'] = undefined;
-    } catch (e: any) {
-      catchError(results.diagnostics, e);
-    }
+    // all set, let's go ahead and reset the require back to the default
+    require.extensions['.ts'] = undefined;
+  } catch (e: any) {
+    catchError(results.diagnostics, e);
   }
 
   return results;

--- a/src/compiler/sys/resolve/resolve-module-async.ts
+++ b/src/compiler/sys/resolve/resolve-module-async.ts
@@ -1,18 +1,10 @@
 import { isString, normalizeFsPath, normalizePath } from '@utils';
-import { basename, dirname } from 'path';
+import { dirname } from 'path';
 import resolve, { AsyncOpts } from 'resolve';
 
 import type * as d from '../../../declarations';
-import { fetchModuleAsync } from '../fetch/fetch-module-async';
-import { getCommonDirUrl, getNodeModuleFetchUrl, packageVersions } from '../fetch/fetch-utils';
 import { InMemoryFileSystem } from '../in-memory-fs';
-import {
-  COMMON_DIR_FILENAMES,
-  getCommonDirName,
-  getPackageDirPath,
-  isCommonDirModuleFile,
-  shouldFetchModule,
-} from './resolve-utils';
+import { getPackageDirPath } from './resolve-utils';
 
 export const resolveModuleIdAsync = (
   sys: d.CompilerSystem,
@@ -66,17 +58,6 @@ export const createCustomResolverAsync = (
         return;
       }
 
-      if (shouldFetchModule(fsFilePath)) {
-        const endsWithExt = exts.some((ext) => fsFilePath.endsWith(ext));
-        if (endsWithExt) {
-          const url = getNodeModuleFetchUrl(sys, packageVersions, fsFilePath);
-          const content = await fetchModuleAsync(sys, inMemoryFs, packageVersions, url, fsFilePath);
-          const checkFileExists = typeof content === 'string';
-          cb(null, checkFileExists);
-          return;
-        }
-      }
-
       cb(null, false);
     },
 
@@ -87,32 +68,6 @@ export const createCustomResolverAsync = (
       if (stat.isDirectory) {
         cb(null, true);
         return;
-      }
-
-      if (shouldFetchModule(fsDirPath)) {
-        if (basename(fsDirPath) === 'node_modules') {
-          // just the /node_modules directory
-          inMemoryFs.sys.createDirSync(fsDirPath);
-          inMemoryFs.clearFileCache(fsDirPath);
-          cb(null, true);
-          return;
-        }
-
-        if (isCommonDirModuleFile(fsDirPath)) {
-          // don't bother seeing if it's a directory if it has a common file extension
-          cb(null, false);
-          return;
-        }
-
-        for (const fileName of COMMON_DIR_FILENAMES) {
-          const url = getCommonDirUrl(sys, packageVersions, fsDirPath, fileName);
-          const filePath = getCommonDirName(fsDirPath, fileName);
-          const content = await fetchModuleAsync(sys, inMemoryFs, packageVersions, url, filePath);
-          if (isString(content)) {
-            cb(null, true);
-            return;
-          }
-        }
       }
 
       cb(null, false);

--- a/src/compiler/sys/resolve/resolve-module-sync.ts
+++ b/src/compiler/sys/resolve/resolve-module-sync.ts
@@ -1,13 +1,9 @@
 import { isString, normalizeFsPath, normalizePath } from '@utils';
-import { basename, dirname } from 'path';
+import { dirname } from 'path';
 import resolve, { SyncOpts } from 'resolve';
 
 import type * as d from '../../../declarations';
-import { IS_WEB_WORKER_ENV } from '../environment';
-import { fetchModuleSync } from '../fetch/fetch-module-sync';
-import { getCommonDirUrl, getNodeModuleFetchUrl, packageVersions } from '../fetch/fetch-utils';
 import { InMemoryFileSystem } from '../in-memory-fs';
-import { COMMON_DIR_FILENAMES, getCommonDirName, isCommonDirModuleFile, shouldFetchModule } from './resolve-utils';
 
 export const resolveRemoteModuleIdSync = (
   config: d.Config,
@@ -36,11 +32,7 @@ const resolveRemotePackageJsonSync = (config: d.Config, inMemoryFs: InMemoryFile
     const filePath = normalizePath(
       config.sys.getLocalModulePath({ rootDir: config.rootDir, moduleId, path: 'package.json' })
     );
-    let pkgJson = inMemoryFs.readFileSync(filePath);
-    if (!isString(pkgJson) && IS_WEB_WORKER_ENV) {
-      const url = config.sys.getRemoteModuleUrl({ moduleId, path: 'package.json' });
-      pkgJson = fetchModuleSync(config.sys, inMemoryFs, packageVersions, url, filePath);
-    }
+    const pkgJson = inMemoryFs.readFileSync(filePath);
     if (typeof pkgJson === 'string') {
       try {
         return JSON.parse(pkgJson) as d.PackageJsonData;
@@ -76,56 +68,14 @@ export const createCustomResolverSync = (
       const fsFilePath = normalizeFsPath(filePath);
 
       const stat = inMemoryFs.statSync(fsFilePath);
-      if (stat.isFile) {
-        return true;
-      }
-
-      if (shouldFetchModule(fsFilePath)) {
-        const endsWithExt = exts.some((ext) => fsFilePath.endsWith(ext));
-        if (!endsWithExt) {
-          return false;
-        }
-
-        const url = getNodeModuleFetchUrl(sys, packageVersions, fsFilePath);
-        const content = fetchModuleSync(sys, inMemoryFs, packageVersions, url, fsFilePath);
-        return typeof content === 'string';
-      }
-
-      return false;
+      return stat.isFile;
     },
 
     isDirectory(dirPath: string) {
       const fsDirPath = normalizeFsPath(dirPath);
 
       const stat = inMemoryFs.statSync(fsDirPath);
-      if (stat.isDirectory) {
-        return true;
-      }
-
-      if (shouldFetchModule(fsDirPath)) {
-        if (basename(fsDirPath) === 'node_modules') {
-          // just the /node_modules directory
-          inMemoryFs.sys.createDirSync(fsDirPath);
-          inMemoryFs.clearFileCache(fsDirPath);
-          return true;
-        }
-
-        if (isCommonDirModuleFile(fsDirPath)) {
-          // don't bother seeing if it's a directory if it has a common file extension
-          return false;
-        }
-
-        const checkFileExists = (fileName: string) => {
-          const url = getCommonDirUrl(sys, packageVersions, fsDirPath, fileName);
-          const filePath = getCommonDirName(fsDirPath, fileName);
-          const content = fetchModuleSync(sys, inMemoryFs, packageVersions, url, filePath);
-          return isString(content);
-        };
-
-        return COMMON_DIR_FILENAMES.some(checkFileExists);
-      }
-
-      return false;
+      return stat.isDirectory;
     },
 
     readFileSync(p: string) {

--- a/src/compiler/sys/resolve/resolve-utils.ts
+++ b/src/compiler/sys/resolve/resolve-utils.ts
@@ -1,7 +1,6 @@
 import { normalizePath } from '@utils';
 
 import type * as d from '../../../declarations';
-import { IS_BROWSER_ENV, IS_FETCH_ENV } from '../environment';
 
 const COMMON_DIR_MODULE_EXTS = ['.tsx', '.ts', '.mjs', '.js', '.jsx', '.json', '.md'];
 
@@ -65,8 +64,6 @@ export const setPackageVersionByContent = (pkgVersions: Map<string, string>, pkg
 export const isLocalModule = (p: string) => p.startsWith('.') || p.startsWith('/');
 
 export const isStencilCoreImport = (p: string) => p.startsWith('@stencil/core');
-
-export const shouldFetchModule = (p: string) => IS_FETCH_ENV && IS_BROWSER_ENV && isNodeModulePath(p);
 
 export const isNodeModulePath = (p: string) => normalizePath(p).split('/').includes('node_modules');
 

--- a/src/compiler/sys/stencil-sys.ts
+++ b/src/compiler/sys/stencil-sys.ts
@@ -22,9 +22,7 @@ import type {
 } from '../../declarations';
 import { version } from '../../version';
 import { buildEvents } from '../events';
-import { HAS_WEB_WORKER, IS_BROWSER_ENV } from './environment';
 import { resolveModuleIdAsync } from './resolve/resolve-module-async';
-import { createWebWorkerMainController } from './worker/web-worker-main';
 
 /**
  * Create an in-memory `CompilerSystem` object, optionally using a supplied
@@ -46,7 +44,7 @@ export const createSystem = (c?: { logger?: Logger }): CompilerSystem => {
   const addDestroy = (cb: () => void) => destroys.add(cb);
   const removeDestroy = (cb: () => void) => destroys.delete(cb);
   const events = buildEvents();
-  const hardwareConcurrency = (IS_BROWSER_ENV && navigator.hardwareConcurrency) || 1;
+  const hardwareConcurrency = 1;
 
   const destroy = async () => {
     const waits: Promise<void>[] = [];
@@ -624,9 +622,7 @@ export const createSystem = (c?: { logger?: Logger }): CompilerSystem => {
     writeFile,
     writeFileSync,
     generateContentHash,
-    createWorkerController: HAS_WEB_WORKER
-      ? (maxConcurrentWorkers) => createWebWorkerMainController(sys, maxConcurrentWorkers)
-      : null,
+    createWorkerController: null,
     details: {
       cpuModel: '',
       freemem: () => 0,

--- a/src/compiler/sys/typescript/typescript-resolve-module.ts
+++ b/src/compiler/sys/typescript/typescript-resolve-module.ts
@@ -1,10 +1,9 @@
-import { isRemoteUrl, isString, normalizePath } from '@utils';
+import { isString, normalizePath } from '@utils';
 import { basename, dirname, isAbsolute, join, resolve } from 'path';
 import ts from 'typescript';
 
 import type * as d from '../../../declarations';
 import { version } from '../../../version';
-import { IS_BROWSER_ENV, IS_NODE_ENV } from '../environment';
 import { InMemoryFileSystem } from '../in-memory-fs';
 import { resolveRemoteModuleIdSync } from '../resolve/resolve-module-sync';
 import {
@@ -18,28 +17,6 @@ import {
   isTsxFile,
 } from '../resolve/resolve-utils';
 import { patchTsSystemFileSystem } from './typescript-sys';
-
-// TODO(STENCIL-728): fix typing of `inMemoryFs` parameter in `patchTypescript`, related functions
-export const patchTypeScriptResolveModule = (config: d.Config, inMemoryFs: InMemoryFileSystem) => {
-  let compilerExe: string;
-  if (config.sys) {
-    compilerExe = config.sys.getCompilerExecutingPath();
-  } else if (IS_BROWSER_ENV) {
-    compilerExe = location.href;
-  }
-
-  if (shouldPatchRemoteTypeScript(compilerExe)) {
-    const resolveModuleName = ((ts as any).__resolveModuleName = ts.resolveModuleName);
-
-    ts.resolveModuleName = (moduleName, containingFile, compilerOptions, host, cache, redirectedReference) => {
-      const resolvedModule = patchedTsResolveModule(config, inMemoryFs, moduleName, containingFile);
-      if (resolvedModule) {
-        return resolvedModule;
-      }
-      return resolveModuleName(moduleName, containingFile, compilerOptions, host, cache, redirectedReference);
-    };
-  }
-};
 
 export const tsResolveModuleName = (
   config: d.Config,
@@ -235,5 +212,3 @@ const getTsResolveExtension = (p: string) => {
   }
   return ts.Extension.Ts;
 };
-
-const shouldPatchRemoteTypeScript = (compilerExe: string) => !IS_NODE_ENV && isRemoteUrl(compilerExe);

--- a/src/compiler/sys/typescript/typescript-sys.ts
+++ b/src/compiler/sys/typescript/typescript-sys.ts
@@ -6,7 +6,6 @@ import type * as d from '../../../declarations';
 import { IS_CASE_SENSITIVE_FILE_NAMES, IS_WEB_WORKER_ENV } from '../environment';
 import { fetchUrlSync } from '../fetch/fetch-module-sync';
 import { InMemoryFileSystem } from '../in-memory-fs';
-import { patchTypeScriptResolveModule } from './typescript-resolve-module';
 
 // TODO(STENCIL-728): fix typing of `inMemoryFs` parameter in `patchTypescript`, related functions
 export const patchTsSystemFileSystem = (
@@ -197,7 +196,6 @@ export const patchTypescript = (config: d.Config, inMemoryFs: InMemoryFileSystem
       patchTsSystemFileSystem(config, config.sys, inMemoryFs, ts.sys);
       patchTsSystemWatch(config.sys, ts.sys);
     }
-    patchTypeScriptResolveModule(config, inMemoryFs);
     (ts as any).__patched = true;
   }
 };


### PR DESCRIPTION
This removes the `IS_NODE_ENV` variable from our environment module which previously was used to switch between browser-specific and node-specific approaches to various things in the Stencil compilation process.

Following the merge of #4317 we only support one runtime, node, for compiling Stencil components, so we can assume that `IS_NODE_ENV` is `true` and delete code accordingly.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
