### PR TITLE
fix(compiler): sourcemap generation without ext runtime

### DIFF
--- a/src/compiler/transformers/core-runtime-apis.ts
+++ b/src/compiler/transformers/core-runtime-apis.ts
@@ -1,6 +1,5 @@
 import type * as d from '../../declarations';
 
-export const ATTACH_SHADOW = '__stencil_attachShadow';
 export const CREATE_EVENT = '__stencil_createEvent';
 export const DEFINE_CUSTOM_ELEMENT = '__stencil_defineCustomElement';
 export const GET_ELEMENT = '__stencil_getElement';
@@ -12,7 +11,6 @@ export const REGISTER_HOST = '__stencil_registerHost';
 export const H = '__stencil_h';
 
 export const RUNTIME_APIS = {
-  attachShadow: `attachShadow as ${ATTACH_SHADOW}`,
   createEvent: `createEvent as ${CREATE_EVENT}`,
   defineCustomElement: `defineCustomElement as ${DEFINE_CUSTOM_ELEMENT}`,
   getElement: `getElement as ${GET_ELEMENT}`,

--- a/src/compiler/transformers/test/core-runtime-apis.spec.ts
+++ b/src/compiler/transformers/test/core-runtime-apis.spec.ts
@@ -21,23 +21,23 @@ describe('addCoreRuntimeApi()', () => {
     expect(mockModule.coreRuntimeApis).toBeDefined();
     expect(mockModule.coreRuntimeApis).toHaveLength(0);
 
-    addCoreRuntimeApi(mockModule, RUNTIME_APIS.attachShadow);
-    expect(mockModule.coreRuntimeApis).toEqual([RUNTIME_APIS.attachShadow]);
+    addCoreRuntimeApi(mockModule, RUNTIME_APIS.Host);
+    expect(mockModule.coreRuntimeApis).toEqual([RUNTIME_APIS.Host]);
 
     addCoreRuntimeApi(mockModule, RUNTIME_APIS.createEvent);
-    expect(mockModule.coreRuntimeApis).toEqual([RUNTIME_APIS.attachShadow, RUNTIME_APIS.createEvent]);
+    expect(mockModule.coreRuntimeApis).toEqual([RUNTIME_APIS.Host, RUNTIME_APIS.createEvent]);
   });
 
   it("does not allow duplicate entries in a module's coreRuntimeApis", () => {
     expect(mockModule.coreRuntimeApis).toBeDefined();
     expect(mockModule.coreRuntimeApis).toHaveLength(0);
 
-    addCoreRuntimeApi(mockModule, RUNTIME_APIS.attachShadow);
-    expect(mockModule.coreRuntimeApis).toEqual([RUNTIME_APIS.attachShadow]);
+    addCoreRuntimeApi(mockModule, RUNTIME_APIS.Host);
+    expect(mockModule.coreRuntimeApis).toEqual([RUNTIME_APIS.Host]);
 
     // attempt to add the api again, doing so shall not create a duplicate entry
-    addCoreRuntimeApi(mockModule, RUNTIME_APIS.attachShadow);
-    expect(mockModule.coreRuntimeApis).toEqual([RUNTIME_APIS.attachShadow]);
+    addCoreRuntimeApi(mockModule, RUNTIME_APIS.Host);
+    expect(mockModule.coreRuntimeApis).toEqual([RUNTIME_APIS.Host]);
   });
 });
 
@@ -57,12 +57,12 @@ describe('addOutputTargetCoreRuntimeApi()', () => {
     expect(mockModule.outputTargetCoreRuntimeApis).toBeDefined();
     expect(Object.entries(mockModule.outputTargetCoreRuntimeApis)).toHaveLength(0);
 
-    addOutputTargetCoreRuntimeApi(mockModule, DIST_CUSTOM_ELEMENTS, RUNTIME_APIS.attachShadow);
-    expect(mockModule.outputTargetCoreRuntimeApis).toEqual({ [DIST_CUSTOM_ELEMENTS]: [RUNTIME_APIS.attachShadow] });
+    addOutputTargetCoreRuntimeApi(mockModule, DIST_CUSTOM_ELEMENTS, RUNTIME_APIS.Host);
+    expect(mockModule.outputTargetCoreRuntimeApis).toEqual({ [DIST_CUSTOM_ELEMENTS]: [RUNTIME_APIS.Host] });
 
     addOutputTargetCoreRuntimeApi(mockModule, DIST_CUSTOM_ELEMENTS, RUNTIME_APIS.createEvent);
     expect(mockModule.outputTargetCoreRuntimeApis).toEqual({
-      [DIST_CUSTOM_ELEMENTS]: [RUNTIME_APIS.attachShadow, RUNTIME_APIS.createEvent],
+      [DIST_CUSTOM_ELEMENTS]: [RUNTIME_APIS.Host, RUNTIME_APIS.createEvent],
     });
   });
 
