### PR TITLE
chore(ci): pin puppeteer for node 14 starter tests (v3)

### DIFF
--- a/.github/workflows/test-component-starter.yml
+++ b/.github/workflows/test-component-starter.yml
@@ -58,6 +58,15 @@ jobs:
         working-directory: ./tmp-component-starter
         shell: bash
 
+      # newer versions of puppeteer use the `??=` operator, which node 14 doesn't understand.
+      # puppeteer v20 dropped support for Node 14, pin a known working version of puppeteer v19 for cases where we need
+      # to land something to the v3-maintenance branch.
+      - name: Install Puppeteer (Node 14)
+        run: npm i -D -E puppeteer@19.11.1
+        working-directory: ./tmp-component-starter
+        shell: bash
+        if: ${{ matrix.node == 14 }}
+
       - name: Build Starter Project
         run: npm run build
         working-directory: ./tmp-component-starter


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Smoke tests for the component starter will fail under node 14 with the following:

```
[03:11.4]  @stencil/core
[03:12.2]  [LOCAL DEV] v3.4.1-dev.1688761098.7e0fe1b
[03:12.4]  testing e2e and spec files

[ ERROR ]  Unexpected token '??='
           D:\a\stencil\stencil\tmp-component-starter\node_modules\puppeteer-core\lib\cjs\puppeteer\common\util.js:399
```

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit pins the version of puppeteer used by the component starter smoke tests. newer versions of puppeteer use the `??=` operator, which node 14 doesn't know how to parse. since the component starter's versioning is only expressed in git (and the cli doesn't know how to download a specific version backed by a git-sha), we pin the version of puppeteer to a known working version for node 14.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

CI passes for all component starter flows 🎉 

See how we install puppeteer v19 only for Node 14:
![Screenshot 2023-07-14 at 2 22 53 PM](https://github.com/ionic-team/stencil/assets/1930213/393aacac-280c-42f9-abe9-b26e067ccc86)
![Screenshot 2023-07-14 at 2 22 43 PM](https://github.com/ionic-team/stencil/assets/1930213/72480bd7-6d3a-44bf-a83e-8fee9612bd57)

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
