### PR TITLE
refactor(compiler): propagate `ValidatedConfig`

### DIFF
--- a/src/compiler/bundle/typescript-plugin.ts
+++ b/src/compiler/bundle/typescript-plugin.ts
@@ -70,7 +70,7 @@ export const typescriptPlugin = (compilerCtx: d.CompilerCtx, bundleOpts: BundleO
   };
 };
 
-export const resolveIdWithTypeScript = (config: d.Config, compilerCtx: d.CompilerCtx): Plugin => {
+export const resolveIdWithTypeScript = (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx): Plugin => {
   return {
     name: `resolveIdWithTypeScript`,
 

--- a/src/compiler/sys/typescript/typescript-resolve-module.ts
+++ b/src/compiler/sys/typescript/typescript-resolve-module.ts
@@ -19,7 +19,7 @@ import {
 import { patchTsSystemFileSystem } from './typescript-sys';
 
 export const tsResolveModuleName = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   moduleName: string,
   containingFile: string
@@ -38,7 +38,7 @@ export const tsResolveModuleName = (
 };
 
 export const tsResolveModuleNamePackageJsonPath = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   moduleName: string,
   containingFile: string

--- a/src/compiler/sys/typescript/typescript-sys.ts
+++ b/src/compiler/sys/typescript/typescript-sys.ts
@@ -8,7 +8,7 @@ import { InMemoryFileSystem } from '../in-memory-fs';
 
 // TODO(STENCIL-728): fix typing of `inMemoryFs` parameter in `patchTypescript`, related functions
 export const patchTsSystemFileSystem = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerSys: d.CompilerSystem,
   inMemoryFs: InMemoryFileSystem,
   tsSys: ts.System
@@ -165,12 +165,10 @@ const patchTsSystemWatch = (compilerSystem: d.CompilerSystem, tsSys: ts.System) 
 };
 
 // TODO(STENCIL-728): fix typing of `inMemoryFs` parameter in `patchTypescript`, related functions
-export const patchTypescript = (config: d.Config, inMemoryFs: InMemoryFileSystem) => {
+export const patchTypescript = (config: d.ValidatedConfig, inMemoryFs: InMemoryFileSystem) => {
   if (!(ts as any).__patched) {
-    if (config.sys) {
-      patchTsSystemFileSystem(config, config.sys, inMemoryFs, ts.sys);
-      patchTsSystemWatch(config.sys, ts.sys);
-    }
+    patchTsSystemFileSystem(config, config.sys, inMemoryFs, ts.sys);
+    patchTsSystemWatch(config.sys, ts.sys);
     (ts as any).__patched = true;
   }
 };

--- a/src/compiler/transformers/collections/add-external-import.ts
+++ b/src/compiler/transformers/collections/add-external-import.ts
@@ -6,7 +6,7 @@ import { tsResolveModuleNamePackageJsonPath } from '../../sys/typescript/typescr
 import { parseCollection } from './parse-collection-module';
 
 export const addExternalImport = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   moduleFile: d.Module,

--- a/src/compiler/transformers/collections/parse-collection-components.ts
+++ b/src/compiler/transformers/collections/parse-collection-components.ts
@@ -5,7 +5,7 @@ import type * as d from '../../../declarations';
 import { updateModule } from '../static-to-meta/parse-static';
 
 export const parseCollectionComponents = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   collectionDir: string,
@@ -21,7 +21,7 @@ export const parseCollectionComponents = (
 };
 
 export const transpileCollectionModule = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   collection: d.CollectionCompilerMeta,

--- a/src/compiler/transformers/collections/parse-collection-manifest.ts
+++ b/src/compiler/transformers/collections/parse-collection-manifest.ts
@@ -5,7 +5,7 @@ import type * as d from '../../../declarations';
 import { parseCollectionComponents, transpileCollectionModule } from './parse-collection-components';
 
 export const parseCollectionManifest = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   collectionName: string,
@@ -40,7 +40,7 @@ export const parseCollectionDependencies = (collectionManifest: d.CollectionMani
 };
 
 export const parseGlobal = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   collectionDir: string,

--- a/src/compiler/transformers/collections/parse-collection-module.ts
+++ b/src/compiler/transformers/collections/parse-collection-module.ts
@@ -5,7 +5,7 @@ import type * as d from '../../../declarations';
 import { parseCollectionManifest } from './parse-collection-manifest';
 
 export const parseCollection = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   moduleId: string,

--- a/src/compiler/transformers/static-to-meta/import.ts
+++ b/src/compiler/transformers/static-to-meta/import.ts
@@ -6,7 +6,7 @@ import type * as d from '../../../declarations';
 import { addExternalImport } from '../collections/add-external-import';
 
 export const parseModuleImport = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   moduleFile: d.Module,

--- a/src/compiler/transformers/static-to-meta/parse-static.ts
+++ b/src/compiler/transformers/static-to-meta/parse-static.ts
@@ -10,7 +10,7 @@ import { parseModuleImport } from './import';
 import { parseStringLiteral } from './string-literal';
 
 export const updateModule = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   tsSourceFile: ts.SourceFile,

--- a/src/compiler/transformers/static-to-meta/visitor.ts
+++ b/src/compiler/transformers/static-to-meta/visitor.ts
@@ -9,7 +9,7 @@ import { parseModuleImport } from './import';
 import { parseStringLiteral } from './string-literal';
 
 export const convertStaticToMeta = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   typeChecker: ts.TypeChecker,

--- a/src/compiler/transformers/test/transpile.ts
+++ b/src/compiler/transformers/test/transpile.ts
@@ -1,5 +1,5 @@
 import type * as d from '@stencil/core/declarations';
-import { mockBuildCtx, mockCompilerCtx, mockConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
 import ts from 'typescript';
 
 import { convertDecoratorsToStatic } from '../decorators-to-static/convert-decorators';
@@ -23,7 +23,7 @@ import { getScriptTarget } from '../transform-utils';
  */
 export function transpileModule(
   input: string,
-  config?: d.Config | null,
+  config?: d.ValidatedConfig | null,
   compilerCtx?: d.CompilerCtx | null,
   beforeTransformers: ts.TransformerFactory<ts.SourceFile>[] = [],
   afterTransformers: ts.TransformerFactory<ts.SourceFile>[] = [],
@@ -61,7 +61,7 @@ export function transpileModule(
     ...tsConfig,
   };
 
-  config = config || mockConfig();
+  config = config || mockValidatedConfig();
   compilerCtx = compilerCtx || mockCompilerCtx(config);
 
   const sourceFile = ts.createSourceFile(inputFileName, input, options.target);

--- a/src/compiler/transpile.ts
+++ b/src/compiler/transpile.ts
@@ -1,14 +1,15 @@
 import rollupPluginUtils from '@rollup/pluginutils';
 import type {
-  Config,
   TransformCssToEsmInput,
   TransformOptions,
   TranspileOptions,
   TranspileResults,
+  ValidatedConfig,
 } from '@stencil/core/internal';
 import { catchError, getInlineSourceMappingUrlLinker, isString } from '@utils';
 
 import { getTranspileConfig, getTranspileCssConfig, getTranspileResults } from './config/transpile-options';
+import { validateConfig } from './config/validate-config';
 import { transformCssToEsm, transformCssToEsmSync } from './style/css-to-esm';
 import { patchTypescript } from './sys/typescript/typescript-sys';
 import { getPublicCompilerMeta } from './transformers/add-component-meta-static';
@@ -40,8 +41,9 @@ export const transpile = async (code: string, opts: TranspileOptions = {}): Prom
   try {
     if (shouldTranspileModule(results.inputFileExtension)) {
       const { config, compileOpts, transformOpts } = getTranspileConfig(opts);
-      patchTypescript(config, null);
-      transpileCode(config, compileOpts, transformOpts, results);
+      const validatedConfig = validateConfig(config, {}).config;
+      patchTypescript(validatedConfig, null);
+      transpileCode(validatedConfig, compileOpts, transformOpts, results);
     } else if (results.inputFileExtension === 'd.ts') {
       results.code = '';
     } else if (results.inputFileExtension === 'css') {
@@ -72,8 +74,9 @@ export const transpileSync = (code: string, opts: TranspileOptions = {}): Transp
   try {
     if (shouldTranspileModule(results.inputFileExtension)) {
       const { config, compileOpts, transformOpts } = getTranspileConfig(opts);
-      patchTypescript(config, null);
-      transpileCode(config, compileOpts, transformOpts, results);
+      const validatedConfig = validateConfig(config, {}).config;
+      patchTypescript(validatedConfig, null);
+      transpileCode(validatedConfig, compileOpts, transformOpts, results);
     } else if (results.inputFileExtension === 'd.ts') {
       results.code = '';
     } else if (results.inputFileExtension === 'css') {
@@ -90,7 +93,7 @@ export const transpileSync = (code: string, opts: TranspileOptions = {}): Transp
 };
 
 const transpileCode = (
-  config: Config,
+  config: ValidatedConfig,
   transpileOpts: TranspileOptions,
   transformOpts: TransformOptions,
   results: TranspileResults

--- a/src/compiler/transpile/transpile-module.ts
+++ b/src/compiler/transpile/transpile-module.ts
@@ -23,7 +23,7 @@ import { updateStencilCoreImports } from '../transformers/update-stencil-core-im
  * @returns the results of compiling the provided input string
  */
 export const transpileModule = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   input: string,
   transformOpts: d.TransformOptions
 ): d.TranspileModuleResults => {


### PR DESCRIPTION
This propagates the `ValidatedConfig` in place of the `Config`, branching out from `src/compiler/transpile.ts`

## What is the current behavior?

Not enough `ValidatedConfig`


## What is the new behavior?

A bit more `ValidatedConfig`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I don't think this should affect anything, and should really only give us more safety, so just make sure that things are working as they should be!
