### PR TITLE
chore(repo): split internal and user-facing jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  preset: './testing/jest-preset.js',
   moduleNameMapper: {
     '@app-data': '<rootDir>/internal/app-data/index.cjs',
     '@app-globals': '<rootDir>/internal/app-globals/index.cjs',
@@ -12,6 +11,8 @@ module.exports = {
     '@sys-api-node': '<rootDir>/sys/node/index.js',
     '@utils': '<rootDir>/src/utils',
     '^typescript$': '<rootDir>/scripts/build/typescript-modified-for-jest.js',
+    '^@stencil/core/internal/app-data$': '<rootDir>/internal/app-data/index.cjs',
+    '^@stencil/core/internal/testing$': '<rootDir>/internal/testing/index.js',
   },
   coverageDirectory: './coverage/',
   coverageReporters: ['json', 'lcov', 'text', 'clover'],
@@ -36,7 +37,10 @@ module.exports = {
     '<rootDir>/src/testing/**/*.{js,jsx,ts,tsx}',
     '<rootDir>/src/utils/**/*.{js,jsx,ts,tsx}',
   ],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'mjs', 'jsx', 'json', 'd.ts'],
   modulePathIgnorePatterns: ['/bin', '/www'],
+  setupFilesAfterEnv: ['<rootDir>/testing/jest-setuptestframework.js'],
+  testEnvironment: '<rootDir>/testing/jest-environment.js',
   testPathIgnorePatterns: [
     '<rootDir>/.cache/',
     '<rootDir>/.github/',
@@ -57,7 +61,10 @@ module.exports = {
     '<rootDir>/testing/',
   ],
   testRegex: '/(src|scripts)/.*\\.spec\\.(ts|tsx|js)$',
-  // TODO(STENCIL-307): Move away from Jasmine runner for internal Stencil tests, which involves re-working environment
-  // setup
+  // TODO(STENCIL-307): Move away from Jasmine runner for internal Stencil tests as a part of the (internal) Jest 28+ upgrade
   testRunner: 'jest-jasmine2',
+  transform: {
+    '^.+\\.(ts|tsx|jsx|css|mjs)$': '<rootDir>/testing/jest-preprocessor.js',
+  },
+  watchPathIgnorePatterns: ['^.+\\.d\\.ts$'],
 };


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We have a jest config that is shared both internally and externally, and is one of the blockers to the jest 28+ upgrade.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit separates stencil's internal testing jest configuration (used when running unit tests on the stencil project itself), and the jest configuration used by stencil projects (when a stencil user runs `npm t` in their project).

with this commit, we remove the inheritance on the jest configuration that we bundle with stencil for end users. in order to ensure that stencil's internal tests continue to function, the internal jest config has been updated to have near parity with the external one. the intent of this commit is _not_ to optimize the jest config, but rather separate the two so that we can begin to bring support for newer versions of jest to end users without dragging out the process (i.e. upgrading ourselves)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

I ran our testing suite in `main` and this branch, all tests/suites ran + passed for both branches (the number of skipped/passed lined up).

I also diffed the output of `npm t -- --verbose --debug --no-cache` on this branch and `main`. There are a few module path mapping differences, but I do not believe we need these for Stencil internally:
```
diff today-jest-config.json new-jest-config.json 
```
```diff
-           "^@stencil/core/cli$",
-           "/Users/ryan/workspaces/stencil/cli/index.js"
-         ],
-         [
-           "^@stencil/core/compiler$",
-           "/Users/ryan/workspaces/stencil/compiler/stencil.js"
-         ],
-         [
-           "^@stencil/core/internal$",
-           "/Users/ryan/workspaces/stencil/internal/testing/index.js"
-         ],
-         [
-           "^@stencil/core/internal/app-globals$",
-           "/Users/ryan/workspaces/stencil/internal/app-globals/index.js"
-         ],
-         [
-           "/Users/ryan/workspaces/stencil/internal/testing/index.js"
-         ],
-         [
-           "^@stencil/core/mock-doc$",
-           "/Users/ryan/workspaces/stencil/mock-doc/index.cjs"
-         ],
-         [
-           "^@stencil/core/sys$",
-           "/Users/ryan/workspaces/stencil/sys/node/index.js"
-         ],
-         [
-           "^@stencil/core/testing$",
-           "/Users/ryan/workspaces/stencil/testing/index.js"
-         ],
-         [
-           "^@stencil/core$",
```
## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
