### PR TITLE
chore(repo): remove package ignores

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -63,11 +63,6 @@
       allowedVersions: '<5.0.0',
     },
     {
-      // TODO(STENCIL-771): Remove this entry + upgrade after the TypeScript 5.0 upgrade
-      matchPackageNames: ['dts-bundle-generator'],
-      allowedVersions: '<8.0.0',
-    },
-    {
       // disable Jest updates until the new testing architecture is in place
       matchPackageNames: ['@types/jest', 'jest', 'jest-cli', 'jest-environment-node'],
       groupName: 'Jest',
@@ -82,21 +77,6 @@
     {
       matchPackageNames: ['inquirer'],
       allowedVersions: '<=7.3.3',
-    },
-    // TODO(STENCIL-716): remove this once Stencil drops support for Node 14
-    {
-      matchPackageNames: ['@types/fs-extra'],
-      allowedVersions: '<10.0.0',
-    },
-    // TODO(STENCIL-716): remove this once Stencil drops support for Node 14
-    {
-      matchPackageNames: ['glob'],
-      allowedVersions: '<9.0.0',
-    },
-    // TODO(STENCIL-716): remove this once Stencil drops support for Node 14
-    {
-      matchPackageNames: ['minimatch'],
-      allowedVersions: '<6.0.0',
     },
     {
       matchPackagePrefixes: ['@typescript-eslint'],


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

we're ignoring a few packages that we don't need to anymore in renovate
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit removes a handful of packages that were being ignored by renovate either due to requiring us to drop Node 14 or adopt TypeScript 5. now that we've done both, let's get these packages back up to date.

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

N/A - if something should come up (e.g. we can't upgrade a package) we can always re add it to the list
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
