### PR TITLE
feat(typescript): update to typescript 5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "semver": "^7.3.7",
         "sizzle": "^2.3.6",
         "terser": "5.20.0",
-        "typescript": "~5.1.6",
+        "typescript": "~5.2.2",
         "webpack": "^5.75.0",
         "ws": "8.14.2"
       },
@@ -10929,9 +10929,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -19537,9 +19537,9 @@
       }
     },
     "typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "semver": "^7.3.7",
     "sizzle": "^2.3.6",
     "terser": "5.20.0",
-    "typescript": "~5.1.6",
+    "typescript": "~5.2.2",
     "webpack": "^5.75.0",
     "ws": "8.14.2"
   },

--- a/renovate.json5
+++ b/renovate.json5
@@ -60,9 +60,9 @@
       allowedVersions: '<21.0.0',
     },
     {
-      // TODO(STENCIL-710): Increment this value as a part of updating TypeScript
+      // Increment this value as a part of updating TypeScript
       matchPackageNames: ['typescript'],
-      allowedVersions: '<5.1.6',
+      allowedVersions: '<5.3.0',
     },
     {
       // disable Jest updates until the new testing architecture is in place

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -8,7 +8,7 @@
       "dom",
       "es2020"
     ],
-    "module": "CommonJS",
+    "module": "NodeNext",
     "moduleResolution": "nodenext",
     "outDir": "build/",
     "pretty": true,


### PR DESCRIPTION
This does the TS 5.2 upgrade. In order to get the project to build I didn't have to do much other than install the package.

I did have to adjust the `module` setting in `scripts/package.json`, to account for this change: <https://devblogs.microsoft.com/typescript/announcing-typescript-5-2/#module-and-moduleresolution-must-match-under-recent-node-js-settings>


## What is the current behavior?

Yucky, old, awful typescript 5.1!

## What is the new behavior?

TypeScript 5.2

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

After upgrading the package I built it locally and installed it into Framework and checked that Framework builds with no issues and the tests run.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
