### PR TITLE
fix(runtime): add onSelect to textarea and input

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1031,6 +1031,7 @@ export namespace JSXBase {
     minlength?: number | string;
     multiple?: boolean;
     name?: string;
+    onSelect?: (event: Event) => void;
     pattern?: string;
     placeholder?: string;
     readOnly?: boolean;
@@ -1269,6 +1270,7 @@ export namespace JSXBase {
     minLength?: number;
     minlength?: number | string;
     name?: string;
+    onSelect?: (event: Event) => void;
     placeholder?: string;
     readOnly?: boolean;
     readonly?: boolean | string;

--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1032,6 +1032,7 @@ export namespace JSXBase {
     multiple?: boolean;
     name?: string;
     onSelect?: (event: Event) => void;
+    onselect?: (event: Event) => void;
     pattern?: string;
     placeholder?: string;
     readOnly?: boolean;
@@ -1271,6 +1272,7 @@ export namespace JSXBase {
     minlength?: number | string;
     name?: string;
     onSelect?: (event: Event) => void;
+    onselect?: (event: Event) => void;
     placeholder?: string;
     readOnly?: boolean;
     readonly?: boolean | string;


### PR DESCRIPTION
## What is the current behavior?
Currently stencil is lacking the `onSelect` attribute on the `<input>` and `<textarea>` html elements, so trying to use them fails to compile.

GitHub Issue Number: 

https://github.com/ionic-team/stencil/issues/4617

## What is the new behavior?

-  adds the attribute to these elements.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

I monkey patched this into my app which then was able to compile and the attribute was added to the html element correctly.

## Other information

Apparently this has been around for ages and is well supported:

https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/select_event

https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement/select_event