### PR TITLE
doc(compiler): add JSDoc for the lazy component transformers

### DIFF
--- a/src/compiler/transformers/component-lazy/lazy-component.ts
+++ b/src/compiler/transformers/component-lazy/lazy-component.ts
@@ -9,24 +9,47 @@ import { addWatchers } from '../watcher-meta-transform';
 import { updateLazyComponentConstructor } from './lazy-constructor';
 import { addLazyElementGetter } from './lazy-element-getter';
 
+/**
+ * Update the class declaration node for a Stencil component in order to make
+ * it suitable for 'taking over' a bootstrapped lazy build. This involves making
+ * edits to the constructor, handling initialization code for various class
+ * members, and so on.
+ *
+ * @param transformOpts transform options
+ * @param styleStatements an out param for style-related statements
+ * @param classNode the class declaration node
+ * @param moduleFile information on the class' home module
+ * @param cmp metadata collected during the compilation process
+ * @returns the updated class
+ */
 export const updateLazyComponentClass = (
   transformOpts: d.TransformOptions,
   styleStatements: ts.Statement[],
   classNode: ts.ClassDeclaration,
   moduleFile: d.Module,
   cmp: d.ComponentCompilerMeta,
-) => {
+): ts.VariableStatement | ts.ClassDeclaration => {
   const members = updateLazyComponentMembers(transformOpts, styleStatements, classNode, moduleFile, cmp);
   return updateComponentClass(transformOpts, classNode, classNode.heritageClauses, members);
 };
 
+/**
+ * Handling updating the component's members for lazy-build duty.
+ *
+ * @param transformOpts transform options
+ * @param styleStatements an out param for style-related statements
+ * @param classNode the class declaration node
+ * @param moduleFile information on the class' home module
+ * @param cmp metadata collected during the compilation process
+ * @returns the updated class members
+ */
 const updateLazyComponentMembers = (
   transformOpts: d.TransformOptions,
   styleStatements: ts.Statement[],
   classNode: ts.ClassDeclaration,
   moduleFile: d.Module,
   cmp: d.ComponentCompilerMeta,
-) => {
+): ts.ClassElement[] => {
   const classMembers = removeStaticMetaProperties(classNode);
 
   updateLazyComponentConstructor(classMembers, moduleFile, cmp);

--- a/src/compiler/transformers/component-lazy/lazy-constructor.ts
+++ b/src/compiler/transformers/component-lazy/lazy-constructor.ts
@@ -5,6 +5,14 @@ import { addCoreRuntimeApi, REGISTER_INSTANCE, RUNTIME_APIS } from '../core-runt
 import { addCreateEvents } from '../create-event';
 import { retrieveTsModifiers } from '../transform-utils';
 
+/**
+ * Update the constructor for a Stencil component's class in order to prepare
+ * it for lazy-build duty (i.e. to take over a bootstrapped component)
+ *
+ * @param classMembers an out param of class members for the component
+ * @param moduleFile information about the component's home module
+ * @param cmp compiler metadata about the component
+ */
 export const updateLazyComponentConstructor = (
   classMembers: ts.ClassElement[],
   moduleFile: d.Module,
@@ -42,7 +50,18 @@ export const updateLazyComponentConstructor = (
   }
 };
 
-const registerInstanceStatement = (moduleFile: d.Module) => {
+/**
+ * Create a statement containing an expression calling the `registerInstance`
+ * helper with the {@link d.HostRef} argument passed to the lazy element
+ * constructor
+ *
+ * **NOTE** this mutates the `moduleFile` param to add an import of the
+ * `registerInstance` method from the Stencil core component runtime API.
+ *
+ * @param moduleFile information about a module containing a Stencil component
+ * @returns an expression statement for a call to the `registerInstance` helper
+ */
+const registerInstanceStatement = (moduleFile: d.Module): ts.ExpressionStatement => {
   addCoreRuntimeApi(moduleFile, RUNTIME_APIS.registerInstance);
 
   return ts.factory.createExpressionStatement(

--- a/src/compiler/transformers/component-lazy/lazy-element-getter.ts
+++ b/src/compiler/transformers/component-lazy/lazy-element-getter.ts
@@ -3,6 +3,14 @@ import ts from 'typescript';
 import type * as d from '../../../declarations';
 import { addCoreRuntimeApi, GET_ELEMENT, RUNTIME_APIS } from '../core-runtime-apis';
 
+/**
+ * If a Stencil component was declared with an `@Element` ref, transform the
+ * class to support this getter.
+ *
+ * @param classMembers an out param which holds class members for the component
+ * @param moduleFile information about the stencil component's home module
+ * @param cmp metadata gathered about the Stencil component during compilation
+ */
 export const addLazyElementGetter = (
   classMembers: ts.ClassElement[],
   moduleFile: d.Module,

--- a/src/compiler/transformers/component-lazy/transform-lazy-component.ts
+++ b/src/compiler/transformers/component-lazy/transform-lazy-component.ts
@@ -7,6 +7,19 @@ import { updateStyleImports } from '../style-imports';
 import { getComponentMeta, getModuleFromSourceFile } from '../transform-utils';
 import { updateLazyComponentClass } from './lazy-component';
 
+/**
+ * Return a transformer factory which transforms a Stencil component to make it
+ * suitable for 'taking over' a bootstrapped component in the lazy build.
+ *
+ * Note that this is an 'output target' level transformer, i.e. it is
+ * designed to be run on a Stencil component which has already undergone
+ * initial transformation (which handles things like converting decorators to
+ * static and so on).
+ *
+ * @param compilerCtx a Stencil compiler context object
+ * @param transformOpts transform options
+ * @returns a {@link ts.TransformerFactory} for carrying out necessary transformations
+ */
 export const lazyComponentTransform = (
   compilerCtx: d.CompilerCtx,
   transformOpts: d.TransformOptions,

--- a/src/compiler/transformers/component-native/tranform-to-native-component.ts
+++ b/src/compiler/transformers/component-native/tranform-to-native-component.ts
@@ -17,6 +17,12 @@ import { updateNativeComponentClass } from './native-component';
  * that are defined by classes extending `HTMLElement` with a
  * `connectedCallback` method and so on.
  *
+ * Note that this is an 'output target' level transformer, i.e. it is
+ * designed to be run on a Stencil component which has already undergone
+ * initial transformation (which handles things like converting decorators to
+ * static and so on).
+
+ *
  * @param compilerCtx the current compiler context, which acts as the source of truth for the transformations
  * @param transformOpts the transformation configuration to use when performing the transformations
  * @returns a transformer factory, to be run by the TypeScript compiler


### PR DESCRIPTION
Just adding some documentation about how the transformers in `src/compiler/transformers/component-lazy` work (and what they're supposed to do).


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
