### PR TITLE
fix(compiler): ensures transformed paths are relative paths for `dist-collection`

### DIFF
--- a/src/compiler/transformers/map-imports-to-path-aliases.ts
+++ b/src/compiler/transformers/map-imports-to-path-aliases.ts
@@ -74,6 +74,39 @@ export const mapImportsToPathAliases = (
               importPath = normalizePath(
                 relative(dirname(destinationFilePath), resolvePathInDestination).replace(extensionRegex, '')
               );
+              // if the importee is a sibling file of the importer then `relative` will
+              // produce a somewhat confusing result. We use `dirname` to get the
+              // directory of the importer, so for example, assume we have two files
+              // `foo/bar.ts` and `foo/baz.ts` like so:
+              //
+              // ```
+              // foo
+              // ├── bar.ts
+              // └── baz.ts
+              // ```
+              //
+              // then if `baz.ts` imports a symbol from `bar.ts` we'll call
+              // `relative(fromdir, to)` like so:
+              //
+              // ```ts
+              // relative(dirname("foo/baz.ts"), "foo/bar.ts")
+              // // equivalently
+              // relative("foo", "foo/bar.ts")
+              // ```
+              //
+              // you'd think that in this case `relative` would return `'./bar.ts'` as
+              // a correct relative path to `bar.ts` from the `foo` directory, but
+              // actually in this case it returns just `bar.ts`. So since when updating
+              // import paths we're only concerned with `paths` aliases that should be
+              // transformed to relative imports anyway, we check to see if the new
+              // `importPath` starts with `'.'`, and add `'./'` if it doesn't, since
+              // otherwise Node will interpret `bar` as a module name, not a relative
+              // path.
+              //
+              // Note also that any relative paths as module specifiers which _don't_
+              // need to be transformed (e.g. `'./foo'`) have already been handled
+              // above.
+              importPath = importPath.startsWith('.') ? importPath : './' + importPath;
             }
           }
 

--- a/src/compiler/transformers/test/map-imports-to-path-aliases.spec.ts
+++ b/src/compiler/transformers/test/map-imports-to-path-aliases.spec.ts
@@ -122,7 +122,7 @@ describe('mapImportsToPathAliases', () => {
 
     module = transpileModule(inputText, config, null, [], [mapImportsToPathAliases(config, '', outputTarget)]);
 
-    expect(module.outputText).toContain('import { utils } from "utils";');
+    expect(module.outputText).toContain('import { utils } from "./utils";');
   });
 
   // The resolved module is not part of the output directory


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The aliased path transformation logic for the `dist-collection` output target does not correctly account for the case where the imported file is a sibling of the importing file. In this case, the generated import path is missing the leading `./`.

This was caused by changes in #4501 

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

In the case that a generated import path does not start with a `.`, a `./` will be pre-pended to the path

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

A reproduction can be found [here](https://github.com/tanner-reits/dist-relative-transformed-paths). Brief testing steps can be found in the repro readme.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

This is also a problem in v3.4.1. We'll want to backfill this change to the v3 maintenance branch as well