### PR TITLE
chore(snc): bring type of string props on `Diagnostic` inline with use

### DIFF
--- a/src/compiler/config/test/load-config.spec.ts
+++ b/src/compiler/config/test/load-config.spec.ts
@@ -114,14 +114,14 @@ describe('load config', () => {
       const loadedConfig = await loadConfig({ configPath: noTsConfigPath });
       expect(loadedConfig.diagnostics).toHaveLength(1);
       expect<d.Diagnostic>(loadedConfig.diagnostics[0]).toEqual({
-        absFilePath: null,
+        absFilePath: undefined,
         header: 'Missing tsconfig.json',
         level: 'error',
         lines: [],
         messageText: `Unable to load TypeScript config file. Please create a "tsconfig.json" file within the "./${path.dirname(
           noTsConfigPath,
         )}" directory.`,
-        relFilePath: null,
+        relFilePath: undefined,
         type: 'build',
       });
     });
@@ -132,14 +132,14 @@ describe('load config', () => {
       const loadConfigResults = await loadConfig();
       expect(loadConfigResults.diagnostics).toHaveLength(1);
       expect<d.Diagnostic>(loadConfigResults.diagnostics[0]).toEqual({
-        absFilePath: null,
+        absFilePath: undefined,
         header: 'Missing tsconfig.json',
         level: 'error',
         lines: [],
         messageText: expect.stringMatching(
           `Unable to load TypeScript config file. Please create a "tsconfig.json" file within the`,
         ),
-        relFilePath: null,
+        relFilePath: undefined,
         type: 'build',
       });
     });

--- a/src/compiler/config/test/validate-testing.spec.ts
+++ b/src/compiler/config/test/validate-testing.spec.ts
@@ -395,12 +395,12 @@ describe('validateTesting', () => {
       expect(config.testing.allowableMismatchedPixels).toBe(pixelCount);
       expect(diagnostics).toHaveLength(1);
       expect(diagnostics[0]).toEqual({
-        absFilePath: null,
+        absFilePath: undefined,
         header: 'Build Error',
         level: 'error',
         lines: [],
         messageText: 'allowableMismatchedPixels must be a value that is 0 or greater',
-        relFilePath: null,
+        relFilePath: undefined,
         type: 'build',
       });
     });
