### PR TITLE
fix(compiler): handle `@supports` blocks when scoping css

### DIFF
--- a/src/utils/shadow-css.ts
+++ b/src/utils/shadow-css.ts
@@ -80,7 +80,8 @@ const _polyfillHostRe = /-shadowcsshost/gim;
  * @param selector The CSS selector we want to match for replacement
  * @returns A look-behind regex containing the selector
  */
-const createSupportsRuleRe = (selector: string) => new RegExp(`(?<!(^@supports(.*)))(${selector}\\b)`, 'gim');
+const createSupportsRuleRe = (selector: string) =>
+  new RegExp(`((?<!(^@supports(.*)))|(?<=\{.*))(${selector}\\b)`, 'gim');
 const _colonSlottedRe = createSupportsRuleRe('::slotted');
 const _colonHostRe = createSupportsRuleRe(':host');
 const _colonHostContextRe = createSupportsRuleRe(':host-context');

--- a/src/utils/shadow-css.ts
+++ b/src/utils/shadow-css.ts
@@ -77,6 +77,16 @@ const _polyfillHostRe = /-shadowcsshost/gim;
  * Little helper for generating a regex that will match a specified
  * CSS selector when that selector is _not_ a part of a `@supports` rule.
  *
+ * The pattern will match the provided `selector` (i.e. ':host', ':host-context', etc.)
+ * when that selector is not a part of a `@supports` selector rule _or_ if the selector
+ * is a part of the rule's declaration.
+ *
+ * For instance, if we create the regex with the selector ':host-context':
+ * - '@supports selector(:host-context())' will return no matches (starts with '@supports')
+ * - '@supports selector(:host-context()) { :host-context() { ... }}' will match the second ':host-context' (part of declaration)
+ * - ':host-context() { ... }' will match ':host-context' (selector is not a '@supports' rule)
+ * - ':host() { ... }' will return no matches (selector doesn't match selector used to create regex)
+ *
  * @param selector The CSS selector we want to match for replacement
  * @returns A look-behind regex containing the selector
  */

--- a/src/utils/test/scope-css.spec.ts
+++ b/src/utils/test/scope-css.spec.ts
@@ -206,6 +206,12 @@ describe('ShadowCss', function () {
       expect(s(':host.class:before {}', 'a')).toEqual('.class.a-h:before {}');
       expect(s(':host(:not(p)):before {}', 'a')).toEqual('.a-h:not(p):before {}');
     });
+
+    it('should not replace the selector in a `@supports` rule', () => {
+      expect(s('@supports selector(:host()) {:host {color: red; }}', 'a')).toEqual(
+        '@supports selector(:host()) {.a-h {color:red;}}'
+      );
+    });
   });
 
   describe(':host-context', () => {
@@ -231,6 +237,13 @@ describe('ShadowCss', function () {
       expect(s(':host-context([a="b"]) {}', 'a')).toEqual('[a="b"].a-h, [a="b"] .a-h {}');
       expect(s(':host-context([a=b]) {}', 'a')).toEqual('[a=b].a-h, [a="b"] .a-h {}');
     });
+
+    it('should not replace the selector in a `@supports` rule', () => {
+      expect(s('@supports selector(:host-context(.class1)) {:host-context(.class1) {color: red; }}', 'a')).toEqual(
+        '@supports selector(:host-context(.class1)) {.class1.a-h, .class1 .a-h {color:red;}}'
+      );
+    });
+    ``;
   });
 
   describe('::slotted', () => {
@@ -306,6 +319,12 @@ describe('ShadowCss', function () {
     it('should handle multiple selector, commentOriginalSelector', () => {
       const r = s('::slotted(ul), ::slotted(li) {}', 'sc-ion-tag', true);
       expect(r).toEqual('/*!@::slotted(ul), ::slotted(li)*/.sc-ion-tag-s > ul, .sc-ion-tag-s > li {}');
+    });
+
+    it('should not replace the selector in a `@supports` rule', () => {
+      expect(s('@supports selector(::slotted(*)) {::slotted(*) {color: red; }}', 'sc-cmp')).toEqual(
+        '@supports selector(::slotted(*)) {.sc-cmp-s > * {color:red;}}'
+      );
     });
   });
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Builds for the `dist-hydrate-script` will fail with a PostCSS error when a component's styles contain an `@supports` block with a pseudo-selector:

```css
@supports selector(:host()) {
  :host() {
    color: red;
  }
}
```

GitHub Issue Number: N/A

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Updates the Stencil [scopeCss()](https://github.com/ionic-team/stencil/blob/main/src/utils/shadow-css.ts#L418) method to not transform certain pseudo-selectors (`:host`, `:host-context`, `::slotted`) when they are a part of the CSS selector in an `@supports` block.

With this change, the block defined in the "current behavior" section will transform to something like the following:

```css
@supports selector(:host()) {
  .sc-my-cmp-h {
    color: red;
  }
}
```

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

**Automated Tests**
Unit tests continue to pass and new tests were added for the `@supports` cases.

**Manual Tests**
1. Clone [this](https://github.com/tanner-reits/stencil-prerender) repo and switch to [this](https://github.com/tanner-reits/stencil-prerender/tree/postcss-supports-issue) branch
2. From root, run `npx lerna bootstrap` to install dependencies
3. From root, run `cd packages/stencil-library && npm run build`
4. Observe build errors
5. From root, run `npm i ../../stencil-core-4.0.1.tgz -w stencil-library` to install the local build of this PR
6. From root, run `cd packages/stencil-library && npm run build`
7. Observe no build errors

You can also spin-up the node app in the repro to see the CSS getting applied to a rendered web component. For more information on making changes to the repro, see its [README](https://github.com/tanner-reits/stencil-prerender/tree/postcss-supports-issue#readme)

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
