### PR TITLE
refactor(compiler): use updateConstructor in lazy transform

### DIFF
--- a/src/compiler/transformers/component-hydrate/hydrate-component.ts
+++ b/src/compiler/transformers/component-hydrate/hydrate-component.ts
@@ -31,7 +31,7 @@ const updateHydrateHostComponentMembers = (
 ) => {
   const classMembers = removeStaticMetaProperties(classNode);
 
-  updateLazyComponentConstructor(classMembers, moduleFile, cmp);
+  updateLazyComponentConstructor(classMembers, classNode, moduleFile, cmp);
   addLazyElementGetter(classMembers, moduleFile, cmp);
   addWatchers(classMembers, cmp);
   addHydrateRuntimeCmpMeta(classMembers, cmp);

--- a/src/compiler/transformers/component-lazy/lazy-component.ts
+++ b/src/compiler/transformers/component-lazy/lazy-component.ts
@@ -52,7 +52,7 @@ const updateLazyComponentMembers = (
 ): ts.ClassElement[] => {
   const classMembers = removeStaticMetaProperties(classNode);
 
-  updateLazyComponentConstructor(classMembers, moduleFile, cmp);
+  updateLazyComponentConstructor(classMembers, classNode, moduleFile, cmp);
   addLazyElementGetter(classMembers, moduleFile, cmp);
   addWatchers(classMembers, cmp);
   transformHostData(classMembers, moduleFile);

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -960,12 +960,14 @@ export const retrieveTsModifiers = (node: ts.Node): ReadonlyArray<ts.Modifier> |
  * @param classMembers a list of class members for that class
  * @param statements a list of statements which should be added to the
  * constructor
+ * @param parameters an optional list of parameters for the constructor
  * @returns a list of updated class elements
  */
 export const updateConstructor = (
   classNode: ts.ClassDeclaration,
   classMembers: ts.ClassElement[],
   statements: ts.Statement[],
+  parameters?: ts.ParameterDeclaration[],
 ): ts.ClassElement[] => {
   const constructorIndex = classMembers.findIndex((m) => m.kind === ts.SyntaxKind.Constructor);
   const constructorMethod = classMembers[constructorIndex];
@@ -994,7 +996,7 @@ export const updateConstructor = (
     classMembers[constructorIndex] = ts.factory.updateConstructorDeclaration(
       constructorMethod,
       retrieveTsModifiers(constructorMethod),
-      constructorMethod.parameters,
+      constructorMethod.parameters.concat(parameters ?? []),
       ts.factory.updateBlock(constructorMethod?.body ?? ts.factory.createBlock([]), statements),
     );
   } else {
@@ -1007,7 +1009,7 @@ export const updateConstructor = (
     // add the new constructor to the class members, putting it at the
     // beginning
     classMembers.unshift(
-      ts.factory.createConstructorDeclaration(undefined, [], ts.factory.createBlock(statements, true)),
+      ts.factory.createConstructorDeclaration(undefined, parameters ?? [], ts.factory.createBlock(statements, true)),
     );
   }
 


### PR DESCRIPTION
This updates the lazy component transform to use the `updateConstructor` helper, similar to the changes made in #4741.

This is a small refactor to bring the code here in line with how things are done int he native-component transform.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
