### PR TITLE
chore(ci): enable production ci releases

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -1,5 +1,4 @@
-name: 'Stencil Production Release (TEST)'
-
+name: 'Stencil Production Release'
 on:
   workflow_dispatch:
     inputs:
@@ -27,10 +26,61 @@ jobs:
   release-stencil-production-build:
     name: Publish Production Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
-      - name: Echo GH Input
+      - name: Checkout Code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          # A depth of 0 gets the entire git history.
+          # We need git history to generate the changelog; however, we don't know how deep to go.
+          # Since publishing is a one-off activity, just get everything.
+          fetch-depth: 0
+
+      - name: Get Core Dependencies
+        uses: ./.github/workflows/actions/get-core-dependencies
+
+      # Log the input from GitHub Actions for easy traceability
+      - name: Log GitHub Input
         run: |
-          echo "I do not use these values yet!"
           echo "Version: ${{ inputs.version }}"
           echo "Tag: ${{ inputs.tag }}"
+        shell: bash
+
+      - name: Run Publish Preparation Script
+        run: npm run release.ci.prepare -- --version ${{ inputs.version }} --tag ${{ inputs.tag }} --any-branch
+        shell: bash
+
+      - name: Log Generated Changes
+        run: git --no-pager diff
+        shell: bash
+
+      # Commit the Changelog, NOTICE, License, package.json, etc.
+      # Note:
+      # - The version (and vermoji) is pulled directly from the compiled Stencil binary, as the value from the action's
+      #   input form may be a word such as 'major'. This requires the version to have already been incremented to show
+      #   the correct version in the commit message.
+      # - `stencil info` returns "<TAB>Stencil: <VERSION> <VERMOJI>
+      #   we match on "Stencil:" and capture the current version + vermoji to print "<VERMOJI> v<VERSION>"
+      - name: Commit Release Preparations
+        run: |
+          git config user.name "Stencil Release Bot (on behalf of ${{ github.actor }})"
+          git config user.email "stencil-release-bot@ionic.io"
+          git add .
+          git commit -m "$(./bin/stencil info | awk '/Stencil:/ { print $4,"v"$3;}')"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+
+      - name: Prepare NPM Token
+        run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+        shell: bash
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Run Publish Scripts
+        # pass the generated version number instead of the input, since we've already incremented it in the prerelease
+        # step
+        run: npm run release.ci -- --version $(./bin/stencil version) --tag ${{ inputs.tag }} --any-branch
         shell: bash

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "prettier.base": "prettier --cache \"./({bin,scripts,src,test}/**/*.{ts,tsx,js,jsx})|bin/stencil|.github/(**/)?*.(yml|yaml)|*.js\"",
     "prettier.dry-run": "npm run prettier.base -- --list-different",
     "release": "npm run tsc.scripts && node scripts/build --release --publish",
+    "release.ci.prepare": "npm run tsc.scripts && NODE_OPTIONS=--max-old-space-size=4096 node scripts/build --release --ci-prepare",
+    "release.ci": "npm run tsc.scripts && node scripts/build --release --ci-publish",
     "release.prepare": "npm run tsc.scripts && node scripts/build --release --prepare",
     "rollup": "rollup --config",
     "rollup.prod": "rollup --config --config-prod",

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -1,30 +1,49 @@
-# Manually Testing Stencil's Browser API
+# Releasing Stencil
 
-Stencil's Browser API should be checked manually prior to a release. There are plans to get programmatic testing in
-place in the future.
+Stencil can either be released by CI/CD (via GitHub Actions), or manually.
+An automated release is the preferred way of creating a new release of the project.
+Manual releases should only be performed when there are extenuating circumstances preventing an automated release.
 
-1. Build Stencil from the root of this repo: `npm run ci && npm run build`
-2. `cd test/browser-compile`
-3. Start the application: `npm start`
-4. Validate the output is properly transpiled
+## Automated Releases
 
