### PR TITLE
fix(testing): remove use of `emulate` field in `E2EPage()`

### DIFF
--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1806,8 +1806,11 @@ export interface TestingConfig extends JestConfig {
   browserDevtools?: boolean;
 
   /**
-   * Array of browser emulations to be using during e2e tests. A full e2e
+   * Array of browser emulations to be used during _screenshot_ tests. A full screenshot
    * test is ran for each emulation.
+   *
+   * To emulate a device display for your e2e tests, use the `setViewport` method on a test's E2E page.
+   * An example can be found in [the Stencil docs](https://stenciljs.com/docs/end-to-end-testing#emulate-a-display).
    */
   emulate?: EmulateConfig[];
 

--- a/src/testing/puppeteer/puppeteer-declarations.ts
+++ b/src/testing/puppeteer/puppeteer-declarations.ts
@@ -28,6 +28,7 @@ type PuppeteerPage = Omit<
   | 'bringToFront'
   | 'browser'
   | 'screenshot'
+  | 'emulate'
   | 'emulateMedia'
   | 'frames'
   | 'goBack'

--- a/src/testing/puppeteer/puppeteer-declarations.ts
+++ b/src/testing/puppeteer/puppeteer-declarations.ts
@@ -28,7 +28,6 @@ type PuppeteerPage = Omit<
   | 'bringToFront'
   | 'browser'
   | 'screenshot'
-  | 'emulate'
   | 'emulateMedia'
   | 'frames'
   | 'goBack'

--- a/src/testing/puppeteer/puppeteer-page.ts
+++ b/src/testing/puppeteer/puppeteer-page.ts
@@ -1,5 +1,5 @@
-import type { E2EProcessEnv, EmulateConfig, HostElement, JestEnvironmentGlobal } from '@stencil/core/internal';
-import type { ConsoleMessage, ConsoleMessageLocation, ElementHandle, JSHandle, Page, WaitForOptions } from 'puppeteer';
+import type { E2EProcessEnv, HostElement, JestEnvironmentGlobal } from '@stencil/core/internal';
+import type { ConsoleMessage, ConsoleMessageLocation, ElementHandle, JSHandle, WaitForOptions } from 'puppeteer';
 
 import type {
   E2EPage,
@@ -30,7 +30,6 @@ export async function newE2EPage(opts: NewE2EPageOptions = {}): Promise<E2EPage>
     page._e2eGoto = page.goto;
     page._e2eClose = page.close;
 
-    await setPageEmulate(page as any);
     await page.setCacheEnabled(false);
     await initPageEvents(page);
 
@@ -274,26 +273,6 @@ async function waitForStencil(page: E2EPage, options: WaitForOptions) {
   } catch (e) {
     throw new Error(`App did not load in allowed time. Please ensure the content loads a stencil application.`);
   }
-}
-
-async function setPageEmulate(page: Page) {
-  if (page.isClosed()) {
-    return;
-  }
-
-  const emulateJsonContent = env.__STENCIL_EMULATE__;
-  if (!emulateJsonContent) {
-    return;
-  }
-
-  const screenshotEmulate = JSON.parse(emulateJsonContent) as EmulateConfig;
-
-  const emulateOptions = {
-    viewport: screenshotEmulate.viewport,
-    userAgent: screenshotEmulate.userAgent,
-  };
-
-  await (page as Page).emulate(emulateOptions);
 }
 
 async function waitForChanges(page: E2EPageInternal) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The implementation for the existing `emulate` field on the testing config is very unclear. This value only come into effect when screenshot testing is enabled.

GitHub Issue Number: Fixes #4601 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removes the logic in the `newE2EPage()` related to the `emulate` config value.
- Updates the documentation on the `emulate` field to make it clear that it only applied to screenshot testing
- A follow-up PR for the Stencil documentation (https://github.com/ionic-team/stencil-site/pull/1191) will add a recipe to the documentation for emulating device viewports in e2e tests

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

**Automated tests**
Automated unit and e2e tests continue to pass.

**Manual tests**
1. Clone the repro in the associated issue (https://github.com/jongirard/stencil-emulate-viewport-bug)
2. Add the following code snipped to the e2e test for "can click the desktop content" immediately before the call to `page.setContent()`:
```ts
await page.setViewport({
  width: 1000,
  height: 600,
});
```
3. Tests will now pass

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
