### PR TITLE
refactor(cli): update check-version typings

### DIFF
--- a/src/cli/check-version.ts
+++ b/src/cli/check-version.ts
@@ -2,14 +2,30 @@ import { isFunction } from '@utils';
 
 import type { ValidatedConfig } from '../declarations';
 
-export const startCheckVersion = async (config: ValidatedConfig, currentVersion: string) => {
+/**
+ * Retrieve a reference to the active `CompilerSystem`'s `checkVersion` function
+ * @param config the Stencil configuration associated with the currently compiled project
+ * @param currentVersion the Stencil compiler's version string
+ * @returns a reference to `checkVersion`, or `null` if one does not exist on the current `CompilerSystem`
+ */
+export const startCheckVersion = async (
+  config: ValidatedConfig,
+  currentVersion: string,
+): Promise<(() => void) | null> => {
   if (config.devMode && !config.flags.ci && !currentVersion.includes('-dev.') && isFunction(config.sys.checkVersion)) {
     return config.sys.checkVersion(config.logger, currentVersion);
   }
   return null;
 };
 
-export const printCheckVersionResults = async (versionChecker: Promise<() => void>) => {
+/**
+ * Print the results of running the provided `versionChecker`.
+ *
+ * Does not print if no `versionChecker` is provided.
+ *
+ * @param versionChecker the function to invoke.
+ */
+export const printCheckVersionResults = async (versionChecker: Promise<(() => void) | null>): Promise<void> => {
   if (versionChecker) {
     const checkVersionResults = await versionChecker;
     if (isFunction(checkVersionResults)) {

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -974,6 +974,7 @@ export interface CompilerSystem {
   applyGlobalPatch?(fromDir: string): Promise<void>;
   applyPrerenderGlobalPatch?(opts: { devServerHostUrl: string; window: any }): void;
   cacheStorage?: CacheStorage;
+  // TODO(STENCIL-898): Make this property non-optional, check for unnecessary null checks on it
   checkVersion?: (logger: Logger, currentVersion: string) => Promise<() => void>;
   copy?(copyTasks: Required<CopyTask>[], srcDir: string): Promise<CopyResults>;
   /**


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
this commit updates the typings of `check-version` functions, to make it clear that they can return `null` (in theory). in practice, i don't believe this is possible. however, fixing that would require a breaking change. for now, we'll fix the typings for 4.X and come back and remove null checks for 5.x.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing
N/A
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
