### PR TITLE
fix(jest): use correct minimum jest version

### DIFF
--- a/.github/workflows/test-component-starter.yml
+++ b/.github/workflows/test-component-starter.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        jest: ['24', '25', '26', '27']
         node: ['16', '18', '20']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
@@ -84,6 +85,9 @@ jobs:
         run: npm i ../stencil-eval.tgz
         working-directory: ./tmp-component-starter
         shell: bash
+
+      - name: Install Jest
+        run: npm install --dev-dependencies jest@${{ matrix.jest }} jest-cli@${{ matrix.jest }} @types/jest@${{ matrix.jest }}
 
       - name: Build Starter Project
         run: npm run build

--- a/src/sys/node/node-sys.ts
+++ b/src/sys/node/node-sys.ts
@@ -665,7 +665,7 @@ export function createNodeSys(c: { process?: any; logger?: Logger } = {}): Compi
 
   sys.lazyRequire = new NodeLazyRequire(nodeResolve, {
     '@types/jest': { minVersion: '24.9.1', recommendedVersion: '27.0.3', maxVersion: '27.0.0' },
-    jest: { minVersion: '24.9.1', recommendedVersion: '27.0.3', maxVersion: '27.0.0' },
+    jest: { minVersion: '24.9.0', recommendedVersion: '27.0.3', maxVersion: '27.0.0' },
     'jest-cli': { minVersion: '24.9.0', recommendedVersion: '27.4.5', maxVersion: '27.0.0' },
     puppeteer: { minVersion: '10.0.0', recommendedVersion: '20' },
     'puppeteer-core': { minVersion: '10.0.0', recommendedVersion: '20' },


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When a user attempts to use jest 24, they are greeted with an error:
```console
$ npm t

> new-test@0.0.1 test
> stencil test --spec --e2e

[51:38.0]  @stencil/core
[51:38.1]  v4.3.0 🐫

[ ERROR ]  Please install supported versions of dev dependencies with either npm or yarn.
           npm install --save-dev jest@27.0.3
```
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the check for the minimum allowed version of jest from v24.9.1 to v24.9.0. while working on the jest refactoring, it was discovered that v24.9.1 does not exist, making it impossible for anyone to use v24

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

You can validate the bug exists today by trying to use Jest 24 in a new component starter project:
```bash
cd /tmp \
&& npm init stencil@latest component jest-24-test \
&& cd $_ \
&& npm i jest@24 jest-cli@24 @types/jest@24 \
&& npm t

> new-test@0.0.1 test
> stencil test --spec --e2e

[51:38.0]  @stencil/core
[51:38.1]  v4.3.0 🐫

[ ERROR ]  Please install supported versions of dev dependencies with either npm or yarn.
           npm install --save-dev jest@27.0.3
```

To verify this fix, build this branch:
```bash
npm ci \
&& npm run clean \
&& npm run build \
&& npm pack
```

Then spun up a new stencil component library with it:
```bash
cd /tmp \
&& npm init stencil@latest component jest-fix-test \
&& cd $_ \
&& npm i [PATH_TO_TARBALL] \
&& npm i jest@24 jest-cli@24 @types/jest@24 \
&& npm t
```
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

this commit updates the component starter ci tests to run each version of
jest that we support

STENCIL-953