### PR TITLE
chore(repo): create initial pull request action

### DIFF
--- a/.github/workflows/create-production-pr.yml
+++ b/.github/workflows/create-production-pr.yml
@@ -1,0 +1,81 @@
+name: 'Stencil Release PR Creation'
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: choice
+        description: Which version should be published?
+        options:
+          - prerelease
+          - prepatch
+          - preminor
+          - premajor
+          - patch
+          - minor
+          - major
+
+jobs:
+  create-stencil-release-pull-request:
+    name: Generate Stencil Release PR
+    runs-on: ubuntu-latest
+    steps:
+      # Log the input from GitHub Actions for easy traceability
+      - name: Log GitHub Input
+        run: |
+          echo "Version: ${{ inputs.version }}"
+        shell: bash
+
+      - name: Checkout Code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          # A depth of 0 gets the entire git history.
+          # We need git history to generate the changelog; however, we don't know how deep to go.
+          # Since publishing is a one-off activity, just get everything.
+          fetch-depth: 0
+
+      - name: Get Core Dependencies
+        uses: ./.github/workflows/actions/get-core-dependencies
+
+      - name: Run Publish Preparation Script
+        run: npm run release.ci.prepare -- --version ${{ inputs.version }} --any-branch
+        shell: bash
+
+      - name: Log Generated Changes
+        run: git --no-pager diff
+        shell: bash
+
+      - name: Generate Version String and Branch Name
+        id: name_gen
+        run: |
+          VERSION_STR=$(jq '.version' package.json | sed s/\"//g)
+          echo "VERSION_STR=$VERSION_STR" >> "$GITHUB_OUTPUT"
+          echo "BRANCH_NAME=release/$VERSION_STR-run-${{ github.run_number }}-${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Print Version String and Branch Name
+        run: |
+          echo Version: ${{ steps.name_gen.outputs.VERSION_STR }}
+          echo Branch Name: ${{ steps.name_gen.outputs.BRANCH_NAME }}
+        shell: bash
+
+      - name: Create Git Branch
+        # Note: We'll let GitHub clean up the branch for us (this is configured in the repo settings on GitHub)
+        run: git checkout -b ${{ steps.name_gen.outputs.BRANCH_NAME }}
+
+      # Commit the CHANGELOG.md, NOTICE.md, LICENSE.md, package.json, etc.
+      - name: Commit Release Preparations
+        run: |
+          git config user.name "Stencil Release Bot (on behalf of ${{ github.actor }})"
+          git config user.email "stencil-release-bot@ionic.io"
+          git add .
+          git commit -m "v${{ steps.name_gen.outputs.VERSION_STR }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+
+      - name: Push Branch to GitHub
+        run: |
+          git push --set-upstream origin ${{ steps.name_gen.outputs.BRANCH_NAME }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

our automated release process for production isn't compatible with the merge queue we have set up
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
this commit creates a new action that will (eventually) go on to create
pull requests for the stencil team when it is time to release a new
version of the library. the (eventual) intent is for stencil engineers
to run this workflow, which will generate a pull request that includes:
- version bumps in package.json & package-lock.json
- changelog, notice, and license generation

this commit currently only creates a new branch and commit. the branch
includes the version string, as well as the run/attempt in github
actions to tie us back to the run that created it.

at this point, the creation of the pull request is not included. the
intended library to use
(https://github.com/peter-evans/create-pull-request) does not work on
push/pull_request events in GHA without additional permissions. by
adding this action, we can test it without generating a new token.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

In https://github.com/ionic-team/stencil/pull/4675/commits/1179138708c6fca0f8c05651fadb0891006e36e2, I had a `push` event configured for  this job. The logs are attached for those wanting to see the output. 
[1_Generate Stencil Release PR (1).txt](https://github.com/ionic-team/stencil/files/12314993/1_Generate.Stencil.Release.PR.1.txt)

I also was able to verify the branch was created successfully - 
![Screenshot 2023-08-10 at 11 30 34 AM](https://github.com/ionic-team/stencil/assets/1930213/aaee63f4-a395-4b10-9f23-1acee2864971)



<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

This commit does not remove 'extraneous' steps from the CI-based preparations. That is, it still builds Stencil, bundles it, runs karma/unit tests, etc. _outside of_ the CI workflow steps that we use in PRs. I'll update those in a separate PR. This is meant to just give me the ability to start hacking on PR creation
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