-# Release
+1. Run the [Stencil Production Release](https://github.com/ionic-team/stencil/actions/workflows/release-production.yml)
+in GitHub
+   1. Run the workflow from the `main` branch, _unless_ the release is for a previous major version of Stencil.
+   In that scenario, select the `v#-maintenance` branch corresponding to the version of Stencil being released.
+   For example, `v3-maintenance` to release a new version of Stencil v3.
+   2. Stencil follows semantic versioning. Select the appropriate version from the dropdown for this release.
+   3. Stencil should be published under the `latest` tag, _unless_ the release is for a previous major version of
+   Stencil.
+2. Proceed to the [Follow-Up section](#follow-up) of this document to run manual follow-up tasks.
 
-1. `npm run release.prepare`
-2. Check the [CHANGELOG.md](../CHANGELOG.md) and make sure it includes all the changes that have landed since the last 
+## Manual Releases
+
+⚠️ Manual releases should only be performed when there are extenuating circumstances that prevent an automated one from occurring ⚠️
+
+✍️ Authoring permissions are needed for an individual to perform a manual release. If needed, please ping Ionic leadership. ✍️
+
+1. Run `npm run clean` locally to clear out any cached build artifacts.
+2. Run `npm run release.prepare`. This will install dependencies, bundle Stencil, run tests, etc.
+3. Check the [CHANGELOG.md](../CHANGELOG.md) and make sure it includes all the changes that have landed since the last 
 release.
-3. Commit the changes - use the commit message :emoji: v<VERSION>. e.g. :star2: v2.7.0 
-4. `npm run release`
-5. Publish the release notes in GitHub
-6. Navigate to the [Stencil Site](https://github.com/ionic-team/stencil-site/pulls) repository and merge and PRs 
+4. Commit the changes - use the commit message '<emoji> v<VERSION>'. e.g. `git commit -m '🤦‍ v2.7.0'` (note the emoji is 
+used literally, as opposed to ':facepalm:').
+5. Run `npm run release`, which will push the commit/tag to GitHub and publish to NPM.
+6. Proceed to the [Follow-Up section](#follow-up) of this document to run manual follow-up tasks.
+
+# Follow-Up Steps
+
+The following steps should be always run, regardless of whether an automated or manual release was performed.
+
+1. Publish the release notes in GitHub using GitHub's [release notes form](https://github.com/ionic-team/stencil/releases/new).
+2. Navigate to the [Stencil Site](https://github.com/ionic-team/stencil-site/pulls) repository and merge PRs
    containing documentation that has been approved, but not merged that is related to the release. Such PRs should be
    labelled as `do not merge: waiting for next stencil release`. It's a good idea to review _all_ PRs though, just in
-   case :wink:
-7. If there are any 'next' branches in GitHub, say for a future major version of Stencil (e.g. `v3.0.0-dev`), now is a
-   good time to sync them with the `main` branch.
-8. Perform the following tasks in JIRA:
-   1. Mark this version of Stencil as 'released' in JIRA
-   2. Move the task card in this current sprint to the 'Done' swimlane
-   3. Stub out the next release and task for the release in JIRA
-9. Ensure all GitHub Issues associated with stories/tasks that shipped in this version of Stencil are closed
-10. :tada:
+   case.
+3. If there are any 'next' branches in GitHub, say for a future major version of Stencil (e.g. `v5.0.0-dev`), now is a
+   good time to rebase them against the `main` branch.
+4. Perform the following tasks in JIRA:
+   1. Mark this version of Stencil as 'released' in JIRA on the 'Releases' page.
+   2. Move the task card in this current sprint to the 'Done' swim-lane.
+   3. Stub out the next release and task for the release in JIRA.
+5. Ensure all GitHub Issues associated with stories/tasks that shipped in this version of Stencil are closed.

--- a/scripts/release-tasks.ts
+++ b/scripts/release-tasks.ts
@@ -96,7 +96,7 @@ export async function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<st
             throw new Error('Not on `main` branch. Use --any-branch to publish anyway.');
           }
         }),
-      skip: () => isDryRun,
+      skip: () => isDryRun || opts.isCI, // in CI, we may be publishing from another branch
     },
     {
       title: 'Check local working tree',
@@ -106,7 +106,7 @@ export async function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<st
             throw new Error('Unclean working tree. Commit or stash changes first.');
           }
         }),
