### PR TITLE
 chore(snc): replace config argument types (pt 3)

### DIFF
--- a/src/compiler/prerender/prerender-main.ts
+++ b/src/compiler/prerender/prerender-main.ts
@@ -262,7 +262,7 @@ const createPrerenderTemplate = async (config: d.ValidatedConfig, templateHtml: 
 };
 
 const createComponentGraphPath = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   componentGraph: d.BuildResultsComponentGraph,
   outputTarget: d.OutputTargetWww,
 ) => {

--- a/src/compiler/style/css-imports.ts
+++ b/src/compiler/style/css-imports.ts
@@ -21,7 +21,7 @@ import { stripCssComments } from './style-utils';
  * @returns an object with concatenated styleText and imports
  */
 export const parseCssImports = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   srcFilePath: string,
@@ -158,7 +158,7 @@ const loadStyleText = async (compilerCtx: d.CompilerCtx, cssImportData: d.CssImp
  * @returns a Promise wrapping a list of CSS import data objects
  */
 export const getCssImports = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
   filePath: string,
@@ -226,7 +226,7 @@ export const getCssImports = async (
 export const isCssNodeModule = (url: string) => url.startsWith('~');
 
 export const resolveCssNodeModule = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   diagnostics: d.Diagnostic[],
   filePath: string,

--- a/src/compiler/style/optimize-css.ts
+++ b/src/compiler/style/optimize-css.ts
@@ -4,7 +4,7 @@ import type * as d from '../../declarations';
 import { optimizeCssId } from '../../version';
 
 export const optimizeCss = async (
-  config: d.Config,
+  config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   diagnostics: d.Diagnostic[],
   styleText: string,

--- a/src/compiler/transformers/decorators-to-static/component-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/component-decorator.ts
@@ -28,7 +28,7 @@ import { styleToStatic } from './style-to-static';
  * decorator
  */
 export const componentDecoratorToStatic = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   typeChecker: ts.TypeChecker,
   diagnostics: d.Diagnostic[],
   cmpNode: ts.ClassDeclaration,
@@ -84,7 +84,7 @@ export const componentDecoratorToStatic = (
  * @returns whether or not the component is valid
  */
 const validateComponent = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   diagnostics: d.Diagnostic[],
   typeChecker: ts.TypeChecker,
   componentOptions: d.ComponentOptions,

--- a/src/compiler/transformers/decorators-to-static/convert-decorators.ts
+++ b/src/compiler/transformers/decorators-to-static/convert-decorators.ts
@@ -41,7 +41,7 @@ import { watchDecoratorsToStatic } from './watch-decorator';
  * TypeScript to transform source code during the compilation process
  */
 export const convertDecoratorsToStatic = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   diagnostics: d.Diagnostic[],
   typeChecker: ts.TypeChecker,
   program: ts.Program,
@@ -85,7 +85,7 @@ export const convertDecoratorsToStatic = (
  * @returns a class node, possibly updated with new static values
  */
 const visitClassDeclaration = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   diagnostics: d.Diagnostic[],
   typeChecker: ts.TypeChecker,
   program: ts.Program,

--- a/src/compiler/transformers/decorators-to-static/method-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/method-decorator.ts
@@ -18,7 +18,7 @@ import {
 import { isDecoratorNamed } from './decorator-utils';
 
 export const methodDecoratorsToStatic = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   diagnostics: d.Diagnostic[],
   cmpNode: ts.ClassDeclaration,
   decoratedProps: ts.ClassElement[],
@@ -38,7 +38,7 @@ export const methodDecoratorsToStatic = (
 };
 
 const parseMethodDecorator = (
-  config: d.Config,
+  config: d.ValidatedConfig,
   diagnostics: d.Diagnostic[],
   tsSourceFile: ts.SourceFile,
   typeChecker: ts.TypeChecker,

--- a/src/testing/jest/jest-config.ts
+++ b/src/testing/jest/jest-config.ts
@@ -152,7 +152,7 @@ export function buildJestConfig(config: d.ValidatedConfig): string {
   return JSON.stringify(jestConfig);
 }
 
-export function getProjectListFromCLIArgs(config: d.Config, argv: Config.Argv): Config.Path[] {
+export function getProjectListFromCLIArgs(config: d.ValidatedConfig, argv: Config.Argv): Config.Path[] {
   const projects = argv.projects ? argv.projects : [];
 
   projects.push(config.rootDir);

--- a/src/utils/test/util.spec.ts
+++ b/src/utils/test/util.spec.ts
@@ -1,4 +1,4 @@
-import { mockBuildCtx, mockConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockValidatedConfig } from '@stencil/core/testing';
 import * as util from '@utils';
 
 import type * as d from '../../declarations';
@@ -7,7 +7,7 @@ import { stubDiagnostic } from '../../dev-server/test/Diagnostic.stub';
 describe('util', () => {
   describe('generatePreamble', () => {
     it('generates a comment with a single line preamble', () => {
-      const testConfig = mockConfig({ preamble: 'I am Stencil' });
+      const testConfig = mockValidatedConfig({ preamble: 'I am Stencil' });
 
       const result = util.generatePreamble(testConfig);
 
@@ -17,7 +17,7 @@ describe('util', () => {
     });
 
     it('generates a comment with a multi-line preamble', () => {
-      const testConfig = mockConfig({ preamble: 'I am Stencil\nHear me roar' });
+      const testConfig = mockValidatedConfig({ preamble: 'I am Stencil\nHear me roar' });
 
       const result = util.generatePreamble(testConfig);
 
@@ -28,7 +28,7 @@ describe('util', () => {
     });
 
     it('returns an empty string if no preamble is provided', () => {
-      const testConfig = mockConfig();
+      const testConfig = mockValidatedConfig();
 
       const result = util.generatePreamble(testConfig);
 
@@ -36,7 +36,7 @@ describe('util', () => {
     });
 
     it('returns an empty string a null preamble is provided', () => {
-      const testConfig = mockConfig({ preamble: undefined });
+      const testConfig = mockValidatedConfig({ preamble: undefined });
 
       const result = util.generatePreamble(testConfig);
 
@@ -44,7 +44,7 @@ describe('util', () => {
     });
 
     it('returns an empty string if an empty preamble is provided', () => {
-      const testConfig = mockConfig({ preamble: '' });
+      const testConfig = mockValidatedConfig({ preamble: '' });
 
       const result = util.generatePreamble(testConfig);
 

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -60,7 +60,7 @@ export const isDtsFile = (filePath: string): boolean => {
  * @param config the Stencil configuration file
  * @returns the generated preamble
  */
-export const generatePreamble = (config: d.Config): string => {
+export const generatePreamble = (config: d.ValidatedConfig): string => {
   const { preamble } = config;
 
   if (!preamble) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates a handful of function parameter types from the unvalidated `Config` type `ValidatedConfig`. this has 2 benefits:

1. it "naturally" fixes a handful of strictNullChecks violations in cases where the caller of the function updated already had a ref to the `ValidatedConfig`
2. it helps with future refactorings of `ValidatedConfig` where we add new keys to be required on the object, as it allows us to: 
    1. find new violations where a property is needed a bit easier in these converted functions 
    1. in theory, automatically dismisses strictNullChecks violations when a key is added to the type, since it can now be properly checked

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Tests should continue to pass
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

This is the amount of work I could (safely) do/test over ~15 minutes, so it's by no means comprehensive.

For each fn I updated, I:
- Checked if the caller(s) already had a `ValidatedConfig` in their fn definitions
  - If all callers did, I updated the fn signature of the function in question 
  - If all callers did not have a `ValidatedConfig`, then I repeated the process for each caller. In all cases, I found a `ValidatedConfig`. This only consisted cases of where we didn't propagate the type down to callers all the way

I think this is the last time I'll run this exercise until the next JEDI days. There's some replacements to be made in `buildDone` and related functions, but that requires some work around making sure we don't introduce a breaking change in the public API
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
