### PR TITLE
chore(snc): drop snc count for serialize-css

### DIFF
--- a/src/compiler/style/css-parser/serialize-css.ts
+++ b/src/compiler/style/css-parser/serialize-css.ts
@@ -272,10 +272,10 @@ const removeSelectorWhitespace = (selector: string) => {
   return rtn;
 };
 
-const removeMediaWhitespace = (media: string) => {
+const removeMediaWhitespace = (media: string | undefined) => {
   let rtn = '';
   let char = '';
-  media = media.trim();
+  media = media?.trim() ?? '';
 
   for (let i = 0, l = media.length; i < l; i++) {
     char = media[i];

--- a/src/compiler/style/css-parser/serialize-css.ts
+++ b/src/compiler/style/css-parser/serialize-css.ts
@@ -197,7 +197,7 @@ const serializeCssKeyframes = (opts: SerializeOpts, node: CssNode) => {
 };
 
 const serializeCssKeyframe = (opts: SerializeOpts, node: CssNode) => {
-  return node.values.join(',') + '{' + serializeCssMapVisit(opts, node.declarations) + '}';
+  return (node.values?.join(',') ?? '') + '{' + serializeCssMapVisit(opts, node.declarations) + '}';
 };
 
 const serializeCssFontFace = (opts: SerializeOpts, node: CssNode) => {
@@ -217,7 +217,7 @@ const serializeCssSupports = (opts: SerializeOpts, node: CssNode) => {
 };
 
 const serializeCssPage = (opts: SerializeOpts, node: CssNode) => {
-  const sel = node.selectors.join(', ');
+  const sel = node.selectors?.join(', ') ?? '';
   return '@page ' + sel + '{' + serializeCssMapVisit(opts, node.declarations) + '}';
 };
 

--- a/src/compiler/style/css-parser/serialize-css.ts
+++ b/src/compiler/style/css-parser/serialize-css.ts
@@ -35,7 +35,7 @@ const serializeCssVisitNode = (opts: SerializeOpts, node: CssNode, index: number
     return serializeCssRule(opts, node);
   }
   if (nodeType === CssNodeType.Comment) {
-    if (node.comment[0] === '!') {
+    if (node.comment?.[0] === '!') {
       return `/*${node.comment}*/`;
     } else {
       return '';

--- a/src/compiler/style/css-parser/serialize-css.ts
+++ b/src/compiler/style/css-parser/serialize-css.ts
@@ -230,7 +230,7 @@ const serializeCssDocument = (opts: SerializeOpts, node: CssNode) => {
   return doc + '{' + documentCss + '}';
 };
 
-const serializeCssMapVisit = (opts: SerializeOpts, nodes: CssNode[] | void) => {
+const serializeCssMapVisit = (opts: SerializeOpts, nodes: CssNode[] | undefined | null): string => {
   let rtn = '';
 
   if (nodes) {

--- a/src/compiler/style/css-parser/serialize-css.ts
+++ b/src/compiler/style/css-parser/serialize-css.ts
@@ -83,7 +83,7 @@ const serializeCssVisitNode = (opts: SerializeOpts, node: CssNode, index: number
 const serializeCssRule = (opts: SerializeOpts, node: CssNode) => {
   const decls = node.declarations;
   const usedSelectors = opts.usedSelectors;
-  const selectors = node.selectors.slice();
+  const selectors = node.selectors?.slice() ?? [];
 
   if (decls == null || decls.length === 0) {
     return '';
@@ -160,10 +160,12 @@ const serializeCssRule = (opts: SerializeOpts, node: CssNode) => {
 
   const cleanedSelectors: string[] = [];
   let cleanedSelector = '';
-  for (const selector of node.selectors) {
-    cleanedSelector = removeSelectorWhitespace(selector);
-    if (!cleanedSelectors.includes(cleanedSelector)) {
-      cleanedSelectors.push(cleanedSelector);
+  if (node.selectors) {
+    for (const selector of node.selectors) {
+      cleanedSelector = removeSelectorWhitespace(selector);
+      if (!cleanedSelectors.includes(cleanedSelector)) {
+        cleanedSelectors.push(cleanedSelector);
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the function signature of `serializeCssMapVisit` to
replace `void` as an argument type with `undefined | null`, which
matches that of a all other arguments provided to this function in its
actual usage

this commit also fixes cases where we did not handle possibly undefined variables correctly

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Tests continue to pass
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
