### PR TITLE
chore(tsconfig): add noUncheckedIndexedAccess option to tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitAny": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strictFunctionTypes": true,


### PR DESCRIPTION
This makes it so that if you access a property on an object which has an index type (like `Record<string, number>`) then the value of the property access will be `number | undefined` rather than just `number`. This makes property access safer by forcing you do handle the `undefined` case (although in our non-strictNullChecks world it won't matter much).

See the TypeScript docs here:
<https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess>

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
