### PR TITLE
feat(runtime): watch native HTML attributes

### DIFF
--- a/src/compiler/transformers/decorators-to-static/convert-decorators.ts
+++ b/src/compiler/transformers/decorators-to-static/convert-decorators.ts
@@ -119,7 +119,7 @@ const visitClassDeclaration = (
       filteredMethodsAndFields,
     );
     elementDecoratorsToStatic(diagnostics, decoratedMembers, typeChecker, filteredMethodsAndFields);
-    watchDecoratorsToStatic(config, diagnostics, decoratedMembers, watchable, filteredMethodsAndFields);
+    watchDecoratorsToStatic(decoratedMembers, filteredMethodsAndFields);
     listenDecoratorsToStatic(diagnostics, decoratedMembers, filteredMethodsAndFields);
   }
 

--- a/src/compiler/transformers/decorators-to-static/convert-decorators.ts
+++ b/src/compiler/transformers/decorators-to-static/convert-decorators.ts
@@ -103,11 +103,10 @@ const visitClassDeclaration = (
   componentDecoratorToStatic(config, typeChecker, diagnostics, classNode, filteredMethodsAndFields, componentDecorator);
 
   // stores a reference to fields that should be watched for changes
-  const watchable = new Set<string>();
   // parse member decorators (Prop, State, Listen, Event, Method, Element and Watch)
   if (decoratedMembers.length > 0) {
-    propDecoratorsToStatic(diagnostics, decoratedMembers, typeChecker, program, watchable, filteredMethodsAndFields);
-    stateDecoratorsToStatic(decoratedMembers, watchable, filteredMethodsAndFields);
+    propDecoratorsToStatic(diagnostics, decoratedMembers, typeChecker, program, filteredMethodsAndFields);
+    stateDecoratorsToStatic(decoratedMembers, filteredMethodsAndFields);
     eventDecoratorsToStatic(diagnostics, decoratedMembers, typeChecker, program, filteredMethodsAndFields);
     methodDecoratorsToStatic(
       config,

--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -26,7 +26,6 @@ import { getDeclarationParameters, isDecoratorNamed } from './decorator-utils';
  * Only those decorated with `@Prop()` will be parsed.
  * @param typeChecker a reference to the TypeScript type checker
  * @param program a {@link ts.Program} object
- * @param watchable a collection of class members that can be watched for changes using Stencil's `@Watch` decorator
  * @param newMembers a collection that parsed `@Prop` annotated class members should be pushed to as a side effect of
  * calling this function
  */
@@ -35,12 +34,11 @@ export const propDecoratorsToStatic = (
   decoratedProps: ts.ClassElement[],
   typeChecker: ts.TypeChecker,
   program: ts.Program,
-  watchable: Set<string>,
   newMembers: ts.ClassElement[],
 ): void => {
   const properties = decoratedProps
     .filter(ts.isPropertyDeclaration)
-    .map((prop) => parsePropDecorator(diagnostics, typeChecker, program, prop, watchable))
+    .map((prop) => parsePropDecorator(diagnostics, typeChecker, program, prop))
     .filter((prop): prop is ts.PropertyAssignment => prop != null);
 
   if (properties.length > 0) {
@@ -55,7 +53,6 @@ export const propDecoratorsToStatic = (
  * @param typeChecker a reference to the TypeScript type checker
  * @param program a {@link ts.Program} object
  * @param prop the TypeScript `PropertyDeclaration` to parse
- * @param watchable a collection of class members that can be watched for changes using Stencil's `@Watch` decorator
  * @returns a property assignment expression to be added to the Stencil component's class
  */
 const parsePropDecorator = (
@@ -63,7 +60,6 @@ const parsePropDecorator = (
   typeChecker: ts.TypeChecker,
   program: ts.Program,
   prop: ts.PropertyDeclaration,
-  watchable: Set<string>,
 ): ts.PropertyAssignment | null => {
   const propDecorator = retrieveTsDecorators(prop)?.find(isDecoratorNamed('Prop'));
   if (propDecorator == null) {
@@ -120,7 +116,7 @@ const parsePropDecorator = (
     ts.factory.createStringLiteral(propName),
     convertValueToLiteral(propMeta),
   );
-  watchable.add(propName);
+
   return staticProp;
 };
 

--- a/src/compiler/transformers/decorators-to-static/state-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/state-decorator.ts
@@ -11,17 +11,12 @@ import { isDecoratorNamed } from './decorator-utils';
  * with which they can be replaced.
  *
  * @param decoratedProps TypeScript AST nodes representing class members
- * @param watchable set of names of fields which should be watched for changes
  * @param newMembers an out param containing new class members
  */
-export const stateDecoratorsToStatic = (
-  decoratedProps: ts.ClassElement[],
-  watchable: Set<string>,
-  newMembers: ts.ClassElement[],
-) => {
+export const stateDecoratorsToStatic = (decoratedProps: ts.ClassElement[], newMembers: ts.ClassElement[]) => {
   const states = decoratedProps
     .filter(ts.isPropertyDeclaration)
-    .map((prop) => stateDecoratorToStatic(prop, watchable))
+    .map(stateDecoratorToStatic)
     .filter((state): state is ts.PropertyAssignment => !!state);
 
   if (states.length > 0) {
@@ -38,18 +33,17 @@ export const stateDecoratorsToStatic = (
  * decorated with other decorators.
  *
  * @param prop A TypeScript AST node representing a class property declaration
- * @param watchable set of names of fields which should be watched for changes
  * @returns a property assignment AST Node which maps the name of the state
  * prop to an empty object
  */
-const stateDecoratorToStatic = (prop: ts.PropertyDeclaration, watchable: Set<string>): ts.PropertyAssignment | null => {
+const stateDecoratorToStatic = (prop: ts.PropertyDeclaration): ts.PropertyAssignment | null => {
   const stateDecorator = retrieveTsDecorators(prop)?.find(isDecoratorNamed('State'));
   if (stateDecorator == null) {
     return null;
   }
 
   const stateName = prop.name.getText();
-  watchable.add(stateName);
+
   return ts.factory.createPropertyAssignment(
     ts.factory.createStringLiteral(stateName),
     ts.factory.createObjectLiteralExpression([], true),

--- a/src/compiler/transformers/decorators-to-static/watch-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/watch-decorator.ts
@@ -1,4 +1,4 @@
-import { augmentDiagnosticWithNode, buildError, buildWarn, flatOne } from '@utils';
+import { flatOne } from '@utils';
 import ts from 'typescript';
 
 import type * as d from '../../../declarations';
@@ -24,21 +24,16 @@ export const watchDecoratorsToStatic = (
 };
 
 const parseWatchDecorator = (
-  config: d.Config,
-  diagnostics: d.Diagnostic[],
-  watchable: Set<string>,
+  _config: d.Config,
+  _diagnostics: d.Diagnostic[],
+  _watchable: Set<string>,
   method: ts.MethodDeclaration,
 ): d.ComponentCompilerWatch[] => {
   const methodName = method.name.getText();
   const decorators = retrieveTsDecorators(method) ?? [];
   return decorators.filter(isDecoratorNamed('Watch')).map((decorator) => {
     const [propName] = getDeclarationParameters<string>(decorator);
-    if (!watchable.has(propName)) {
-      const diagnostic = config.devMode ? buildWarn(diagnostics) : buildError(diagnostics);
-      diagnostic.messageText = `@Watch('${propName}') is trying to watch for changes in a property that does not exist.
-        Make sure only properties decorated with @State() or @Prop() are watched.`;
-      augmentDiagnosticWithNode(diagnostic, decorator);
-    }
+
     return {
       propName,
       methodName,

--- a/src/compiler/transformers/decorators-to-static/watch-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/watch-decorator.ts
@@ -5,16 +5,8 @@ import type * as d from '../../../declarations';
 import { convertValueToLiteral, createStaticGetter, retrieveTsDecorators } from '../transform-utils';
 import { getDeclarationParameters, isDecoratorNamed } from './decorator-utils';
 
-export const watchDecoratorsToStatic = (
-  config: d.Config,
-  diagnostics: d.Diagnostic[],
-  decoratedProps: ts.ClassElement[],
-  watchable: Set<string>,
-  newMembers: ts.ClassElement[],
-) => {
-  const watchers = decoratedProps
-    .filter(ts.isMethodDeclaration)
-    .map((method) => parseWatchDecorator(config, diagnostics, watchable, method));
+export const watchDecoratorsToStatic = (decoratedProps: ts.ClassElement[], newMembers: ts.ClassElement[]) => {
+  const watchers = decoratedProps.filter(ts.isMethodDeclaration).map((method) => parseWatchDecorator(method));
 
   const flatWatchers = flatOne(watchers);
 
@@ -23,12 +15,7 @@ export const watchDecoratorsToStatic = (
   }
 };
 
-const parseWatchDecorator = (
-  _config: d.Config,
-  _diagnostics: d.Diagnostic[],
-  _watchable: Set<string>,
-  method: ts.MethodDeclaration,
-): d.ComponentCompilerWatch[] => {
+const parseWatchDecorator = (method: ts.MethodDeclaration): d.ComponentCompilerWatch[] => {
   const methodName = method.name.getText();
   const decorators = retrieveTsDecorators(method) ?? [];
   return decorators.filter(isDecoratorNamed('Watch')).map((decorator) => {

--- a/src/compiler/transformers/decorators-to-static/watch-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/watch-decorator.ts
@@ -6,7 +6,7 @@ import { convertValueToLiteral, createStaticGetter, retrieveTsDecorators } from 
 import { getDeclarationParameters, isDecoratorNamed } from './decorator-utils';
 
 export const watchDecoratorsToStatic = (decoratedProps: ts.ClassElement[], newMembers: ts.ClassElement[]) => {
-  const watchers = decoratedProps.filter(ts.isMethodDeclaration).map((method) => parseWatchDecorator(method));
+  const watchers = decoratedProps.filter(ts.isMethodDeclaration).map(parseWatchDecorator);
 
   const flatWatchers = flatOne(watchers);
 

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -1386,6 +1386,9 @@ export type ComponentRuntimeMetaCompact = [
 
   /** listeners */
   ComponentRuntimeHostListener[]?,
+
+  /** watchers */
+  ComponentConstructorWatchers?,
 ];
 
 /**

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -69,7 +69,7 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
         cmpMeta.$attrsToReflect$ = [];
       }
       if (BUILD.watchCallback) {
-        cmpMeta.$watchers$ = {};
+        cmpMeta.$watchers$ = compactMeta[4] ?? {};
       }
       if (BUILD.shadowDom && !supportsShadow && cmpMeta.$flags$ & CMP_FLAGS.shadowDomEncapsulation) {
         // TODO(STENCIL-854): Remove code related to legacy shadowDomShim field

--- a/src/runtime/proxy-component.ts
+++ b/src/runtime/proxy-component.ts
@@ -154,7 +154,7 @@ export const proxyComponent = (
               const entry = cmpMeta.$watchers$[attrName];
               entry?.forEach((callbackName) => {
                 if (instance[callbackName] != null) {
-                  instance[callbackName].call(this, newValue, oldValue, attrName);
+                  instance[callbackName].call(instance, newValue, oldValue, attrName);
                 }
               });
             }

--- a/src/runtime/proxy-component.ts
+++ b/src/runtime/proxy-component.ts
@@ -125,7 +125,6 @@ export const proxyComponent = (
           if (this.hasOwnProperty(propName)) {
             newValue = this[propName];
             delete this[propName];
-            this[propName] = newValue === null && typeof this[propName] === 'boolean' ? false : newValue;
           } else if (
             prototype.hasOwnProperty(propName) &&
             typeof this[propName] === 'number' &&
@@ -135,7 +134,7 @@ export const proxyComponent = (
             // APIs to reflect props as attributes. Calls to `setAttribute(someElement, propName)` will result in
             // `propName` to be converted to a `DOMString`, which may not be what we want for other primitive props.
             return;
-          } else {
+          } else if (propName == null) {
             // At this point we should know this is not a "member", so we can treat it like watching an attribute
             // on a vanilla web component
             const hostRef = getHostRef(this);
@@ -157,7 +156,11 @@ export const proxyComponent = (
                 }
               });
             }
+
+            return;
           }
+
+          this[propName] = newValue === null && typeof this[propName] === 'boolean' ? false : newValue;
         });
       };
 

--- a/src/runtime/proxy-component.ts
+++ b/src/runtime/proxy-component.ts
@@ -149,10 +149,12 @@ export const proxyComponent = (
               flags & HOST_FLAGS.isWatchReady &&
               newValue !== oldValue
             ) {
+              const elm = BUILD.lazyLoad ? hostRef.$hostElement$ : this;
+              const instance = BUILD.lazyLoad ? hostRef.$lazyInstance$ : (elm as any);
               const entry = cmpMeta.$watchers$[attrName];
               entry?.forEach((callbackName) => {
-                if (this[callbackName] != null) {
-                  this[callbackName].call(this, newValue, oldValue, attrName);
+                if (instance[callbackName] != null) {
+                  instance[callbackName].call(this, newValue, oldValue, attrName);
                 }
               });
             }

--- a/src/utils/format-component-runtime-meta.ts
+++ b/src/utils/format-component-runtime-meta.ts
@@ -58,6 +58,15 @@ export const stringifyRuntimeData = (data: any) => {
   return json;
 };
 
+/**
+ * Transforms Stencil compiler metadata into a {@link d.ComponentCompilerMeta} object.
+ * This handles processing any compiler metadata transformed from components' uses of `@Watch()`.
+ * The map of watched attributes to their callback(s) will be immediately available
+ * to the runtime at bootstrap.
+ *
+ * @param compilerMeta Component metadata gathered during compilation
+ * @returns An object mapping watched attributes to their respective callback(s)
+ */
 const formatComponentRuntimeWatchers = (compilerMeta: d.ComponentCompilerMeta) => {
   const watchers: d.ComponentConstructorWatchers = {};
 

--- a/src/utils/format-component-runtime-meta.ts
+++ b/src/utils/format-component-runtime-meta.ts
@@ -38,11 +38,13 @@ export const formatComponentRuntimeMeta = (
 
   const members = formatComponentRuntimeMembers(compilerMeta, includeMethods);
   const hostListeners = formatHostListeners(compilerMeta);
+  const watchers = formatComponentRuntimeWatchers(compilerMeta);
   return trimFalsy([
     flags,
     compilerMeta.tagName,
     Object.keys(members).length > 0 ? members : undefined,
     hostListeners.length > 0 ? hostListeners : undefined,
+    Object.keys(watchers).length > 0 ? watchers : undefined,
   ]);
 };
 
@@ -54,6 +56,16 @@ export const stringifyRuntimeData = (data: any) => {
     return `JSON.parse(${JSON.stringify(json)})`;
   }
   return json;
+};
+
+const formatComponentRuntimeWatchers = (compilerMeta: d.ComponentCompilerMeta) => {
+  const watchers: d.ComponentConstructorWatchers = {};
+
+  compilerMeta.watchers.forEach(({ propName, methodName }) => {
+    watchers[propName] = [...(watchers[propName] ?? []), methodName];
+  });
+
+  return watchers;
 };
 
 const formatComponentRuntimeMembers = (

--- a/test/karma/test-app/components.d.ts
+++ b/test/karma/test-app/components.d.ts
@@ -340,6 +340,8 @@ export namespace Components {
     }
     interface Tag88 {
     }
+    interface WatchNativeAttributes {
+    }
 }
 export interface EsmImportCustomEvent<T> extends CustomEvent<T> {
     detail: T;
@@ -1174,6 +1176,12 @@ declare global {
         prototype: HTMLTag88Element;
         new (): HTMLTag88Element;
     };
+    interface HTMLWatchNativeAttributesElement extends Components.WatchNativeAttributes, HTMLStencilElement {
+    }
+    var HTMLWatchNativeAttributesElement: {
+        prototype: HTMLWatchNativeAttributesElement;
+        new (): HTMLWatchNativeAttributesElement;
+    };
     interface HTMLElementTagNameMap {
         "append-child": HTMLAppendChildElement;
         "attribute-basic": HTMLAttributeBasicElement;
@@ -1309,6 +1317,7 @@ declare global {
         "svg-class": HTMLSvgClassElement;
         "tag-3d-component": HTMLTag3dComponentElement;
         "tag-88": HTMLTag88Element;
+        "watch-native-attributes": HTMLWatchNativeAttributesElement;
     }
 }
 declare namespace LocalJSX {
@@ -1649,6 +1658,8 @@ declare namespace LocalJSX {
     }
     interface Tag88 {
     }
+    interface WatchNativeAttributes {
+    }
     interface IntrinsicElements {
         "append-child": AppendChild;
         "attribute-basic": AttributeBasic;
@@ -1784,6 +1795,7 @@ declare namespace LocalJSX {
         "svg-class": SvgClass;
         "tag-3d-component": Tag3dComponent;
         "tag-88": Tag88;
+        "watch-native-attributes": WatchNativeAttributes;
     }
 }
 export { LocalJSX as JSX };
@@ -1924,6 +1936,7 @@ declare module "@stencil/core" {
             "svg-class": LocalJSX.SvgClass & JSXBase.HTMLAttributes<HTMLSvgClassElement>;
             "tag-3d-component": LocalJSX.Tag3dComponent & JSXBase.HTMLAttributes<HTMLTag3dComponentElement>;
             "tag-88": LocalJSX.Tag88 & JSXBase.HTMLAttributes<HTMLTag88Element>;
+            "watch-native-attributes": LocalJSX.WatchNativeAttributes & JSXBase.HTMLAttributes<HTMLWatchNativeAttributesElement>;
         }
     }
 }

--- a/test/karma/test-app/input-basic/karma.spec.ts
+++ b/test/karma/test-app/input-basic/karma.spec.ts
@@ -1,6 +1,6 @@
 import { setupDomTests, waitForChanges } from '../util';
 
-describe('attribute-basic', function () {
+describe('input-basic', function () {
   const { setupDom, tearDownDom } = setupDomTests(document);
   let app: HTMLElement;
 

--- a/test/karma/test-app/watch-native-attributes/cmp.tsx
+++ b/test/karma/test-app/watch-native-attributes/cmp.tsx
@@ -1,0 +1,22 @@
+import { Component, Element, h, State, Watch } from '@stencil/core';
+
+@Component({
+  tag: 'watch-native-attributes',
+})
+export class WatchNativeAttributes {
+  @Element() el!: HTMLElement;
+
+  @State() callbackTriggered = false;
+
+  @Watch('aria-label')
+  onAriaLabelChange() {
+    this.callbackTriggered = true;
+  }
+
+  render() {
+    return [
+      <p>Label: {this.el.getAttribute('aria-label')}</p>,
+      <p>Callback triggered: {`${this.callbackTriggered}`}</p>,
+    ];
+  }
+}

--- a/test/karma/test-app/watch-native-attributes/index.html
+++ b/test/karma/test-app/watch-native-attributes/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<meta charset="utf8" />
+<script src="./build/testapp.esm.js" type="module"></script>
+<script src="./build/testapp.js" nomodule></script>
+
+<watch-native-attributes aria-label="myStartingLabel"></watch-native-attributes>

--- a/test/karma/test-app/watch-native-attributes/karma.spec.ts
+++ b/test/karma/test-app/watch-native-attributes/karma.spec.ts
@@ -1,0 +1,21 @@
+import { setupDomTests, waitForChanges } from '../util';
+
+describe('watch native attributes', () => {
+  const { setupDom, tearDownDom } = setupDomTests(document);
+  let app: HTMLElement;
+
+  beforeEach(async () => {
+    app = await setupDom('/watch-native-attributes/index.html');
+  });
+  afterEach(tearDownDom);
+
+  it('triggers the callback for the watched attribute', async () => {
+    const cmp = app.querySelector('watch-native-attributes');
+    expect(cmp.innerText).toBe('Label: myStartingLabel\n\nCallback triggered: false');
+
+    cmp.setAttribute('aria-label', 'myNewLabel');
+    await waitForChanges();
+
+    expect(cmp.innerText).toBe('Label: myNewLabel\n\nCallback triggered: true');
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Stencil does not allow developers to watch native HTML attributes via the `@Watch()` decorator. So, syntax like the following is not valid:

```tsx
@Watch('aria-label')
onAriaLabelChange() {
  // do something
}
```

In fact, the compiler will throw an error if the string provided to the decorator is not a Stencil class "member" (state or prop).

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The `@Watch()` decorator can now be used with both Stencil class "member" (state or prop), as well as any native HTML attributes like aria attributes, `src`, etc.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

**Automated Tests**

All existing tests continue to pass and a new e2e test was added to test the behavior with a native attribute.

**Manual Tests**

I tested this with both lazy and custom-elements builds. A build of this commit can be used to test in a component starter for lazy builds. 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

The Framework team has asked for us to support this for some time.
