### PR TITLE
chore(compiler): remove unused ts resolve module

### DIFF
--- a/src/compiler/sys/typescript/tests/typescript-resolve-module.spec.ts
+++ b/src/compiler/sys/typescript/tests/typescript-resolve-module.spec.ts
@@ -1,21 +1,13 @@
-import ts from 'typescript';
-
 import type * as d from '../../../../declarations';
-import { normalizePath } from '../../../../utils';
-import { createInMemoryFs, InMemoryFileSystem } from '../../../sys/in-memory-fs';
 import { createSystem } from '../../../sys/stencil-sys';
 import { ensureExtension } from '../typescript-resolve-module';
-import { patchedTsResolveModule } from '../typescript-resolve-module';
 
 describe('typescript resolve module', () => {
   const config: d.Config = { rootDir: '/some/path' };
-  let inMemoryFs: InMemoryFileSystem;
-  let sys: d.CompilerSystem;
 
   beforeEach(() => {
     config.rootDir = '/some/path';
-    config.sys = sys = createSystem();
-    inMemoryFs = createInMemoryFs(sys);
+    config.sys = createSystem();
   });
 
   describe('ensureExtension', () => {
@@ -39,72 +31,5 @@ describe('typescript resolve module', () => {
       const r = ensureExtension(url, containingUrl);
       expect(r).toBe(url);
     });
-  });
-
-  it('resolve ./stencil-private.d.ts to full dts path when imported by internal dts url', async () => {
-    const moduleName = './stencil-private';
-    const containingFile = normalizePath(
-      sys.getLocalModulePath({ rootDir: config.rootDir, moduleId: '@stencil/core', path: 'internal/index.d.ts' }),
-    );
-    expect(containingFile).toBe('/some/path/node_modules/@stencil/core/internal/index.d.ts');
-
-    await inMemoryFs.writeFile('/some/path/node_modules/@stencil/core/internal/stencil-private.d.ts', '');
-
-    const r = patchedTsResolveModule(config, inMemoryFs, moduleName, containingFile);
-    expect(r).toEqual({
-      resolvedModule: {
-        extension: ts.Extension.Dts,
-        resolvedFileName: '/some/path/node_modules/@stencil/core/internal/stencil-private.d.ts',
-        packageId: {
-          name: moduleName,
-          subModuleName: '',
-          version: '__VERSION:STENCIL__',
-        },
-      },
-      failedLookupLocations: [],
-    });
-  });
-
-  it('resolve @stencil/core/internal to internal dts url', () => {
-    const moduleName = '@stencil/core/internal';
-    const containingFile = './cmp.tsx';
-    const r = patchedTsResolveModule(config, inMemoryFs, moduleName, containingFile);
-    expect(r).toEqual({
-      resolvedModule: {
-        extension: ts.Extension.Dts,
-        resolvedFileName: '/some/path/node_modules/@stencil/core/internal/index.d.ts',
-        packageId: {
-          name: moduleName,
-          subModuleName: '',
-          version: '__VERSION:STENCIL__',
-        },
-      },
-      failedLookupLocations: [],
-    });
-  });
-
-  it('resolve @stencil/core to internal dts url', () => {
-    const moduleName = '@stencil/core';
-    const containingFile = './cmp.tsx';
-    const r = patchedTsResolveModule(config, inMemoryFs, moduleName, containingFile);
-    expect(r).toEqual({
-      resolvedModule: {
-        extension: ts.Extension.Dts,
-        resolvedFileName: '/some/path/node_modules/@stencil/core/internal/index.d.ts',
-        packageId: {
-          name: moduleName,
-          subModuleName: '',
-          version: '__VERSION:STENCIL__',
-        },
-      },
-      failedLookupLocations: [],
-    });
-  });
-
-  it('local path', () => {
-    const moduleName = './module.ts';
-    const containingFile = './cmp.tsx';
-    const r = patchedTsResolveModule(config, inMemoryFs, moduleName, containingFile);
-    expect(r.resolvedModule.resolvedFileName).toEqual('./module.ts');
   });
 });


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
this commit removes an unused function, `patchedTsResolveModule`, from the codebase. it was found/discovered while removing `strictNullChecks` violations related to `Config` and `ValidatedConfig`. is has been removed in a separate commit/pull request in the off chance we need to revert this.

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
