### PR TITLE
refactor(compiler): create a util function for name of a property decl

### DIFF
--- a/src/compiler/transformers/decorators-to-static/convert-decorators.ts
+++ b/src/compiler/transformers/decorators-to-static/convert-decorators.ts
@@ -2,7 +2,12 @@ import { augmentDiagnosticWithNode, buildError } from '@utils';
 import ts from 'typescript';
 
 import type * as d from '../../../declarations';
-import { retrieveTsDecorators, retrieveTsModifiers, updateConstructor } from '../transform-utils';
+import {
+  retrieveTsDecorators,
+  retrieveTsModifiers,
+  tsPropDeclNameAsString,
+  updateConstructor,
+} from '../transform-utils';
 import { componentDecoratorToStatic } from './component-decorator';
 import { isDecoratorNamed } from './decorator-utils';
 import {
@@ -349,34 +354,7 @@ function handleClassFields(classNode: ts.ClassDeclaration, classMembers: ts.Clas
 
   for (const member of classMembers) {
     if (shouldInitializeInConstructor(member) && ts.isPropertyDeclaration(member)) {
-      const declarationName: ts.DeclarationName = ts.getNameOfDeclaration(member);
-
-      // The name of a class field declaration can be a computed property name,
-      // like so:
-      //
-      // ```ts
-      // const argName = "arghhh"
-      //
-      // class MyClass {
-      //   [argName] = "best property around";
-      // }
-      // ```
-      //
-      // In this case we need to get the expression which evaluates to some
-      // valid property name and call `.getText` on it. In the case that it's
-      // _not_ a computed property name, like
-      //
-      // ```ts
-      // class MyClass {
-      //   argName = "best property around";
-      // }
-      // ```
-      //
-      // we can just call `.getText` on the name itself.
-      const memberName =
-        declarationName.kind === ts.SyntaxKind.ComputedPropertyName
-          ? declarationName.expression.getText()
-          : declarationName.getText();
+      const memberName = tsPropDeclNameAsString(member);
 
       // this is a class field that we'll need to handle, so lets push a statement for
       // initializing the value onto our statements list

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -1046,3 +1046,41 @@ const createConstructorBodyWithSuper = (): ts.ExpressionStatement => {
     ts.factory.createCallExpression(ts.factory.createIdentifier('super'), undefined, undefined),
   );
 };
+
+/**
+ * Given a {@link ts.PropertyDeclaration} node get its name as a string
+ *
+ * @param node a property decl node
+ * @returns the name of the property in string form
+ */
+export const tsPropDeclNameAsString = (node: ts.PropertyDeclaration): string => {
+  const declarationName: ts.DeclarationName = ts.getNameOfDeclaration(node);
+
+  // The name of a class field declaration can be a computed property name,
+  // like so:
+  //
+  // ```ts
+  // const argName = "arghhh"
+  //
+  // class MyClass {
+  //   [argName] = "best property around";
+  // }
+  // ```
+  //
+  // In this case we need to get the expression which evaluates to some
+  // valid property name and call `.getText` on it. In the case that it's
+  // _not_ a computed property name, like
+  //
+  // ```ts
+  // class MyClass {
+  //   argName = "best property around";
+  // }
+  // ```
+  //
+  // we can just call `.getText` on the name itself.
+  const memberName =
+    declarationName.kind === ts.SyntaxKind.ComputedPropertyName
+      ? declarationName.expression.getText()
+      : declarationName.getText();
+  return memberName;
+};


### PR DESCRIPTION
Pull some code out of `convert-decorators.ts` into a helper function in our transformer utility module for getting the name of a property declaration as a string. If you had a class like this:

```ts
class {
  foo: "bar";
}
```

this utility would let you get the string `"foo"` given the TypeScript syntax tree node corresponding to the `foo: "bar";` line in the source.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
