### PR TITLE
docs(compiler): add JSDoc for 'native-component' transformers

### DIFF
--- a/src/compiler/transformers/component-native/native-component.ts
+++ b/src/compiler/transformers/component-native/native-component.ts
@@ -13,6 +13,22 @@ import { addNativeElementGetter } from './native-element-getter';
 import { addNativeComponentMeta } from './native-meta';
 import { addNativeStaticStyle } from './native-static-style';
 
+/**
+ * Update a {@link ts.ClassDeclaration} which corresponds to a Stencil
+ * component to ensure that it will work as a standalone custom element in the
+ * browser (a 'native' web component).
+ *
+ * This involves ensuring that the class extends `HTMLElement`, ensuring that
+ * it has a constructor, adding a `connectedCallback` method, and a few things
+ * that are Stencil-specific implementation details.
+ *
+ * @param transformOpts options governing how Stencil components should be
+ * transformed
+ * @param classNode the class to transform
+ * @param moduleFile information about the class' home module
+ * @param cmp metadata about the stencil component of interest
+ * @returns an updated class
+ */
 export const updateNativeComponentClass = (
   transformOpts: d.TransformOptions,
   classNode: ts.ClassDeclaration,
@@ -25,7 +41,9 @@ export const updateNativeComponentClass = (
 };
 
 /**
- * Generate a heritage clause (e.g. `extends [IDENTIFIER]`) for a Stencil component to extend `HTMLElement`
+ * Update or generate a heritage clause (e.g. `extends [IDENTIFIER]`) for a
+ * Stencil component to extend `HTMLElement`
+ *
  * @param classNode the syntax tree of the Stencil component class to update
  * @param moduleFile the Stencil Module associated with the provided class node
  * @returns the generated heritage clause
@@ -51,6 +69,21 @@ const updateNativeHostComponentHeritageClauses = (
   return [heritageClause];
 };
 
+/**
+ * Perform various modifications to the class members of a Stencil component
+ * which are necessary for it to be a 'native' web component.
+ *
+ * This includes adding or updating the constructor, adding a
+ * `connectedCallback` method, implementing the `@Element` decorator, and
+ * adding static values for watchers.
+ *
+ * @param transformOpts options governing how Stencil components should be
+ * transformed
+ * @param classNode the class to transform
+ * @param moduleFile information about the class' home module
+ * @param cmp metadata about the stencil component of interest
+ * @returns an updated list of class elements
+ */
 const updateNativeHostComponentMembers = (
   transformOpts: d.TransformOptions,
   classNode: ts.ClassDeclaration,

--- a/src/compiler/transformers/component-native/native-connected-callback.ts
+++ b/src/compiler/transformers/component-native/native-connected-callback.ts
@@ -2,6 +2,15 @@ import ts from 'typescript';
 
 import type * as d from '../../../declarations';
 
+/**
+ * Add or update a `connectedCallback` method for a Stencil component
+ *
+ * *Note*: This function will mutate either the `classMembers` parameter or
+ * one of its members.
+ *
+ * @param classMembers the members on the component's class
+ * @param cmp metadata about the component
+ */
 export const addNativeConnectedCallback = (classMembers: ts.ClassElement[], cmp: d.ComponentCompilerMeta) => {
   // function call to stencil's exported connectedCallback(elm, plt)
 
@@ -18,7 +27,7 @@ export const addNativeConnectedCallback = (classMembers: ts.ClassElement[], cmp:
       ),
     );
     const connectedCallback = classMembers.find((classMember) => {
-      return ts.isMethodDeclaration(classMember) && (classMember.name as any).escapedText === 'connectedCallback';
+      return ts.isMethodDeclaration(classMember) && (classMember.name as any).escapedText === CONNECTED_CALLBACK;
     }) as ts.MethodDeclaration;
 
     if (connectedCallback != null) {
@@ -26,7 +35,7 @@ export const addNativeConnectedCallback = (classMembers: ts.ClassElement[], cmp:
       const callbackMethod = ts.factory.createMethodDeclaration(
         undefined,
         undefined,
-        'connectedCallback',
+        CONNECTED_CALLBACK,
         undefined,
         undefined,
         [],
@@ -40,7 +49,7 @@ export const addNativeConnectedCallback = (classMembers: ts.ClassElement[], cmp:
       const callbackMethod = ts.factory.createMethodDeclaration(
         undefined,
         undefined,
-        'connectedCallback',
+        CONNECTED_CALLBACK,
         undefined,
         undefined,
         [],
@@ -51,3 +60,5 @@ export const addNativeConnectedCallback = (classMembers: ts.ClassElement[], cmp:
     }
   }
 };
+
+const CONNECTED_CALLBACK = 'connectedCallback';

--- a/src/compiler/transformers/component-native/native-element-getter.ts
+++ b/src/compiler/transformers/component-native/native-element-getter.ts
@@ -2,6 +2,15 @@ import ts from 'typescript';
 
 import type * as d from '../../../declarations';
 
+/**
+ * Add a getter to a Stencil component class which returns the element's
+ * instance at runtime.
+ *
+ * *Note*: this will modify the `classMembers` param by adding a new element.
+ *
+ * @param classMembers members of the class in question
+ * @param cmp metadata about the stencil component of interest
+ */
 export const addNativeElementGetter = (classMembers: ts.ClassElement[], cmp: d.ComponentCompilerMeta) => {
   // @Element() element;
   // is transformed into:

--- a/src/compiler/transformers/component-native/tranform-to-native-component.ts
+++ b/src/compiler/transformers/component-native/tranform-to-native-component.ts
@@ -11,8 +11,12 @@ import { getComponentMeta, getModuleFromSourceFile } from '../transform-utils';
 import { updateNativeComponentClass } from './native-component';
 
 /**
- * A function that returns a transformation factory. The returned factory performs a series of transformations on
- * Stencil components, in order to generate 'native' web components.
+ * A function that returns a transformation factory. The returned factory
+ * performs a series of transformations on Stencil components, in order to
+ * generate 'native' web components, which is to say standalone custom elements
+ * that are defined by classes extending `HTMLElement` with a
+ * `connectedCallback` method and so on.
+ *
  * @param compilerCtx the current compiler context, which acts as the source of truth for the transformations
  * @param transformOpts the transformation configuration to use when performing the transformations
  * @returns a transformer factory, to be run by the TypeScript compiler

--- a/src/compiler/transformers/watcher-meta-transform.ts
+++ b/src/compiler/transformers/watcher-meta-transform.ts
@@ -3,6 +3,16 @@ import ts from 'typescript';
 import type * as d from '../../declarations';
 import { convertValueToLiteral, createStaticGetter } from './transform-utils';
 
+/**
+ * Add a getter to a class for a static representation of the watchers
+ * registered on the Stencil component.
+ *
+ * *Note*: this will conditionally mutate the `classMembers` param, adding a
+ * new element.
+ *
+ * @param classMembers a list of class members
+ * @param cmp metadata about the stencil component of interest
+ */
 export const addWatchers = (classMembers: ts.ClassElement[], cmp: d.ComponentCompilerMeta) => {
   if (cmp.watchers.length > 0) {
     const watcherObj: d.ComponentConstructorWatchers = {};


### PR DESCRIPTION
This adds JSDocs for several functions involved in the `native-component` transformer, which is used in the `dist-custom-elements` output target to transform Stencil components into standalone custom elements.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->