### PR TITLE
refactor(hydrate): remove unused build conditionals

### DIFF
--- a/src/compiler/output-targets/dist-hydrate-script/bundle-hydrate-factory.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/bundle-hydrate-factory.ts
@@ -15,7 +15,6 @@ export const bundleHydrateFactory = async (
   config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
-  _build: d.BuildConditionals,
   appFactoryEntryCode: string,
 ) => {
   try {

--- a/src/compiler/output-targets/dist-hydrate-script/generate-hydrate-app.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/generate-hydrate-app.ts
@@ -5,7 +5,6 @@ import { RollupOptions } from 'rollup';
 import { rollup } from 'rollup';
 
 import type * as d from '../../../declarations';
-import { getBuildFeatures, updateBuildConditionals } from '../../app-core/app-data';
 import {
   STENCIL_HYDRATE_FACTORY_ID,
   STENCIL_INTERNAL_HYDRATE_ID,
@@ -76,12 +75,9 @@ export const generateHydrateApp = async (
 const generateHydrateFactory = async (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
   if (!buildCtx.hasError) {
     try {
-      const cmps = buildCtx.components;
-      const build = getHydrateBuildConditionals(config, cmps);
-
       const appFactoryEntryCode = await generateHydrateFactoryEntry(buildCtx);
 
-      const rollupFactoryBuild = await bundleHydrateFactory(config, compilerCtx, buildCtx, build, appFactoryEntryCode);
+      const rollupFactoryBuild = await bundleHydrateFactory(config, compilerCtx, buildCtx, appFactoryEntryCode);
       if (rollupFactoryBuild != null) {
         const rollupOutput = await rollupFactoryBuild.generate({
           format: 'cjs',
@@ -121,24 +117,4 @@ const generateHydrateFactoryEntry = async (buildCtx: d.BuildCtx) => {
   s.append(`export { hydrateApp }\n`);
 
   return s.toString();
-};
-
-const getHydrateBuildConditionals = (config: d.ValidatedConfig, cmps: d.ComponentCompilerMeta[]) => {
-  const build = getBuildFeatures(cmps) as d.BuildConditionals;
-
-  build.lazyLoad = true;
-  build.hydrateClientSide = false;
-  build.hydrateServerSide = true;
-
-  updateBuildConditionals(config, build);
-  build.lifecycleDOMEvents = false;
-  build.devTools = false;
-  build.hotModuleReplacement = false;
-  build.cloneNodeFix = false;
-  build.appendChildSlotFix = false;
-  build.slotChildNodesFix = false;
-  // TODO(STENCIL-854): Remove code related to legacy shadowDomShim field
-  build.shadowDomShim = false;
-
-  return build;
 };


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit removes an unused function for getting `BuildConditionals` for the hydrate output target.

`src/compiler/output-targets/dist-hydrate-script/bundle-hydrate-factory.ts#bundleHydrateFactory` had a declared parameter `_build`, whose value is unused in the body of the function. `bundleHyrdateFactory` is not exported by stencil, and only has one callsite at
`src/compiler/output-targets/dist-hydrate-script/generate-hydrate-app.ts#generateHydrateFactory`. the argument passed to `bundleHydrateFactory` was generated by calling a `generate-hydrate-app#getHydrateBuildConditionals` function. however, the build conditionals have not been used since a refactor that occurred in dd6f1e177bd57f649f713fb01aec8252848d5e80, where it was used by the legacy hydrate build (https://github.com/ionic-team/stencil/blame/dd6f1e177bd57f649f713fb01aec8252848d5e80/src/compiler/component-hydrate_legacy/bundle-hydrate-factory_legacy.ts#L12).


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Build should continue to pass - this is (subtle-y) dead code elimination
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
