### PR TITLE
refactor(compiler): remove requireFunc

### DIFF
--- a/src/compiler/config/transpile-options.ts
+++ b/src/compiler/config/transpile-options.ts
@@ -11,7 +11,6 @@ import type {
   TranspileResults,
 } from '../../declarations';
 import { STENCIL_INTERNAL_CLIENT_ID } from '../bundle/entry-alias-ids';
-import { requireFunc } from '../sys/environment';
 import { parseImportPath } from '../transformers/stencil-import-path';
 
 export const getTranspileResults = (code: string, input: TranspileOptions) => {
@@ -59,7 +58,7 @@ export const getTranspileConfig = (input: TranspileOptions): TranspileConfig => 
   if (input.sys) {
     transpileCtx.sys = input.sys;
   } else if (!transpileCtx.sys) {
-    transpileCtx.sys = requireFunc('../sys/node/index.js').createNodeSys();
+    transpileCtx.sys = require('../sys/node/index.js').createNodeSys();
   }
 
   const compileOpts: TranspileOptions = {

--- a/src/compiler/optimize/autoprefixer.ts
+++ b/src/compiler/optimize/autoprefixer.ts
@@ -1,7 +1,7 @@
 import { Postcss } from 'postcss';
 
 import type * as d from '../../declarations';
-import { IS_NODE_ENV, requireFunc } from '../sys/environment';
+import { IS_NODE_ENV } from '../sys/environment';
 
 type CssProcessor = ReturnType<Postcss>;
 let cssProcessor: CssProcessor;
@@ -102,7 +102,7 @@ export const autoprefixCss = async (cssText: string, opts: boolean | null | d.Au
  * @returns postCSS with the Autoprefixer plugin applied
  */
 const getProcessor = (autoprefixerOpts: d.AutoprefixerOptions): CssProcessor => {
-  const { postcss, autoprefixer } = requireFunc('../sys/node/autoprefixer.js');
+  const { postcss, autoprefixer } = require('../sys/node/autoprefixer.js');
   if (!cssProcessor) {
     cssProcessor = postcss([autoprefixer(autoprefixerOpts)]);
   }

--- a/src/compiler/prerender/prerender-worker.ts
+++ b/src/compiler/prerender/prerender-worker.ts
@@ -2,7 +2,6 @@ import { catchError, isFunction, isPromise, isRootPath, normalizePath } from '@u
 import { dirname, join } from 'path';
 
 import type * as d from '../../declarations';
-import { requireFunc } from '../sys/environment';
 import { crawlAnchorsForNextUrls } from './crawl-urls';
 import { getPrerenderConfig } from './prerender-config';
 import { getHydrateOptions } from './prerender-hydrate-options';
@@ -33,7 +32,7 @@ export const prerenderWorker = async (sys: d.CompilerSystem, prerenderRequest: d
     const componentGraph = getComponentGraph(sys, prerenderCtx, prerenderRequest.componentGraphPath);
 
     // webpack work-around/hack
-    const hydrateApp = requireFunc(prerenderRequest.hydrateAppFilePath);
+    const hydrateApp = require(prerenderRequest.hydrateAppFilePath);
 
     if (prerenderCtx.templateHtml == null) {
       // cache template html in this process

--- a/src/compiler/sys/environment.ts
+++ b/src/compiler/sys/environment.ts
@@ -20,5 +20,3 @@ export const IS_WEB_WORKER_ENV =
 export const HAS_WEB_WORKER = IS_BROWSER_ENV && typeof Worker === 'function';
 
 export const IS_FETCH_ENV = typeof fetch === 'function';
-
-export const requireFunc = IS_NODE_ENV ? require : () => {};


### PR DESCRIPTION
Now that we're node-only for compiling components we don't need this any longer (or, put another way, it's just become an alias for `require` anyway)

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
