### PR TITLE
docs(compiler): add JSDoc to `component-decorator.ts`

### DIFF
--- a/src/compiler/transformers/decorators-to-static/component-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/component-decorator.ts
@@ -6,6 +6,27 @@ import { convertValueToLiteral, createStaticGetter, retrieveTsDecorators } from 
 import { getDeclarationParameters } from './decorator-utils';
 import { styleToStatic } from './style-to-static';
 
+/**
+ * Perform code generation to create new class members for a Stencil component
+ * which will drive the runtime functionality specified by various options
+ * passed to the `@Component` decorator.
+ *
+ * Inputs are validated (@see {@link validateComponent}) before code generation
+ * is performed.
+ *
+ * **Note**: in this function and in functions that it calls the `newMembers`
+ * parameter is treated as an out parameter and mutated, with new class members
+ * added to it.
+ *
+ * @param config a user-supplied config
+ * @param typeChecker a TypeScript type checker instance
+ * @param diagnostics an array of diagnostics for surfacing errors and warnings
+ * @param cmpNode a TypeScript class declaration node corresponding to a
+ * Stencil component
+ * @param newMembers an out param to hold newly generated class members
+ * @param componentDecorator the TypeScript decorator node for the `@Component`
+ * decorator
+ */
 export const componentDecoratorToStatic = (
   config: d.Config,
   typeChecker: ts.TypeChecker,
@@ -46,13 +67,29 @@ export const componentDecoratorToStatic = (
   }
 };
 
+/**
+ * Perform validation on a Stencil component in preparation for some
+ * component-level code generation, checking that the class declaration node
+ * itself doesn't have any problems and that the options passed to the
+ * `@Component` decorator are valid.
+ *
+ * @param config a user-supplied config
+ * @param diagnostics an array of diagnostics for surfacing errors and warnings
+ * @param typeChecker a TypeScript type checker instance
+ * @param componentOptions the options passed to the `@Component` director
+ * @param cmpNode a TypeScript class declaration node corresponding to a
+ * Stencil component
+ * @param componentDecorator the TypeScript decorator node for the `@Component`
+ * decorator
+ * @returns whether or not the component is valid
+ */
 const validateComponent = (
   config: d.Config,
   diagnostics: d.Diagnostic[],
   typeChecker: ts.TypeChecker,
   componentOptions: d.ComponentOptions,
   cmpNode: ts.ClassDeclaration,
-  componentDecorator: ts.Node,
+  componentDecorator: ts.Decorator,
 ) => {
   const extendNode =
     cmpNode.heritageClauses && cmpNode.heritageClauses.find((c) => c.token === ts.SyntaxKind.ExtendsKeyword);
@@ -128,18 +165,29 @@ const validateComponent = (
   return true;
 };
 
-const findTagNode = (propName: string, node: ts.Node) => {
+/**
+ * Given a TypeScript Decorator node, try to find a property with a given name
+ * on an object possibly passed to it as an argument. If found, return the node
+ * to initialize the value, and if no such property is found return the
+ * decorator instead.
+ *
+ * @param propName the name of the argument to search for
+ * @param node the decorator node to search within
+ * @returns the initializer for the property (if found) or the decorator
+ */
+const findTagNode = (propName: string, node: ts.Decorator): ts.Decorator | ts.Expression => {
+  let out: ts.Decorator | ts.Expression = node;
+
   if (ts.isDecorator(node) && ts.isCallExpression(node.expression)) {
     const arg = node.expression.arguments[0];
     if (ts.isObjectLiteralExpression(arg)) {
-      arg.properties.forEach((p) => {
-        if (ts.isPropertyAssignment(p)) {
-          if (p.name.getText() === propName) {
-            node = p.initializer;
-          }
+      arg.properties.forEach((prop) => {
+        if (ts.isPropertyAssignment(prop) && prop.name.getText() === propName) {
+          out = prop.initializer;
         }
       });
     }
   }
-  return node;
+
+  return out;
 };


### PR DESCRIPTION
This adds JSDoc comments to functions responsible for transforming the `@Component` decorator to static which were previously undocumented. It also includes a few code changes to make it a bit more obvious what one function is doing (variable renames and the like).

## What is the current behavior?

These functions are just sitting there!

## What is the new behavior?

Just documenting a few functions!

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

The code changes are limited to renaming things and type-level changes, so I don't have too many concerns there.
