### PR TITLE
refactor(compiler): create type for static getters

### DIFF
--- a/src/compiler/transformers/decorators-to-static/decorators-constants.ts
+++ b/src/compiler/transformers/decorators-to-static/decorators-constants.ts
@@ -39,3 +39,31 @@ export const MEMBER_DECORATORS_TO_REMOVE = [
  * class fields to instead initialize them in a constructor.
  */
 export const CONSTRUCTOR_DEFINED_MEMBER_DECORATORS = ['State', 'Prop'] as const satisfies readonly StencilDecorator[];
+
+/**
+ * The names used for the static getters added to Stencil components when they
+ * are transformed to remove decorated properties.
+ */
+export const STATIC_GETTER_NAMES = [
+  'COMPILER_META',
+  'assetsDirs',
+  'cmpMeta',
+  'delegatesFocus',
+  'elementRef',
+  'encapsulation',
+  'events',
+  'is',
+  'listeners',
+  'methods',
+  'originalStyleUrls',
+  'properties',
+  'states',
+  'style',
+  'styleMode',
+  'styleUrl',
+  'styleUrls',
+  'styles',
+  'watchers',
+] as const;
+
+export type StencilStaticGetter = (typeof STATIC_GETTER_NAMES)[number];

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -2,7 +2,7 @@ import { augmentDiagnosticWithNode, buildError, normalizePath, readOnlyArrayHasS
 import ts from 'typescript';
 
 import type * as d from '../../declarations';
-import { MEMBER_DECORATORS_TO_REMOVE } from './decorators-to-static/decorators-constants';
+import { MEMBER_DECORATORS_TO_REMOVE, StencilStaticGetter } from './decorators-to-static/decorators-constants';
 import { addToLibrary, findTypeWithName, getHomeModule, getOriginalTypeName } from './type-library';
 
 export const getScriptTarget = () => {
@@ -156,7 +156,10 @@ const objectToObjectLiteral = (obj: { [key: string]: any }, refs: WeakSet<any>):
  * @param returnExpression a TypeScript AST node to return from the getter
  * @returns an AST node representing a getter
  */
-export const createStaticGetter = (propName: string, returnExpression: ts.Expression): ts.GetAccessorDeclaration => {
+export const createStaticGetter = (
+  propName: StencilStaticGetter,
+  returnExpression: ts.Expression,
+): ts.GetAccessorDeclaration => {
   return ts.factory.createGetAccessorDeclaration(
     [ts.factory.createToken(ts.SyntaxKind.StaticKeyword)],
     propName,


### PR DESCRIPTION
This is a small refactor which turns a `Set<string>` into a `ReadonlyArray<string>` and pushes a bit more information into the type system about how 'static getters' are created during the compilation process.

If you're unfamiliar with this, when Stencil is compiling a component it finds any properties which are decorated with our custom decorators (e.g. `@Prop` and so on) and transforms the TypeScript `ClassDeclaration` node to 1) remove the syntax nodes for the decorated property and 2) add a `static get () { ... }` member to the class.

These static getters are then used in various ways later in the compilation process. Generally the values stuck in them are parsed into the `ComponentCompilerMeta`, then the `dist-custom-elements` output target removes them entirely, and lazy-based builds (like `www`) use them at runtime.

Right now, unfortunately, these are somewhat stringly typed! Before this change we did not have a type-level assurance that the names being used for these static getters were consistent. This change moves the needle on this a bit, although it's possible that the new type (`StencilStaticGetter`) could be used more widely.

STENCIL-856

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

This is essentially a type-only change, with a very small change in runtime logic. I think if the project builds and the tests are passing we should be good.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
