### PR TITLE
chore(release): override angular issue prefixes 

### DIFF
--- a/scripts/release-tasks.ts
+++ b/scripts/release-tasks.ts
@@ -106,7 +106,7 @@ export async function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<st
             throw new Error('Unclean working tree. Commit or stash changes first.');
           }
         }),
-      skip: () => true || isDryRun,
+      skip: () => isDryRun,
     },
     {
       title: 'Check remote history',
@@ -116,7 +116,7 @@ export async function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<st
             throw new Error('Remote history differs. Please pull changes.');
           }
         }),
-      skip: () => true || isDryRun,
+      skip: () => isDryRun,
     },
   );
 
@@ -134,14 +134,14 @@ export async function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<st
         title: `Bundle @stencil/core ${color.dim('(' + opts.buildId + ')')}`,
         task: () => bundleBuild(opts),
       },
-      // {
-      //   title: 'Run jest tests',
-      //   task: () => execa('npm', ['run', 'test.jest'], { cwd: rootDir }),
-      // },
-      // {
-      //   title: 'Run karma tests',
-      //   task: () => execa('npm', ['run', 'test.karma.prod'], { cwd: rootDir }),
-      // },
+      {
+        title: 'Run jest tests',
+        task: () => execa('npm', ['run', 'test.jest'], { cwd: rootDir }),
+      },
+      {
+        title: 'Run karma tests',
+        task: () => execa('npm', ['run', 'test.karma.prod'], { cwd: rootDir }),
+      },
       {
         title: 'Build license',
         task: () => createLicense(rootDir),

--- a/scripts/release-tasks.ts
+++ b/scripts/release-tasks.ts
@@ -106,7 +106,7 @@ export async function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<st
             throw new Error('Unclean working tree. Commit or stash changes first.');
           }
         }),
-      skip: () => isDryRun,
+      skip: () => true || isDryRun,
     },
     {
       title: 'Check remote history',
@@ -116,7 +116,7 @@ export async function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<st
             throw new Error('Remote history differs. Please pull changes.');
           }
         }),
-      skip: () => isDryRun,
+      skip: () => true || isDryRun,
     },
   );
 
@@ -134,14 +134,14 @@ export async function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<st
         title: `Bundle @stencil/core ${color.dim('(' + opts.buildId + ')')}`,
         task: () => bundleBuild(opts),
       },
