### PR TITLE
feat(compiler): computed properties can be used with Stencil decorators

### DIFF
--- a/src/compiler/transformers/decorators-to-static/component-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/component-decorator.ts
@@ -3,7 +3,7 @@ import ts from 'typescript';
 
 import type * as d from '../../../declarations';
 import { convertValueToLiteral, createStaticGetter, retrieveTsDecorators } from '../transform-utils';
-import { getDeclarationParameters } from './decorator-utils';
+import { getDecoratorParameters } from './decorator-utils';
 import { styleToStatic } from './style-to-static';
 
 /**
@@ -35,7 +35,7 @@ export const componentDecoratorToStatic = (
   newMembers: ts.ClassElement[],
   componentDecorator: ts.Decorator,
 ) => {
-  const [componentOptions] = getDeclarationParameters<d.ComponentOptions>(componentDecorator, typeChecker);
+  const [componentOptions] = getDecoratorParameters<d.ComponentOptions>(componentDecorator, typeChecker);
   if (!componentOptions) {
     return;
   }

--- a/src/compiler/transformers/decorators-to-static/component-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/component-decorator.ts
@@ -35,7 +35,7 @@ export const componentDecoratorToStatic = (
   newMembers: ts.ClassElement[],
   componentDecorator: ts.Decorator,
 ) => {
-  const [componentOptions] = getDeclarationParameters<d.ComponentOptions>(componentDecorator);
+  const [componentOptions] = getDeclarationParameters<d.ComponentOptions>(componentDecorator, typeChecker);
   if (!componentOptions) {
     return;
   }

--- a/src/compiler/transformers/decorators-to-static/convert-decorators.ts
+++ b/src/compiler/transformers/decorators-to-static/convert-decorators.ts
@@ -130,7 +130,7 @@ const visitClassDeclaration = (
   // We call the `handleClassFields` method which handles transforming any
   // class fields, removing them from the class and adding statements to the
   // class' constructor which instantiate them there instead.
-  const updatedClassFields = handleClassFields(classNode, filteredMethodsAndFields);
+  const updatedClassFields = handleClassFields(classNode, filteredMethodsAndFields, typeChecker);
 
   validateMethods(diagnostics, classMembers);
 
@@ -345,15 +345,20 @@ export const filterDecorators = (
  *
  * @param classNode a TypeScript AST node for a Stencil component class
  * @param classMembers the class members that we need to update
+ * @param typeChecker a reference to the {@link ts.TypeChecker}
  * @returns a list of updated class elements which can be inserted into the class
  */
