### PR TITLE
chore(repo): clean up start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "rollup.prod.ci": "rollup --config --config-prod --config-ci",
     "rollup.watch": "rollup --watch --config",
     "spellcheck": "cspell --no-progress \"src/**/*.ts\" \"src/**/*.tsx\" \"scripts/**/*.ts\" \"*.md\"",
-    "start": "npm run watch",
     "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --coverage",
     "test.analysis": "cd test && npm run analysis.build-and-analyze",
     "test.bundlers": "cd test && npm run bundlers",


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There seems to be a `start` script that is of no use anymore. The original `watch` task was removed in https://github.com/ionic-team/stencil/pull/3665

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- removed `start` script

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
n/a

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
n/a