-      {
-        title: 'Run jest tests',
-        task: () => execa('npm', ['run', 'test.jest'], { cwd: rootDir }),
-      },
-      {
-        title: 'Run karma tests',
-        task: () => execa('npm', ['run', 'test.karma.prod'], { cwd: rootDir }),
-      },
+      // {
+      //   title: 'Run jest tests',
+      //   task: () => execa('npm', ['run', 'test.jest'], { cwd: rootDir }),
+      // },
+      // {
+      //   title: 'Run karma tests',
+      //   task: () => execa('npm', ['run', 'test.karma.prod'], { cwd: rootDir }),
+      // },
       {
         title: 'Build license',
         task: () => createLicense(rootDir),

--- a/scripts/utils/conventional-changelog-config.ts
+++ b/scripts/utils/conventional-changelog-config.ts
@@ -1,0 +1,34 @@
+/**
+ * Options for [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog), which is
+ * used to generate the Stencil changelog at release time.
+ */
+module.exports = {
+  parserOpts: {
+    /**
+     * Override the conventional-changelog parser default configuration and any provided preset (e.g. 'Angular') for
+     * detecting issues. Stencil uses the "Angular preset", which defaults the "issuesPrefixes" field to a single pound
+     * sign ('#'). This sometimes gets mistaken by the changelog generator as an issue that is fixed, when it fact it's
+     * cross-reference to another issue.
+     *
+     * Note: Only the git commit message is being parsed, not the GitHub Issue summary. For any of the values below to
+     * be picked up by conventional-changelog, they must be added to the git commit message.
+     *
+     * Reference for this property: [GitHub README]{@link https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#issueprefixes}
+     * By default, [these are case-insensitive]{@link https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#issueprefixescasesensitive)}
+     */
+    issuePrefixes: [
+      'fixes: #',
+      'fixes:#',
+      'fixes- #',
+      'fixes-#',
+      'fixes #',
+      'fixes#',
+      'closes: #',
+      'closes:#',
+      'closes- #',
+      'closes-#',
+      'closes #',
+      'closes#',
+    ],
+  },
+};

--- a/scripts/utils/release-utils.ts
+++ b/scripts/utils/release-utils.ts
@@ -90,14 +90,24 @@ export function prettyVersionDiff(oldVersion: string, inc: any): string {
 }
 
 /**
- * Write CHANGELOG.md to disk. Stencil uses the Angular-variant of conventional commits; commits must be formatted
- * accordingly in order to be added to the changelog properly.
+ * Write changes to the local CHANGELOG.md on disk.
+ *
+ * Stencil uses the Angular-variant of conventional commits; commits must be formatted accordingly in order to be added
+ * to the changelog properly.
  * @param opts build options to be used to update the changelog
  */
 export async function updateChangeLog(opts: BuildOptions): Promise<void> {
   const ccPath = join(opts.nodeModulesDir, '.bin', 'conventional-changelog');
+  const ccConfigPath = join(opts.scriptsBuildDir, 'utils', 'conventional-changelog-config.js');
   const { execa } = await import('execa');
-  await execa('node', [ccPath, '-p', 'angular', '-o', '-i', opts.changelogPath, '-s'], { cwd: opts.rootDir });
+  // API Docs for conventional-changelog: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-core#api
+  await execa(
+    'node',
+    [ccPath, '--preset', 'angular', '--infile', opts.changelogPath, '--outfile', '--same-file', '--config', ccConfigPath],
+    {
+      cwd: opts.rootDir,
+    },
+  );
 
   let changelog = await fs.readFile(opts.changelogPath, 'utf8');
   changelog = changelog.replace(/\# \[/, '# ' + opts.vermoji + ' [');

--- a/scripts/utils/release-utils.ts
+++ b/scripts/utils/release-utils.ts
@@ -103,7 +103,17 @@ export async function updateChangeLog(opts: BuildOptions): Promise<void> {
   // API Docs for conventional-changelog: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-core#api
   await execa(
     'node',
-    [ccPath, '--preset', 'angular', '--infile', opts.changelogPath, '--outfile', '--same-file', '--config', ccConfigPath],
+    [
+      ccPath,
+      '--preset',
+      'angular',
+      '--infile',
+      opts.changelogPath,
+      '--outfile',
+      '--same-file',
+      '--config',
+      ccConfigPath,
+    ],
     {
       cwd: opts.rootDir,
     },


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When we run the release scripts, conventional-changelog parses the git commit
messages from the last release to the HEAD of the `main` branch in order to determine
what should be included in the changelog. Stencil uses the Angular preset to inform
conventional-changelog that we use Angular's flavor of conventional commits.

The Angular preset defaults the "issue prefix" setting to "#". As a result, when a commit
is being parsed, any time a "#" is found, conventional changelog assumes that it is an issue
and adds the "closes #[NUMBER]" text to the changelog. This can prove to be wrong more
often than not, especially when the team cross references issues/pull requests. As an example,
commit https://github.com/ionic-team/stencil/commit/1d79672809dcaa3b56ec3761e46f9d1ef51915ad includes the following text:

> ... this is accomplished by
using the output-target-specific runtime api slots introduced in https://github.com/ionic-team/stencil/pull/4200.
this prevents the `HTMLElement` import from polluting the
sourcemaps/source used in the `dist-hydrate-script` target

Note how this commit only cross-references #4200. However, the generated changelog will read:

> * **compiler:** sourcemap errors for dist-custom-elements + dist-hydrate-script ([#4527](https://github.com/ionic-team/stencil/issues/4527)) ([1d79672](https://github.com/ionic-team/stencil/commit/1d79672809dcaa3b56ec3761e46f9d1ef51915ad)), closes [#4200](https://github.com/ionic-team/stencil/issues/4200)
 
Which simply isn't true!

This requires manual clean up, which is a simply an annoying manual process I've been doing for a while 😅 

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit introduces a configuration file for conventional changelog,
in order to override the angular presets that stencil uses today. the
motivation for this change is that when a stencil developer cross
references an issue in stencil in a commit message, conventional-changelog
& the angular preset assumes it's an issue number that's been closed.
when writing the changelog,  the text "closes #ISSUE_NUMBER" is erroneously
added to CHANGELOG.md, which has to be manually fixed at release time.

now, only if any of the `issuePrefixes` in the config are provided in the commit
message (note: not the github issue), will this 'closes #[NUMBER]' text be added

doing this helps in the immediate future (the engineer performing the
release doesn't have to manually update CHANGELOG.md) and will be useful
when the team enables ci-based releases.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

1. From the HEAD of `main` (989b53f5d0afcf7d9bb0bd8d4d8fd9dd3d2171f7 as of this writing), run the release preparation script - `npm run release.prepare`
2. Inspect the changes to `CHANGELOG.md`, you'll find three items we erroneously tag with 'closes':
```md
* **compiler:** sourcemap errors for dist-custom-elements + dist-hydrate-script ([#4527](https://github.com/ionic-team/stencil/issues/4527)) ([1d79672](https://github.com/ionic-team/stencil/commit/1d79672809dcaa3b56ec3761e46f9d1ef51915ad)), closes [#4200](https://github.com/ionic-team/stencil/issues/4200)
* **lazy:** adjust the type of `defineCustomElements` ([#4592](https://github.com/ionic-team/stencil/issues/4592)) ([5c85c33](https://github.com/ionic-team/stencil/commit/5c85c332a7390b30fdba1d8598e618e5bf0f2b59)), closes [#4419](https://github.com/ionic-team/stencil/issues/4419) [/github.com/ionic-team/stencil/blob/7d5dc6cf5e0d2020c513cc87b6b2e5b93eece9bc/src/compiler/output-targets/output-lazy-loader.ts#L88](https://github.com//github.com/ionic-team/stencil/blob/7d5dc6cf5e0d2020c513cc87b6b2e5b93eece9bc/src/compiler/output-targets/output-lazy-loader.ts/issues/L88) [#4589](https://github.com/ionic-team/stencil/issues/4589)
* **output-targets:** fix path normalization logic ([#4545](https://github.com/ionic-team/stencil/issues/4545)) ([cd5849c](https://github.com/ionic-team/stencil/commit/cd5849c6e1853750adde2b71791ca825f38f730d)), closes [#4317](https://github.com/ionic-team/stencil/issues/4317) [/github.com/ionic-team/stencil/blob/b911f1986a0d583bd1e3cd42cbbca9b255c32f2d/src/compiler/sys/modules/path.ts#L35-L38](https://github.com//github.com/ionic-team/stencil/blob/b911f1986a0d583bd1e3cd42cbbca9b255c32f2d/src/compiler/sys/modules/path.ts/issues/L35-L38) [#4317](https://github.com/ionic-team/stencil/issues/4317) [#4543](https://github.com/ionic-team/stencil/issues/4543)
```
3. Also note there is one that we correctly mark:
```md
* **rollup-config:** deprecate BundlingConfig#namedExports ([#4532](https://github.com/ionic-team/stencil/issues/4532)) ([a353769](https://github.com/ionic-team/stencil/commit/a353769b0094cd502a9ce35f797f74c7dc1d9232)), closes [#2523](https://github.com/ionic-team/stencil/issues/2523)
```
4. Check out the second commit in this PR (makes things go faster) and rerun the release prep scripts with `--any-branch`: `npm run release.prepare -- --any-branch`
5. Observe only the git commit message from step 3 is marked with 'closes':
```md
* **rollup-config:** deprecate BundlingConfig#namedExports ([#4532](https://github.com/ionic-team/stencil/issues/4532)) ([a353769](https://github.com/ionic-team/stencil/commit/a353769b0094cd502a9ce35f797f74c7dc1d9232)), closes [#2523](https://github.com/ionic-team/stencil/issues/2523)
```
## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