@@ -446,12 +446,12 @@ describe('validateTesting', () => {
         expect(config.testing.allowableMismatchedRatio).toBe(allowableMismatchedRatio);
         expect(diagnostics).toHaveLength(1);
         expect(diagnostics[0]).toEqual({
-          absFilePath: null,
+          absFilePath: undefined,
           header: 'Build Error',
           level: 'error',
           lines: [],
           messageText: 'allowableMismatchedRatio must be a value ranging from 0 to 1',
-          relFilePath: null,
+          relFilePath: undefined,
           type: 'build',
         });
       },
@@ -493,12 +493,12 @@ describe('validateTesting', () => {
         expect(config.testing.pixelmatchThreshold).toBe(pixelmatchThreshold);
         expect(diagnostics).toHaveLength(1);
         expect(diagnostics[0]).toEqual({
-          absFilePath: null,
+          absFilePath: undefined,
           header: 'Build Error',
           level: 'error',
           lines: [],
           messageText: 'pixelmatchThreshold must be a value ranging from 0 to 1',
-          relFilePath: null,
+          relFilePath: undefined,
           type: 'build',
         });
       },
@@ -700,12 +700,12 @@ describe('validateTesting', () => {
       expect(config.testing.waitBeforeScreenshot).toBe(waitBeforeScreenshot);
       expect(diagnostics).toHaveLength(1);
       expect(diagnostics[0]).toEqual({
-        absFilePath: null,
+        absFilePath: undefined,
         header: 'Build Error',
         level: 'error',
         lines: [],
         messageText: 'waitBeforeScreenshot must be a value that is 0 or greater',
-        relFilePath: null,
+        relFilePath: undefined,
         type: 'build',
       });
     });

--- a/src/compiler/optimize/minify-js.ts
+++ b/src/compiler/optimize/minify-js.ts
@@ -63,8 +63,8 @@ const loadMinifyJsDiagnostics = (sourceText: string, diagnostics: d.Diagnostic[]
     header: 'Minify JS',
     code: '',
     messageText: error.message,
-    absFilePath: null,
-    relFilePath: null,
+    absFilePath: undefined,
+    relFilePath: undefined,
     lines: [],
   };
 

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -2408,7 +2408,7 @@ export interface LoadConfigResults {
 }
 
 export interface Diagnostic {
-  absFilePath?: string | undefined | null;
+  absFilePath?: string | undefined;
   code?: string;
   columnNumber?: number | undefined;
   debugText?: string;
@@ -2418,7 +2418,7 @@ export interface Diagnostic {
   lineNumber?: number | undefined;
   lines: PrintLine[];
   messageText: string;
-  relFilePath?: string | undefined | null;
+  relFilePath?: string | undefined;
   type: string;
 }
 

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -2408,7 +2408,7 @@ export interface LoadConfigResults {
 }
 
 export interface Diagnostic {
-  absFilePath?: string | undefined;
+  absFilePath?: string | undefined | null;
   code?: string;
   columnNumber?: number | undefined;
   debugText?: string;
@@ -2418,7 +2418,7 @@ export interface Diagnostic {
   lineNumber?: number | undefined;
   lines: PrintLine[];
   messageText: string;
-  relFilePath?: string | undefined;
+  relFilePath?: string | undefined | null;
   type: string;
 }
 

--- a/src/dev-server/test/Diagnostic.stub.ts
+++ b/src/dev-server/test/Diagnostic.stub.ts
@@ -9,12 +9,12 @@ import * as d from '@stencil/core/declarations';
  */
 export const stubDiagnostic = (overrides: Partial<d.Diagnostic> = {}): d.Diagnostic => {
   const defaults: d.Diagnostic = {
-    absFilePath: null,
+    absFilePath: undefined,
     header: 'Mock Error',
     level: 'error',
     lines: [],
     messageText: 'mock error',
-    relFilePath: null,
+    relFilePath: undefined,
     type: 'mock',
   };
 

--- a/src/hydrate/platform/hydrate-app.ts
+++ b/src/hydrate/platform/hydrate-app.ts
@@ -263,8 +263,8 @@ function renderCatchError(opts: d.HydrateFactoryOptions, results: d.HydrateResul
     type: 'build',
     header: 'Hydrate Error',
     messageText: '',
-    relFilePath: null,
-    absFilePath: null,
+    relFilePath: undefined,
+    absFilePath: undefined,
     lines: [],
   };
 

--- a/src/hydrate/runner/render-utils.ts
+++ b/src/hydrate/runner/render-utils.ts
@@ -127,8 +127,8 @@ export function renderBuildDiagnostic(
     type: 'build',
     header: header,
     messageText: msg,
-    relFilePath: null,
-    absFilePath: null,
+    relFilePath: undefined,
+    absFilePath: undefined,
     lines: [],
   };
 

--- a/src/utils/logger/logger-rollup.ts
+++ b/src/utils/logger/logger-rollup.ts
@@ -20,8 +20,8 @@ export const loadRollupDiagnostics = (
     code: rollupError.code,
     header: `Rollup${formattedCode.length > 0 ? ': ' + formattedCode : ''}`,
     messageText: formattedCode,
-    relFilePath: null,
-    absFilePath: null,
+    relFilePath: undefined,
+    absFilePath: undefined,
     lines: [],
   };
 

--- a/src/utils/message-utils.ts
+++ b/src/utils/message-utils.ts
@@ -17,8 +17,8 @@ export const buildError = (diagnostics?: d.Diagnostic[]): d.Diagnostic => {
     type: 'build',
     header: 'Build Error',
     messageText: 'build error',
-    relFilePath: null,
-    absFilePath: null,
+    relFilePath: undefined,
+    absFilePath: undefined,
     lines: [],
   };
 
@@ -45,8 +45,6 @@ export const buildWarn = (diagnostics: d.Diagnostic[]): d.Diagnostic => {
     type: 'build',
     header: 'Build Warn',
     messageText: 'build warn',
-    relFilePath: null,
-    absFilePath: null,
     lines: [],
   };
 
@@ -144,8 +142,6 @@ export const catchError = (diagnostics: d.Diagnostic[], err: Error | null | unde
     type: 'build',
     header: 'Build Error',
     messageText: 'build error',
-    relFilePath: null,
-    absFilePath: null,
     lines: [],
   };
 

--- a/src/utils/test/message-utils.spec.ts
+++ b/src/utils/test/message-utils.spec.ts
@@ -12,8 +12,8 @@ describe('message-utils', () => {
           type: 'build',
           header: 'Build Error',
           messageText: 'build error',
-          relFilePath: null,
-          absFilePath: null,
+          relFilePath: undefined,
+          absFilePath: undefined,
           lines: [],
         });
       });
@@ -46,8 +46,8 @@ describe('message-utils', () => {
             type: 'build',
             header: 'Build Error',
             messageText: stackTrace,
-            relFilePath: null,
-            absFilePath: null,
+            relFilePath: undefined,
+            absFilePath: undefined,
             lines: [],
           });
         });
@@ -76,8 +76,8 @@ describe('message-utils', () => {
               type: 'build',
               header: 'Build Error',
               messageText: taskCanceledMessage,
-              relFilePath: null,
-              absFilePath: null,
+              relFilePath: undefined,
+              absFilePath: undefined,
               lines: [],
             });
           });