-function handleClassFields(classNode: ts.ClassDeclaration, classMembers: ts.ClassElement[]): ts.ClassElement[] {
+function handleClassFields(
+  classNode: ts.ClassDeclaration,
+  classMembers: ts.ClassElement[],
+  typeChecker: ts.TypeChecker,
+): ts.ClassElement[] {
   const statements: ts.ExpressionStatement[] = [];
   const updatedClassMembers: ts.ClassElement[] = [];
 
   for (const member of classMembers) {
     if (shouldInitializeInConstructor(member) && ts.isPropertyDeclaration(member)) {
-      const memberName = tsPropDeclNameAsString(member);
+      const memberName = tsPropDeclNameAsString(member, typeChecker);
 
       // this is a class field that we'll need to handle, so lets push a statement for
       // initializing the value onto our statements list

--- a/src/compiler/transformers/decorators-to-static/convert-decorators.ts
+++ b/src/compiler/transformers/decorators-to-static/convert-decorators.ts
@@ -123,8 +123,8 @@ const visitClassDeclaration = (
       filteredMethodsAndFields,
     );
     elementDecoratorsToStatic(diagnostics, decoratedMembers, typeChecker, filteredMethodsAndFields);
-    watchDecoratorsToStatic(decoratedMembers, filteredMethodsAndFields);
-    listenDecoratorsToStatic(diagnostics, decoratedMembers, filteredMethodsAndFields);
+    watchDecoratorsToStatic(typeChecker, decoratedMembers, filteredMethodsAndFields);
+    listenDecoratorsToStatic(diagnostics, typeChecker, decoratedMembers, filteredMethodsAndFields);
   }
 
   // We call the `handleClassFields` method which handles transforming any

--- a/src/compiler/transformers/decorators-to-static/convert-decorators.ts
+++ b/src/compiler/transformers/decorators-to-static/convert-decorators.ts
@@ -111,7 +111,7 @@ const visitClassDeclaration = (
   // parse member decorators (Prop, State, Listen, Event, Method, Element and Watch)
   if (decoratedMembers.length > 0) {
     propDecoratorsToStatic(diagnostics, decoratedMembers, typeChecker, program, filteredMethodsAndFields);
-    stateDecoratorsToStatic(decoratedMembers, filteredMethodsAndFields);
+    stateDecoratorsToStatic(decoratedMembers, filteredMethodsAndFields, typeChecker);
     eventDecoratorsToStatic(diagnostics, decoratedMembers, typeChecker, program, filteredMethodsAndFields);
     methodDecoratorsToStatic(
       config,

--- a/src/compiler/transformers/decorators-to-static/decorator-utils.ts
+++ b/src/compiler/transformers/decorators-to-static/decorator-utils.ts
@@ -22,11 +22,10 @@ const getDecoratorParameter = (arg: ts.Expression, typeChecker: ts.TypeChecker):
     const type = typeChecker.getTypeAtLocation(arg);
     if (type !== undefined && type.isLiteral()) {
       /**
-       * Enum members are property access expressions, so we can evaluate them
-       * to get the enum member value as a string.
-       *
-       * This enables developers to use enum members in decorators.
-       * e.g. @Watch(MyEnum.VALUE)
+       * Using enums or variables require us to resolve the value for
+       * the computed property/identifier via the TS type checker. As long
+       * as the type resolves to a literal, we can grab its value to be used
+       * as the `@Watch()` decorator argument.
        */
       return type.value;
     }

--- a/src/compiler/transformers/decorators-to-static/decorator-utils.ts
+++ b/src/compiler/transformers/decorators-to-static/decorator-utils.ts
@@ -19,8 +19,8 @@ const getDeclarationParameter = (arg: ts.Expression, typeChecker: ts.TypeChecker
   } else if (ts.isStringLiteral(arg)) {
     return arg.text;
   } else if (ts.isPropertyAccessExpression(arg)) {
-    const symbol = typeChecker.getTypeAtLocation(arg);
-    if (symbol !== undefined && symbol.isLiteral()) {
+    const type = typeChecker.getTypeAtLocation(arg);
+    if (type !== undefined && type.isLiteral()) {
       /**
        * Enum members are property access expressions, so we can evaluate them
        * to get the enum member value as a string.
@@ -28,7 +28,7 @@ const getDeclarationParameter = (arg: ts.Expression, typeChecker: ts.TypeChecker
        * This enables developers to use enum members in decorators.
        * e.g. @Watch(MyEnum.VALUE)
        */
-      return symbol.value;
+      return type.value;
     }
   }
 

--- a/src/compiler/transformers/decorators-to-static/decorator-utils.ts
+++ b/src/compiler/transformers/decorators-to-static/decorator-utils.ts
@@ -18,7 +18,7 @@ const getDeclarationParameter = (arg: ts.Expression, typeChecker: ts.TypeChecker
     return objectLiteralToObjectMap(arg);
   } else if (ts.isStringLiteral(arg)) {
     return arg.text;
-  } else if (ts.isPropertyAccessExpression(arg)) {
+  } else if (ts.isPropertyAccessExpression(arg) || ts.isIdentifier(arg)) {
     const type = typeChecker.getTypeAtLocation(arg);
     if (type !== undefined && type.isLiteral()) {
       /**

--- a/src/compiler/transformers/decorators-to-static/decorator-utils.ts
+++ b/src/compiler/transformers/decorators-to-static/decorator-utils.ts
@@ -3,17 +3,17 @@ import ts from 'typescript';
 import { objectLiteralToObjectMap } from '../transform-utils';
 import type { StencilDecorator } from './decorators-constants';
 
-export const getDeclarationParameters: GetDeclarationParameters = (
+export const getDecoratorParameters: GetDecoratorParameters = (
   decorator: ts.Decorator,
   typeChecker: ts.TypeChecker,
 ): any => {
   if (!ts.isCallExpression(decorator.expression)) {
     return [];
   }
-  return decorator.expression.arguments.map((arg) => getDeclarationParameter(arg, typeChecker));
+  return decorator.expression.arguments.map((arg) => getDecoratorParameter(arg, typeChecker));
 };
 
-const getDeclarationParameter = (arg: ts.Expression, typeChecker: ts.TypeChecker): any => {
+const getDecoratorParameter = (arg: ts.Expression, typeChecker: ts.TypeChecker): any => {
   if (ts.isObjectLiteralExpression(arg)) {
     return objectLiteralToObjectMap(arg);
   } else if (ts.isStringLiteral(arg)) {
@@ -50,7 +50,7 @@ export const isDecoratorNamed = (propName: StencilDecorator) => {
   };
 };
 
-export interface GetDeclarationParameters {
+export interface GetDecoratorParameters {
   <T>(decorator: ts.Decorator, typeChecker: ts.TypeChecker): [T];
   <T, T1>(decorator: ts.Decorator, typeChecker: ts.TypeChecker): [T, T1];
   <T, T1, T2>(decorator: ts.Decorator, typeChecker: ts.TypeChecker): [T, T1, T2];

--- a/src/compiler/transformers/decorators-to-static/decorator-utils.ts
+++ b/src/compiler/transformers/decorators-to-static/decorator-utils.ts
@@ -15,6 +15,15 @@ const getDeclarationParameter = (arg: ts.Expression): any => {
     return objectLiteralToObjectMap(arg);
   } else if (ts.isStringLiteral(arg)) {
     return arg.text;
+  } else if (ts.isPropertyAccessExpression(arg)) {
+    /**
+     * Enum members are property access expressions, so we can evaluate them
+     * to get the enum member value as a string.
+     *
+     * This enables developers to use enum members in decorators.
+     * e.g. @Watch(MyEnum.VALUE)
+     */
+    return arg.name.getText();
   }
 
   throw new Error(`invalid decorator argument: ${arg.getText()}`);

--- a/src/compiler/transformers/decorators-to-static/event-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/event-decorator.ts
@@ -11,7 +11,7 @@ import {
   serializeSymbol,
   validateReferences,
 } from '../transform-utils';
-import { getDeclarationParameters, isDecoratorNamed } from './decorator-utils';
+import { getDecoratorParameters, isDecoratorNamed } from './decorator-utils';
 
 export const eventDecoratorsToStatic = (
   diagnostics: d.Diagnostic[],
@@ -58,7 +58,7 @@ const parseEventDecorator = (
     return null;
   }
 
-  const [eventOpts] = getDeclarationParameters<d.EventOptions>(eventDecorator, typeChecker);
+  const [eventOpts] = getDecoratorParameters<d.EventOptions>(eventDecorator, typeChecker);
   const symbol = typeChecker.getSymbolAtLocation(prop.name);
   const eventName = getEventName(eventOpts, memberName);
 

--- a/src/compiler/transformers/decorators-to-static/event-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/event-decorator.ts
@@ -58,7 +58,7 @@ const parseEventDecorator = (
     return null;
   }
 
-  const [eventOpts] = getDeclarationParameters<d.EventOptions>(eventDecorator);
+  const [eventOpts] = getDeclarationParameters<d.EventOptions>(eventDecorator, typeChecker);
   const symbol = typeChecker.getSymbolAtLocation(prop.name);
   const eventName = getEventName(eventOpts, memberName);
 

--- a/src/compiler/transformers/decorators-to-static/listen-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/listen-decorator.ts
@@ -3,7 +3,7 @@ import ts from 'typescript';
 
 import type * as d from '../../../declarations';
 import { convertValueToLiteral, createStaticGetter, retrieveTsDecorators } from '../transform-utils';
-import { getDeclarationParameters, isDecoratorNamed } from './decorator-utils';
+import { getDecoratorParameters, isDecoratorNamed } from './decorator-utils';
 
 export const listenDecoratorsToStatic = (
   diagnostics: d.Diagnostic[],
@@ -33,7 +33,7 @@ const parseListenDecorators = (
 
   return listenDecorators.map((listenDecorator) => {
     const methodName = method.name.getText();
-    const [listenText, listenOptions] = getDeclarationParameters<string, d.ListenOptions>(listenDecorator, typeChecker);
+    const [listenText, listenOptions] = getDecoratorParameters<string, d.ListenOptions>(listenDecorator, typeChecker);
 
     const eventNames = listenText.split(',');
     if (eventNames.length > 1) {

--- a/src/compiler/transformers/decorators-to-static/listen-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/listen-decorator.ts
@@ -7,12 +7,13 @@ import { getDeclarationParameters, isDecoratorNamed } from './decorator-utils';
 
 export const listenDecoratorsToStatic = (
   diagnostics: d.Diagnostic[],
+  typeChecker: ts.TypeChecker,
   decoratedMembers: ts.ClassElement[],
   newMembers: ts.ClassElement[],
 ) => {
   const listeners = decoratedMembers
     .filter(ts.isMethodDeclaration)
-    .map((method) => parseListenDecorators(diagnostics, method));
+    .map((method) => parseListenDecorators(diagnostics, typeChecker, method));
 
   const flatListeners = flatOne(listeners);
   if (flatListeners.length > 0) {
@@ -22,6 +23,7 @@ export const listenDecoratorsToStatic = (
 
 const parseListenDecorators = (
   diagnostics: d.Diagnostic[],
+  typeChecker: ts.TypeChecker,
   method: ts.MethodDeclaration,
 ): d.ComponentCompilerListener[] => {
   const listenDecorators = (retrieveTsDecorators(method) ?? []).filter(isDecoratorNamed('Listen'));
@@ -31,7 +33,7 @@ const parseListenDecorators = (
 
   return listenDecorators.map((listenDecorator) => {
     const methodName = method.name.getText();
-    const [listenText, listenOptions] = getDeclarationParameters<string, d.ListenOptions>(listenDecorator);
+    const [listenText, listenOptions] = getDeclarationParameters<string, d.ListenOptions>(listenDecorator, typeChecker);
 
     const eventNames = listenText.split(',');
     if (eventNames.length > 1) {

--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -69,7 +69,13 @@ const parsePropDecorator = (
   const decoratorParams = getDeclarationParameters<d.PropOptions>(propDecorator, typeChecker);
   const propOptions: d.PropOptions = decoratorParams[0] || {};
 
-  const propName = prop.name.getText();
+  let propName = prop.name.getText();
+  if (ts.isComputedPropertyName(prop.name)) {
+    const type = typeChecker.getTypeAtLocation(prop.name.expression);
+    if (type != null && type.isLiteral()) {
+      propName = type.value.toString();
+    }
+  }
 
   if (isMemberPrivate(prop)) {
     const err = buildError(diagnostics);

--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -12,6 +12,7 @@ import {
   retrieveTsDecorators,
   retrieveTsModifiers,
   serializeSymbol,
+  tsPropDeclNameAsString,
   typeToString,
   validateReferences,
 } from '../transform-utils';
@@ -69,13 +70,7 @@ const parsePropDecorator = (
   const decoratorParams = getDeclarationParameters<d.PropOptions>(propDecorator, typeChecker);
   const propOptions: d.PropOptions = decoratorParams[0] || {};
 
-  let propName = prop.name.getText();
-  if (ts.isComputedPropertyName(prop.name)) {
-    const type = typeChecker.getTypeAtLocation(prop.name.expression);
-    if (type != null && type.isLiteral()) {
-      propName = type.value.toString();
-    }
-  }
+  const propName = tsPropDeclNameAsString(prop, typeChecker);
 
   if (isMemberPrivate(prop)) {
     const err = buildError(diagnostics);

--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -66,7 +66,7 @@ const parsePropDecorator = (
     return null;
   }
 
-  const decoratorParams = getDeclarationParameters<d.PropOptions>(propDecorator);
+  const decoratorParams = getDeclarationParameters<d.PropOptions>(propDecorator, typeChecker);
   const propOptions: d.PropOptions = decoratorParams[0] || {};
 
   const propName = prop.name.getText();

--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -16,7 +16,7 @@ import {
   typeToString,
   validateReferences,
 } from '../transform-utils';
-import { getDeclarationParameters, isDecoratorNamed } from './decorator-utils';
+import { getDecoratorParameters, isDecoratorNamed } from './decorator-utils';
 
 /**
  * Parse a collection of class members decorated with `@Prop()`
@@ -67,7 +67,7 @@ const parsePropDecorator = (
     return null;
   }
 
-  const decoratorParams = getDeclarationParameters<d.PropOptions>(propDecorator, typeChecker);
+  const decoratorParams = getDecoratorParameters<d.PropOptions>(propDecorator, typeChecker);
   const propOptions: d.PropOptions = decoratorParams[0] || {};
 
   const propName = tsPropDeclNameAsString(prop, typeChecker);

--- a/src/compiler/transformers/decorators-to-static/state-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/state-decorator.ts
@@ -42,7 +42,10 @@ export const stateDecoratorsToStatic = (
  * @returns a property assignment AST Node which maps the name of the state
  * prop to an empty object
  */
-const stateDecoratorToStatic = (prop: ts.PropertyDeclaration, typeChecker: ts.TypeChecker): ts.PropertyAssignment | null => {
+const stateDecoratorToStatic = (
+  prop: ts.PropertyDeclaration,
+  typeChecker: ts.TypeChecker,
+): ts.PropertyAssignment | null => {
   const stateDecorator = retrieveTsDecorators(prop)?.find(isDecoratorNamed('State'));
   if (stateDecorator == null) {
     return null;

--- a/src/compiler/transformers/decorators-to-static/state-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/state-decorator.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
 
-import { createStaticGetter, retrieveTsDecorators } from '../transform-utils';
+import { createStaticGetter, retrieveTsDecorators, tsPropDeclNameAsString } from '../transform-utils';
 import { isDecoratorNamed } from './decorator-utils';
 
 /**
@@ -48,13 +48,7 @@ const stateDecoratorToStatic = (prop: ts.PropertyDeclaration, typeChecker: ts.Ty
     return null;
   }
 
-  let stateName = prop.name.getText();
-  if (ts.isComputedPropertyName(prop.name)) {
-    const type = typeChecker.getTypeAtLocation(prop.name.expression);
-    if (type != null && type.isLiteral()) {
-      stateName = type.value.toString();
-    }
-  }
+  const stateName = tsPropDeclNameAsString(prop, typeChecker);
 
   return ts.factory.createPropertyAssignment(
     ts.factory.createStringLiteral(stateName),

--- a/src/compiler/transformers/decorators-to-static/watch-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/watch-decorator.ts
@@ -3,7 +3,7 @@ import ts from 'typescript';
 
 import type * as d from '../../../declarations';
 import { convertValueToLiteral, createStaticGetter, retrieveTsDecorators } from '../transform-utils';
-import { getDeclarationParameters, isDecoratorNamed } from './decorator-utils';
+import { getDecoratorParameters, isDecoratorNamed } from './decorator-utils';
 
 export const watchDecoratorsToStatic = (
   typeChecker: ts.TypeChecker,

--- a/src/compiler/transformers/decorators-to-static/watch-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/watch-decorator.ts
@@ -5,8 +5,14 @@ import type * as d from '../../../declarations';
 import { convertValueToLiteral, createStaticGetter, retrieveTsDecorators } from '../transform-utils';
 import { getDeclarationParameters, isDecoratorNamed } from './decorator-utils';
 
-export const watchDecoratorsToStatic = (decoratedProps: ts.ClassElement[], newMembers: ts.ClassElement[]) => {
-  const watchers = decoratedProps.filter(ts.isMethodDeclaration).map(parseWatchDecorator);
+export const watchDecoratorsToStatic = (
+  typeChecker: ts.TypeChecker,
+  decoratedProps: ts.ClassElement[],
+  newMembers: ts.ClassElement[],
+) => {
+  const watchers = decoratedProps
+    .filter(ts.isMethodDeclaration)
+    .map((method) => parseWatchDecorator(typeChecker, method));
 
   const flatWatchers = flatOne(watchers);
 
@@ -15,12 +21,12 @@ export const watchDecoratorsToStatic = (decoratedProps: ts.ClassElement[], newMe
   }
 };
 
-const parseWatchDecorator = (method: ts.MethodDeclaration): d.ComponentCompilerWatch[] => {
+const parseWatchDecorator = (typeChecker: ts.TypeChecker, method: ts.MethodDeclaration): d.ComponentCompilerWatch[] => {
   const methodName = method.name.getText();
   const decorators = retrieveTsDecorators(method) ?? [];
   return decorators.filter(isDecoratorNamed('Watch')).map((decorator) => {
-    const [propName] = getDeclarationParameters<string>(decorator);
-
+    const [propName] = getDeclarationParameters<string>(decorator, typeChecker);
+    
     return {
       propName,
       methodName,

--- a/src/compiler/transformers/decorators-to-static/watch-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/watch-decorator.ts
@@ -25,8 +25,8 @@ const parseWatchDecorator = (typeChecker: ts.TypeChecker, method: ts.MethodDecla
   const methodName = method.name.getText();
   const decorators = retrieveTsDecorators(method) ?? [];
   return decorators.filter(isDecoratorNamed('Watch')).map((decorator) => {
-    const [propName] = getDeclarationParameters<string>(decorator, typeChecker);
-    
+    const [propName] = getDecoratorParameters<string>(decorator, typeChecker);
+
     return {
       propName,
       methodName,

--- a/src/compiler/transformers/test/convert-decorators.spec.ts
+++ b/src/compiler/transformers/test/convert-decorators.spec.ts
@@ -153,6 +153,40 @@ describe('convert-decorators', () => {
     );
   });
 
+  it('should get the correct literal for a computed property enum used for a `@State`', async () => {
+    const t = transpileModule(`
+      enum MyEnum {
+        MY_PROP = 'myVal'
+      }
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @State() [MyEnum.MY_PROP]: string;
+      }
+    `);
+
+    expect(t.states).toEqual([
+      {
+        name: 'myVal',
+      },
+    ]);
+  });
+
+  it('should get the correct literal for a computed property variable used for a `@State`', async () => {
+    const t = transpileModule(`
+      const tmp = 'myVal';
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @State() [tmp]: string;
+      }
+    `);
+
+    expect(t.states).toEqual([
+      {
+        name: 'myVal',
+      },
+    ]);
+  });
+
   it('should not add a constructor if no class fields are present', async () => {
     const t = transpileModule(`
     @Component({tag: 'cmp-a'})

--- a/src/compiler/transformers/test/convert-decorators.spec.ts
+++ b/src/compiler/transformers/test/convert-decorators.spec.ts
@@ -74,6 +74,60 @@ describe('convert-decorators', () => {
     );
   });
 
+  it('should get the correct literal for a computed property enum used for a `@Prop`', async () => {
+    const t = transpileModule(`
+      enum MyEnum {
+        MY_PROP = 'myVal'
+      }
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() [MyEnum.MY_PROP]: string;
+      }
+    `);
+
+    expect(t.properties).toEqual([
+      {
+        name: 'myVal',
+        type: 'string',
+        attribute: 'my-val',
+        reflect: false,
+        mutable: false,
+        required: false,
+        optional: false,
+        defaultValue: undefined,
+        complexType: { original: 'string', resolved: 'string', references: {} },
+        docs: { tags: [], text: '' },
+        internal: false,
+      },
+    ]);
+  });
+
+  it('should get the correct literal for a computed property variable used for a `@Prop`', async () => {
+    const t = transpileModule(`
+      const tmp = 'myVal';
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() [tmp]: string;
+      }
+    `);
+
+    expect(t.properties).toEqual([
+      {
+        name: 'myVal',
+        type: 'string',
+        attribute: 'my-val',
+        reflect: false,
+        mutable: false,
+        required: false,
+        optional: false,
+        defaultValue: undefined,
+        complexType: { original: 'string', resolved: 'string', references: {} },
+        docs: { tags: [], text: '' },
+        internal: false,
+      },
+    ]);
+  });
+
   it('should convert `@State` class fields to properties', async () => {
     const t = transpileModule(`
     @Component({tag: 'cmp-b'})

--- a/src/compiler/transformers/test/decorator-utils.spec.ts
+++ b/src/compiler/transformers/test/decorator-utils.spec.ts
@@ -1,0 +1,53 @@
+import { getDeclarationParameters } from '../decorators-to-static/decorator-utils';
+import ts from 'typescript';
+
+describe('decorator utils', () => {
+  describe('getDeclarationParameters', () => {
+    it('should return an empty array for decorator with no arguments', () => {
+      const decorator: ts.Decorator = {
+        expression: ts.factory.createIdentifier('DecoratorName'),
+      } as unknown as ts.Decorator;
+
+      const typeCheckerMock = {} as ts.TypeChecker;
+      const result = getDeclarationParameters(decorator, typeCheckerMock);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return correct parameters for decorator with multiple string arguments', () => {
+      const decorator: ts.Decorator = {
+        expression: ts.factory.createCallExpression(ts.factory.createIdentifier('DecoratorName'), undefined, [
+          ts.factory.createStringLiteral('arg1'),
+          ts.factory.createStringLiteral('arg2'),
+        ]),
+      } as unknown as ts.Decorator;
+
+      const typeCheckerMock = {} as ts.TypeChecker;
+      const result = getDeclarationParameters(decorator, typeCheckerMock);
+
+      expect(result).toEqual(['arg1', 'arg2']);
+    });
+
+    it('should return enum value for enum member used in decorator', () => {
+      const typeCheckerMock = {
+        getTypeAtLocation: jest.fn(() => ({
+          value: 'arg1',
+          isLiteral: () => true,
+        })),
+      } as unknown as ts.TypeChecker;
+
+      const decorator: ts.Decorator = {
+        expression: ts.factory.createCallExpression(ts.factory.createIdentifier('DecoratorName'), undefined, [
+          ts.factory.createPropertyAccessExpression(
+            ts.factory.createIdentifier('EnumName'),
+            ts.factory.createIdentifier('EnumMemberName'),
+          ),
+        ]),
+      } as unknown as ts.Decorator;
+
+      const result = getDeclarationParameters(decorator, typeCheckerMock);
+
+      expect(result).toEqual(['arg1']);
+    });
+  });
+});

--- a/src/compiler/transformers/test/decorator-utils.spec.ts
+++ b/src/compiler/transformers/test/decorator-utils.spec.ts
@@ -1,5 +1,6 @@
-import { getDeclarationParameters } from '../decorators-to-static/decorator-utils';
 import ts from 'typescript';
+
+import { getDeclarationParameters } from '../decorators-to-static/decorator-utils';
 
 describe('decorator utils', () => {
   describe('getDeclarationParameters', () => {

--- a/src/compiler/transformers/test/decorator-utils.spec.ts
+++ b/src/compiler/transformers/test/decorator-utils.spec.ts
@@ -1,16 +1,16 @@
 import ts from 'typescript';
 
-import { getDeclarationParameters } from '../decorators-to-static/decorator-utils';
+import { getDecoratorParameters } from '../decorators-to-static/decorator-utils';
 
 describe('decorator utils', () => {
-  describe('getDeclarationParameters', () => {
+  describe('getDecoratorParameters', () => {
     it('should return an empty array for decorator with no arguments', () => {
       const decorator: ts.Decorator = {
         expression: ts.factory.createIdentifier('DecoratorName'),
       } as unknown as ts.Decorator;
 
       const typeCheckerMock = {} as ts.TypeChecker;
-      const result = getDeclarationParameters(decorator, typeCheckerMock);
+      const result = getDecoratorParameters(decorator, typeCheckerMock);
 
       expect(result).toEqual([]);
     });
@@ -24,7 +24,7 @@ describe('decorator utils', () => {
       } as unknown as ts.Decorator;
 
       const typeCheckerMock = {} as ts.TypeChecker;
-      const result = getDeclarationParameters(decorator, typeCheckerMock);
+      const result = getDecoratorParameters(decorator, typeCheckerMock);
 
       expect(result).toEqual(['arg1', 'arg2']);
     });
@@ -46,7 +46,7 @@ describe('decorator utils', () => {
         ]),
       } as unknown as ts.Decorator;
 
-      const result = getDeclarationParameters(decorator, typeCheckerMock);
+      const result = getDecoratorParameters(decorator, typeCheckerMock);
 
       expect(result).toEqual(['arg1']);
     });

--- a/test/karma/test-app/components.d.ts
+++ b/test/karma/test-app/components.d.ts
@@ -58,6 +58,16 @@ export namespace Components {
     }
     interface CmpLabelWithSlotSibling {
     }
+    interface ComputedPropertiesPropDecorator {
+        "first": string;
+        "last": string;
+        "middle": string;
+    }
+    interface ComputedPropertiesPropDecoratorReflect {
+        "first": string;
+        "last": string;
+        "middle": string;
+    }
     interface ConditionalBasic {
     }
     interface ConditionalRerender {
@@ -451,6 +461,18 @@ declare global {
     var HTMLCmpLabelWithSlotSiblingElement: {
         prototype: HTMLCmpLabelWithSlotSiblingElement;
         new (): HTMLCmpLabelWithSlotSiblingElement;
+    };
+    interface HTMLComputedPropertiesPropDecoratorElement extends Components.ComputedPropertiesPropDecorator, HTMLStencilElement {
+    }
+    var HTMLComputedPropertiesPropDecoratorElement: {
+        prototype: HTMLComputedPropertiesPropDecoratorElement;
+        new (): HTMLComputedPropertiesPropDecoratorElement;
+    };
+    interface HTMLComputedPropertiesPropDecoratorReflectElement extends Components.ComputedPropertiesPropDecoratorReflect, HTMLStencilElement {
+    }
+    var HTMLComputedPropertiesPropDecoratorReflectElement: {
+        prototype: HTMLComputedPropertiesPropDecoratorReflectElement;
+        new (): HTMLComputedPropertiesPropDecoratorReflectElement;
     };
     interface HTMLConditionalBasicElement extends Components.ConditionalBasic, HTMLStencilElement {
     }
@@ -1204,6 +1226,8 @@ declare global {
         "child-with-reflection": HTMLChildWithReflectionElement;
         "cmp-label": HTMLCmpLabelElement;
         "cmp-label-with-slot-sibling": HTMLCmpLabelWithSlotSiblingElement;
+        "computed-properties-prop-decorator": HTMLComputedPropertiesPropDecoratorElement;
+        "computed-properties-prop-decorator-reflect": HTMLComputedPropertiesPropDecoratorReflectElement;
         "conditional-basic": HTMLConditionalBasicElement;
         "conditional-rerender": HTMLConditionalRerenderElement;
         "conditional-rerender-root": HTMLConditionalRerenderRootElement;
@@ -1375,6 +1399,16 @@ declare namespace LocalJSX {
     interface CmpLabel {
     }
     interface CmpLabelWithSlotSibling {
+    }
+    interface ComputedPropertiesPropDecorator {
+        "first"?: string;
+        "last"?: string;
+        "middle"?: string;
+    }
+    interface ComputedPropertiesPropDecoratorReflect {
+        "first"?: string;
+        "last"?: string;
+        "middle"?: string;
     }
     interface ConditionalBasic {
     }
@@ -1685,6 +1719,8 @@ declare namespace LocalJSX {
         "child-with-reflection": ChildWithReflection;
         "cmp-label": CmpLabel;
         "cmp-label-with-slot-sibling": CmpLabelWithSlotSibling;
+        "computed-properties-prop-decorator": ComputedPropertiesPropDecorator;
+        "computed-properties-prop-decorator-reflect": ComputedPropertiesPropDecoratorReflect;
         "conditional-basic": ConditionalBasic;
         "conditional-rerender": ConditionalRerender;
         "conditional-rerender-root": ConditionalRerenderRoot;
@@ -1827,6 +1863,8 @@ declare module "@stencil/core" {
             "child-with-reflection": LocalJSX.ChildWithReflection & JSXBase.HTMLAttributes<HTMLChildWithReflectionElement>;
             "cmp-label": LocalJSX.CmpLabel & JSXBase.HTMLAttributes<HTMLCmpLabelElement>;
             "cmp-label-with-slot-sibling": LocalJSX.CmpLabelWithSlotSibling & JSXBase.HTMLAttributes<HTMLCmpLabelWithSlotSiblingElement>;
+            "computed-properties-prop-decorator": LocalJSX.ComputedPropertiesPropDecorator & JSXBase.HTMLAttributes<HTMLComputedPropertiesPropDecoratorElement>;
+            "computed-properties-prop-decorator-reflect": LocalJSX.ComputedPropertiesPropDecoratorReflect & JSXBase.HTMLAttributes<HTMLComputedPropertiesPropDecoratorReflectElement>;
             "conditional-basic": LocalJSX.ConditionalBasic & JSXBase.HTMLAttributes<HTMLConditionalBasicElement>;
             "conditional-rerender": LocalJSX.ConditionalRerender & JSXBase.HTMLAttributes<HTMLConditionalRerenderElement>;
             "conditional-rerender-root": LocalJSX.ConditionalRerenderRoot & JSXBase.HTMLAttributes<HTMLConditionalRerenderRootElement>;

--- a/test/karma/test-app/components.d.ts
+++ b/test/karma/test-app/components.d.ts
@@ -71,6 +71,10 @@ export namespace Components {
     interface ComputedPropertiesStateDecorator {
         "changeStates": () => Promise<void>;
     }
+    interface ComputedPropertiesWatchDecorator {
+        "first": string;
+        "last": string;
+    }
     interface ConditionalBasic {
     }
     interface ConditionalRerender {
@@ -482,6 +486,12 @@ declare global {
     var HTMLComputedPropertiesStateDecoratorElement: {
         prototype: HTMLComputedPropertiesStateDecoratorElement;
         new (): HTMLComputedPropertiesStateDecoratorElement;
+    };
+    interface HTMLComputedPropertiesWatchDecoratorElement extends Components.ComputedPropertiesWatchDecorator, HTMLStencilElement {
+    }
+    var HTMLComputedPropertiesWatchDecoratorElement: {
+        prototype: HTMLComputedPropertiesWatchDecoratorElement;
+        new (): HTMLComputedPropertiesWatchDecoratorElement;
     };
     interface HTMLConditionalBasicElement extends Components.ConditionalBasic, HTMLStencilElement {
     }
@@ -1238,6 +1248,7 @@ declare global {
         "computed-properties-prop-decorator": HTMLComputedPropertiesPropDecoratorElement;
         "computed-properties-prop-decorator-reflect": HTMLComputedPropertiesPropDecoratorReflectElement;
         "computed-properties-state-decorator": HTMLComputedPropertiesStateDecoratorElement;
+        "computed-properties-watch-decorator": HTMLComputedPropertiesWatchDecoratorElement;
         "conditional-basic": HTMLConditionalBasicElement;
         "conditional-rerender": HTMLConditionalRerenderElement;
         "conditional-rerender-root": HTMLConditionalRerenderRootElement;
@@ -1421,6 +1432,10 @@ declare namespace LocalJSX {
         "middle"?: string;
     }
     interface ComputedPropertiesStateDecorator {
+    }
+    interface ComputedPropertiesWatchDecorator {
+        "first"?: string;
+        "last"?: string;
     }
     interface ConditionalBasic {
     }
@@ -1734,6 +1749,7 @@ declare namespace LocalJSX {
         "computed-properties-prop-decorator": ComputedPropertiesPropDecorator;
         "computed-properties-prop-decorator-reflect": ComputedPropertiesPropDecoratorReflect;
         "computed-properties-state-decorator": ComputedPropertiesStateDecorator;
+        "computed-properties-watch-decorator": ComputedPropertiesWatchDecorator;
         "conditional-basic": ConditionalBasic;
         "conditional-rerender": ConditionalRerender;
         "conditional-rerender-root": ConditionalRerenderRoot;
@@ -1879,6 +1895,7 @@ declare module "@stencil/core" {
             "computed-properties-prop-decorator": LocalJSX.ComputedPropertiesPropDecorator & JSXBase.HTMLAttributes<HTMLComputedPropertiesPropDecoratorElement>;
             "computed-properties-prop-decorator-reflect": LocalJSX.ComputedPropertiesPropDecoratorReflect & JSXBase.HTMLAttributes<HTMLComputedPropertiesPropDecoratorReflectElement>;
             "computed-properties-state-decorator": LocalJSX.ComputedPropertiesStateDecorator & JSXBase.HTMLAttributes<HTMLComputedPropertiesStateDecoratorElement>;
+            "computed-properties-watch-decorator": LocalJSX.ComputedPropertiesWatchDecorator & JSXBase.HTMLAttributes<HTMLComputedPropertiesWatchDecoratorElement>;
             "conditional-basic": LocalJSX.ConditionalBasic & JSXBase.HTMLAttributes<HTMLConditionalBasicElement>;
             "conditional-rerender": LocalJSX.ConditionalRerender & JSXBase.HTMLAttributes<HTMLConditionalRerenderElement>;
             "conditional-rerender-root": LocalJSX.ConditionalRerenderRoot & JSXBase.HTMLAttributes<HTMLConditionalRerenderRootElement>;

--- a/test/karma/test-app/components.d.ts
+++ b/test/karma/test-app/components.d.ts
@@ -68,6 +68,9 @@ export namespace Components {
         "last": string;
         "middle": string;
     }
+    interface ComputedPropertiesStateDecorator {
+        "changeStates": () => Promise<void>;
+    }
     interface ConditionalBasic {
     }
     interface ConditionalRerender {
@@ -473,6 +476,12 @@ declare global {
     var HTMLComputedPropertiesPropDecoratorReflectElement: {
         prototype: HTMLComputedPropertiesPropDecoratorReflectElement;
         new (): HTMLComputedPropertiesPropDecoratorReflectElement;
+    };
+    interface HTMLComputedPropertiesStateDecoratorElement extends Components.ComputedPropertiesStateDecorator, HTMLStencilElement {
+    }
+    var HTMLComputedPropertiesStateDecoratorElement: {
+        prototype: HTMLComputedPropertiesStateDecoratorElement;
+        new (): HTMLComputedPropertiesStateDecoratorElement;
     };
     interface HTMLConditionalBasicElement extends Components.ConditionalBasic, HTMLStencilElement {
     }
@@ -1228,6 +1237,7 @@ declare global {
         "cmp-label-with-slot-sibling": HTMLCmpLabelWithSlotSiblingElement;
         "computed-properties-prop-decorator": HTMLComputedPropertiesPropDecoratorElement;
         "computed-properties-prop-decorator-reflect": HTMLComputedPropertiesPropDecoratorReflectElement;
+        "computed-properties-state-decorator": HTMLComputedPropertiesStateDecoratorElement;
         "conditional-basic": HTMLConditionalBasicElement;
         "conditional-rerender": HTMLConditionalRerenderElement;
         "conditional-rerender-root": HTMLConditionalRerenderRootElement;
@@ -1409,6 +1419,8 @@ declare namespace LocalJSX {
         "first"?: string;
         "last"?: string;
         "middle"?: string;
+    }
+    interface ComputedPropertiesStateDecorator {
     }
     interface ConditionalBasic {
     }
@@ -1721,6 +1733,7 @@ declare namespace LocalJSX {
         "cmp-label-with-slot-sibling": CmpLabelWithSlotSibling;
         "computed-properties-prop-decorator": ComputedPropertiesPropDecorator;
         "computed-properties-prop-decorator-reflect": ComputedPropertiesPropDecoratorReflect;
+        "computed-properties-state-decorator": ComputedPropertiesStateDecorator;
         "conditional-basic": ConditionalBasic;
         "conditional-rerender": ConditionalRerender;
         "conditional-rerender-root": ConditionalRerenderRoot;
@@ -1865,6 +1878,7 @@ declare module "@stencil/core" {
             "cmp-label-with-slot-sibling": LocalJSX.CmpLabelWithSlotSibling & JSXBase.HTMLAttributes<HTMLCmpLabelWithSlotSiblingElement>;
             "computed-properties-prop-decorator": LocalJSX.ComputedPropertiesPropDecorator & JSXBase.HTMLAttributes<HTMLComputedPropertiesPropDecoratorElement>;
             "computed-properties-prop-decorator-reflect": LocalJSX.ComputedPropertiesPropDecoratorReflect & JSXBase.HTMLAttributes<HTMLComputedPropertiesPropDecoratorReflectElement>;
+            "computed-properties-state-decorator": LocalJSX.ComputedPropertiesStateDecorator & JSXBase.HTMLAttributes<HTMLComputedPropertiesStateDecoratorElement>;
             "conditional-basic": LocalJSX.ConditionalBasic & JSXBase.HTMLAttributes<HTMLConditionalBasicElement>;
             "conditional-rerender": LocalJSX.ConditionalRerender & JSXBase.HTMLAttributes<HTMLConditionalRerenderElement>;
             "conditional-rerender-root": LocalJSX.ConditionalRerenderRoot & JSXBase.HTMLAttributes<HTMLConditionalRerenderRootElement>;

--- a/test/karma/test-app/computed-properties-prop-decorator/cmp-reflect.tsx
+++ b/test/karma/test-app/computed-properties-prop-decorator/cmp-reflect.tsx
@@ -1,0 +1,37 @@
+import { Component, h, Prop } from '@stencil/core';
+
+enum Foo {
+  // names are explicitly different to ensure we aren't
+  // just resolving the declaration name.
+  BAR = 'first',
+  BAZ = 'middle',
+}
+
+const MyProp = 'last';
+
+@Component({
+  tag: 'computed-properties-prop-decorator-reflect',
+})
+export class ComputedPropertiesPropDecoratorReflect {
+  @Prop({
+    reflect: true,
+    attribute: 'first-name',
+  })
+  [Foo.BAR] = 'no';
+
+  @Prop() [Foo.BAZ]: string;
+
+  @Prop({
+    reflect: true,
+    attribute: 'last-name',
+  })
+  [MyProp] = 'content';
+
+  getText() {
+    return (this.first || '') + (this.middle ? ` ${this.middle}` : '') + (this.last ? ` ${this.last}` : '');
+  }
+
+  render() {
+    return <div>{this.getText()}</div>;
+  }
+}

--- a/test/karma/test-app/computed-properties-prop-decorator/cmp.tsx
+++ b/test/karma/test-app/computed-properties-prop-decorator/cmp.tsx
@@ -1,0 +1,29 @@
+import { Component, h, Prop } from '@stencil/core';
+
+enum Foo {
+  // names are explicitly different to ensure we aren't
+  // just resolving the declaration name.
+  BAR = 'first',
+  BAZ = 'middle',
+}
+
+const MyProp = 'last';
+
+@Component({
+  tag: 'computed-properties-prop-decorator',
+})
+export class ComputedPropertiesPropDecorator {
+  @Prop() [Foo.BAR] = 'no';
+
+  @Prop() [Foo.BAZ]: string;
+
+  @Prop() [MyProp] = 'content';
+
+  getText() {
+    return (this.first || '') + (this.middle ? ` ${this.middle}` : '') + (this.last ? ` ${this.last}` : '');
+  }
+
+  render() {
+    return <div>{this.getText()}</div>;
+  }
+}

--- a/test/karma/test-app/computed-properties-prop-decorator/index.html
+++ b/test/karma/test-app/computed-properties-prop-decorator/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset="utf8" />
+<script src="./build/testapp.esm.js" type="module"></script>
+<script src="./build/testapp.js" nomodule></script>
+
+<computed-properties-prop-decorator></computed-properties-prop-decorator>
+<computed-properties-prop-decorator-reflect></computed-properties-prop-decorator-reflect>
+
+<button type="button">Change prop values</button>
+
+<script>
+  document.querySelector('button').addEventListener('click', () => {
+    const cmp = document.querySelector('computed-properties-prop-decorator');
+    cmp.setAttribute('first', 'These');
+    cmp.setAttribute('middle', 'are');
+    cmp.setAttribute('last', 'my props');
+  });
+</script>

--- a/test/karma/test-app/computed-properties-prop-decorator/karma.spec.ts
+++ b/test/karma/test-app/computed-properties-prop-decorator/karma.spec.ts
@@ -1,0 +1,31 @@
+import { setupDomTests, waitForChanges } from '../util';
+
+describe('conditional-basic', function () {
+  const { setupDom, tearDownDom } = setupDomTests(document);
+  let app: HTMLElement;
+
+  beforeEach(async () => {
+    app = await setupDom('/computed-properties-prop-decorator/index.html');
+  });
+  afterEach(tearDownDom);
+
+  it('correctly sets computed property `@Prop()`s and triggers re-renders', async () => {
+    const el = app.querySelector('computed-properties-prop-decorator');
+    expect(el.textContent).toBe('no content');
+    const button = app.querySelector('button');
+    expect(button).toBeDefined();
+
+    button.click();
+    await waitForChanges();
+    expect(el.textContent).toBe('These are my props');
+  });
+
+  it('has the default value reflected to the correct attribute on the host', async () => {
+    const el = app.querySelector('computed-properties-prop-decorator-reflect');
+
+    const firstNameAttr = el.getAttribute('first-name');
+    expect(firstNameAttr).toEqual('no');
+    const lastNameAttr = el.getAttribute('last-name');
+    expect(lastNameAttr).toEqual('content');
+  });
+});

--- a/test/karma/test-app/computed-properties-prop-decorator/karma.spec.ts
+++ b/test/karma/test-app/computed-properties-prop-decorator/karma.spec.ts
@@ -1,6 +1,6 @@
 import { setupDomTests, waitForChanges } from '../util';
 
-describe('conditional-basic', function () {
+describe('computed-properties-peop-decorator', function () {
   const { setupDom, tearDownDom } = setupDomTests(document);
   let app: HTMLElement;
 

--- a/test/karma/test-app/computed-properties-prop-decorator/karma.spec.ts
+++ b/test/karma/test-app/computed-properties-prop-decorator/karma.spec.ts
@@ -1,6 +1,6 @@
 import { setupDomTests, waitForChanges } from '../util';
 
-describe('computed-properties-peop-decorator', function () {
+describe('computed-properties-prop-decorator', function () {
   const { setupDom, tearDownDom } = setupDomTests(document);
   let app: HTMLElement;
 

--- a/test/karma/test-app/computed-properties-state-decorator/cmp.tsx
+++ b/test/karma/test-app/computed-properties-state-decorator/cmp.tsx
@@ -1,0 +1,33 @@
+import { Component, h, Method, State } from '@stencil/core';
+
+enum Foo {
+  // names are explicitly different to ensure we aren't
+  // just resolving the declaration name.
+  BAR = 'rendered',
+}
+
+const MyProp = 'mode';
+
+@Component({
+  tag: 'computed-properties-state-decorator',
+})
+export class ComputedPropertiesStateDecorator {
+  @State() [Foo.BAR] = false;
+
+  @State() [MyProp] = 'default';
+
+  @Method()
+  async changeStates() {
+    this.rendered = true;
+    this.mode = 'super';
+  }
+
+  render() {
+    return (
+      <div>
+        <p>Has rendered: {this.rendered.toString()}</p>
+        <p>Mode: {this.mode}</p>
+      </div>
+    );
+  }
+}

--- a/test/karma/test-app/computed-properties-state-decorator/index.html
+++ b/test/karma/test-app/computed-properties-state-decorator/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset="utf8" />
+<script src="./build/testapp.esm.js" type="module"></script>
+<script src="./build/testapp.js" nomodule></script>
+
+<computed-properties-state-decorator></computed-properties-state-decorator>
+
+<button type="button">Change state values</button>
+
+<script>
+  document.querySelector('button').addEventListener('click', () => {
+    const cmp = document.querySelector('computed-properties-state-decorator');
+    cmp.changeStates();
+  });
+</script>

--- a/test/karma/test-app/computed-properties-state-decorator/karma.spec.ts
+++ b/test/karma/test-app/computed-properties-state-decorator/karma.spec.ts
@@ -1,0 +1,24 @@
+import { setupDomTests, waitForChanges } from '../util';
+
+describe('conditional-basic', function () {
+  const { setupDom, tearDownDom } = setupDomTests(document);
+  let app: HTMLElement;
+
+  beforeEach(async () => {
+    app = await setupDom('/computed-properties-state-decorator/index.html');
+  });
+  afterEach(tearDownDom);
+
+  it('correctly sets computed property `@State()`s and triggers re-renders', async () => {
+    const el = app.querySelector('computed-properties-state-decorator');
+    expect(el.innerText).toBe('Has rendered: false\n\nMode: default');
+
+    const button = app.querySelector('button');
+    expect(button).toBeDefined();
+
+    button.click();
+    await waitForChanges();
+
+    expect(el.innerText).toBe('Has rendered: true\n\nMode: super');
+  });
+});

--- a/test/karma/test-app/computed-properties-state-decorator/karma.spec.ts
+++ b/test/karma/test-app/computed-properties-state-decorator/karma.spec.ts
@@ -1,6 +1,6 @@
 import { setupDomTests, waitForChanges } from '../util';
 
-describe('conditional-basic', function () {
+describe('computed-properties-state-decorator', function () {
   const { setupDom, tearDownDom } = setupDomTests(document);
   let app: HTMLElement;
 

--- a/test/karma/test-app/computed-properties-watch-decorator/cmp.tsx
+++ b/test/karma/test-app/computed-properties-watch-decorator/cmp.tsx
@@ -1,0 +1,48 @@
+import { Component, h, Prop, Watch } from '@stencil/core';
+
+enum Foo {
+  // names are explicitly different to ensure we aren't
+  // just resolving the declaration name.
+  BAR = 'first',
+}
+
+const MyProp = 'last';
+
+@Component({
+  tag: 'computed-properties-watch-decorator',
+})
+export class ComputedPropertiesWatchDecorator {
+  @Prop() [Foo.BAR] = 'no';
+
+  @Prop() [MyProp] = 'content';
+
+  firstNameCalledWith: any;
+  lastNameCalledWith: any;
+
+  @Watch(Foo.BAR)
+  onFirstNameChange(newVal: string, oldVal: string, attrName: string) {
+    this.firstNameCalledWith = {
+      newVal,
+      oldVal,
+      attrName,
+    };
+  }
+
+  @Watch(MyProp)
+  onLastNameChange(newVal: string, oldVal: string, attrName: string) {
+    this.lastNameCalledWith = {
+      newVal,
+      oldVal,
+      attrName,
+    };
+  }
+
+  render() {
+    return (
+      <div>
+        <p>First name called with: {this.firstNameCalledWith ? JSON.stringify(this.firstNameCalledWith) : 'not yet'}</p>
+        <p>Last name called with: {this.lastNameCalledWith ? JSON.stringify(this.lastNameCalledWith) : 'not yet'}</p>
+      </div>
+    );
+  }
+}

--- a/test/karma/test-app/computed-properties-watch-decorator/index.html
+++ b/test/karma/test-app/computed-properties-watch-decorator/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset="utf8" />
+<script src="./build/testapp.esm.js" type="module"></script>
+<script src="./build/testapp.js" nomodule></script>
+
+<computed-properties-watch-decorator></computed-properties-watch-decorator>
+
+<button type="button">Trigger watch callbacks</button>
+
+<script>
+  document.querySelector('button').addEventListener('click', () => {
+    const cmp = document.querySelector('computed-properties-watch-decorator');
+    cmp.setAttribute('first', 'Bob');
+    cmp.setAttribute('last', 'Builder');
+  });
+</script>

--- a/test/karma/test-app/computed-properties-watch-decorator/karma.spec.ts
+++ b/test/karma/test-app/computed-properties-watch-decorator/karma.spec.ts
@@ -1,0 +1,38 @@
+import { setupDomTests, waitForChanges } from '../util';
+
+describe('computed-properties-watch-decorator', function () {
+  const { setupDom, tearDownDom } = setupDomTests(document);
+  let app: HTMLElement;
+
+  beforeEach(async () => {
+    app = await setupDom('/computed-properties-watch-decorator/index.html');
+  });
+  afterEach(tearDownDom);
+
+  it('triggers the watch callback when the associated prop changes', async () => {
+    const el = app.querySelector('computed-properties-watch-decorator');
+    expect(el.innerText).toBe('First name called with: not yet\n\nLast name called with: not yet');
+
+    const button = app.querySelector('button');
+    expect(button).toBeDefined();
+
+    button.click();
+    await waitForChanges();
+
+    const firstNameCalledWith = {
+      newVal: 'Bob',
+      oldVal: 'no',
+      attrName: 'first',
+    };
+    const lastNameCalledWith = {
+      newVal: 'Builder',
+      oldVal: 'content',
+      attrName: 'last',
+    };
+    expect(el.innerText).toBe(
+      `First name called with: ${JSON.stringify(firstNameCalledWith)}\n\nLast name called with: ${JSON.stringify(
+        lastNameCalledWith,
+      )}`,
+    );
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: Fixes #4350 

- Using computed property names is not valid for Stencil decorators. Trying something like:

```ts
enum MyEnum {
  first = 'first'
}

...

@Prop() [myEnum.first]: string;
```

Will result in the string `[myEnum.first]` being used as the prop name.

- Using computed values is not valid for Stencil decorator arguments. Trying something like:

```ts
enum MyEnum {
  first = 'first'
}

...

@Prop() first: string;

@Watch(MyEnum.first) 
firstChanged() { }
```

Will throw the following error:
> [ ERROR ]  invalid decorator argument: MyEnum.first at getDeclarationParameter

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Type checker looks up the symbol reference for a property access expression or computed property name to find the actual value.
- This allows any of the above examples to generate valid Stencil output

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Manual tested in a new Stencil project. 
- Created a new type for `MyEnum` based on the code snippet shared above
- Updated the `@Prop() first` decorator to `@Prop() [MyEnum.first]`
- Added a `@Watch` decorator to `MyComponent.tsx` 
- Logged the result in the callback
- Used a local dev build of Stencil with the modified change
- Verified log statement logs when watch callback fires
- Verified no exceptions from the compiler are thrown

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

