### PR TITLE
chore(readme): fix discord badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@
   <a href="https://twitter.com/stenciljs">
     <img src="https://img.shields.io/badge/follow-%40stenciljs-1DA1F2?logo=twitter" alt="Follow @stenciljs">
   </a>
-  <a href="[https://ionic.link/discord](https://chat.stenciljs.com)">
+  <a href="https://chat.stenciljs.com">
     <img src="https://img.shields.io/discord/520266681499779082?color=7289DA&label=%23stencil&logo=discord&logoColor=white" alt="Official Ionic Discord" />
   </a>
 </p>


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
this commit fixes the discord badge. previously, it was not clickable/did not link properly to the stencil discord. instead, it opened the badge image in a new tab. now, clicking the badge should link to discord

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

- View the rich diff, click the badge
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
