### PR TITLE
chore(ci): add v3-maintenance to test-browserstack (v3)

### DIFF
--- a/.github/workflows/test-browserstack.yml
+++ b/.github/workflows/test-browserstack.yml
@@ -6,10 +6,11 @@ on:
     branches:
       - 'main'
       - 'v3.*-feature'
+      - 'v3-maintenance'
   push:
     branches:
       - 'main'
-      - 'stencil/v4-dev'
+      - 'v3-maintenance'
 
 env:
   BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSER_STACK_ACCESS_KEY }}

--- a/.github/workflows/test-browserstack.yml
+++ b/.github/workflows/test-browserstack.yml
@@ -5,7 +5,6 @@ on:
   pull_request_target:
     branches:
       - 'main'
-      - 'v3.*-feature'
       - 'v3-maintenance'
   push:
     branches:


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the `test-browserstack` workflow to allow for browserstack to run when the `v3-maintenance` git branch is either a pull request target (i.e. someone created a PR against the branch) or when the branch is pushed to (i.e. someone merged a PR).


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

N/A - Browserstack should run (note the target branch is `v3-maintenance`), but we have to merge this first 😢 
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
