### PR TITLE
fix(runtime): adds a testing check to the forceUpdate method

### DIFF
--- a/src/runtime/test/globals.spec.tsx
+++ b/src/runtime/test/globals.spec.tsx
@@ -33,10 +33,10 @@ describe('globals', () => {
   });
 
   it('build values', () => {
-    expect(Build.isBrowser).toBe(true);
+    expect(Build.isBrowser).toBe(false);
     expect(Build.isDev).toBe(true);
     expect(Build.isTesting).toBe(true);
-    expect(Build.isServer).toBe(false);
+    expect(Build.isServer).toBe(true);
   });
 
   it('Env is defined', () => {

--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -362,7 +362,7 @@ export const postUpdateComponent = (hostRef: d.HostRef) => {
 };
 
 export const forceUpdate = (ref: any) => {
-  if (BUILD.updatable && Build.isBrowser) {
+  if (BUILD.updatable && (Build.isBrowser || Build.isTesting)) {
     const hostRef = getHostRef(ref);
     const isConnected = hostRef.$hostElement$.isConnected;
     if (

--- a/src/testing/platform/testing-build.ts
+++ b/src/testing/platform/testing-build.ts
@@ -2,7 +2,7 @@ import type * as d from '@stencil/core/internal';
 
 export const Build: d.UserBuildConditionals = {
   isDev: true,
-  isBrowser: true,
-  isServer: false,
+  isBrowser: false,
+  isServer: true,
   isTesting: true,
 };

--- a/test/end-to-end/src/build-data/build-data.spec.ts
+++ b/test/end-to-end/src/build-data/build-data.spec.ts
@@ -11,7 +11,7 @@ describe('build-data', () => {
     expect(root).toEqualHtml(`
       <build-data>
         <p>isDev: true</p>
-        <p>isBrowser: true</p>
+        <p>isBrowser: false</p>
         <p>isTesting: true</p>
       </build-data>
     `);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The changes to testing build conditionals made [here](https://github.com/ionic-team/stencil/commit/b203263482140fde31edfb7a91ac6054f5f98460#diff-4bb40df78659571d0bbbd5cd771c28484c1a1c9beefd451d6d004c7d4ed0c80f) were causing tests to fail in the Ionic Framework.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This commit adds a check for `isTesting` in addition to `isBrowser` so that the forceUpdate logic can run in test environments without needing to change the testing build conditional values. These changes were causing tests to fail in Framework.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Installed a build of this branch in the framework `feature-7.3` branch and confirmed the reported test failures are resolved. Also confirmed that all internal Stencil tests (unit & e2e) continue to pass.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
