### PR TITLE
feat(config): add experimentalSlotFixes config value

### DIFF
--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -394,6 +394,31 @@ describe('validation', () => {
     expect(config.extras.tagNameTransform).toBe(false);
   });
 
+  it('should set slot config based on `experimentalSlotFixes`', () => {
+    userConfig.extras = {};
+    userConfig.extras.experimentalSlotFixes = true;
+    const { config } = validateConfig(userConfig, bootstrapConfig);
+    expect(config.extras.appendChildSlotFix).toBe(true);
+    expect(config.extras.cloneNodeFix).toBe(true);
+    expect(config.extras.slotChildNodesFix).toBe(true);
+    expect(config.extras.scopedSlotTextContentFix).toBe(true);
+  });
+
+  it('should override slot fix config based on `experimentalSlotFixes`', () => {
+    userConfig.extras = {
+      appendChildSlotFix: false,
+      slotChildNodesFix: false,
+      cloneNodeFix: false,
+      scopedSlotTextContentFix: false,
+    };
+    userConfig.extras.experimentalSlotFixes = true;
+    const { config } = validateConfig(userConfig, bootstrapConfig);
+    expect(config.extras.appendChildSlotFix).toBe(true);
+    expect(config.extras.cloneNodeFix).toBe(true);
+    expect(config.extras.slotChildNodesFix).toBe(true);
+    expect(config.extras.scopedSlotTextContentFix).toBe(true);
+  });
+
   it('should set taskQueue "async" by default', () => {
     const { config } = validateConfig(userConfig, bootstrapConfig);
     expect(config.taskQueue).toBe('async');

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -111,6 +111,18 @@ export const validateConfig = (
   validatedConfig.extras.slotChildNodesFix = !!validatedConfig.extras.slotChildNodesFix;
   validatedConfig.extras.initializeNextTick = !!validatedConfig.extras.initializeNextTick;
   validatedConfig.extras.tagNameTransform = !!validatedConfig.extras.tagNameTransform;
+  // TODO(STENCIL-914): remove `experimentalSlotFixes` when it's the default behavior
+  validatedConfig.extras.experimentalSlotFixes = !!validatedConfig.extras.experimentalSlotFixes;
+
+  // if the user has set `extras.experimentalSlotFixes` then we turn on all of
+  // the slot-related fixes automatically.
+  // TODO(STENCIL-914): remove `experimentalSlotFixes` when it's the default behavior
+  if (validatedConfig.extras.experimentalSlotFixes) {
+    validatedConfig.extras.appendChildSlotFix = true;
+    validatedConfig.extras.cloneNodeFix = true;
+    validatedConfig.extras.slotChildNodesFix = true;
+    validatedConfig.extras.scopedSlotTextContentFix = true;
+  }
 
   validatedConfig.buildEs5 =
     validatedConfig.buildEs5 === true || (!validatedConfig.devMode && validatedConfig.buildEs5 === 'prod');

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -368,6 +368,13 @@ export interface ConfigExtras {
    * can be customized at runtime. Defaults to `false`.
    */
   tagNameTransform?: boolean;
+
+  // TODO(STENCIL-914): remove `experimentalSlotFixes` when it's the default behavior
+  /**
+   * Enables all slot-related fixes such as {@link slotChildNodesFix}, and
+   * {@link scopedSlotTextContentFix}.
+   */
+  experimentalSlotFixes?: boolean;
 }
 
 export interface Config extends StencilConfig {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

Docs PR here: <https://github.com/ionic-team/stencil-site/pull/1196>

## What is the current behavior?

Too many different slot fix config values!

## What is the new behavior?

if you set `config.extras.experimentalSlotFixes` to `true` then you'll automatically get all the other slot fix configuration options set to `true` as well.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Try setting the value to `true`! You should see relevant values in `config.extras` get set to `true` as well.