### PR TITLE
fix(compiler): restrict config extras slot fix flags

### DIFF
--- a/src/compiler/app-core/app-data.ts
+++ b/src/compiler/app-core/app-data.ts
@@ -163,16 +163,17 @@ export const updateBuildConditionals = (config: ValidatedConfig, b: BuildConditi
   b.asyncLoading = !!(b.asyncLoading || b.lazyLoad || b.taskQueue || b.initializeNextTick);
   b.cssAnnotations = true;
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
-  b.appendChildSlotFix = config.extras.appendChildSlotFix;
+  b.appendChildSlotFix = config.extras.experimentalSlotFixes === true ? true : config.extras.appendChildSlotFix;
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
-  b.slotChildNodesFix = config.extras.slotChildNodesFix;
+  b.slotChildNodesFix = config.extras.experimentalSlotFixes === true ? true : config.extras.slotChildNodesFix;
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
   b.patchPseudoShadowDom = config.extras.experimentalSlotFixes;
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
-  b.cloneNodeFix = config.extras.cloneNodeFix;
+  b.cloneNodeFix = config.extras.experimentalSlotFixes === true ? true : config.extras.cloneNodeFix;
   b.lifecycleDOMEvents = !!(b.isDebug || config._isTesting || config.extras.lifecycleDOMEvents);
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
-  b.scopedSlotTextContentFix = !!config.extras.scopedSlotTextContentFix;
+  b.scopedSlotTextContentFix =
+    config.extras.experimentalSlotFixes === true ? true : config.extras.scopedSlotTextContentFix;
   b.scriptDataOpts = config.extras.scriptDataOpts;
   b.attachStyles = true;
   b.invisiblePrehydration = typeof config.invisiblePrehydration === 'undefined' ? true : config.invisiblePrehydration;

--- a/src/compiler/app-core/app-data.ts
+++ b/src/compiler/app-core/app-data.ts
@@ -163,17 +163,16 @@ export const updateBuildConditionals = (config: ValidatedConfig, b: BuildConditi
   b.asyncLoading = !!(b.asyncLoading || b.lazyLoad || b.taskQueue || b.initializeNextTick);
   b.cssAnnotations = true;
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
-  b.appendChildSlotFix = config.extras.experimentalSlotFixes === true ? true : config.extras.appendChildSlotFix;
+  b.appendChildSlotFix = config.extras.appendChildSlotFix;
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
-  b.slotChildNodesFix = config.extras.experimentalSlotFixes === true ? true : config.extras.slotChildNodesFix;
+  b.slotChildNodesFix = config.extras.slotChildNodesFix;
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
   b.patchPseudoShadowDom = config.extras.experimentalSlotFixes;
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
-  b.cloneNodeFix = config.extras.experimentalSlotFixes === true ? true : config.extras.cloneNodeFix;
+  b.cloneNodeFix = config.extras.cloneNodeFix;
   b.lifecycleDOMEvents = !!(b.isDebug || config._isTesting || config.extras.lifecycleDOMEvents);
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
-  b.scopedSlotTextContentFix =
-    config.extras.experimentalSlotFixes === true ? true : config.extras.scopedSlotTextContentFix;
+  b.scopedSlotTextContentFix = !!config.extras.scopedSlotTextContentFix;
   b.scriptDataOpts = config.extras.scriptDataOpts;
   b.attachStyles = true;
   b.invisiblePrehydration = typeof config.invisiblePrehydration === 'undefined' ? true : config.invisiblePrehydration;

--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -385,16 +385,28 @@ describe('validation', () => {
 
   it('should set extras defaults', () => {
     const { config } = validateConfig(userConfig, bootstrapConfig);
-    expect(config.extras.experimentalSlotFixes).toBe(false);
-    expect((config.extras as any).cloneNodeFix).toBe(false);
+    expect(config.extras.appendChildSlotFix).toBe(false);
+    expect(config.extras.cloneNodeFix).toBe(false);
     expect(config.extras.lifecycleDOMEvents).toBe(false);
     expect(config.extras.scriptDataOpts).toBe(false);
-    expect((config.extras as any).slotChildNodesFix).toBe(false);
+    expect(config.extras.slotChildNodesFix).toBe(false);
     expect(config.extras.initializeNextTick).toBe(false);
     expect(config.extras.tagNameTransform).toBe(false);
   });
 
+  it('should set slot config based on `experimentalSlotFixes`', () => {
+    userConfig.extras = {};
+    userConfig.extras.experimentalSlotFixes = true;
+    const { config } = validateConfig(userConfig, bootstrapConfig);
+    expect(config.extras.appendChildSlotFix).toBe(true);
+    expect(config.extras.cloneNodeFix).toBe(true);
+    expect(config.extras.slotChildNodesFix).toBe(true);
+    expect(config.extras.scopedSlotTextContentFix).toBe(true);
+  });
+
   it('should override slot fix config based on `experimentalSlotFixes`', () => {
+    // This test is to verify the flags get overwritten correctly even if an
+    // invalid config is ingested. Hence, the `any` cast
     userConfig.extras = {
       appendChildSlotFix: false,
       slotChildNodesFix: false,
@@ -403,10 +415,10 @@ describe('validation', () => {
       experimentalSlotFixes: true,
     } as any;
     const { config } = validateConfig(userConfig, bootstrapConfig);
-    expect((config.extras as any).appendChildSlotFix).toBe(undefined);
-    expect((config.extras as any).cloneNodeFix).toBe(undefined);
-    expect((config.extras as any).slotChildNodesFix).toBe(undefined);
-    expect((config.extras as any).scopedSlotTextContentFix).toBe(undefined);
+    expect(config.extras.appendChildSlotFix).toBe(true);
+    expect(config.extras.cloneNodeFix).toBe(true);
+    expect(config.extras.slotChildNodesFix).toBe(true);
+    expect(config.extras.scopedSlotTextContentFix).toBe(true);
   });
 
   it('should set taskQueue "async" by default', () => {

--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -385,23 +385,13 @@ describe('validation', () => {
 
   it('should set extras defaults', () => {
     const { config } = validateConfig(userConfig, bootstrapConfig);
-    expect(config.extras.appendChildSlotFix).toBe(false);
-    expect(config.extras.cloneNodeFix).toBe(false);
+    expect(config.extras.experimentalSlotFixes).toBe(false);
+    expect((config.extras as any).cloneNodeFix).toBe(false);
     expect(config.extras.lifecycleDOMEvents).toBe(false);
     expect(config.extras.scriptDataOpts).toBe(false);
-    expect(config.extras.slotChildNodesFix).toBe(false);
+    expect((config.extras as any).slotChildNodesFix).toBe(false);
     expect(config.extras.initializeNextTick).toBe(false);
     expect(config.extras.tagNameTransform).toBe(false);
-  });
-
-  it('should set slot config based on `experimentalSlotFixes`', () => {
-    userConfig.extras = {};
-    userConfig.extras.experimentalSlotFixes = true;
-    const { config } = validateConfig(userConfig, bootstrapConfig);
-    expect(config.extras.appendChildSlotFix).toBe(true);
-    expect(config.extras.cloneNodeFix).toBe(true);
-    expect(config.extras.slotChildNodesFix).toBe(true);
-    expect(config.extras.scopedSlotTextContentFix).toBe(true);
   });
 
   it('should override slot fix config based on `experimentalSlotFixes`', () => {
@@ -410,13 +400,13 @@ describe('validation', () => {
       slotChildNodesFix: false,
       cloneNodeFix: false,
       scopedSlotTextContentFix: false,
-    };
-    userConfig.extras.experimentalSlotFixes = true;
+      experimentalSlotFixes: true,
+    } as any;
     const { config } = validateConfig(userConfig, bootstrapConfig);
-    expect(config.extras.appendChildSlotFix).toBe(true);
-    expect(config.extras.cloneNodeFix).toBe(true);
-    expect(config.extras.slotChildNodesFix).toBe(true);
-    expect(config.extras.scopedSlotTextContentFix).toBe(true);
+    expect((config.extras as any).appendChildSlotFix).toBe(undefined);
+    expect((config.extras as any).cloneNodeFix).toBe(undefined);
+    expect((config.extras as any).slotChildNodesFix).toBe(undefined);
+    expect((config.extras as any).scopedSlotTextContentFix).toBe(undefined);
   });
 
   it('should set taskQueue "async" by default', () => {

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -112,32 +112,31 @@ export const validateConfig = (
   // TODO(STENCIL-914): remove when `experimentalSlotFixes` is the default behavior
   // If the user set `experimentalSlotFixes` and any individual slot fix flags, we need to log a warning
   // to the user that we will "override" the individual flags
-  if (
-    validatedConfig.extras.experimentalSlotFixes === true &&
-    ((validatedConfig.extras as any).appendChildSlotFix === true ||
-      (validatedConfig.extras as any).cloneNodeFix === true ||
-      (validatedConfig.extras as any).slotChildNodesFix === true ||
-      (validatedConfig.extras as any).scopedSlotTextContentFix === true)
-  ) {
-    const warning = buildError(diagnostics);
-    warning.level = 'warn';
-    warning.messageText =
-      'The `experimentalSlotFixes` flag cannot be used in combination with other slot fix flags. These individual flags will be ignored. Please update your Stencil config accordingly.';
-  }
+  // if (
+  //   validatedConfig.extras.experimentalSlotFixes === true &&
+  //   ((validatedConfig.extras as any).appendChildSlotFix === true ||
+  //     (validatedConfig.extras as any).cloneNodeFix === true ||
+  //     (validatedConfig.extras as any).slotChildNodesFix === true ||
+  //     (validatedConfig.extras as any).scopedSlotTextContentFix === true)
+  // ) {
+  //   const warning = buildError(diagnostics);
+  //   warning.level = 'warn';
+  //   warning.messageText =
+  //     'The `experimentalSlotFixes` flag cannot be used in combination with other slot fix flags. These individual flags will be ignored. Please update your Stencil config accordingly.';
+  // }
 
   // TODO(STENCIL-914): remove `experimentalSlotFixes` when it's the default behavior
   validatedConfig.extras.experimentalSlotFixes = !!validatedConfig.extras.experimentalSlotFixes;
-  if (validatedConfig.extras.experimentalSlotFixes === false) {
+  if (validatedConfig.extras.experimentalSlotFixes === true) {
+    validatedConfig.extras.appendChildSlotFix = true;
+    validatedConfig.extras.cloneNodeFix = true;
+    validatedConfig.extras.slotChildNodesFix = true;
+    validatedConfig.extras.scopedSlotTextContentFix = true;
+  } else {
     validatedConfig.extras.appendChildSlotFix = !!validatedConfig.extras.appendChildSlotFix;
     validatedConfig.extras.cloneNodeFix = !!validatedConfig.extras.cloneNodeFix;
     validatedConfig.extras.slotChildNodesFix = !!validatedConfig.extras.slotChildNodesFix;
     validatedConfig.extras.scopedSlotTextContentFix = !!validatedConfig.extras.scopedSlotTextContentFix;
-  } else {
-    // Make sure the options don't exist on the config at all
-    delete (validatedConfig.extras as any).appendChildSlotFix;
-    delete (validatedConfig.extras as any).cloneNodeFix;
-    delete (validatedConfig.extras as any).slotChildNodesFix;
-    delete (validatedConfig.extras as any).scopedSlotTextContentFix;
   }
 
   validatedConfig.buildEs5 =

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -1,7 +1,14 @@
 import { createNodeLogger, createNodeSys } from '@sys-api-node';
 import { buildError, isBoolean, isNumber, isString, sortBy } from '@utils';
 
-import { ConfigBundle, Diagnostic, LoadConfigInit, UnvalidatedConfig, ValidatedConfig } from '../../declarations';
+import {
+  ConfigBundle,
+  ConfigExtras,
+  Diagnostic,
+  LoadConfigInit,
+  UnvalidatedConfig,
+  ValidatedConfig,
+} from '../../declarations';
 import { setBooleanConfig } from './config-utils';
 import { validateOutputTargets } from './outputs';
 import { validateDevServer } from './validate-dev-server';
@@ -113,7 +120,7 @@ export const validateConfig = (
   // If the user set `experimentalSlotFixes` and any individual slot fix flags to `false`, we need to log a warning
   // to the user that we will "override" the individual flags
   if (validatedConfig.extras.experimentalSlotFixes === true) {
-    const possibleFlags: (keyof ValidatedConfig['extras'])[] = [
+    const possibleFlags: (keyof ConfigExtras)[] = [
       'appendChildSlotFix',
       'slotChildNodesFix',
       'cloneNodeFix',

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -109,6 +109,22 @@ export const validateConfig = (
   validatedConfig.extras.initializeNextTick = !!validatedConfig.extras.initializeNextTick;
   validatedConfig.extras.tagNameTransform = !!validatedConfig.extras.tagNameTransform;
 
+  // TODO(STENCIL-914): remove when `experimentalSlotFixes` is the default behavior
+  // If the user set `experimentalSlotFixes` and any individual slot fix flags, we need to log a warning
+  // to the user that we will "override" the individual flags
+  if (
+    userConfig.extras.experimentalSlotFixes === true &&
+    ((userConfig.extras as any).appendChildSlotFix === true ||
+      (userConfig.extras as any).cloneNodeFix === true ||
+      (userConfig.extras as any).slotChildNodesFix === true ||
+      (userConfig.extras as any).scopedSlotTextContentFix === true)
+  ) {
+    const warning = buildError(diagnostics);
+    warning.level = 'warn';
+    warning.messageText =
+      'The `experimentalSlotFixes` flag cannot be used in combination with other slot fix flags. These individual flags will be ignored. Please update your Stencil config accordingly.';
+  }
+
   // TODO(STENCIL-914): remove `experimentalSlotFixes` when it's the default behavior
   validatedConfig.extras.experimentalSlotFixes = !!validatedConfig.extras.experimentalSlotFixes;
   if (validatedConfig.extras.experimentalSlotFixes === false) {

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -104,24 +104,24 @@ export const validateConfig = (
   }
 
   validatedConfig.extras = validatedConfig.extras || {};
-  validatedConfig.extras.appendChildSlotFix = !!validatedConfig.extras.appendChildSlotFix;
-  validatedConfig.extras.cloneNodeFix = !!validatedConfig.extras.cloneNodeFix;
   validatedConfig.extras.lifecycleDOMEvents = !!validatedConfig.extras.lifecycleDOMEvents;
   validatedConfig.extras.scriptDataOpts = !!validatedConfig.extras.scriptDataOpts;
-  validatedConfig.extras.slotChildNodesFix = !!validatedConfig.extras.slotChildNodesFix;
   validatedConfig.extras.initializeNextTick = !!validatedConfig.extras.initializeNextTick;
   validatedConfig.extras.tagNameTransform = !!validatedConfig.extras.tagNameTransform;
+
   // TODO(STENCIL-914): remove `experimentalSlotFixes` when it's the default behavior
   validatedConfig.extras.experimentalSlotFixes = !!validatedConfig.extras.experimentalSlotFixes;
-
-  // if the user has set `extras.experimentalSlotFixes` then we turn on all of
-  // the slot-related fixes automatically.
-  // TODO(STENCIL-914): remove `experimentalSlotFixes` when it's the default behavior
-  if (validatedConfig.extras.experimentalSlotFixes) {
-    validatedConfig.extras.appendChildSlotFix = true;
-    validatedConfig.extras.cloneNodeFix = true;
-    validatedConfig.extras.slotChildNodesFix = true;
-    validatedConfig.extras.scopedSlotTextContentFix = true;
+  if (validatedConfig.extras.experimentalSlotFixes === false) {
+    validatedConfig.extras.appendChildSlotFix = !!validatedConfig.extras.appendChildSlotFix;
+    validatedConfig.extras.cloneNodeFix = !!validatedConfig.extras.cloneNodeFix;
+    validatedConfig.extras.slotChildNodesFix = !!validatedConfig.extras.slotChildNodesFix;
+    validatedConfig.extras.scopedSlotTextContentFix = !!validatedConfig.extras.scopedSlotTextContentFix;
+  } else {
+    // Make sure the options don't exist on the config at all
+    delete (validatedConfig.extras as any).appendChildSlotFix;
+    delete (validatedConfig.extras as any).cloneNodeFix;
+    delete (validatedConfig.extras as any).slotChildNodesFix;
+    delete (validatedConfig.extras as any).scopedSlotTextContentFix;
   }
 
   validatedConfig.buildEs5 =

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -130,7 +130,7 @@ export const validateConfig = (
     if (conflictingFlags.length > 0) {
       const warning = buildError(diagnostics);
       warning.level = 'warn';
-      warning.messageText = `The 'experimentalSlotFixes' flag cannot be used in combination with other slot fix flags disabled. The following flags will be ignored: ${conflictingFlags.join(
+      warning.messageText = `If the 'experimentalSlotFixes' flag is enabled it will override any slot fix flags which are disabled. In particular, the following currently-disabled flags will be ignored: ${conflictingFlags.join(
         ', ',
       )}. Please update your Stencil config accordingly.`;
     }

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -110,20 +110,24 @@ export const validateConfig = (
   validatedConfig.extras.tagNameTransform = !!validatedConfig.extras.tagNameTransform;
 
   // TODO(STENCIL-914): remove when `experimentalSlotFixes` is the default behavior
-  // If the user set `experimentalSlotFixes` and any individual slot fix flags, we need to log a warning
+  // If the user set `experimentalSlotFixes` and any individual slot fix flags to `false`, we need to log a warning
   // to the user that we will "override" the individual flags
-  // if (
-  //   validatedConfig.extras.experimentalSlotFixes === true &&
-  //   ((validatedConfig.extras as any).appendChildSlotFix === true ||
-  //     (validatedConfig.extras as any).cloneNodeFix === true ||
-  //     (validatedConfig.extras as any).slotChildNodesFix === true ||
-  //     (validatedConfig.extras as any).scopedSlotTextContentFix === true)
-  // ) {
-  //   const warning = buildError(diagnostics);
-  //   warning.level = 'warn';
-  //   warning.messageText =
-  //     'The `experimentalSlotFixes` flag cannot be used in combination with other slot fix flags. These individual flags will be ignored. Please update your Stencil config accordingly.';
-  // }
+  if (validatedConfig.extras.experimentalSlotFixes === true) {
+    const possibleFlags: (keyof ValidatedConfig['extras'])[] = [
+      'appendChildSlotFix',
+      'slotChildNodesFix',
+      'cloneNodeFix',
+      'scopedSlotTextContentFix',
+    ];
+    const conflictingFlags = possibleFlags.filter((flag) => validatedConfig.extras[flag] === false);
+    if (conflictingFlags.length > 0) {
+      const warning = buildError(diagnostics);
+      warning.level = 'warn';
+      warning.messageText = `The 'experimentalSlotFixes' flag cannot be used in combination with other slot fix flags disabled. The following flags will be ignored: ${conflictingFlags.join(
+        ', ',
+      )}. Please update your Stencil config accordingly.`;
+    }
+  }
 
   // TODO(STENCIL-914): remove `experimentalSlotFixes` when it's the default behavior
   validatedConfig.extras.experimentalSlotFixes = !!validatedConfig.extras.experimentalSlotFixes;

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -113,11 +113,11 @@ export const validateConfig = (
   // If the user set `experimentalSlotFixes` and any individual slot fix flags, we need to log a warning
   // to the user that we will "override" the individual flags
   if (
-    userConfig.extras.experimentalSlotFixes === true &&
-    ((userConfig.extras as any).appendChildSlotFix === true ||
-      (userConfig.extras as any).cloneNodeFix === true ||
-      (userConfig.extras as any).slotChildNodesFix === true ||
-      (userConfig.extras as any).scopedSlotTextContentFix === true)
+    validatedConfig.extras.experimentalSlotFixes === true &&
+    ((validatedConfig.extras as any).appendChildSlotFix === true ||
+      (validatedConfig.extras as any).cloneNodeFix === true ||
+      (validatedConfig.extras as any).slotChildNodesFix === true ||
+      (validatedConfig.extras as any).scopedSlotTextContentFix === true)
   ) {
     const warning = buildError(diagnostics);
     warning.level = 'warn';

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -339,7 +339,7 @@ interface ConfigExtrasBase {
 }
 
 // TODO(STENCIL-914): delete this interface when `experimentalSlotFixes` is the default behavior
-type ConfigExtrasSlotFixes<ExpirimentalFixesEnabled extends boolean, IndividualFlags extends boolean> = {
+type ConfigExtrasSlotFixes<ExperimentalFixesEnabled extends boolean, IndividualFlags extends boolean> = {
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
   /**
    * By default, the slot polyfill does not update `appendChild()` so that it appends
@@ -381,7 +381,7 @@ type ConfigExtrasSlotFixes<ExpirimentalFixesEnabled extends boolean, IndividualF
    * Enables all slot-related fixes such as {@link slotChildNodesFix}, and
    * {@link scopedSlotTextContentFix}.
    */
-  experimentalSlotFixes?: ExpirimentalFixesEnabled;
+  experimentalSlotFixes?: ExperimentalFixesEnabled;
 };
 
 export type ConfigExtras = ConfigExtrasBase &

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -292,27 +292,7 @@ export interface StencilConfig {
   stencilCoreResolvedId?: string;
 }
 
-export interface ConfigExtras {
-  // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
-  /**
-   * By default, the slot polyfill does not update `appendChild()` so that it appends
-   * new child nodes into the correct child slot like how shadow dom works. This is an opt-in
-   * polyfill for those who need it when using `element.appendChild(node)` and expecting the
-   * child to be appended in the same location shadow dom would. This is not required for
-   * IE11 or Edge 18, but can be enabled if the app is using `appendChild()`. Defaults to `false`.
-   */
-  appendChildSlotFix?: boolean;
-
-  // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
-  /**
-   * By default, the runtime does not polyfill `cloneNode()` when cloning a component
-   * that uses the slot polyfill. This is an opt-in polyfill for those who need it.
-   * This is not required for IE11 or Edge 18, but can be enabled if the app is using
-   * `cloneNode()` and unexpected node are being cloned due to the slot polyfill
-   * simulating shadow dom. Defaults to `false`.
-   */
-  cloneNodeFix?: boolean;
-
+interface ConfigExtrasBase {
   /**
    * Experimental flag. Projects that use a Stencil library built using the `dist` output target may have trouble lazily
    * loading components when using a bundler such as Vite or Parcel. Setting this flag to `true` will change how Stencil
@@ -343,13 +323,6 @@ export interface ConfigExtras {
    */
   scriptDataOpts?: boolean;
 
-  // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
-  /**
-   * Experimental flag to align the behavior of invoking `textContent` on a scoped component to act more like a
-   * component that uses the shadow DOM. Defaults to `false`
-   */
-  scopedSlotTextContentFix?: boolean;
-
   /**
    * When a component is first attached to the DOM, this setting will wait a single tick before
    * rendering. This works around an Angular issue, where Angular attaches the elements before
@@ -357,6 +330,42 @@ export interface ConfigExtras {
    * Defaults to `false`.
    */
   initializeNextTick?: boolean;
+
+  /**
+   * Enables the tagNameTransform option of `defineCustomElements()`, so the component tagName
+   * can be customized at runtime. Defaults to `false`.
+   */
+  tagNameTransform?: boolean;
+}
+
+// TODO(STENCIL-914): delete this interface when `experimentalSlotFixes` is the default behavior
+interface ConfigExtrasSlotFixes {
+  // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
+  /**
+   * By default, the slot polyfill does not update `appendChild()` so that it appends
+   * new child nodes into the correct child slot like how shadow dom works. This is an opt-in
+   * polyfill for those who need it when using `element.appendChild(node)` and expecting the
+   * child to be appended in the same location shadow dom would. This is not required for
+   * IE11 or Edge 18, but can be enabled if the app is using `appendChild()`. Defaults to `false`.
+   */
+  appendChildSlotFix?: boolean;
+
+  // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
+  /**
+   * By default, the runtime does not polyfill `cloneNode()` when cloning a component
+   * that uses the slot polyfill. This is an opt-in polyfill for those who need it.
+   * This is not required for IE11 or Edge 18, but can be enabled if the app is using
+   * `cloneNode()` and unexpected node are being cloned due to the slot polyfill
+   * simulating shadow dom. Defaults to `false`.
+   */
+  cloneNodeFix?: boolean;
+
+  // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
+  /**
+   * Experimental flag to align the behavior of invoking `textContent` on a scoped component to act more like a
+   * component that uses the shadow DOM. Defaults to `false`
+   */
+  scopedSlotTextContentFix?: boolean;
 
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
   /**
@@ -367,19 +376,26 @@ export interface ConfigExtras {
    */
   slotChildNodesFix?: boolean;
 
-  /**
-   * Enables the tagNameTransform option of `defineCustomElements()`, so the component tagName
-   * can be customized at runtime. Defaults to `false`.
-   */
-  tagNameTransform?: boolean;
-
   // TODO(STENCIL-914): remove `experimentalSlotFixes` when it's the default behavior
   /**
    * Enables all slot-related fixes such as {@link slotChildNodesFix}, and
    * {@link scopedSlotTextContentFix}.
    */
-  experimentalSlotFixes?: boolean;
+  experimentalSlotFixes?: false;
 }
+
+export type ConfigExtras = ConfigExtrasBase &
+  (
+    | ConfigExtrasSlotFixes
+    | {
+        // TODO(STENCIL-914): remove `experimentalSlotFixes` when it's the default behavior
+        /**
+         * Enables all slot-related fixes such as {@link slotChildNodesFix}, and
+         * {@link scopedSlotTextContentFix}.
+         */
+        experimentalSlotFixes?: true;
+      }
+  );
 
 export interface Config extends StencilConfig {
   buildAppCore?: boolean;

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -339,7 +339,7 @@ interface ConfigExtrasBase {
 }
 
 // TODO(STENCIL-914): delete this interface when `experimentalSlotFixes` is the default behavior
-interface ConfigExtrasSlotFixes {
+type ConfigExtrasSlotFixes<ExpirimentalFixesEnabled extends boolean, IndividualFlags extends boolean> = {
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
   /**
    * By default, the slot polyfill does not update `appendChild()` so that it appends
@@ -348,7 +348,7 @@ interface ConfigExtrasSlotFixes {
    * child to be appended in the same location shadow dom would. This is not required for
    * IE11 or Edge 18, but can be enabled if the app is using `appendChild()`. Defaults to `false`.
    */
-  appendChildSlotFix?: boolean;
+  appendChildSlotFix?: IndividualFlags;
 
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
   /**
@@ -358,14 +358,14 @@ interface ConfigExtrasSlotFixes {
    * `cloneNode()` and unexpected node are being cloned due to the slot polyfill
    * simulating shadow dom. Defaults to `false`.
    */
-  cloneNodeFix?: boolean;
+  cloneNodeFix?: IndividualFlags;
 
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
   /**
    * Experimental flag to align the behavior of invoking `textContent` on a scoped component to act more like a
    * component that uses the shadow DOM. Defaults to `false`
    */
-  scopedSlotTextContentFix?: boolean;
+  scopedSlotTextContentFix?: IndividualFlags;
 
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
   /**
@@ -374,28 +374,18 @@ interface ConfigExtrasSlotFixes {
    * getters are not patched to only show the child nodes and elements of the default slot.
    * Defaults to `false`.
    */
-  slotChildNodesFix?: boolean;
+  slotChildNodesFix?: IndividualFlags;
 
   // TODO(STENCIL-914): remove `experimentalSlotFixes` when it's the default behavior
   /**
    * Enables all slot-related fixes such as {@link slotChildNodesFix}, and
    * {@link scopedSlotTextContentFix}.
    */
-  experimentalSlotFixes?: false;
-}
+  experimentalSlotFixes?: ExpirimentalFixesEnabled;
+};
 
 export type ConfigExtras = ConfigExtrasBase &
-  (
-    | ConfigExtrasSlotFixes
-    | {
-        // TODO(STENCIL-914): remove `experimentalSlotFixes` when it's the default behavior
-        /**
-         * Enables all slot-related fixes such as {@link slotChildNodesFix}, and
-         * {@link scopedSlotTextContentFix}.
-         */
-        experimentalSlotFixes?: true;
-      }
-  );
+  (ConfigExtrasSlotFixes<true, true> | ConfigExtrasSlotFixes<false, boolean>);
 
 export interface Config extends StencilConfig {
   buildAppCore?: boolean;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

A user can currently set both the `experimentalSlotFixes` flag and any of the other scoped slot patch flags (like `slotChildNodesFix`). So a config may look like:

```ts
// stencil.config.ts

extras: {
  experimentalSlotFixes: true,
  slotChildNodesFix: true
}
```

This can be confusing since the `experimentalSlotFixes` flag will override any of the other patch flags.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The config type (and downstream validation logic) will only allow the individual patch flags to be set if `experimentalSlotFixes` is omitted or explicitly set `false`

```ts
// stencil.config.ts

extras: {
  experimentalSlotFixes: true,
  slotChildNodesFix: true // <-- valid
}
```

```ts
// stencil.config.ts

extras: {
  experimentalSlotFixes: false,
  slotChildNodesFix: true // <-- valid
}
```

```ts
// stencil.config.ts

extras: {
  slotChildNodesFix: true // <-- valid
}
```

```ts
// stencil.config.ts

extras: {
  experimentalSlotFixes: true,
  slotChildNodesFix: false // <-- invalid
}
```

If a user does build a project with one of the invalid config options, a warning will be logged at compile time stating that the individual flags will be overridden based on `experimentalSlotFixes`.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

**Automated tests**
Automated tests for config validation were updated accordingly.

**Manual tests**
A build of this commit can be installed in a component starter. In the `stencil.config.ts`, verify that the following results in intellisense errors and a compile-time warning during `npm run build`:

```ts
extras: {
    experimentalSlotFixes: true,
    slotChildNodesFix: false,
}
```

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
