### PR TITLE
chore(snc): add 'extras' to ValidatedConfig

### DIFF
--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -86,6 +86,7 @@ export const validateConfig = (
   const validatedConfig: ValidatedConfig = {
     devServer: {}, // assign `devServer` before spreading `config`, in the event 'devServer' is not a key on `config`
     ...config,
+    extras: config.extras || {},
     // flags _should_ be JSON safe
     flags: JSON.parse(JSON.stringify(config.flags || {})),
     hydratedFlag: validateHydrated(config),
@@ -110,7 +111,6 @@ export const validateConfig = (
     validatedConfig.devMode = DEFAULT_DEV_MODE;
   }
 
-  validatedConfig.extras = validatedConfig.extras || {};
   validatedConfig.extras.lifecycleDOMEvents = !!validatedConfig.extras.lifecycleDOMEvents;
   validatedConfig.extras.scriptDataOpts = !!validatedConfig.extras.scriptDataOpts;
   validatedConfig.extras.initializeNextTick = !!validatedConfig.extras.initializeNextTick;

--- a/src/compiler/output-targets/dist-lazy/generate-lazy-module.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-lazy-module.ts
@@ -48,7 +48,7 @@ export const generateLazyModules = async (
     }),
   );
 
-  if ((!!config.extras?.experimentalImportInjection || !!config.extras?.enableImportInjection) && !isBrowserBuild) {
+  if ((!!config.extras.experimentalImportInjection || !!config.extras.enableImportInjection) && !isBrowserBuild) {
     addStaticImports(rollupResults, bundleModules);
   }
 

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -456,6 +456,7 @@ type RequireFields<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 type StrictConfigFields =
   | 'cacheDir'
   | 'devServer'
+  | 'extras'
   | 'flags'
   | 'hydratedFlag'
   | 'logger'

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -34,6 +34,7 @@ export function mockValidatedConfig(overrides: Partial<ValidatedConfig> = {}): V
   return {
     ...baseConfig,
     devServer: {},
+    extras: {},
     flags: createConfigFlags(),
     hydratedFlag: null,
     logger: mockLogger(),


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the `ValidatedConfig` interface to include `extras`. doing so eliminates ~25 strictNullChecks violations from the codebase. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

The type checker should continue to pass.

I updated any cases of using optional chaining on `extras` in the codebase that I could find.

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

I can see a world where there's an argument to _not_ make this required. LMK what you think!

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
