### PR TITLE
feat(compiler): include `getAssetPath` in generated export statement

### DIFF
--- a/src/compiler/output-targets/dist-custom-elements/custom-elements-types.ts
+++ b/src/compiler/output-targets/dist-custom-elements/custom-elements-types.ts
@@ -94,10 +94,10 @@ const generateCustomElementsTypesOutput = async (
         ]
       : []),
     `/**`,
-    ` * Get the base path to where the assets can be found. Use \`setAssetPath(path)\``,
+    ` * Get the base path to where the assets can be found. Use "setAssetPath(path)"`,
     ` * if the path needs to be customized.`,
     ` */`,
-    `export declare function getAssetPath(path: string): string;`,
+    `export declare const getAssetPath: (path: string) => string;`,
     ``,
     `/**`,
     ` * Used to manually set the base path where assets can be found.`,

--- a/src/compiler/output-targets/dist-custom-elements/custom-elements-types.ts
+++ b/src/compiler/output-targets/dist-custom-elements/custom-elements-types.ts
@@ -94,6 +94,12 @@ const generateCustomElementsTypesOutput = async (
         ]
       : []),
     `/**`,
+    ` * Get the base path to where the assets can be found. Use \`setAssetPath(path)\``,
+    ` * if the path needs to be customized.`,
+    ` */`,
+    `export declare function getAssetPath(path: string): string;`,
+    ``,
+    `/**`,
     ` * Used to manually set the base path where assets can be found.`,
     ` * If the script is used as "module", it's recommended to use "import.meta.url",`,
     ` * such as "setAssetPath(import.meta.url)". Other options include`,

