### PR TITLE
fix(compiler): resolve implicit enum types

### DIFF
--- a/src/compiler/transformers/decorators-to-static/component-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/component-decorator.ts
@@ -109,7 +109,9 @@ const validateComponent = (
   if (!config._isTesting) {
     const nonTypeExports = typeChecker
       .getExportsOfModule(typeChecker.getSymbolAtLocation(cmpNode.getSourceFile()))
-      .filter((symbol) => (symbol.flags & (ts.SymbolFlags.Interface | ts.SymbolFlags.TypeAlias)) === 0)
+      .filter(
+        (symbol) => (symbol.flags & (ts.SymbolFlags.Interface | ts.SymbolFlags.TypeAlias | ts.SymbolFlags.Enum)) === 0,
+      )
       .filter((symbol) => symbol.name !== cmpNode.name.text);
 
     nonTypeExports.forEach((symbol) => {

--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -174,7 +174,21 @@ const getComplexType = (
   return {
     original: nodeType ? nodeType.getText() : typeToString(typeChecker, type),
     resolved: resolveType(typeChecker, type),
-    references: getAttributeTypeInfo(node, node.getSourceFile(), typeChecker, program),
+    references: getAttributeTypeInfo(
+      // If the node did not explicity have a type set (i.e. `name: string`), then
+      // we can generate a type node via the type checker to resolve references for inferred types.
+      //
+      // This is only a concern with non-primitive types such as a user-defined enum.
+      //
+      // For instance, a @Prop() defined as:
+      // @Prop() mode = ComponentModes.DEFAULT;
+      // Should be able to correctly infer the type to be `ComponentModes` and
+      // resolve the reference to this type for use in generated component type declarations.
+      nodeType ? node : typeChecker.typeToTypeNode(type, undefined, undefined),
+      node.getSourceFile(),
+      typeChecker,
+      program,
+    ),
   };
 };
 

--- a/src/compiler/transformers/test/parse-props.spec.ts
+++ b/src/compiler/transformers/test/parse-props.spec.ts
@@ -34,6 +34,41 @@ describe('parse props', () => {
     expect(t.cmp?.hasProp).toBe(true);
   });
 
+  it('should correctly parse a prop with an inferred enum type', () => {
+    const t = transpileModule(`
+    export enum Mode {
+      DEFAULT = 'default'
+    }
+    @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() val: Mode;
+      }
+    `);
+
+    // Using the `properties` array directly here since the `transpileModule`
+    // method doesn't like the top-level enum export with the current `target` and
+    // `module` values for the tsconfig
+    expect(t.properties[0]).toEqual({
+      name: 'val',
+      type: 'string',
+      attribute: 'val',
+      reflect: false,
+      mutable: false,
+      required: false,
+      optional: false,
+      defaultValue: undefined,
+      complexType: {
+        original: 'Mode',
+        resolved: 'Mode',
+        references: {
+          Mode: { location: 'local', path: 'module.tsx', id: 'module.tsx::Mode' },
+        },
+      },
+      docs: { tags: [], text: '' },
+      internal: false,
+    });
+  });
+
   it('should correctly parse a prop with an unresolved type', () => {
     const t = transpileModule(`
     @Component({tag: 'cmp-a'})

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -539,18 +539,17 @@ const getTypeReferenceLocation = (
   const isExported = sourceFile.statements.some((st) => {
     const statementModifiers = retrieveTsModifiers(st);
 
-    // Is the interface defined in the file and exported
-    const isInterfaceDeclarationExported =
-      ts.isInterfaceDeclaration(st) &&
-      (<ts.Identifier>st.name).getText() === typeName &&
+    const isDeclarationExported = (statement: ts.InterfaceDeclaration | ts.TypeAliasDeclaration | ts.EnumDeclaration) =>
+      (<ts.Identifier>statement.name).getText() === typeName &&
       Array.isArray(statementModifiers) &&
       statementModifiers.some((mod) => mod.kind === ts.SyntaxKind.ExportKeyword);
 
-    const isTypeAliasDeclarationExported =
-      ts.isTypeAliasDeclaration(st) &&
-      (<ts.Identifier>st.name).getText() === typeName &&
-      Array.isArray(statementModifiers) &&
-      statementModifiers.some((mod) => mod.kind === ts.SyntaxKind.ExportKeyword);
+    // Is the interface defined in the file and exported
+    const isInterfaceDeclarationExported = ts.isInterfaceDeclaration(st) && isDeclarationExported(st);
+
+    const isTypeAliasDeclarationExported = ts.isTypeAliasDeclaration(st) && isDeclarationExported(st);
+
+    const isEnumDeclarationExported = ts.isEnumDeclaration(st) && isDeclarationExported(st);
 
     // Is the interface exported through a named export
     const isTypeInExportDeclaration =
@@ -558,7 +557,12 @@ const getTypeReferenceLocation = (
       ts.isNamedExports(st.exportClause) &&
       st.exportClause.elements.some((nee) => nee.name.getText() === typeName);
 
-    return isInterfaceDeclarationExported || isTypeAliasDeclarationExported || isTypeInExportDeclaration;
+    return (
+      isInterfaceDeclarationExported ||
+      isTypeAliasDeclarationExported ||
+      isEnumDeclarationExported ||
+      isTypeInExportDeclaration
+    );
   });
 
   if (isExported) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Stencil will not resolve an implicit enum type on a `Prop()`:

```ts
export enum Mode {
  DEFAULT = 'default'
}

@Prop() mode = Mode.DEFAULT
```

would result in an `any` type used in the generated `components.d.ts` file(s).

GitHub Issue Number: Fixes #2243 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Stencil will now correctly infer the type for the enum so long as it is exported (either from a separate file, or the component file). 

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

**Automated tests**

Added a unit test for the case where an enum is exported from the component file that uses it. Testing the case where the type lives in a separate file is not possible with the current test setup and `transpileModule` methods.

**Manual tests**

Tested both cases for exported types in a component started. The generated `component.d.ts` files correctly imported and re-exported the referenced type.

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

There are still some use cases where Stencil will not correctly resolve types (inferred or not). The most prominent instance is if a type is not exported. In this case, the generated `components.d.ts` file will still show the type as `any`. This is because we would need to recursively resolve the string representation of the complex type. This is something we could add in the future, but was out of scope of this work.