@@ -110,8 +110,8 @@ describe('message-utils', () => {
             type: 'build',
             header: 'Build Error',
             messageText: message,
-            relFilePath: null,
-            absFilePath: null,
+            relFilePath: undefined,
+            absFilePath: undefined,
             lines: [],
           });
         });
@@ -134,8 +134,8 @@ describe('message-utils', () => {
             type: 'build',
             header: 'Build Error',
             messageText: 'UNKNOWN ERROR',
-            relFilePath: null,
-            absFilePath: null,
+            relFilePath: undefined,
+            absFilePath: undefined,
             lines: [],
           });
         });
@@ -155,8 +155,8 @@ describe('message-utils', () => {
               type: 'build',
               header: 'Build Error',
               messageText: taskCanceledMessage,
-              relFilePath: null,
-              absFilePath: null,
+              relFilePath: undefined,
+              absFilePath: undefined,
               lines: [],
             });
           });
@@ -188,8 +188,8 @@ describe('message-utils', () => {
             type: 'build',
             header: 'Build Error',
             messageText: 'Error',
-            relFilePath: null,
-            absFilePath: null,
+            relFilePath: undefined,
+            absFilePath: undefined,
             lines: [],
           });
         });
@@ -216,8 +216,8 @@ describe('message-utils', () => {
           type: 'build',
           header: 'Build Error',
           messageText: message,
-          relFilePath: null,
-          absFilePath: null,
+          relFilePath: undefined,
+          absFilePath: undefined,
           lines: [],
         });
       });
@@ -239,8 +239,8 @@ describe('message-utils', () => {
           type: 'build',
           header: 'Build Error',
           messageText: 'UNKNOWN ERROR',
-          relFilePath: null,
-          absFilePath: null,
+          relFilePath: undefined,
+          absFilePath: undefined,
           lines: [],
         });
       });
@@ -256,8 +256,8 @@ describe('message-utils', () => {
             type: 'build',
             header: 'Build Error',
             messageText: taskCanceledMessage,
-            relFilePath: null,
-            absFilePath: null,
+            relFilePath: undefined,
+            absFilePath: undefined,
             lines: [],
           });
         });


### PR DESCRIPTION
This interface has two properties on it, `absFilePath` and `relFilePath`, which are habitually instantiated as `null` throughout the codebase but were previously typed `string | undefined`. This changes the type on the interface declaration to be `string | undefined | null` to match the interface to the usage.

This technically constitutes a breaking change, since it is modifying the type of a public interface, but in practice it should not be a problem since the type is just being widened (and widened to what it actually will be at runtime in a lot of cases).

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

A public interface is being changed. However, as the type is being widened, it shouldn't be possible for this to generate any new type errors for users, and in fact this change makes the type declaration more in line with the actual runtime type. Still, we may want to put this in a minor instead of a patch.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
