### PR TITLE
chore(jsdoc): add docs to component flag values

### DIFF
--- a/src/compiler/transformers/static-to-meta/encapsulation.ts
+++ b/src/compiler/transformers/static-to-meta/encapsulation.ts
@@ -1,8 +1,19 @@
 import ts from 'typescript';
 
+import type * as d from '../../../declarations';
 import { getStaticValue } from '../transform-utils';
 
-export const parseStaticEncapsulation = (staticMembers: ts.ClassElement[]) => {
+/**
+ * Find and return the type of encapsulation that a component has based on the return value of its static getter of the
+ * same name.
+ *
+ * If no encapsulation static getter is found, or if the found encapsulation getter return value is not an accepted
+ * value, 'none' is returned.
+ *
+ * @param staticMembers a collection of static getters to search
+ * @returns the encapsulation mode to use for a component
+ */
+export const parseStaticEncapsulation = (staticMembers: ts.ClassElement[]): d.Encapsulation => {
   let encapsulation: string = getStaticValue(staticMembers, 'encapsulation');
 
   if (typeof encapsulation === 'string') {
@@ -15,7 +26,20 @@ export const parseStaticEncapsulation = (staticMembers: ts.ClassElement[]) => {
   return 'none';
 };
 
-export const parseStaticShadowDelegatesFocus = (encapsulation: string, staticMembers: ts.ClassElement[]) => {
+/**
+ * Find and return if `delegatesFocus` is enabled for a component based on the return value of its static getter of the
+ * same name.
+ *
+ * @param encapsulation the encapsulation mode to use for a component
+ * @param staticMembers a collection of static getters to search
+ * @returns when `encapsulation` is 'shadow', return `true` if the static getter returns true. If the static getter
+ * returns `false` or does not exist, return `false`. If `encapsulation` is not 'shadow', return `null`, regardless of
+ * the static getter's existence/return value.
+ */
+export const parseStaticShadowDelegatesFocus = (
+  encapsulation: string,
+  staticMembers: ts.ClassElement[],
+): boolean | null => {
   if (encapsulation === 'shadow') {
     const delegatesFocus: boolean = getStaticValue(staticMembers, 'delegatesFocus');
     return !!delegatesFocus;

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -817,6 +817,12 @@ export interface ComponentCompilerMeta extends ComponentCompilerFeatures {
   directDependents?: string[];
 }
 
+/**
+ * The supported style encapsulation modes on a Stencil component:
+ * 1. 'shadow' - native Shadow DOM
+ * 2. 'scoped' - encapsulated styles and polyfilled slots
+ * 3. 'none' - a basic HTML element
+ */
 export type Encapsulation = 'shadow' | 'scoped' | 'none';
 
 /**

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -55,19 +55,55 @@ export const enum HOST_FLAGS {
   devOnDidLoad = 1 << 11,
 }
 
+/**
+ * A set of flags used for bitwise calculations against {@link ComponentRuntimeMeta#$flags$}.
+ *
+ * These flags should only be used in conjunction with {@link ComponentRuntimeMeta#$flags$}.
+ * They should _not_ be used for calculations against other fields/numbers
+ */
 export const enum CMP_FLAGS {
+  /**
+   * Used to determine if a component is using the shadow DOM.
+   * e.g. `shadow: true | {}` is set on the `@Component()` decorator
+   */
   shadowDomEncapsulation = 1 << 0,
+  /**
+   * Used to determine if a component is using scoped stylesheets
+   * e.g. `scoped: true` is set on the `@Component()` decorator
+   */
   scopedCssEncapsulation = 1 << 1,
+  /**
+   * Used to determine if a component does not use the shadow DOM _and_ has `<slot/>` tags in its markup.
+   */
   hasSlotRelocation = 1 << 2,
   // TODO(STENCIL-854): Remove code related to legacy shadowDomShim field
   // Note that when we remove this field we should consider whether we need to
   // retain a placeholder here, since if we want to have compatability between
   // different versions of the runtime then we'll need to not shift the values
   // of the other higher flags down
+  /**
+   * Determines if a shim for the shadow DOM is necessary.
+   *
+   * The shim should only be needed if a component requires {@link shadowDomEncapsulation} and if any output
+   * target-specific criteria are met. Refer to this flag's usage to determine each output target's criteria.
+   */
   needsShadowDomShim = 1 << 3,
+  /**
+   * Determines if `delegatesFocus` is enabled for a component that uses the shadow DOM.
+   * e.g. `shadow: { delegatesFocus: true }` is set on the `@Component()` decorator
+   */
   shadowDelegatesFocus = 1 << 4,
+  /**
+   * Determines if `mode` is set on the `@Component()` decorator
+   */
   hasMode = 1 << 5,
   // TODO(STENCIL-854): Remove code related to legacy shadowDomShim field
+  /**
+   * Determines if styles must be scoped due to either:
+   * 1. A component is using scoped stylesheets ({@link scopedCssEncapsulation})
+   * 2. A component is using the shadow DOM _and_ the output target's rules for requiring a shadow DOM shim have been
+   * met ({@link needsShadowDomShim})
+   */
   needsScopedEncapsulation = scopedCssEncapsulation | needsShadowDomShim,
 }
 


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

No JSDoc :-(
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
this commit adds jsdoc to stencil's `CMP_FLAGS` enumeration, to help clarify the usage of each variant in the enum. this is intended to help guide the discussion around slots, scoped components, etc. as we work to improve various bugs related to this part of the code over the next few weeks


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

N/A - added JSDoc/filled in existing types to function signatures
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
