### PR TITLE
fix(compiler): custom elements relative typedef import paths

### DIFF
--- a/src/compiler/output-targets/dist-custom-elements/custom-elements-types.ts
+++ b/src/compiler/output-targets/dist-custom-elements/custom-elements-types.ts
@@ -82,7 +82,9 @@ const generateCustomElementsTypesOutput = async (
             const localComponentTypeDefFilePath = `./${component.tagName}`;
 
             return [
-              `export { ${importName} as ${exportName} } from '${componentDTSPath}';`,
+              `export { ${importName} as ${exportName} } from '${
+                componentDTSPath.startsWith('.') ? componentDTSPath : './' + componentDTSPath
+              }';`,
               // We need to alias each `defineCustomElement` function typedef to match the aliased name given to the
               // function in the `index.js`
               `export { defineCustomElement as ${defineFunctionExportName} } from '${localComponentTypeDefFilePath}';`,
@@ -206,8 +208,6 @@ const generateCustomElementType = (componentsDtsRelPath: string, cmp: d.Componen
  */
 const relDts = (fromPath: string, dtsPath: string): string => {
   dtsPath = relative(fromPath, dtsPath);
-  if (!dtsPath.startsWith('.')) {
-    dtsPath = '.' + dtsPath;
-  }
-  return normalizePath(dtsPath.replace('.d.ts', ''));
+
+  return normalizePath(dtsPath.replace('.d.ts', ''), true);
 };

--- a/src/compiler/output-targets/test/custom-elements-types.spec.ts
+++ b/src/compiler/output-targets/test/custom-elements-types.spec.ts
@@ -67,6 +67,10 @@ describe('Custom Elements Typedef generation', () => {
       writeFileSpy = jest.spyOn(compilerCtx.fs, 'writeFile');
     });
 
+    afterEach(() => {
+      writeFileSpy.mockRestore();
+    });
+
     it('should generate an index.d.ts file corresponding to the index.js file when outputting to a sub-dir of dist', async () => {
       await generateCustomElementsTypes(config, compilerCtx, buildCtx, 'types_dir');
 
@@ -111,8 +115,6 @@ describe('Custom Elements Typedef generation', () => {
       expect(compilerCtx.fs.writeFile).toHaveBeenCalledWith('my-best-dir/index.d.ts', expectedTypedefOutput, {
         outputTargetType: DIST_CUSTOM_ELEMENTS,
       });
-
-      writeFileSpy.mockRestore();
     });
 
     it('should generate an index.d.ts file corresponding to the index.js file when outputting to top-level of dist', async () => {
@@ -161,8 +163,6 @@ describe('Custom Elements Typedef generation', () => {
       expect(compilerCtx.fs.writeFile).toHaveBeenCalledWith('dist/index.d.ts', expectedTypedefOutput, {
         outputTargetType: DIST_CUSTOM_ELEMENTS,
       });
-
-      writeFileSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If the `dist-custom-elements` output target is configured to write to the top-level distribution directory (i.e `dist`), the paths generated that reference the typedef files are invalid.

GitHub Issue Number: Fixes #4630 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Generated paths will be correctly "relativized" 

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

**Automated tests**
Unit tests continue to pass and a new test was added for this use case

**Manual tests**
1. Create a component starter (`npm init stencil components <name>`)
2. Update the output targets in the `stencil.config.ts` to set the `dist-custom-elements` target as follows:
```ts
{
  type: 'dist-custom-elements',
  dir: 'dist',
  customElementsExportBehavior: 'single-export-module',
}
```
3. Run `npm run build`. Open `dist/my-component.d.ts` or `dist/index.d.ts` and observe there are invalid paths
4. Install a build of this branch.
5. Run `npm run build`. Open either file mentioned in step 3 and notice the paths are now correctly generated as relative paths

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
