### PR TITLE
refactor(compiler): add types for supported decorators

### DIFF
--- a/src/compiler/transformers/decorators-to-static/decorator-utils.ts
+++ b/src/compiler/transformers/decorators-to-static/decorator-utils.ts
@@ -1,6 +1,7 @@
 import ts from 'typescript';
 
 import { objectLiteralToObjectMap } from '../transform-utils';
+import { StencilDecorator } from './decorators-constants';
 
 export const getDeclarationParameters: GetDeclarationParameters = (decorator: ts.Decorator): any => {
   if (!ts.isCallExpression(decorator.expression)) {
@@ -28,7 +29,7 @@ const getDeclarationParameter = (arg: ts.Expression): any => {
  * @param propName the name of the decorator to match against
  * @returns true if the conditions above are both true, false otherwise
  */
-export const isDecoratorNamed = (propName: string) => {
+export const isDecoratorNamed = (propName: StencilDecorator) => {
   return (dec: ts.Decorator): boolean => {
     return ts.isCallExpression(dec.expression) && dec.expression.expression.getText() === propName;
   };

--- a/src/compiler/transformers/decorators-to-static/decorators-constants.ts
+++ b/src/compiler/transformers/decorators-to-static/decorators-constants.ts
@@ -1,17 +1,41 @@
 /**
+ * All the decorators supported by Stencil
+ */
+export const STENCIL_DECORATORS = [
+  'Component',
+  'Element',
+  'Event',
+  'Listen',
+  'Method',
+  'Prop',
+  'State',
+  'Watch',
+] as const;
+
+export type StencilDecorator = (typeof STENCIL_DECORATORS)[number];
+
+/**
  * Decorators on class declarations that we remove as part of the compilation
  * process
  */
-export const CLASS_DECORATORS_TO_REMOVE = ['Component'] as const;
+export const CLASS_DECORATORS_TO_REMOVE = ['Component'] as const satisfies readonly StencilDecorator[];
 
 /**
  * Decorators on class members that we remove as part of the compilation
  * process
  */
-export const MEMBER_DECORATORS_TO_REMOVE = ['Element', 'Event', 'Listen', 'Method', 'Prop', 'State', 'Watch'] as const;
+export const MEMBER_DECORATORS_TO_REMOVE = [
+  'Element',
+  'Event',
+  'Listen',
+  'Method',
+  'Prop',
+  'State',
+  'Watch',
+] as const satisfies readonly StencilDecorator[];
 
 /**
  * Decorators whose 'decorees' we need to rewrite during compilation from
  * class fields to instead initialize them in a constructor.
  */
-export const CONSTRUCTOR_DEFINED_MEMBER_DECORATORS = ['State', 'Prop'] as const;
+export const CONSTRUCTOR_DEFINED_MEMBER_DECORATORS = ['State', 'Prop'] as const satisfies readonly StencilDecorator[];


### PR DESCRIPTION
This adds a new `ReadonlyArray` called `STENCIL_DECORATORS` which holds a list of the named decorators supported in Stencil and also adds a new type derived from that value called `StencilDecorator`. This type is then used to annotate the `isDecoratorNamed` function as an additional guard against typos.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

## What is the new behavior?

This just adds some type-level assurance that when we're checking for decorator names we're not making any typos.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I don't think this should have any runtime impact, so if the test suite passes I think we should be good!
