### PR TITLE
fix(compiler): match tsconfig include paths properly

### DIFF
--- a/src/compiler/sys/typescript/tests/typescript-config.spec.ts
+++ b/src/compiler/sys/typescript/tests/typescript-config.spec.ts
@@ -1,0 +1,35 @@
+import { hasSrcDirectoryInclude } from '../typescript-config';
+
+describe('typescript-config', () => {
+  describe('hasSrcDirectoryInclude', () => {
+    it('returns `false` for a non-array argument', () => {
+      // the intent of this test is to evaluate when a user doesn't provide an array, hence the type assertion
+      expect(hasSrcDirectoryInclude('src' as unknown as string[], 'src')).toBe(false);
+    });
+
+    it('returns `false` for an empty array', () => {
+      expect(hasSrcDirectoryInclude([], 'src/')).toBe(false);
+    });
+
+    it('returns `false` when an entry does not exist in the array', () => {
+      expect(hasSrcDirectoryInclude(['src'], 'source')).toBe(false);
+    });
+
+    it('returns `true` when an entry does exist in the array', () => {
+      expect(hasSrcDirectoryInclude(['src', 'foo'], 'src')).toBe(true);
+    });
+
+    it('returns `true` for globs', () => {
+      expect(hasSrcDirectoryInclude(['src/**/*.ts', 'foo/'], 'src/**/*.ts')).toBe(true);
+    });
+
+    it.each([
+      [['src'], './src'],
+      [['./src'], 'src'],
+      [['../src'], '../src'],
+      [['*'], './*'],
+    ])('returns `true` for relative paths', (includedPaths, srcDir) => {
+      expect(hasSrcDirectoryInclude(includedPaths, srcDir)).toBe(true);
+    });
+  });
+});

--- a/src/compiler/sys/typescript/typescript-config.ts
+++ b/src/compiler/sys/typescript/typescript-config.ts
@@ -166,8 +166,21 @@ const createDefaultTsConfig = (config: d.Config) =>
     2,
   );
 
-const hasSrcDirectoryInclude = (includeProp: string[], src: string) =>
-  Array.isArray(includeProp) && includeProp.includes(src);
+/**
+ * Determines if the included `src` argument belongs in `includeProp`.
+ *
+ * This function normalizes the paths found in both arguments, to catch cases where it's called with:
+ * ```ts
+ * hasSrcDirectoryInclude(['src'], './src'); // should return `true`
+ * ```
+ *
+ * @param includeProp the paths in `include` that should be tested
+ * @param src the path to find in `includeProp`
+ * @returns true if the provided `src` directory is found, `false` otherwise
+ */
+export const hasSrcDirectoryInclude = (includeProp: string[], src: string): boolean =>
+  Array.isArray(includeProp) &&
+  includeProp.some((included) => normalizePath(included, false) === normalizePath(src, false));
 
 const hasStencilConfigInclude = (includeProp: string[]) =>
   Array.isArray(includeProp) && includeProp.includes('stencil.config.ts');


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When `tsconfig.json#include` contains a relative path:
```
"include": [
  "./app/javascript"
],
``` 
and `tsconfig.json#srcDir` includes the non-relative version of that path:
```
srcDir: 'app/javascript',
```

then you receive a very confusing error:
```
[ WARN  ]  tsconfig.json "include" required
           In order for TypeScript to improve watch performance, it's recommended the "tsconfig.json" file should have
           the "include" property, with at least the app's "app/javascript" directory listed. For example: "include":
           ["app/javascript"]
```


GitHub Issue Number: #4667 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit fixes a bug where a user was unable to use relative paths in the `include` property of their `tsconfig.json` file if `srcDir` was also specified. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

- Unit tests have been added to the function in question
- Tested a dev build - `@stencil/core@v4.0.4-dev.1691704809.9fb61d7` - against the minimal reproduction case
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