@@ -70,12 +70,12 @@ describe('addOutputTargetCoreRuntimeApi()', () => {
     expect(mockModule.outputTargetCoreRuntimeApis).toBeDefined();
     expect(Object.entries(mockModule.outputTargetCoreRuntimeApis)).toHaveLength(0);
 
-    addOutputTargetCoreRuntimeApi(mockModule, DIST_CUSTOM_ELEMENTS, RUNTIME_APIS.attachShadow);
-    expect(mockModule.outputTargetCoreRuntimeApis).toEqual({ [DIST_CUSTOM_ELEMENTS]: [RUNTIME_APIS.attachShadow] });
+    addOutputTargetCoreRuntimeApi(mockModule, DIST_CUSTOM_ELEMENTS, RUNTIME_APIS.Host);
+    expect(mockModule.outputTargetCoreRuntimeApis).toEqual({ [DIST_CUSTOM_ELEMENTS]: [RUNTIME_APIS.Host] });
 
     // attempt to add the api again, doing so shall not create a duplicate entry
-    addOutputTargetCoreRuntimeApi(mockModule, DIST_CUSTOM_ELEMENTS, RUNTIME_APIS.attachShadow);
-    expect(mockModule.outputTargetCoreRuntimeApis).toEqual({ [DIST_CUSTOM_ELEMENTS]: [RUNTIME_APIS.attachShadow] });
+    addOutputTargetCoreRuntimeApi(mockModule, DIST_CUSTOM_ELEMENTS, RUNTIME_APIS.Host);
+    expect(mockModule.outputTargetCoreRuntimeApis).toEqual({ [DIST_CUSTOM_ELEMENTS]: [RUNTIME_APIS.Host] });
   });
 });
 

--- a/src/compiler/transformers/test/native-constructor.spec.ts
+++ b/src/compiler/transformers/test/native-constructor.spec.ts
@@ -38,7 +38,7 @@ describe('nativeComponentTransform', () => {
       const transpiledModule = transpileModule(code, null, compilerCtx, [], [transformer]);
 
       expect(transpiledModule.outputText).toContain(
-        `import { defineCustomElement as __stencil_defineCustomElement, HTMLElement, attachShadow as __stencil_attachShadow } from "@stencil/core";`
+        `import { defineCustomElement as __stencil_defineCustomElement, HTMLElement } from "@stencil/core";`
       );
       expect(transpiledModule.outputText).toContain(`this.__attachShadow()`);
     });
@@ -63,7 +63,7 @@ describe('nativeComponentTransform', () => {
       const transpiledModule = transpileModule(code, null, compilerCtx, [], [transformer]);
 
       expect(transpiledModule.outputText).toContain(
-        `import { defineCustomElement as __stencil_defineCustomElement, HTMLElement, attachShadow as __stencil_attachShadow } from "@stencil/core";`
+        `import { defineCustomElement as __stencil_defineCustomElement, HTMLElement } from "@stencil/core";`
       );
       expect(transpiledModule.outputText).toContain(`this.__attachShadow()`);
     });

--- a/test/karma/test-app/custom-elements-delegates-focus/karma.spec.ts
+++ b/test/karma/test-app/custom-elements-delegates-focus/karma.spec.ts
@@ -15,8 +15,7 @@ describe('custom-elements-delegates-focus', () => {
     const elm: Element = app.querySelector('custom-elements-delegates-focus');
 
     expect(elm.shadowRoot).toBeDefined();
-    // as of TypeScript 4.3, `delegatesFocus` does not exist on the `shadowRoot` object
-    expect((elm.shadowRoot as any).delegatesFocus).toBe(true);
+    expect(elm.shadowRoot.delegatesFocus).toBe(true);
   });
 
   it('does not set delegatesFocus when shadow is set to "true"', async () => {
@@ -25,7 +24,6 @@ describe('custom-elements-delegates-focus', () => {
     const elm: Element = app.querySelector('custom-elements-no-delegates-focus');
 
     expect(elm.shadowRoot).toBeDefined();
-    // as of TypeScript 4.3, `delegatesFocus` does not exist on the `shadowRoot` object
-    expect((elm.shadowRoot as any).delegatesFocus).toBe(false);
+    expect(elm.shadowRoot.delegatesFocus).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->
This is a redo of https://github.com/ionic-team/stencil/pull/4529, I accidentally merged that into the parent branch, which I didn't want to do (I wanted 2 distinct commits in git history). The mentioned PR has been previously approved, but I had to create a new one since GH doesn't appear to allow you to reopen a merged PR

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See 'new behavior' section

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit fixes a bug where projects using the `dist-custom-elements`
output target with `externalRuntime: false` would receive the following
error when building their project:
```
[ WARN  ]  Bundling Warning SOURCEMAP_ERROR
           Error when using sourcemap for reporting an error: Can't resolve original location of error.
```

the cause of this error was attempting to import a function,
`attachShadow` that is no longer exported from the runtime bundle (as of
https://github.com/ionic-team/stencil/pull/3117). to date, this has not
had an effect on stencil (as the import gets treeshaken away). however,
when trying to generate sourcemaps for a project using this
configuration would cause a mismatch between what was expected to be in
the produced output (the import statement) and what was really there (no
import statement)

this commit removes the RUNTIME_APIS.ATTACH_SHADOW field that is no
longer used in the codebase. it's only usage was in tests for adding
runtime apis, and has been replaced with another field from
`RUNTIME_APIS`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Tests for delegates-focus (unit and karma) continue to pass
## Other information

Relies on #4527 to land first

This is a redo of https://github.com/ionic-team/stencil/pull/4529, I accidentally merged that into the parent branch, which I didn't want to do (I wanted 2 distinct commits in git history)
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
