### PR TITLE
chore(ci): create release pull requests

### DIFF
--- a/.github/workflows/create-production-pr.yml
+++ b/.github/workflows/create-production-pr.yml
@@ -1,4 +1,4 @@
-name: 'Stencil Release PR Creation'
+name: 'Stencil Production Release PR Creation'
 on:
   workflow_dispatch:
     inputs:
@@ -14,6 +14,14 @@ on:
           - patch
           - minor
           - major
+      base:
+        required: true
+        type: choice
+        description: Which base branch should be targeted?
+        default: main
+        options:
+          - main
+          - v3-maintenance
 
 jobs:
   create-stencil-release-pull-request:
@@ -33,10 +41,12 @@ jobs:
           # We need git history to generate the changelog; however, we don't know how deep to go.
           # Since publishing is a one-off activity, just get everything.
           fetch-depth: 0
+          ref: ${{ inputs.base }}
 
       - name: Get Core Dependencies
         uses: ./.github/workflows/actions/get-core-dependencies
 
+      # TODO(STENCIL-927): Backport changes to the v3 branch
       - name: Run Publish Preparation Script
         run: npm run release.ci.prepare -- --version ${{ inputs.version }} --any-branch
         shell: bash
@@ -59,23 +69,18 @@ jobs:
           echo Branch Name: ${{ steps.name_gen.outputs.BRANCH_NAME }}
         shell: bash
 
-      - name: Create Git Branch
-        # Note: We'll let GitHub clean up the branch for us (this is configured in the repo settings on GitHub)
-        run: git checkout -b ${{ steps.name_gen.outputs.BRANCH_NAME }}
-
-      # Commit the CHANGELOG.md, NOTICE.md, LICENSE.md, package.json, etc.
-      - name: Commit Release Preparations
-        run: |
-          git config user.name "Stencil Release Bot (on behalf of ${{ github.actor }})"
-          git config user.email "stencil-release-bot@ionic.io"
-          git add .
-          git commit -m "v${{ steps.name_gen.outputs.VERSION_STR }}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-
-      - name: Push Branch to GitHub
-        run: |
-          git push --set-upstream origin ${{ steps.name_gen.outputs.BRANCH_NAME }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create the Pull Request
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
+        with:
+          # create a new pull request using the specified base branch
+          base: ${{ inputs.base }}
+          # specifies the name of the branch to create off of the base branch
+          branch: '${{ steps.name_gen.outputs.BRANCH_NAME }}'
+          # TODO(STENCIL-928): Remove this once pipeline is 'ready'
+          draft: true
+          # create a commit message containing the semver version, prefixed with a 'v' - e.g. 'v4.1.0'
+          commit-message: 'v${{ steps.name_gen.outputs.VERSION_STR }}'
+          # set the title of the pull request, otherwise it'll default to generic message
+          title: 'Release v${{ steps.name_gen.outputs.VERSION_STR }}'
+          # the body of the pull request summary can be empty
+          body: ''

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,18 +6,27 @@ Manual releases should only be performed when there are extenuating circumstance
 
 ## Automated Releases
 
+⚠️ Do not run this workflow at this time ⚠️
+
+⚠️ It is currently not in a working state ⚠️
+
 1. Call a `code-freeze` in the Stencil team channel
 1. Check that [Stencil's Merge
    Queue](https://github.com/ionic-team/stencil/queue/) is empty (nothing is
    queued for merge).
-1. Run the [Stencil Production Release](https://github.com/ionic-team/stencil/actions/workflows/release-production.yml)
+1. Run the [Stencil Production Release PR Creation Workflow](https://github.com/ionic-team/stencil/actions/workflows/create-production-pr.yml)
 in GitHub
    1. Run the workflow from the `main` branch, _unless_ the release is for a previous major version of Stencil.
    In that scenario, select the `v#-maintenance` branch corresponding to the version of Stencil being released.
    For example, `v3-maintenance` to release a new version of Stencil v3.
    1. Stencil follows semantic versioning. Select the appropriate version from the dropdown for this release.
-   1. Stencil should be published under the `latest` tag, _unless_ the release is for a previous major version of
-   Stencil.
+   1. Hit "Run Workflow" and wait for a new pull request to be created.
+1. Open the pull request that was opened as a result of running the Stencil Production Release PR Creation Workflow.
+1. Complete the following (temporary) steps:
+   1. Close the pull request and reopen it. This allows actions that the team gates pull requests on to run.
+   1. Mark the pull request as ready for review.
+1. Ask the Stencil team for an approval on the PR
+1. Once approved, add it to the merge queue
 1. Proceed to the [Follow-Up section](#follow-up-steps) of this document to run manual follow-up tasks.
 
 ## Manual Releases


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit adds the initial workflow step to create a pull request using the action. it currently has a few limitations regarding access tokens, but is usable with a small workaround (noted in RELEASE.md)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

I ran the workflow per the instructions in `RELEASE.md`, whose results can be seen [here](https://github.com/ionic-team/stencil/actions/runs/5931698742).
[This created a PR](https://github.com/ionic-team/stencil/pull/4715), which I closed/re-opened to verify the workflows ran

## Other information

in that PR, you'll notice that some of the license text is removed. As far as I can tell, some of the TXT/MD files aren't getting picked up in GH Actions. I'm not sure if they're not there (I need to check), or if something else is awry. I'm also simultaneously trying to chase down what our actual license requirements are here. I think we'd be OK to merge this as-is, since we're still calling packages out and what their licenses are.

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
