### PR TITLE
chore(repo): use latest ubuntu in tests

### DIFF
--- a/.github/workflows/test-analysis.yml
+++ b/.github/workflows/test-analysis.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         node: ['16', '18', '20']
-        os: ['ubuntu-20.04', 'windows-latest']
+        os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         node: ['16', '18', '20']
-        os: ['ubuntu-20.04', 'windows-latest']
+        os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         node: ['16', '18', '20']
-        os: ['ubuntu-20.04', 'windows-latest']
+        os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit finishes the revert of
https://github.com/ionic-team/stencil/pull/3888. the ubuntu versions in the changed github matrices can't be properly updated/detected by renovate, which is why they fell behind in the first place

STENCIL-755

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

All test workflows updated here continue to pass.

You can see new 'ubuntu-latest' checks occurring/passing here, and the old v20 ones obviously won't run

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

I will probably wait to merge this until after Monday's release. Reason being is that I need to update the CI checks that we gate on, and I don't wanna cause a snowball of rebases right before the release.


I found this while culling the backlog yesterday, and thought it'd be a nice/quick win for something we could easily "just close out"
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
