### PR TITLE
chore(snc): replace config argument types

### DIFF
--- a/src/compiler/app-core/app-es5-disabled.ts
+++ b/src/compiler/app-core/app-es5-disabled.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import type * as d from '../../declarations';
 
 export const generateEs5DisabledMessage = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   outputTarget: d.OutputTargetWww,
 ) => {
@@ -17,7 +17,7 @@ export const generateEs5DisabledMessage = async (
   return fileName;
 };
 
-const getDisabledMessageScript = (config: d.Config) => {
+const getDisabledMessageScript = (config: d.ValidatedConfig) => {
   const style = `
 <style>
 body {

--- a/src/compiler/app-core/app-polyfills.ts
+++ b/src/compiler/app-core/app-polyfills.ts
@@ -2,7 +2,11 @@ import { join } from 'path';
 
 import type * as d from '../../declarations';
 
-export const getClientPolyfill = async (config: d.Config, compilerCtx: d.CompilerCtx, polyfillFile: string) => {
+export const getClientPolyfill = async (
+  config: d.ValidatedConfig,
+  compilerCtx: d.CompilerCtx,
+  polyfillFile: string,
+) => {
   const polyfillFilePath = join(
     config.sys.getCompilerExecutingPath(),
     '..',
@@ -15,7 +19,7 @@ export const getClientPolyfill = async (config: d.Config, compilerCtx: d.Compile
   return compilerCtx.fs.readFile(polyfillFilePath);
 };
 
-export const getAppBrowserCorePolyfills = async (config: d.Config, compilerCtx: d.CompilerCtx) => {
+export const getAppBrowserCorePolyfills = async (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx) => {
   // read all the polyfill content, in this particular order
   const polyfills = INLINE_POLYFILLS.slice();
 

--- a/src/compiler/app-core/bundle-app-core.ts
+++ b/src/compiler/app-core/bundle-app-core.ts
@@ -16,7 +16,7 @@ import { STENCIL_CORE_ID } from '../bundle/entry-alias-ids';
 export const generateRollupOutput = async (
   build: RollupBuild,
   options: OutputOptions,
-  config: d.Config,
+  config: d.ValidatedConfig,
   entryModules: d.EntryModule[],
 ): Promise<d.RollupResult[] | null> => {
   if (build == null) {

--- a/src/compiler/build/compiler-ctx.ts
+++ b/src/compiler/build/compiler-ctx.ts
@@ -62,7 +62,7 @@ export class CompilerContext implements d.CompilerCtx {
   }
 }
 
-export const getModuleLegacy = (_config: d.Config, compilerCtx: d.CompilerCtx, sourceFilePath: string) => {
+export const getModuleLegacy = (compilerCtx: d.CompilerCtx, sourceFilePath: string) => {
   sourceFilePath = normalizePath(sourceFilePath);
 
   const moduleFile = compilerCtx.moduleMap.get(sourceFilePath);

--- a/src/compiler/build/watch-build.ts
+++ b/src/compiler/build/watch-build.ts
@@ -259,7 +259,7 @@ export const createWatchBuild = async (
  * @param config The Stencil project's config
  * @param compilerCtx The compiler context for the Stencil project
  */
-const watchSrcDirectory = async (config: d.Config, compilerCtx: d.CompilerCtx) => {
+const watchSrcDirectory = async (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx) => {
   const srcFiles = await compilerCtx.fs.readdir(config.srcDir, {
     recursive: true,
     excludeDirNames: ['.cache', '.git', '.github', '.stencil', '.vscode', 'node_modules'],
@@ -290,7 +290,7 @@ const watchSrcDirectory = async (config: d.Config, compilerCtx: d.CompilerCtx) =
  * @param config The Stencil project's config
  * @param compilerCtx The compiler context for the Stencil project
  */
-const watchRootFiles = async (config: d.Config, compilerCtx: d.CompilerCtx) => {
+const watchRootFiles = async (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx) => {
   // non-src files that cause a rebuild
   // mainly for root level config files, and getting an event when they change
   const rootFiles = await compilerCtx.fs.readdir(config.rootDir, {
@@ -322,7 +322,7 @@ const emitFsChange = (compilerCtx: d.CompilerCtx, buildCtx: BuildContext) => {
 };
 
 const updateCompilerCtxCache = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   path: string,
   kind: d.CompilerFileWatcherEvent,

--- a/src/compiler/bundle/app-data-plugin.ts
+++ b/src/compiler/bundle/app-data-plugin.ts
@@ -142,7 +142,7 @@ export const appDataPlugin = (
   };
 };
 
-export const getGlobalScriptData = (config: d.Config, compilerCtx: d.CompilerCtx) => {
+export const getGlobalScriptData = (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx) => {
   const globalScripts: GlobalScript[] = [];
 
   if (isString(config.globalScript)) {
@@ -210,11 +210,11 @@ const appendBuildConditionals = (config: d.ValidatedConfig, build: d.BuildCondit
   s.append(`export const BUILD = /* ${config.fsNamespace} */ { ${buildData} };\n`);
 };
 
-const appendEnv = (config: d.Config, s: MagicString) => {
+const appendEnv = (config: d.ValidatedConfig, s: MagicString) => {
   s.append(`export const Env = /* ${config.fsNamespace} */ ${JSON.stringify(config.env)};\n`);
 };
 
-const appendNamespace = (config: d.Config, s: MagicString) => {
+const appendNamespace = (config: d.ValidatedConfig, s: MagicString) => {
   s.append(`export const NAMESPACE = '${config.fsNamespace}';\n`);
 };
 

--- a/src/compiler/bundle/core-resolve-plugin.ts
+++ b/src/compiler/bundle/core-resolve-plugin.ts
@@ -16,7 +16,7 @@ import {
 } from './entry-alias-ids';
 
 export const coreResolvePlugin = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   platform: 'client' | 'hydrate' | 'worker',
   externalRuntime: boolean,
@@ -122,7 +122,7 @@ export const Build = {
   };
 };
 
-export const getStencilInternalModule = (config: d.Config, compilerExe: string, internalModule: string) => {
+export const getStencilInternalModule = (config: d.ValidatedConfig, compilerExe: string, internalModule: string) => {
   if (isRemoteUrl(compilerExe)) {
     return normalizePath(
       config.sys.getLocalModulePath({

--- a/src/compiler/bundle/dev-module.ts
+++ b/src/compiler/bundle/dev-module.ts
@@ -125,7 +125,7 @@ const bundleDevModule = async (
   }
 };
 
-const useDevModuleCache = async (config: d.Config, p: string) => {
+const useDevModuleCache = async (config: d.ValidatedConfig, p: string) => {
   if (config.enableCache) {
     for (let i = 0; i < 10; i++) {
       const n = basename(p);
@@ -142,7 +142,7 @@ const useDevModuleCache = async (config: d.Config, p: string) => {
   return false;
 };
 
-const writeCachedFile = async (config: d.Config, results: d.CompilerRequestResponse) => {
+const writeCachedFile = async (config: d.ValidatedConfig, results: d.CompilerRequestResponse) => {
   try {
     await config.sys.createDir(config.cacheDir);
     config.sys.writeFile(results.cachePath, results.content);
@@ -151,7 +151,7 @@ const writeCachedFile = async (config: d.Config, results: d.CompilerRequestRespo
   }
 };
 
-const parseDevModuleUrl = (config: d.Config, u: string) => {
+const parseDevModuleUrl = (config: d.ValidatedConfig, u: string) => {
   const parsedUrl: ParsedDevModuleUrl = {
     nodeModuleId: null,
     nodeModuleVersion: null,
@@ -179,7 +179,7 @@ const parseDevModuleUrl = (config: d.Config, u: string) => {
   return parsedUrl;
 };
 
-const getDevModuleCachePath = (config: d.Config, parsedUrl: ParsedDevModuleUrl) => {
+const getDevModuleCachePath = (config: d.ValidatedConfig, parsedUrl: ParsedDevModuleUrl) => {
   return join(
     config.cacheDir,
     `dev_module_${parsedUrl.nodeModuleId}_${parsedUrl.nodeModuleVersion}_${DEV_MODULE_CACHE_BUSTER}.log`,

--- a/src/compiler/bundle/dev-node-module-resolve.ts
+++ b/src/compiler/bundle/dev-node-module-resolve.ts
@@ -6,7 +6,7 @@ import { InMemoryFileSystem } from '../sys/in-memory-fs';
 import { DEV_MODULE_DIR } from './constants';
 
 export const devNodeModuleResolveId = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   inMemoryFs: InMemoryFileSystem,
   resolvedId: PartialResolvedId,
   importee: string,
@@ -66,7 +66,12 @@ const getPackageJsonPath = (resolvedPath: string, importee: string): string => {
   return null;
 };
 
-const serializeDevNodeModuleUrl = (config: d.Config, moduleId: string, moduleVersion: string, resolvedPath: string) => {
+const serializeDevNodeModuleUrl = (
+  config: d.ValidatedConfig,
+  moduleId: string,
+  moduleVersion: string,
+  resolvedPath: string,
+) => {
   resolvedPath = relative(config.rootDir, resolvedPath);
 
   let id = `/${DEV_MODULE_DIR}/`;

--- a/src/compiler/bundle/ext-format-plugin.ts
+++ b/src/compiler/bundle/ext-format-plugin.ts
@@ -4,7 +4,7 @@ import type { Plugin, TransformPluginContext, TransformResult } from 'rollup';
 
 import type * as d from '../../declarations';
 
-export const extFormatPlugin = (config: d.Config): Plugin => {
+export const extFormatPlugin = (config: d.ValidatedConfig): Plugin => {
   return {
     name: 'extFormatPlugin',
 
@@ -52,7 +52,7 @@ const formatText = (code: string, filePath: string) => {
 };
 
 const formatUrl = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   pluginCtx: TransformPluginContext,
   code: string,
   filePath: string,

--- a/src/compiler/bundle/plugin-helper.ts
+++ b/src/compiler/bundle/plugin-helper.ts
@@ -3,7 +3,7 @@ import { relative } from 'path';
 
 import type * as d from '../../declarations';
 
-export const pluginHelper = (config: d.Config, builtCtx: d.BuildCtx, platform: string) => {
+export const pluginHelper = (config: d.ValidatedConfig, builtCtx: d.BuildCtx, platform: string) => {
   return {
     name: 'pluginHelper',
     resolveId(importee: string, importer: string): null {

--- a/src/compiler/bundle/test/core-resolve-plugin.spec.ts
+++ b/src/compiler/bundle/test/core-resolve-plugin.spec.ts
@@ -1,12 +1,14 @@
+import { mockValidatedConfig } from '@stencil/core/testing';
+
 import { createSystem } from '../../../compiler/sys/stencil-sys';
 import type * as d from '../../../declarations';
 import { getHydratedFlagHead, getStencilInternalModule } from '../core-resolve-plugin';
 
 describe('core resolve plugin', () => {
-  const config: d.Config = {
+  const config: d.ValidatedConfig = mockValidatedConfig({
     rootDir: '/',
     sys: createSystem(),
-  };
+  });
 
   it('http localhost with port url path', () => {
     const compilerExe = 'http://localhost:3333/@stencil/core/compiler/stencil.js?v=1.2.3';

--- a/src/compiler/bundle/typescript-plugin.ts
+++ b/src/compiler/bundle/typescript-plugin.ts
@@ -15,7 +15,11 @@ import type { BundleOptions } from './bundle-interface';
  * @param config the Stencil configuration for the project
  * @returns the rollup plugin for handling TypeScript files.
  */
-export const typescriptPlugin = (compilerCtx: d.CompilerCtx, bundleOpts: BundleOptions, config: d.Config): Plugin => {
+export const typescriptPlugin = (
+  compilerCtx: d.CompilerCtx,
+  bundleOpts: BundleOptions,
+  config: d.ValidatedConfig,
+): Plugin => {
   return {
     name: `${bundleOpts.id}TypescriptPlugin`,
 

--- a/src/compiler/bundle/user-index-plugin.ts
+++ b/src/compiler/bundle/user-index-plugin.ts
@@ -4,7 +4,7 @@ import type { Plugin } from 'rollup';
 import type * as d from '../../declarations';
 import { USER_INDEX_ENTRY_ID } from './entry-alias-ids';
 
-export const userIndexPlugin = (config: d.Config, compilerCtx: d.CompilerCtx): Plugin => {
+export const userIndexPlugin = (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx): Plugin => {
   return {
     name: 'userIndexPlugin',
 

--- a/src/compiler/output-targets/dist-hydrate-script/relocate-hydrate-context.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/relocate-hydrate-context.ts
@@ -2,7 +2,7 @@ import type * as d from '../../../declarations';
 import { getGlobalScriptData } from '../../bundle/app-data-plugin';
 import { HYDRATE_APP_CLOSURE_START } from './hydrate-factory-closure';
 
-export const relocateHydrateContextConst = (config: d.Config, compilerCtx: d.CompilerCtx, code: string) => {
+export const relocateHydrateContextConst = (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx, code: string) => {
   const globalScripts = getGlobalScriptData(config, compilerCtx);
   if (globalScripts.length > 0) {
     const startCode = code.indexOf('/*hydrate context start*/');

--- a/src/compiler/sys/typescript/tests/typescript-sys.spec.ts
+++ b/src/compiler/sys/typescript/tests/typescript-sys.spec.ts
@@ -1,12 +1,14 @@
+import { mockValidatedConfig } from '@stencil/core/testing';
+
 import { createSystem } from '../../../../compiler/sys/stencil-sys';
 import type * as d from '../../../../declarations';
 import { getTypescriptPathFromUrl } from '../typescript-sys';
 
 describe('getTypescriptPathFromUrl', () => {
-  const config: d.Config = {
+  const config: d.ValidatedConfig = mockValidatedConfig({
     rootDir: '/some/path/',
     sys: createSystem(),
-  };
+  });
 
   it('not typescript, return url', () => {
     const tsExecutingUrl = 'https://cdn.jsdelivr.net/npm/@stencil/core@2.0.0/compiler/stencil.js';

--- a/src/compiler/sys/typescript/typescript-sys.ts
+++ b/src/compiler/sys/typescript/typescript-sys.ts
@@ -200,7 +200,7 @@ const patchTypeScriptSysMinimum = () => {
 };
 patchTypeScriptSysMinimum();
 
-export const getTypescriptPathFromUrl = (config: d.Config, tsExecutingUrl: string, url: string) => {
+export const getTypescriptPathFromUrl = (config: d.ValidatedConfig, tsExecutingUrl: string, url: string) => {
   const tsBaseUrl = new URL('..', tsExecutingUrl).href;
   if (url.startsWith(tsBaseUrl)) {
     const tsFilePath = url.replace(tsBaseUrl, '/');

--- a/src/compiler/transformers/static-to-meta/visitor.ts
+++ b/src/compiler/transformers/static-to-meta/visitor.ts
@@ -35,7 +35,7 @@ export const convertStaticToMeta = (
 
     return (tsSourceFile) => {
       dirPath = dirname(tsSourceFile.fileName);
-      moduleFile = getModuleLegacy(config, compilerCtx, tsSourceFile.fileName);
+      moduleFile = getModuleLegacy(compilerCtx, tsSourceFile.fileName);
       resetModuleLegacy(moduleFile);
 
       if (collection != null) {

--- a/src/compiler/types/generate-app-types.ts
+++ b/src/compiler/types/generate-app-types.ts
@@ -64,7 +64,11 @@ export const generateAppTypes = async (
  * @param areTypesInternal determines if non-exported type definitions are being generated or not
  * @returns the contents of the `components.d.ts` file
  */
-const generateComponentTypesFile = (config: d.Config, buildCtx: d.BuildCtx, areTypesInternal: boolean): string => {
+const generateComponentTypesFile = (
+  config: d.ValidatedConfig,
+  buildCtx: d.BuildCtx,
+  areTypesInternal: boolean,
+): string => {
   let typeImportData: d.TypesImportData = {};
   const c: string[] = [];
   const allTypes = new Map<string, number>();


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates a handful of function parameter types from the unvalidated `Config` type `ValidatedConfig`. this has 2 benefits:

1. it "naturally" fixes a handful of strictNullChecks violations in cases where the caller of the function updated already had a ref to the `ValidatedConfig`
2. it helps with future refactorings of `ValidatedConfig` where we add new keys to be required on the object, as it allows us to: 
    1. find new violations where a property is needed a bit easier in these converted functions 
    1. in theory, automatically dismisses strictNullChecks violations when a key is added to the type, since it can now be properly checked

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Tests should continue to pass
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

This is the amount of work I could (safely) do/test over ~15 minutes, so it's by no means comprehensive.

For each fn I updated, I:
- Checked if the caller(s) already had a `ValidatedConfig` in their fn definitions
  - If all callers did, I updated the fn signature of the function in question 
  - If all callers did not have a `ValidatedConfig`, then I repeated the process for each caller. In all cases, I found a `ValidatedConfig`. This only consisted cases of where we didn't propagate the type down to callers all the way

I'll probably do the same exercise tomorrow. I suspect there are a few more easy wins here
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
