### PR TITLE
chore(): add logLevel to ValidatedConfig

### DIFF
--- a/src/compiler/config/load-config.ts
+++ b/src/compiler/config/load-config.ts
@@ -75,16 +75,6 @@ export const loadConfig = async (init: LoadConfigInit = {}): Promise<LoadConfigR
 
     results.config = validated.config;
 
-    if (results.config.flags.debug || results.config.flags.verbose) {
-      results.config.logLevel = 'debug';
-    } else if (results.config.flags.logLevel) {
-      results.config.logLevel = results.config.flags.logLevel;
-    } else if (typeof results.config.logLevel !== 'string') {
-      results.config.logLevel = 'info';
-    }
-
-    results.config.logger.setLevel(results.config.logLevel);
-
     if (!hasError(results.diagnostics)) {
       const tsConfigResults = await validateTsConfig(results.config, sys, init);
       results.diagnostics.push(...tsConfigResults.diagnostics);

--- a/src/compiler/sys/config.ts
+++ b/src/compiler/sys/config.ts
@@ -10,14 +10,5 @@ export const getConfig = (userConfig: d.Config): d.ValidatedConfig => {
   userConfig.flags = flags;
   const config: d.ValidatedConfig = validateConfig(userConfig, {}).config;
 
-  if (config.flags.debug || config.flags.verbose) {
-    config.logLevel = 'debug';
-  } else if (config.flags.logLevel) {
-    config.logLevel = config.flags.logLevel;
-  } else if (typeof config.logLevel !== 'string') {
-    config.logLevel = 'info';
-  }
-  config.logger.setLevel(config.logLevel);
-
   return config;
 };

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -460,6 +460,7 @@ type StrictConfigFields =
   | 'flags'
   | 'hydratedFlag'
   | 'logger'
+  | 'logLevel'
   | 'outputTargets'
   | 'packageJsonFilePath'
   | 'rollupConfig'

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -37,6 +37,7 @@ export function mockValidatedConfig(overrides: Partial<ValidatedConfig> = {}): V
     extras: {},
     flags: createConfigFlags(),
     hydratedFlag: null,
+    logLevel: 'info',
     logger: mockLogger(),
     outputTargets: baseConfig.outputTargets ?? [],
     packageJsonFilePath: path.join(rootDir, 'package.json'),


### PR DESCRIPTION
This adds `logLevel` to the list of properties from `Config` which are required on `ValidatedConfig`. This doesn't actually fix any SNC errors but does let us deduplicate some logic that was present in both `compiler/config/load-config.ts` and `compiler/sys/config.ts`.


## What is the current behavior?

We have some duplication where we have the same logic for setting `config.logLevel` in two places. This just pulls that into the `validate-config.ts` file and makes the field required on the validated config to ensure it's present.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I tested this out with a sample project locally to make sure that the default logging behavior was the same as on `main`, and it looks like nothing changed. Unit tests and whatnot are also passing.
