### PR TITLE
chore(release): ensure correct vermoji baked into distributable

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -7,6 +7,7 @@ import { promptRelease } from './release-prompts';
 import { runReleaseTasks } from './release-tasks';
 import { BuildOptions, getOptions } from './utils/options';
 import { getNewVersion } from './utils/release-utils';
+import { getLatestVermoji } from './utils/vermoji';
 
 /**
  * Runner for creating a release of Stencil
@@ -87,6 +88,9 @@ export async function release(rootDir: string, args: ReadonlyArray<string>): Pro
     });
     // this was bumped already, we just need to copy it from package.json into this field
     prepareOpts.version = prepareOpts.packageJson.version;
+
+    // we generated a vermoji during the preparation step, let's grab it from the changelog
+    prepareOpts.vermoji = getLatestVermoji(prepareOpts.changelogPath);
 
     const tagIdx = args.indexOf('--tag');
     let newTag = null;

--- a/scripts/utils/vermoji.ts
+++ b/scripts/utils/vermoji.ts
@@ -338,3 +338,34 @@ export function getVermoji(changelogPath: string) {
     }
   }
 }
+
+/**
+ * Pull the most recently used vermoji for the provided changelog path
+ * @param changelogPath the path to the changelog to parse
+ * @returns the vermoji found in the changelog, otherwise use a default value.
+ */
+export function getLatestVermoji(changelogPath: string) {
+  let changelogContents = null;
+  try {
+    changelogContents = fs.readFileSync(changelogPath, 'utf8');
+  } catch (err: unknown) {
+    console.error(`Unable to read the changelog at path '${changelogPath}' - ${err}.`);
+    console.error(`Defaulting to ${UNKNOWN_VERMOJI}`);
+    return UNKNOWN_VERMOJI;
+  }
+
+  if (!changelogContents) {
+    console.error(`The changelog at '${changelogPath}' was empty!`);
+    console.error(`Defaulting to ${UNKNOWN_VERMOJI}`);
+    return UNKNOWN_VERMOJI;
+  }
+
+  // grab the first line of the changelog
+  const firstLine = changelogContents.trimStart().split('\n')[0];
+  // match the first line of the changelog with a string that has:
+  // - one or more pound signs (#), followed by a space
+  // - capture the first non-space character(s)
+  const match = firstLine.match(/^#+\s(\S+)/);
+  // if a match was found, return the value in the first capture group. otherwise, use the default vermoji
+  return match ? match[1] : UNKNOWN_VERMOJI;
+}


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

we generate 2 vermoji during the release process. this is due to a small error in not forwarding the one generated during prerelease to the actual release process.

as an example, in stencil 4.3.0, the vermoji shown in `npx stencil info` is 🐫 , but the changelog shows 🎱 

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit fixes a bug in our release scripts where the vermoji generated in the prerelease step of the process would not be properly propagated to the release step. when the entire process was manual, we'd do it all in one fell swooop, writing a tiny file to disk and reading that.

in lieu of that, we can pull the vermoji off of the head of the CHANGELOG.md! this ensures consistency between the two - running `stencil info` and looking at the changelog should show the same emoji.

note that this change intentionally does not get applied to the `getOptions` function for releases. since we still technically support manual releases, adding the change there for vermoji generation would negatively impact vermoji generation


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Manually tested this to ensure that we parse this correctly.

I had some issues extending/mocking/overriding `node:fs` here for unit tests, hence the lack of them here
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
