### PR TITLE
chore(changelog): reconcile changelog emoji

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 🎱 [4.3.0](https://github.com/ionic-team/stencil/compare/v4.2.1...v4.3.0) (2023-09-18)
+# 🐫 [4.3.0](https://github.com/ionic-team/stencil/compare/v4.2.1...v4.3.0) (2023-09-18)
 
 
 ### Bug Fixes
@@ -14,7 +14,7 @@
 
 
 
-## 🌝 [4.2.1](https://github.com/ionic-team/stencil/compare/v4.2.0...v4.2.1) (2023-09-11)
+## 😀 [4.2.1](https://github.com/ionic-team/stencil/compare/v4.2.0...v4.2.1) (2023-09-11)
 
 
 ### Bug Fixes
@@ -23,7 +23,7 @@
 
 
 
-# 🎺 [4.2.0](https://github.com/ionic-team/stencil/compare/v4.2.0-0...v4.2.0) (2023-09-05)
+# 🌲 [4.2.0](https://github.com/ionic-team/stencil/compare/v4.2.0-0...v4.2.0) (2023-09-05)
 
 
 ### Bug Fixes
@@ -37,7 +37,7 @@
 
 
 
-# 🐸 [4.2.0-0](https://github.com/ionic-team/stencil/compare/v4.1.0...v4.2.0-0) (2023-09-05)
+# ⚽️ [4.2.0-0](https://github.com/ionic-team/stencil/compare/v4.1.0...v4.2.0-0) (2023-09-05)
 
 
 ### Bug Fixes


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See 'new behavior'

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit fixes the changelog emojis for multiple stencil releases. when we moved to automated releases, there was a bug that would not propagate the emoji generated in the prerelease step to the release step. this caused a new emoji to be generated and baked into the distributable that did not match the one in the changelog. since stencil releases are immutable, we choose to go back and edit the changelog to match the emojis that were baked in as a part of the release process.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Pulled down each version of Stencil from the latest (4.3.0) in a starter project and ran `npx stencil info` - I grabbed the emoji from that output and put it in the changelog. Repeated the process until I met a match (4.1.0)
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information
#4836 fixes the root issue. this is just clean up

After this lands, I'll update the releases in GitHub themselves
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
