### PR TITLE
revert(test): update dependency rollup-plugin-node-polyfills to ^0.2.0

### DIFF
--- a/test/karma/package-lock.json
+++ b/test/karma/package-lock.json
@@ -19,7 +19,7 @@
         "karma-typescript": "^5.5.4",
         "karma-typescript-es6-transform": "^5.5.4",
         "normalize.css": "^8.0.1",
-        "rollup-plugin-node-polyfills": "^0.2.0",
+        "rollup-plugin-node-polyfills": "^0.1.2",
         "typescript": "~5.1.0",
         "webpack-cli": "^4.9.1",
         "workbox-build": "4.3.1"
@@ -3538,9 +3538,9 @@
       }
     },
     "node_modules/estree-walker": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
+      "integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==",
       "dev": true
     },
     "node_modules/esutils": {
@@ -5824,24 +5824,24 @@
       }
     },
     "node_modules/rollup-plugin-inject": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
-      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-2.2.0.tgz",
+      "integrity": "sha512-Wow9g+qkKbkK96wjLif2HqWOiuR6ZqkZbHSNt5r1bVUDQG96yzmuxlSl1grPzlTG5BbATUE7nA5HhQVfBXEigQ==",
       "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
       "dev": true,
       "dependencies": {
-        "estree-walker": "^0.6.1",
-        "magic-string": "^0.25.3",
-        "rollup-pluginutils": "^2.8.1"
+        "estree-walker": "^0.5.0",
+        "magic-string": "^0.25.0",
+        "rollup-pluginutils": "^2.0.1"
       }
     },
     "node_modules/rollup-plugin-node-polyfills": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
-      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.1.2.tgz",
+      "integrity": "sha512-aeXQCdBqO9uSkOoipdU2xPkhovDZdM0UEbnPJhK4achyWC2RP9WaE6CKUzGtwGNQqTvl3/qYQgQCfbL+d0MEUw==",
       "dev": true,
       "dependencies": {
-        "rollup-plugin-inject": "^3.0.0"
+        "rollup-plugin-inject": "^2.2.0"
       }
     },
     "node_modules/rollup-pluginutils": {
@@ -5852,6 +5852,12 @@
       "dependencies": {
         "estree-walker": "^0.6.1"
       }
+    },
+    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -9791,9 +9797,9 @@
       "peer": true
     },
     "estree-walker": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
+      "integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==",
       "dev": true
     },
     "esutils": {
@@ -11550,23 +11556,23 @@
       }
     },
     "rollup-plugin-inject": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
-      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-2.2.0.tgz",
+      "integrity": "sha512-Wow9g+qkKbkK96wjLif2HqWOiuR6ZqkZbHSNt5r1bVUDQG96yzmuxlSl1grPzlTG5BbATUE7nA5HhQVfBXEigQ==",
       "dev": true,
       "requires": {
-        "estree-walker": "^0.6.1",
-        "magic-string": "^0.25.3",
-        "rollup-pluginutils": "^2.8.1"
+        "estree-walker": "^0.5.0",
+        "magic-string": "^0.25.0",
+        "rollup-pluginutils": "^2.0.1"
       }
     },
     "rollup-plugin-node-polyfills": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
-      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.1.2.tgz",
+      "integrity": "sha512-aeXQCdBqO9uSkOoipdU2xPkhovDZdM0UEbnPJhK4achyWC2RP9WaE6CKUzGtwGNQqTvl3/qYQgQCfbL+d0MEUw==",
       "dev": true,
       "requires": {
-        "rollup-plugin-inject": "^3.0.0"
+        "rollup-plugin-inject": "^2.2.0"
       }
     },
     "rollup-pluginutils": {
@@ -11576,6 +11582,14 @@
       "dev": true,
       "requires": {
         "estree-walker": "^0.6.1"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+          "dev": true
+        }
       }
     },
     "safe-buffer": {

--- a/test/karma/package.json
+++ b/test/karma/package.json
@@ -40,7 +40,7 @@
     "karma-typescript": "^5.5.4",
     "karma-typescript-es6-transform": "^5.5.4",
     "normalize.css": "^8.0.1",
-    "rollup-plugin-node-polyfills": "^0.2.0",
+    "rollup-plugin-node-polyfills": "^0.1.2",
     "typescript": "~5.1.0",
     "webpack-cli": "^4.9.1",
     "workbox-build": "4.3.1"


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

This reverts commit 7e7122706e4313eb0c49e60b1901efd59505ac8d, #4824.

This commit was causing flakiness in our karma tests (or so it's believed).

When 7e7122706e4313eb0c49e60b1901efd59505ac8d was applied, we'd see some flakiness to the tune of the following in our karma tests:

> Firefox 117.0 (Windows 10) prerender server componentDidLoad Order FAILED
>	Error: console.error was called, this is not allowed in a unit test run thrown

While we did introduce this error recently, I believe this has more to do with the polyfills more than anything

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

It's a revert! Go back to the version that worked (for now) 

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Tested this locally. Let's exercise it on CI too
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
