### PR TITLE
chore(repo): update renovate schedule

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -94,8 +94,19 @@
   ],
   // Never rebase the branch or update it unless manually requested to avoid noisy PR emails
   rebaseWhen: 'never',
-  // Note: Timezone for the schedule is specified as UTC
-  schedule: ['every weekday before 11am'],
+  /**
+   * Run every Monday and Thursday between midnight at 11 AM (in UTC)
+   *
+   * Monday and Thursday were chosen to:
+   * - Keep the `minimumReleaseAge` value in mind (three days)
+   * - Prevent spikes/bursts of PRs from Renovate on a single day of the week
+   *
+   * We use cron syntax here as it's more deterministic/easier to provide a value that we know that Renovate will
+   * accept, compared to the natural language syntax which is (subjectively) trickier to test without merging first.
+   *
+   * {@see https://crontab.guru} for debugging cron schedules
+   */
+  schedule: ['* 0-11 * * 1,4'],
   /**
    * Ensure semantic commits are enabled for commits + PR titles.
    *


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Renovate can be a little noisy, even with our current config

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the rate at which renovate runs. justification/details on the configuration can be found in the comments of the configuration file

**This is still up for discussion/alteration**. We talked about slowing this down in Slack, without specifying the degree to which we'll do it. LMK what you think!

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing


Validated the cron schedule  - https://crontab.guru/#*_0-11_*_*_1,4

> At every minute past every hour from 0 through 11 on Monday and Thursday.

AFAICT, we follow the format correctly - https://docs.renovatebot.com/configuration-options/#schedule

> For Cron schedules, you must use the * wildcard for the minutes value, as Renovate doesn't support minute granularity.
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
