### PR TITLE
chore(repo): add glob, minimatch to renovate ignore list

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -8,13 +8,16 @@
    * 2. `renovate-config-validator` will run the validator
    */
   dependencyDashboard: true,
-  // TODO(STENCIL-596): Remove once rollup upgrade is unblocked
   ignoreDeps: [
+    // TODO(STENCIL-596): Remove once rollup upgrade is unblocked
     'rollup',
     'rollup-plugin-sourcemaps',
     '@rollup/plugin-commonjs',
     '@rollup/plugin-node-resolve',
     '@rollup/plugin-replace',
+    // TODO(STENCIL-912): Upgrade these two dependencies
+    'glob',
+    'minimatch',
   ],
   ignorePaths: [
     'test/package.json',


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
this commit (temporarily) adds glob, minimatch to the renovate ignore list. a ticket has been added to the stencil backlog to address this item of tech debt, as it's more effort than originally envisioned to 'simply' upgrade this (see ticket for additional info)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
N/A
## Other information

The upgrade is blocked by our rollup upgrade, sadly :-(

I'll close #4611 and #4625 (temporarily) since I don't think we're going to get to this this quarter
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
