### PR TITLE
fix(lazy): adjust the type of `defineCustomElements`

### DIFF
--- a/src/compiler/output-targets/dist-lazy/lazy-output.ts
+++ b/src/compiler/output-targets/dist-lazy/lazy-output.ts
@@ -187,7 +187,7 @@ const getLazyEntry = (isBrowser: boolean): string => {
   } else {
     s.append(`import { globalScripts } from '${STENCIL_APP_GLOBALS_ID}';\n`);
     s.append(`export const defineCustomElements = (win, options) => {\n`);
-    s.append(`  if (typeof window === 'undefined') return Promise.resolve();\n`);
+    s.append(`  if (typeof window === 'undefined') return undefined;\n`);
     s.append(`  globalScripts();\n`);
     s.append(`  return bootstrapLazy([/*!__STENCIL_LAZY_DATA__*/], options);\n`);
     s.append(`};\n`);

--- a/src/compiler/output-targets/output-lazy-loader.ts
+++ b/src/compiler/output-targets/output-lazy-loader.ts
@@ -85,7 +85,7 @@ export interface CustomElementsDefineOptions {
   ael?: (el: EventTarget, eventName: string, listener: EventListenerOrEventListenerObject, options: boolean | AddEventListenerOptions) => void;
   rel?: (el: EventTarget, eventName: string, listener: EventListenerOrEventListenerObject, options: boolean | AddEventListenerOptions) => void;
 }
-export declare function defineCustomElements(win?: Window, opts?: CustomElementsDefineOptions): Promise<void>;
+export declare function defineCustomElements(win?: Window, opts?: CustomElementsDefineOptions): void;
 export declare function applyPolyfills(): Promise<void>;
 
 /**


### PR DESCRIPTION
This fixes an issue with the type for `defineCustomElements` that we set in output-lazy-loader.ts. In #4419 we changed the return type of the function to be `void` (at runtime) but we didn't make a corresponding adjustment to the type declaration for the function that we generate here:

https://github.com/ionic-team/stencil/blob/7d5dc6cf5e0d2020c513cc87b6b2e5b93eece9bc/src/compiler/output-targets/output-lazy-loader.ts#L88

This change adjusts that type declaration to have a `void` return value, instead of `Promise<void>`.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?

You'll get a type error when you're actually using things correctly, while code that type-checks will not work at runtime. Not good!


## What is the new behavior?

The runtime behavior is now accurate described by the type declaration.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

On #4589 there is a reproduction case linked. If you clone that repro you can confirm the issue by following the steps described in the readme.

Then to confirm this fix works:

- check it out locally, build and pack stencil
- install the `.tgz` into the `stencil-project` package
- rebuild (`npm run build`) and then check that you'll get a type error in the editor if you open up `test.ts`. Adjust the code to fix the error and confirm that you have 1) no type errors and 2) no runtime errors!

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