--- a/src/compiler/output-targets/dist-custom-elements/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements/index.ts
@@ -257,7 +257,7 @@ export const generateEntryPoint = (
 
   // Exports that are always present
   exports.push(
-    `export { setAssetPath, setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_CLIENT_ID}';`,
+    `export { getAssetPath, setAssetPath, setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_CLIENT_ID}';`,
     `export * from '${USER_INDEX_ENTRY_ID}';`,
   );
 

--- a/src/compiler/output-targets/test/custom-elements-types.spec.ts
+++ b/src/compiler/output-targets/test/custom-elements-types.spec.ts
@@ -81,6 +81,12 @@ describe('Custom Elements Typedef generation', () => {
         `export { MyBestComponent as MyBestComponent } from '../types_dir/components/the-other-component/my-real-best-component';`,
         `export { defineCustomElement as defineCustomElementMyBestComponent } from './my-best-component';`,
         '',
+        `/**`,
+        ` * Get the base path to where the assets can be found. Use "setAssetPath(path)"`,
+        ` * if the path needs to be customized.`,
+        ` */`,
+        `export declare const getAssetPath: (path: string) => string;`,
+        '',
         '/**',
         ' * Used to manually set the base path where assets can be found.',
         ' * If the script is used as "module", it\'s recommended to use "import.meta.url",',
@@ -128,6 +134,12 @@ describe('Custom Elements Typedef generation', () => {
         `export { defineCustomElement as defineCustomElementMyComponent } from './my-component';`,
         `export { MyBestComponent as MyBestComponent } from './types_dir/components/the-other-component/my-real-best-component';`,
         `export { defineCustomElement as defineCustomElementMyBestComponent } from './my-best-component';`,
+        '',
+        `/**`,
+        ` * Get the base path to where the assets can be found. Use "setAssetPath(path)"`,
+        ` * if the path needs to be customized.`,
+        ` */`,
+        `export declare const getAssetPath: (path: string) => string;`,
         '',
         '/**',
         ' * Used to manually set the base path where assets can be found.',
@@ -188,6 +200,12 @@ describe('Custom Elements Typedef generation', () => {
     await generateCustomElementsTypes(config, compilerCtx, buildCtx, 'types_dir');
 
     const expectedTypedefOutput = [
+      `/**`,
+      ` * Get the base path to where the assets can be found. Use "setAssetPath(path)"`,
+      ` * if the path needs to be customized.`,
+      ` */`,
+      `export declare const getAssetPath: (path: string) => string;`,
+      '',
       '/**',
       ' * Used to manually set the base path where assets can be found.',
       ' * If the script is used as "module", it\'s recommended to use "import.meta.url",',
@@ -244,6 +262,12 @@ describe('Custom Elements Typedef generation', () => {
     await generateCustomElementsTypes(config, compilerCtx, buildCtx, 'types_dir');
 
     const expectedTypedefOutput = [
+      `/**`,
+      ` * Get the base path to where the assets can be found. Use "setAssetPath(path)"`,
+      ` * if the path needs to be customized.`,
+      ` */`,
+      `export declare const getAssetPath: (path: string) => string;`,
+      '',
       '/**',
       ' * Used to manually set the base path where assets can be found.',
       ' * If the script is used as "module", it\'s recommended to use "import.meta.url",',

--- a/src/compiler/output-targets/test/output-targets-dist-custom-elements.spec.ts
+++ b/src/compiler/output-targets/test/output-targets-dist-custom-elements.spec.ts
@@ -72,7 +72,7 @@ describe('Custom Elements output target', () => {
       });
 
       expect(entryPoint).toEqual(`import { globalScripts } from '${STENCIL_APP_GLOBALS_ID}';
-export { setAssetPath, setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_CLIENT_ID}';
+export { getAssetPath, setAssetPath, setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_CLIENT_ID}';
 export * from '${USER_INDEX_ENTRY_ID}';
 
 globalScripts();
@@ -86,7 +86,7 @@ globalScripts();
       });
 
       expect(entryPoint)
-        .toEqual(`export { setAssetPath, setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_CLIENT_ID}';
+        .toEqual(`export { getAssetPath, setAssetPath, setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_CLIENT_ID}';
 export * from '${USER_INDEX_ENTRY_ID}';
 `);
     });
@@ -164,7 +164,7 @@ export * from '${USER_INDEX_ENTRY_ID}';
         addCustomElementInputs(buildCtx, bundleOptions, config.outputTargets[0] as OutputTargetDistCustomElements);
         expect(bundleOptions.loader['\0core']).toEqual(
           `import { globalScripts } from '${STENCIL_APP_GLOBALS_ID}';
-export { setAssetPath, setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_CLIENT_ID}';
+export { getAssetPath, setAssetPath, setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_CLIENT_ID}';
 export * from '${USER_INDEX_ENTRY_ID}';
 
 globalScripts();
@@ -197,7 +197,7 @@ globalScripts();
         addCustomElementInputs(buildCtx, bundleOptions, config.outputTargets[0] as OutputTargetDistCustomElements);
         expect(bundleOptions.loader['\0core']).toEqual(
           `import { globalScripts } from '${STENCIL_APP_GLOBALS_ID}';
-export { setAssetPath, setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_CLIENT_ID}';
+export { getAssetPath, setAssetPath, setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_CLIENT_ID}';
 export * from '${USER_INDEX_ENTRY_ID}';
 export { StubCmp, defineCustomElement as defineCustomElementStubCmp } from '\0StubCmp';
 export { MyBestComponent, defineCustomElement as defineCustomElementMyBestComponent } from '\0MyBestComponent';
@@ -224,7 +224,7 @@ globalScripts();
         addCustomElementInputs(buildCtx, bundleOptions, config.outputTargets[0] as OutputTargetDistCustomElements);
         expect(bundleOptions.loader['\0core']).toEqual(
           `import { globalScripts } from '${STENCIL_APP_GLOBALS_ID}';
-export { setAssetPath, setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_CLIENT_ID}';
+export { getAssetPath, setAssetPath, setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_CLIENT_ID}';
 export * from '${USER_INDEX_ENTRY_ID}';
 export { ComponentWithJsx, defineCustomElement as defineCustomElementComponentWithJsx } from '\0ComponentWithJsx';
 
@@ -259,7 +259,7 @@ globalScripts();
           `import { globalScripts } from '${STENCIL_APP_GLOBALS_ID}';
 import { StubCmp } from '\0StubCmp';
 import { MyBestComponent } from '\0MyBestComponent';
-export { setAssetPath, setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_CLIENT_ID}';
+export { getAssetPath, setAssetPath, setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_CLIENT_ID}';
 export * from '${USER_INDEX_ENTRY_ID}';
 
 globalScripts();


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`getAssetPath` is not exported from the generated `index.js` file for the `dist-custom-elements` build

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds `getAssetPath` to the generated export statement
- Add a function declaration for `getAssetPath` to the typedef file generation

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

**Automated testing**

Updated unit tests so `getAssetPath` is included in checked output string

**Manual testing**

1. Build, pack, & install this branch into a component starter
2. Run `npm run build`
3. Verify that the `export` statement in `dist/components/index.js` includes `getAssetPath`
4. Verify that there is a type declaration in `dist/components/index.d.ts` for `getAssetPath`

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
