### PR TITLE
chore(ts): enable strictBindCallApply ts compiler flag

### DIFF
--- a/src/compiler/bundle/dev-node-module-resolve.ts
+++ b/src/compiler/bundle/dev-node-module-resolve.ts
@@ -1,5 +1,5 @@
 import { basename, dirname, join, relative } from 'path';
-import { PartialResolvedId } from 'rollup';
+import { ResolveIdResult } from 'rollup';
 
 import type * as d from '../../declarations';
 import { InMemoryFileSystem } from '../sys/in-memory-fs';
@@ -8,12 +8,17 @@ import { DEV_MODULE_DIR } from './constants';
 export const devNodeModuleResolveId = async (
   config: d.ValidatedConfig,
   inMemoryFs: InMemoryFileSystem,
-  resolvedId: PartialResolvedId,
+  resolvedId: ResolveIdResult,
   importee: string,
 ) => {
   if (!shouldCheckDevModule(resolvedId, importee)) {
     return resolvedId;
   }
+
+  if (typeof resolvedId === 'string' || !resolvedId) {
+    return resolvedId;
+  }
+
   const resolvedPath = resolvedId.id;
 
   const pkgPath = getPackageJsonPath(resolvedPath, importee);
@@ -41,9 +46,10 @@ export const devNodeModuleResolveId = async (
   return resolvedId;
 };
 
-const shouldCheckDevModule = (resolvedId: PartialResolvedId, importee: string) =>
+const shouldCheckDevModule = (resolvedId: ResolveIdResult, importee: string) =>
   resolvedId &&
   importee &&
+  typeof resolvedId !== 'string' &&
   resolvedId.id &&
   resolvedId.id.includes('node_modules') &&
   (resolvedId.id.endsWith('.js') || resolvedId.id.endsWith('.mjs')) &&

--- a/src/hydrate/platform/hydrate-app.ts
+++ b/src/hydrate/platform/hydrate-app.ts
@@ -143,9 +143,9 @@ export function hydrateApp(
 
     win.document.createElementNS = function patchedCreateElement(namespaceURI: string, tagName: string) {
       const elm = orgDocumentCreateElementNS.call(win.document, namespaceURI, tagName);
-      patchElement(elm);
+      patchElement(elm as d.HostElement);
       return elm;
-    };
+    } as (typeof window)['document']['createElementNS'];
 
     // ensure we use NodeJS's native setTimeout, not the mocked hydrate app scoped one
     tmrId = global.setTimeout(timeoutExceeded, opts.timeout);

--- a/src/runtime/dom-extras.ts
+++ b/src/runtime/dom-extras.ts
@@ -189,15 +189,18 @@ export const patchSlotInsertAdjacentElement = (HostElementPrototype: HTMLElement
     this: d.HostElement,
     position: InsertPosition,
     element: d.RenderNode,
-  ) {
+  ): Element {
     if (position !== 'afterbegin' && position !== 'beforeend') {
       return originalInsertAdjacentElement.call(this, position, element);
     }
     if (position === 'afterbegin') {
       this.prepend(element);
+      return element;
     } else if (position === 'beforeend') {
       this.append(element);
+      return element;
     }
+    return element;
   };
 };
 

--- a/src/testing/puppeteer/puppeteer-page.ts
+++ b/src/testing/puppeteer/puppeteer-page.ts
@@ -262,8 +262,6 @@ async function e2eSetContent(page: E2EPageInternal, html: string, options: WaitF
   }
 
   await waitForStencil(page, options);
-
-  return rsp;
 }
 
 async function waitForStencil(page: E2EPage, options: WaitForOptions) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strictFunctionTypes": true,
+    "strictBindCallApply": true,
     "outDir": "build",
     "pretty": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
This turns on the `strictBindCallApply` typescript compiler option and then does what I _think_ is something like the minimal set of changes to get the build to pass with that option on.

From [the TypeScript docs](https://www.typescriptlang.org/tsconfig#strictBindCallApply):

> When set, TypeScript will check that the built-in methods of functions `call`, `bind`, and `apply` are invoked with correct argument for the underlying function[...] Otherwise, these functions accept any arguments and will return `any`

I didn't quite realize that without this option doing a `.call` on a function was basically a big type hole! Not good!

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Unit tests and whatnot are passing, but would be good to check also that framework builds without issues.