### PR TITLE
chore(unused-exports): remove an unused function in resolve-utils.ts

### DIFF
--- a/src/compiler/sys/resolve/resolve-utils.ts
+++ b/src/compiler/sys/resolve/resolve-utils.ts
@@ -44,8 +44,6 @@ export const isJsFile = (p: string) => p.endsWith('.js');
 
 export const isJsonFile = (p: string) => p.endsWith('.json');
 
-export const getCommonDirName = (dirPath: string, fileName: string) => dirPath + '/' + fileName;
-
 export const isCommonDirModuleFile = (p: string) => COMMON_DIR_MODULE_EXTS.some((ext) => p.endsWith(ext));
 
 export const setPackageVersion = (pkgVersions: Map<string, string>, pkgName: string, pkgVersion: string) => {


### PR DESCRIPTION
Just saw this one on the unused-exports report and thought why not get rid of that?


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
