### PR TITLE
chore(build): document build conditionals

### DIFF
--- a/src/app-data/index.ts
+++ b/src/app-data/index.ts
@@ -21,9 +21,6 @@ import type { BuildConditionals } from '@stencil/core/internal';
  * `STENCIL_APP_DATA_ID` uses it to replace these defaults with {@link BuildConditionals} that are derived from a
  * Stencil project's contents (i.e. metadata from the components). This replacement happens at a Stencil project's
  * compile time. Such code can be found at `src/compiler/app-core/app-data.ts`.
- *
- *
- * This collection is expected to be updated before used in compilation of a Stencil project.
  */
 export const BUILD: BuildConditionals = {
   allRenderFn: false,

--- a/src/app-data/index.ts
+++ b/src/app-data/index.ts
@@ -1,5 +1,30 @@
 import type { BuildConditionals } from '@stencil/core/internal';
 
+/**
+ * A collection of default build flags for a Stencil project.
+ *
+ * This collection can be found throughout the Stencil codebase, often imported from the `@app-data` module like so:
+ * ```ts
+ * import { BUILD } from '@app-data';
+ * ```
+ * and is used to determine if a portion of the output of a Stencil _project_'s compilation step can be eliminated.
+ *
+ * e.g. When `BUILD.allRenderFn` evaluates to `false`, the compiler will eliminate conditional statements like:
+ * ```ts
+ * if (BUILD.allRenderFn) {
+ *   // some code that will be eliminated if BUILD.allRenderFn is false
+ * }
+ * ```
+ *
+ * `@app-data`, the module that `BUILD` is imported from, is an alias for the `@stencil/core/internal/app-data`, and is
+ * partially referenced by {@link STENCIL_APP_DATA_ID}. The `src/compiler/bundle/app-data-plugin.ts` references
+ * `STENCIL_APP_DATA_ID` uses it to replace these defaults with {@link BuildConditionals} that are derived from a
+ * Stencil project's contents (i.e. metadata from the components). This replacement happens at a Stencil project's
+ * compile time. Such code can be found at `src/compiler/app-core/app-data.ts`.
+ *
+ *
+ * This collection is expected to be updated before used in compilation of a Stencil project.
+ */
 export const BUILD: BuildConditionals = {
   allRenderFn: false,
   cmpDidLoad: true,

--- a/src/compiler/app-core/app-data.ts
+++ b/src/compiler/app-core/app-data.ts
@@ -138,7 +138,7 @@ const getModuleImports = (moduleMap: ModuleMap, filePath: string, importedModule
 };
 
 /**
- * For a provided Stencil project configuration, update provided the build conditionals
+ * Update the provided build conditionals object in-line with a provided Stencil project configuration
  *
  * **This function mutates the build conditionals argument**
  *

--- a/src/compiler/app-core/app-data.ts
+++ b/src/compiler/app-core/app-data.ts
@@ -2,15 +2,23 @@ import {
   BuildConditionals,
   BuildFeatures,
   ComponentCompilerMeta,
-  Config,
   Module,
   ModuleMap,
+  ValidatedConfig,
 } from '@stencil/core/internal';
 import { unique } from '@utils';
 
+/**
+ * Re-export {@link BUILD} defaults
+ */
 export * from '../../app-data';
 
-export const getBuildFeatures = (cmps: ComponentCompilerMeta[]) => {
+/**
+ * Generate a {@link BuildFeatures} entity, based on the provided component metadata
+ * @param cmps a collection of component compiler metadata, used to set values on the generated build features object
+ * @returns the generated build features entity
+ */
+export const getBuildFeatures = (cmps: ComponentCompilerMeta[]): BuildFeatures => {
   const slot = cmps.some((c) => c.htmlTagNames.includes('slot'));
   const shadowDom = cmps.some((c) => c.encapsulation === 'shadow');
   const slotRelocation = cmps.some((c) => c.encapsulation !== 'shadow' && c.htmlTagNames.includes('slot'));
@@ -129,7 +137,15 @@ const getModuleImports = (moduleMap: ModuleMap, filePath: string, importedModule
   return importedModules;
 };
 
-export const updateBuildConditionals = (config: Config, b: BuildConditionals) => {
+/**
+ * For a provided Stencil project configuration, update provided the build conditionals
+ *
+ * **This function mutates the build conditionals argument**
+ *
+ * @param config the Stencil configuration to use to update the provided build conditionals
+ * @param b the build conditionals to update
+ */
+export const updateBuildConditionals = (config: ValidatedConfig, b: BuildConditionals): void => {
   b.isDebug = config.logLevel === 'debug';
   b.isDev = !!config.devMode;
   b.isTesting = !!config._isTesting;

--- a/src/compiler/bundle/app-data-plugin.ts
+++ b/src/compiler/bundle/app-data-plugin.ts
@@ -8,8 +8,18 @@ import type * as d from '../../declarations';
 import { removeCollectionImports } from '../transformers/remove-collection-imports';
 import { APP_DATA_CONDITIONAL, STENCIL_APP_DATA_ID, STENCIL_APP_GLOBALS_ID } from './entry-alias-ids';
 
+/**
+ * A Rollup plugin which bundles application data.
+ *
+ * @param config the Stencil configuration for a particular project
+ * @param compilerCtx the current compiler context
+ * @param buildCtx the current build context
+ * @param build the set build conditionals for the build
+ * @param platform the platform that is being built
+ * @returns a Rollup plugin which carries out the necessary work
+ */
 export const appDataPlugin = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   build: d.BuildConditionals,
@@ -182,7 +192,16 @@ const appendGlobalScripts = (globalScripts: GlobalScript[], s: MagicString) => {
   }
 };
 
-const appendBuildConditionals = (config: d.Config, build: d.BuildConditionals, s: MagicString) => {
+/**
+ * Generates the `BUILD` constant that is used at compile-time in a Stencil project
+ *
+ * **This function mutates the provided string argument**
+ *
+ * @param config the configuration associated with the Stencil project
+ * @param build the build conditionals to serialize into a JS object
+ * @param s a string to append the generated constant onto
+ */
+const appendBuildConditionals = (config: d.ValidatedConfig, build: d.BuildConditionals, s: MagicString): void => {
   const buildData = Object.keys(build)
     .sort()
     .map((key) => key + ': ' + ((build as any)[key] ? 'true' : 'false'))

--- a/src/compiler/bundle/app-data-plugin.ts
+++ b/src/compiler/bundle/app-data-plugin.ts
@@ -195,11 +195,11 @@ const appendGlobalScripts = (globalScripts: GlobalScript[], s: MagicString) => {
 /**
  * Generates the `BUILD` constant that is used at compile-time in a Stencil project
  *
- * **This function mutates the provided string argument**
+ * **This function mutates the provided {@link MagicString} argument**
  *
  * @param config the configuration associated with the Stencil project
  * @param build the build conditionals to serialize into a JS object
- * @param s a string to append the generated constant onto
+ * @param s a `MagicString` to append the generated constant onto
  */
 const appendBuildConditionals = (config: d.ValidatedConfig, build: d.BuildConditionals, s: MagicString): void => {
   const buildData = Object.keys(build)


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

How `BUILD` gets set isn't super clear.
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- this commit adds a small explanation as to how BUILD conditionals get set at compile time of a Stencil project

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I did tighten some types (`Config` -> `ValidatedConfig`). The type checker ought to catch any issues
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
