### PR TITLE
test(hydrate): add a regression test for hydrating SVG children

### DIFF
--- a/test/karma/test-prerender/src/components.d.ts
+++ b/test/karma/test-prerender/src/components.d.ts
@@ -29,6 +29,8 @@ export namespace Components {
     }
     interface CmpTextGreen {
     }
+    interface TestSvg {
+    }
 }
 declare global {
     interface HTMLAppRootElement extends Components.AppRoot, HTMLStencilElement {
@@ -97,6 +99,12 @@ declare global {
         prototype: HTMLCmpTextGreenElement;
         new (): HTMLCmpTextGreenElement;
     };
+    interface HTMLTestSvgElement extends Components.TestSvg, HTMLStencilElement {
+    }
+    var HTMLTestSvgElement: {
+        prototype: HTMLTestSvgElement;
+        new (): HTMLTestSvgElement;
+    };
     interface HTMLElementTagNameMap {
         "app-root": HTMLAppRootElement;
         "cmp-a": HTMLCmpAElement;
@@ -109,6 +117,7 @@ declare global {
         "cmp-scoped-b": HTMLCmpScopedBElement;
         "cmp-text-blue": HTMLCmpTextBlueElement;
         "cmp-text-green": HTMLCmpTextGreenElement;
+        "test-svg": HTMLTestSvgElement;
     }
 }
 declare namespace LocalJSX {
@@ -135,6 +144,8 @@ declare namespace LocalJSX {
     }
     interface CmpTextGreen {
     }
+    interface TestSvg {
+    }
     interface IntrinsicElements {
         "app-root": AppRoot;
         "cmp-a": CmpA;
@@ -147,6 +158,7 @@ declare namespace LocalJSX {
         "cmp-scoped-b": CmpScopedB;
         "cmp-text-blue": CmpTextBlue;
         "cmp-text-green": CmpTextGreen;
+        "test-svg": TestSvg;
     }
 }
 export { LocalJSX as JSX };
@@ -164,6 +176,7 @@ declare module "@stencil/core" {
             "cmp-scoped-b": LocalJSX.CmpScopedB & JSXBase.HTMLAttributes<HTMLCmpScopedBElement>;
             "cmp-text-blue": LocalJSX.CmpTextBlue & JSXBase.HTMLAttributes<HTMLCmpTextBlueElement>;
             "cmp-text-green": LocalJSX.CmpTextGreen & JSXBase.HTMLAttributes<HTMLCmpTextGreenElement>;
+            "test-svg": LocalJSX.TestSvg & JSXBase.HTMLAttributes<HTMLTestSvgElement>;
         }
     }
 }

--- a/test/karma/test-prerender/src/components/hydrate-svg/hydrate-svg.tsx
+++ b/test/karma/test-prerender/src/components/hydrate-svg/hydrate-svg.tsx
@@ -1,0 +1,11 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'test-svg',
+  shadow: true,
+})
+export class TestSvg {
+  render() {
+    return <svg></svg>;
+  }
+}

--- a/test/karma/test-prerender/src/index.html
+++ b/test/karma/test-prerender/src/index.html
@@ -11,5 +11,6 @@
   <app-root></app-root>
   <cmp-client-scoped>scoped light-dom: red if in the correct slot</cmp-client-scoped>
   <cmp-client-shadow>shadow light-dom: red if in the correct slot</cmp-client-shadow>
+  <test-svg></test-svg>
 </body>
 </html>


### PR DESCRIPTION
This adds a regression test for the issue reported in https://github.com/ionic-team/stencil/issues/4278, which doesn't currently occur on `main` but does occur in the branch associated with https://github.com/ionic-team/stencil/pull/2938 (a PR containing a bunch of changes for fixing bugs with slots).

This regression test will give us a bit more safety as we go to add more slot behavior fixes in the future.



GitHub Issue Number: #4278 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Cherry-pick the commit on this branch over the top of #2938 and then confirm that the relevant test fails (due to how the prerender karma tests work what you'll see is actually all tests in that suite failing).

In order to do so you'll need to:

```sh
npm run clean && npm i && npm run build && npm run test.karma.prod
```

(after doing the cherry-pick)

