### PR TITLE
chore(snc): fix errors stemming from `rollupToStencilSourceMap`

### DIFF
--- a/src/compiler/output-targets/dist-custom-elements/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements/index.ts
@@ -145,7 +145,7 @@ export const bundleCustomElements = async (
       const files = rollupOutput.output.map(async (bundle) => {
         if (bundle.type === 'chunk') {
           let code = bundle.code;
-          let sourceMap = rollupToStencilSourceMap(bundle.map);
+          let sourceMap = bundle.map ? rollupToStencilSourceMap(bundle.map) : undefined;
 
           const optimizeResults = await optimizeModule(config, compilerCtx, {
             input: code,

--- a/src/compiler/output-targets/dist-lazy/generate-lazy-module.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-lazy-module.ts
@@ -413,7 +413,7 @@ const convertChunk = async (
   const inlineHelpers = isBrowserBuild || !hasDependency(buildCtx, 'tslib');
   const optimizeResults = await optimizeModule(config, compilerCtx, {
     input: code,
-    sourceMap: sourceMap,
+    sourceMap,
     isCore,
     sourceTarget,
     inlineHelpers,
@@ -423,6 +423,9 @@ const convertChunk = async (
 
   if (typeof optimizeResults.output === 'string') {
     code = optimizeResults.output;
+  }
+
+  if (optimizeResults.sourceMap) {
     sourceMap = optimizeResults.sourceMap;
   }
   return { code, sourceMap };

--- a/src/utils/sourcemaps.ts
+++ b/src/utils/sourcemaps.ts
@@ -7,7 +7,10 @@ import type * as d from '../declarations';
  * @param rollupSourceMap the sourcemap to transform
  * @returns the transformed sourcemap
  */
-export const rollupToStencilSourceMap = (rollupSourceMap: RollupSourceMap | undefined): d.SourceMap => {
+export function rollupToStencilSourceMap(rollupSourceMap: null): null;
+export function rollupToStencilSourceMap(rollupSourceMap: undefined): null;
+export function rollupToStencilSourceMap(rollupSourceMap: RollupSourceMap): d.SourceMap;
+export function rollupToStencilSourceMap(rollupSourceMap: RollupSourceMap | undefined | null): d.SourceMap | null {
   if (!rollupSourceMap) {
     return null;
   }
@@ -19,8 +22,8 @@ export const rollupToStencilSourceMap = (rollupSourceMap: RollupSourceMap | unde
     sources: rollupSourceMap.sources,
     sourcesContent: rollupSourceMap.sourcesContent,
     version: rollupSourceMap.version,
-  };
-};
+  } satisfies d.SourceMap;
+}
 
 /**
  * A JavaScript formatted string used to link generated code back to the original. This string follows the guidelines

--- a/src/utils/test/sourcemaps.spec.ts
+++ b/src/utils/test/sourcemaps.spec.ts
@@ -32,7 +32,7 @@ describe('sourcemaps', () => {
         toUrl: () => 'stub',
       };
 
-      const stencilSourceMap: d.SourceMap = rollupToStencilSourceMap(rollupSourceMap);
+      const stencilSourceMap = rollupToStencilSourceMap(rollupSourceMap);
 
       const expectedSourceMap: d.SourceMap = {
         file: 'index.js',


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?

Typing is just a little bit insufficient here, we can clean it up!


## What is the new behavior?

I think this knocks down the SNC errors by just a few.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
