### PR TITLE
chore(repo): add karma test config to renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -92,6 +92,21 @@
       // this package can be released often, let's look at it every week
       // Note: Timezone for the schedule is specified as UTC
       schedule: ["before 11am on monday"]
+    },
+    {
+      // We intentionally run the karma tests against the oldest LTS of Node we support.
+      // Prevent renovate from trying to bump node
+      matchFileNames: ['./test/karma/package.json'],
+      matchPackageNames: ['node', '@types/node'],
+      allowedVersions: '<=16'
+    },
+    {
+      // We intentionally run the karma tests against the oldest LTS of Node we support.
+      // Prevent renovate from trying to bump npm and keep it in sync with a version that's supported by the version of
+      // Node we run against.
+      matchFileNames: ['./test/karma/package.json'],
+      matchPackageNames: ['npm'],
+      allowedVersions: '<=8'
     }
   ],
   // Never rebase the branch or update it unless manually requested to avoid noisy PR emails


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When we started to allow renovate to bump deps in the karma sub dir (#4816), it started to try to bump npm/node versions as well. We don't exactly want that!
 
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the renovate configuration to prevent renovate from bumping node, node typings, and npm to versions that we do not want to run against at this time. historically, we've tested against the oldest LTS (even if it's not supported by Node anymore, just so long as we support it). this helps continue that.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I've validated that the changes are valid renovate syntax, but I'm not 100% sure that these are the right settings. We'll have to merge and see 😢 I did look through their docs and GH discussions, and this seems ot be the most promising
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
