### PR TITLE
chore(snc): replace addtl config arg types

### DIFF
--- a/src/compiler/fs-watch/fs-watch-rebuild.ts
+++ b/src/compiler/fs-watch/fs-watch-rebuild.ts
@@ -90,7 +90,7 @@ export const hasStyleChanges = (buildCtx: d.BuildCtx): boolean => buildCtx.files
  * @param buildCtx the build context
  * @returns whether or not HTML files were changed
  */
-export const hasHtmlChanges = (config: d.Config, buildCtx: d.BuildCtx): boolean => {
+export const hasHtmlChanges = (config: d.ValidatedConfig, buildCtx: d.BuildCtx): boolean => {
   const anyHtmlChanged = buildCtx.filesChanged.some((f) => f.toLowerCase().endsWith('.html'));
 
   if (anyHtmlChanged) {
@@ -121,7 +121,7 @@ export const updateCacheFromRebuild = (compilerCtx: d.CompilerCtx, buildCtx: d.B
   });
 };
 
-export const isWatchIgnorePath = (config: d.Config, path: string) => {
+export const isWatchIgnorePath = (config: d.ValidatedConfig, path: string) => {
   if (isString(path)) {
     const isWatchIgnore = (config.watchIgnoredRegex as RegExp[]).some((reg) => reg.test(path));
     if (isWatchIgnore) {

--- a/src/compiler/html/add-script-attr.ts
+++ b/src/compiler/html/add-script-attr.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 import type * as d from '../../declarations';
 import { getAbsoluteBuildDir } from './html-utils';
 
-export const addScriptDataAttribute = (config: d.Config, doc: Document, outputTarget: d.OutputTargetWww) => {
+export const addScriptDataAttribute = (config: d.ValidatedConfig, doc: Document, outputTarget: d.OutputTargetWww) => {
   const resourcesUrl = getAbsoluteBuildDir(outputTarget);
   const entryEsmFilename = `${config.fsNamespace}.esm.js`;
   const entryNoModuleFilename = `${config.fsNamespace}.js`;

--- a/src/compiler/html/inject-sw-script.ts
+++ b/src/compiler/html/inject-sw-script.ts
@@ -3,7 +3,7 @@ import { getRegisterSW, UNREGISTER_SW } from '../service-worker/generate-sw';
 import { generateServiceWorkerUrl } from '../service-worker/service-worker-util';
 
 export const updateIndexHtmlServiceWorker = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   buildCtx: d.BuildCtx,
   doc: Document,
   outputTarget: d.OutputTargetWww,

--- a/src/compiler/html/inline-esm-import.ts
+++ b/src/compiler/html/inline-esm-import.ts
@@ -8,7 +8,7 @@ import { getAbsoluteBuildDir } from './html-utils';
 import { injectModulePreloads } from './inject-module-preloads';
 
 export const optimizeEsmImport = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   doc: Document,
   outputTarget: d.OutputTargetWww,

--- a/src/compiler/html/update-global-styles-link.ts
+++ b/src/compiler/html/update-global-styles-link.ts
@@ -4,7 +4,7 @@ import type * as d from '../../declarations';
 import { getAbsoluteBuildDir } from './html-utils';
 
 export const updateGlobalStylesLink = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   doc: Document,
   globalScriptFilename: string,
   outputTarget: d.OutputTargetWww,

--- a/src/compiler/output-targets/copy/hashed-copy.ts
+++ b/src/compiler/output-targets/copy/hashed-copy.ts
@@ -2,7 +2,7 @@ import { dirname, extname, join } from 'path';
 
 import type * as d from '../../../declarations';
 
-export const generateHashedCopy = async (config: d.Config, compilerCtx: d.CompilerCtx, path: string) => {
+export const generateHashedCopy = async (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx, path: string) => {
   try {
     const content = await compilerCtx.fs.readFile(path);
     const hash = await config.sys.generateContentHash(content, config.hashedFileNameLength);

--- a/src/compiler/prerender/prerender-main.ts
+++ b/src/compiler/prerender/prerender-main.ts
@@ -252,7 +252,7 @@ const runPrerenderOutputTarget = async (
   }
 };
 
-const createPrerenderTemplate = async (config: d.Config, templateHtml: string) => {
+const createPrerenderTemplate = async (config: d.ValidatedConfig, templateHtml: string) => {
   const hash = await config.sys.generateContentHash(templateHtml, 12);
   const templateFileName = `prerender-${hash}.html`;
   const templateId = join(config.sys.tmpDirSync(), templateFileName);

--- a/src/compiler/prerender/prerender-template-html.ts
+++ b/src/compiler/prerender/prerender-template-html.ts
@@ -11,7 +11,7 @@ import {
 } from './prerender-optimize';
 
 export const generateTemplateHtml = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   prerenderConfig: d.PrerenderConfig,
   diagnostics: d.Diagnostic[],
   isDebug: boolean,

--- a/src/compiler/sys/typescript/typescript-config.ts
+++ b/src/compiler/sys/typescript/typescript-config.ts
@@ -110,7 +110,7 @@ export const validateTsConfig = async (config: d.ValidatedConfig, sys: d.Compile
   return tsconfig;
 };
 
-const getTsConfigPath = async (config: d.Config, sys: d.CompilerSystem, init: d.LoadConfigInit) => {
+const getTsConfigPath = async (config: d.ValidatedConfig, sys: d.CompilerSystem, init: d.LoadConfigInit) => {
   const tsconfig = {
     path: null as string,
     content: null as string,
@@ -144,7 +144,7 @@ const getTsConfigPath = async (config: d.Config, sys: d.CompilerSystem, init: d.
   return tsconfig;
 };
 
-const createDefaultTsConfig = (config: d.Config) =>
+const createDefaultTsConfig = (config: d.ValidatedConfig) =>
   JSON.stringify(
     {
       compilerOptions: {

--- a/src/compiler/transpile/run-program.ts
+++ b/src/compiler/transpile/run-program.ts
@@ -175,7 +175,7 @@ export const runTsProgram = async (
  * @returns a relative path to a suitable location where the typedef file can be
  * written
  */
-export const getRelativeDts = (config: d.Config, srcPath: string, emitDtsPath: string): string => {
+export const getRelativeDts = (config: d.ValidatedConfig, srcPath: string, emitDtsPath: string): string => {
   const parts: string[] = [];
   for (let i = 0; i < 30; i++) {
     if (normalizePath(config.srcDir) === srcPath) {

--- a/src/compiler/transpile/validate-components.ts
+++ b/src/compiler/transpile/validate-components.ts
@@ -2,13 +2,13 @@ import { buildError, relative } from '@utils';
 
 import type * as d from '../../declarations';
 
-export const validateTranspiledComponents = (config: d.Config, buildCtx: d.BuildCtx) => {
+export const validateTranspiledComponents = (config: d.ValidatedConfig, buildCtx: d.BuildCtx) => {
   for (const cmp of buildCtx.components) {
     validateUniqueTagNames(config, buildCtx, cmp);
   }
 };
 
-const validateUniqueTagNames = (config: d.Config, buildCtx: d.BuildCtx, cmp: d.ComponentCompilerMeta) => {
+const validateUniqueTagNames = (config: d.ValidatedConfig, buildCtx: d.BuildCtx, cmp: d.ComponentCompilerMeta) => {
   const tagName = cmp.tagName;
   const cmpsWithTagName = buildCtx.components.filter((c) => c.tagName === tagName);
   if (cmpsWithTagName.length > 1) {

--- a/src/compiler/types/update-import-refs.ts
+++ b/src/compiler/types/update-import-refs.ts
@@ -17,7 +17,7 @@ export const updateReferenceTypeImports = (
   typeCounts: Map<string, number>,
   cmp: d.ComponentCompilerMeta,
   filePath: string,
-  config: d.Config,
+  config: d.ValidatedConfig,
 ): d.TypesImportData => {
   const updateImportReferences = updateImportReferenceFactory(typeCounts, filePath, config);
 
@@ -53,7 +53,7 @@ type ImportReferenceUpdater = (
 const updateImportReferenceFactory = (
   typeCounts: Map<string, number>,
   filePath: string,
-  config: d.Config,
+  config: d.ValidatedConfig,
 ): ImportReferenceUpdater => {
   /**
    * Determines the number of times that a type identifier (name) has been used. If an identifier has been used before,

--- a/src/utils/logger/logger-rollup.ts
+++ b/src/utils/logger/logger-rollup.ts
@@ -6,7 +6,7 @@ import { buildWarn } from '../message-utils';
 import { splitLineBreaks } from './logger-utils';
 
 export const loadRollupDiagnostics = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   rollupError: RollupError,

--- a/src/utils/output-target.ts
+++ b/src/utils/output-target.ts
@@ -35,7 +35,7 @@ export const relativeImport = (pathFrom: string, pathTo: string, ext?: string, a
   return normalizePath(`${relativePath}/${basename(pathTo, ext)}`);
 };
 
-export const getComponentsDtsSrcFilePath = (config: d.Config) => join(config.srcDir, GENERATED_DTS);
+export const getComponentsDtsSrcFilePath = (config: d.ValidatedConfig) => join(config.srcDir, GENERATED_DTS);
 
 export const getComponentsDtsTypesFilePath = (outputTarget: d.OutputTargetDist | d.OutputTargetDistTypes) =>
   join(outputTarget.typesDir, GENERATED_DTS);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

Please review, ~but do not merge.~ Parent landed
Depends on https://github.com/ionic-team/stencil/pull/4794.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates a handful of function parameter types from the unvalidated `Config` type `ValidatedConfig`. this has 2 benefits:

1. it "naturally" fixes a handful of strictNullChecks violations in cases where the caller of the function updated already had a ref to the `ValidatedConfig`
2. it helps with future refactorings of `ValidatedConfig` where we add new keys to be required on the object, as it allows us to: 
    1. find new violations where a property is needed a bit easier in these converted functions 
    1. in theory, automatically dismisses strictNullChecks violations when a key is added to the type, since it can now be properly checked

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Tests should continue to pass
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

This is the amount of work I could (safely) do/test over ~15 minutes, so it's by no means comprehensive.

For each fn I updated, I:
- Checked if the caller(s) already had a `ValidatedConfig` in their fn definitions
  - If all callers did, I updated the fn signature of the function in question 
  - If all callers did not have a `ValidatedConfig`, then I repeated the process for each caller. In all cases, I found a `ValidatedConfig`. This only consisted cases of where we didn't propagate the type down to callers all the way

I'll probably do the same exercise Monday. I suspect there are a few more easy wins here
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
