### PR TITLE
fix(typings): add crossorigin html attr to img

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -971,6 +971,8 @@ export namespace JSXBase {
 
   export interface ImgHTMLAttributes<T> extends HTMLAttributes<T> {
     alt?: string;
+    crossOrigin?: string;
+    crossorigin?: string;
     decoding?: 'async' | 'auto' | 'sync';
     importance?: 'low' | 'auto' | 'high';
     height?: number | string;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #4685 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit adds the `crossorigin` html attribute for image tags (`img`) to stencil's public runtime typings. upon applying this commit, projects using stencil should be able to type the following in their `render` function and not receive a typing error:
```tsx
render() {
  return <img crossorigin="anonymous"></img>
}
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

A type error is shown in editors and the output of the build command in v4.0.4:
<img width="738" alt="Screenshot 2023-08-16 at 9 55 08 AM" src="https://github.com/ionic-team/stencil/assets/1930213/6975cda9-a616-45cc-9726-92c7f0c71c03">
```
stencil build --docs

[55:43.3]  @stencil/core
[55:43.4]  v4.0.4 🍧
[55:44.3]  build, img-test, prod mode, started ...
[55:44.3]  transpile started ...
[55:45.4]  transpile finished in 1.07 s

[ ERROR ]  TypeScript: src/components/my-component/my-component.tsx:32:14
           Type '{ crossorigin: string; }' is not assignable to type 'ImgHTMLAttributes<HTMLImageElement>'.Property
           'crossorigin' does not exist on type 'ImgHTMLAttributes<HTMLImageElement>'.

     L31:  <div>
     L32:    <img crossorigin=''></img>
     L33:    Hello, World! I'm {this.getText()}

[55:45.4]  build failed in 1.08 s
```

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
On applying this commit, no type errors are found:
<img width="327" alt="Screenshot 2023-08-16 at 9 54 27 AM" src="https://github.com/ionic-team/stencil/assets/1930213/2abb33dd-2776-4818-b815-7a132e8c7864">


## Other information

`crossorigin` is typed as a 'string' in that theoretically, anything can be put as a value for it. If anything other than 'anonymous' or 'use-credentials' is provided, the browser _should_ fall back to 'anonymous'. however, i don't think that enforcing that behavior is necessary/our role to do on the type-side of things
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
