### PR TITLE
chore(snc): resolve snc in test init

### DIFF
--- a/src/testing/testing.ts
+++ b/src/testing/testing.ts
@@ -24,14 +24,20 @@ export const createTesting = async (config: ValidatedConfig): Promise<Testing> =
   const { createCompiler } = require('../compiler/stencil.js');
   const compiler: Compiler = await createCompiler(config);
 
-  let devServer: DevServer;
-  let puppeteerBrowser: puppeteer.Browser;
+  let devServer: DevServer | null;
+  let puppeteerBrowser: puppeteer.Browser | null;
 
-  const run = async (opts: TestingRunOptions = {}) => {
+  /**
+   * Initiate running spec and/or end-to-end tests with Stencil
+   * @param opts running options to apply when
+   * @returns true if all tests passed. Returns false if any tests failed or an error occurred during the test
+   * setup/running process
+   */
+  const run = async (opts: TestingRunOptions = {}): Promise<boolean> => {
     let doScreenshots = false;
     let passed = false;
     let env: E2EProcessEnv;
-    let compilerWatcher: CompilerWatcher = null;
+    let compilerWatcher: CompilerWatcher | null = null;
     const msg: string[] = [];
 
     try {
@@ -72,7 +78,7 @@ export const createTesting = async (config: ValidatedConfig): Promise<Testing> =
         // e2e tests only
         // do a build, start a dev server
         // and spin up a puppeteer browser
-        let buildTask: Promise<CompilerBuildResults> = null;
+        let buildTask: Promise<CompilerBuildResults> | null = null;
 
         (config.outputTargets as OutputTargetWww[]).forEach((outputTarget) => {
           outputTarget.empty = false;
@@ -126,7 +132,7 @@ export const createTesting = async (config: ValidatedConfig): Promise<Testing> =
 
           const styleUrl = getAppStyleUrl(config, devServer.browserUrl);
           if (styleUrl) {
-            env.__STENCIL_APP_STYLE_URL__ = getAppStyleUrl(config, devServer.browserUrl);
+            env.__STENCIL_APP_STYLE_URL__ = styleUrl;
             config.logger.debug(`e2e app style url: ${env.__STENCIL_APP_STYLE_URL__}`);
           }
         }


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
this commit resolves a handful of strict null checks violations in `testing.ts`. most violations involved widening the type of some variable to explicitly state it could be null. this ought to be a safe operation, as we were already assigning `null` to these variables already - the change only aligns the type system with what was originally happening at runtime.

an extraneous call to `getAppStyleUrl` was removed as well. there are no known side effects that occur as a result of that function call, which ought to make this refactor safe

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Type checker remains happy - there's only one section that could _potentially_ change how Stencil runs, I'll call that out below
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
