### PR TITLE
chore(release): allow nightly to be run on demand

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -6,6 +6,8 @@ on:
     # This is done to have a nightly build ready for the Ionic Framework/Stencil Eval Workflow:
     # https://github.com/ionic-team/ionic-framework/blob/main/.github/workflows/stencil-eval.yml
     - cron: '00 05 * * 1-5'
+  workflow_dispatch:
+    # Allow this workflow to be run on-demand
 
 jobs:
   build_core:


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See 'new behavior'

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the nightly release script to allow the workflow to be run on demand (via GitHub).

the motivation for this is that we had a failing nightly build, but the fix for the failures were merged. we wanted to run the framework nightly tests before a release of stencil, but couldn't kick if off manually (workaround was a dev build of stencil)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing


N/A - unable to test this until we merge it
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
