### PR TITLE
chore(snc): eliminate TS2774 errors

### DIFF
--- a/src/compiler/sys/stencil-sys.ts
+++ b/src/compiler/sys/stencil-sys.ts
@@ -51,7 +51,7 @@ export const createSystem = (c?: { logger?: Logger }): CompilerSystem => {
     destroys.forEach((cb) => {
       try {
         const rtn = cb();
-        if (rtn && rtn.then) {
+        if (rtn && typeof rtn.then === 'function') {
           waits.push(rtn);
         }
       } catch (e) {

--- a/src/sys/node/node-sys.ts
+++ b/src/sys/node/node-sys.ts
@@ -184,7 +184,7 @@ export function createNodeSys(c: { process?: any; logger?: Logger } = {}): Compi
       destroys.forEach((cb) => {
         try {
           const rtn = cb();
-          if (rtn && rtn.then) {
+          if (rtn && typeof rtn.then === 'function') {
             waits.push(rtn);
           }
         } catch (e) {


### PR DESCRIPTION
We had two occurrences of
[TS2774](https://github.com/microsoft/TypeScript/blob/512d6328e17c07a51fe07f58c332c0f51478447b/src/compiler/diagnosticMessages.json#L3390-L3393) in Stencil. This fixes them while adding a bit more assurance that things are the right "shape" at runtime.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
