### PR TITLE
chore(snc): remove snc violation in message-utils test

### DIFF
--- a/src/utils/test/message-utils.spec.ts
+++ b/src/utils/test/message-utils.spec.ts
@@ -176,7 +176,8 @@ describe('message-utils', () => {
 
         beforeEach(() => {
           err = new Error();
-          err.message = undefined;
+          // this test explicitly checks for a bad value for the `message` property, hence the type assertion
+          err.message = undefined as unknown as string;
           err.stack = undefined;
         });
 


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit fixes a single strict null check violation for the message utils tests

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

N/A - the SNC no longer appears
## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