-      skip: () => isDryRun,
+      skip: () => opts.isCI, // don't check the tree in CI, we may have a temp file we need for publish
     },
     {
       title: 'Check remote history',
@@ -141,6 +141,7 @@ export async function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<st
       {
         title: 'Run karma tests',
         task: () => execa('npm', ['run', 'test.karma.prod'], { cwd: rootDir }),
+        skip: () => opts.isCI, // skip this in CI, we'll rely on previous commits to `main` to hope this is OK for now
       },
       {
         title: 'Build license',
@@ -172,7 +173,9 @@ export async function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<st
         title: 'Publish @stencil/core to npm',
         task: () => {
           const cmd = 'npm';
-          const cmdArgs = ['publish', '--otp', opts.otp].concat(opts.tag ? ['--tag', opts.tag] : []);
+          const cmdArgs = ['publish']
+            .concat(opts.tag ? ['--tag', opts.tag] : [])
+            .concat(opts.isCI ? ['--provenance'] : ['--otp', opts.otp]);
 
           if (isDryRun) {
             return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
@@ -224,32 +227,31 @@ export async function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<st
           }
           return postGithubRelease(opts);
         },
+        skip: () => opts.isCI,
       },
     );
   }
 
   const listr = new Listr(tasks);
 
-  listr
-    .run()
-    .then(() => {
-      if (opts.isPublishRelease) {
-        console.log(
-          `\n ${opts.vermoji}  ${color.bold.magenta(pkg.name)} ${color.bold.yellow(newVersion)} published!! ${
-            opts.vermoji
-          }\n`,
-        );
-      } else {
-        console.log(
-          `\n ${opts.vermoji}  ${color.bold.magenta(pkg.name)} ${color.bold.yellow(
-            newVersion,
-          )} prepared, check the diffs and commit ${opts.vermoji}\n`,
-        );
-      }
-    })
-    .catch((err) => {
-      console.log(`\n🤒  ${color.red(err)}\n`);
-      console.log(err);
-      process.exit(1);
-    });
+  try {
+    await listr.run();
+  } catch (err: any) {
+    console.log(`\n🤒  ${color.red(err)}\n`);
+    console.log(err);
+    process.exit(1);
+  }
+  if (opts.isPublishRelease) {
+    console.log(
+      `\n ${opts.vermoji}  ${color.bold.magenta(pkg.name)} ${color.bold.yellow(newVersion)} published!! ${
+        opts.vermoji
+      }\n`,
+    );
+  } else {
+    console.log(
+      `\n ${opts.vermoji}  ${color.bold.magenta(pkg.name)} ${color.bold.yellow(
+        newVersion,
+      )} prepared, check the diffs and commit ${opts.vermoji}\n`,
+    );
+  }
 }


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
I (@rwaskiewicz) manually release Stencil. This is problematic for a few reasons, so let's fix that so anyone on the team can release!
 
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit allows for production releases to be kicked off from a ci workflow (github actions). it updates the `release-production` workflow automate the following manual tasks:
1. running the prerelease scripts, which bundles stencil, validates the output, runs tests, etc.
2. commits the changes
3. pushes the release artifact/tag to npm
4. pushes the git tag to github

this commit is a stopgap to enable the rest of the team to be able to perform releases. it is not our long term solution. rather, it fixes the blocker that is rwaskiewicz when he goes on vacation ;-)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

I've been hacking at this for a bit, but the proof is probably in the pudding. I ran this workflow based on this branch with the parameters of 'prerelease' for version and 'dev' for the tag. The publish to NPM and GitHub works! 🎉 
![Screenshot 2023-07-20 at 2 36 39 PM](https://github.com/ionic-team/stencil/assets/1930213/ac1ac710-c4d8-402d-a7a3-fac9576c2c28)

![Screenshot 2023-07-20 at 2 36 53 PM](https://github.com/ionic-team/stencil/assets/1930213/1c89f20a-61dd-469e-a299-4f199cef7ef5)

I can download v4.0.2-0 and install it successfully. Other than the changes introduced since v4.0.1, the binary contains the exact same files

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

Like I said earlier, this isn't our long term solution. Probably needs a proper design doc, but this provides immediate value for the problem at hand
