### PR TITLE
fix(test): ensure legacy decorators are used when using transpile

### DIFF
--- a/src/compiler/config/transpile-options.ts
+++ b/src/compiler/config/transpile-options.ts
@@ -78,6 +78,9 @@ export const getTranspileConfig = (input: TranspileOptions): TranspileConfig => 
   };
 
   const tsCompilerOptions: CompilerOptions = {
+    // ensure we uses legacy decorators
+    experimentalDecorators: true,
+
     // best we always set this to true
     allowSyntheticDefaultImports: true,
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
Currently, file compiled through `stencil test` do uses the new ECMA decorators, contrary to the output of `stencil build` which always uses legacy TS decorators.
This, combined with what I think might be an issue with how TypeScript handles class modifiers updates, causes the behavior described in #4631.

GitHub Issue Number: #4631 

## What is the new behavior?

### Rejected fix:
Fixing/bypassing the TypeScript update behavior leaves us using the new decorators for `stencil test`, but the legacy ones for `stencil build`. The difference in behavior between the test & the source is not a good thing, obviously.

### Proposed fix:
Ensure we do set the `experimentalDecorators` in the compiler options used by `stencil test`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

 - `patch-package` the behavior in https://github.com/Aadhisivam/stencil-demo/, runs the tests ✅ 
 - Tested on github.com/coveo/ui-kit. ✅ (caveat, we're impacted by https://github.com/ionic-team/stencil/issues/3831 too)

_____

Fixes: #4631 