### PR TITLE
chore(test): remove old jest todos

### DIFF
--- a/src/testing/jest/jest-27-and-under/jest-config.ts
+++ b/src/testing/jest/jest-27-and-under/jest-config.ts
@@ -2,7 +2,6 @@ import type { Config } from '@jest/types';
 import type * as d from '@stencil/core/internal';
 import { isString } from '@utils';
 
-// TODO(STENCIL-306): Remove support for earlier versions of Jest
 /**
  * Helper function for retrieving legacy Jest options. These options have been provided as defaults to Stencil users
  * by Jest + yargs for all users using Jest versions 24 through 26 (inclusively). Between Jest v26 and v27, a few
@@ -146,7 +145,6 @@ export function buildJestConfig(config: d.ValidatedConfig): string {
     jestConfig.verbose = stencilConfigTesting.verbose;
   }
 
-  // TODO(STENCIL-307): Move away from Jasmine runner for Stencil tests, which involves a potentially breaking change
   jestConfig.testRunner = 'jest-jasmine2';
 
   return JSON.stringify(jestConfig);

--- a/src/testing/jest/jest-27-and-under/jest-preprocessor.ts
+++ b/src/testing/jest/jest-27-and-under/jest-preprocessor.ts
@@ -4,7 +4,6 @@ import { loadTypeScriptDiagnostic, normalizePath } from '@utils';
 
 import { transpile } from '../../test-transpile';
 
-// TODO(STENCIL-306): Remove support for earlier versions of Jest
 type Jest26CacheKeyOptions = { instrument: boolean; rootDir: string };
 type Jest26Config = { instrument: boolean; rootDir: string };
 type Jest27TransformOptions = { config: Jest26Config };
@@ -58,7 +57,6 @@ export const jestPreprocessor = {
     jestConfig: Jest26Config | Jest27TransformOptions,
     transformOptions?: Jest26Config,
   ): string {
-    // TODO(STENCIL-306): Drop support for versions of Jest <27
     /**
      * As of Jest 27, `jestConfig` changes its shape (as it's been moved into `transformOptions`). To preserve
      * backwards compatibility, we allow Jest to pass 4 arguments and check the shape of the third and fourth arguments
@@ -134,7 +132,6 @@ export const jestPreprocessor = {
     jestConfigStr: string | Jest27TransformOptions,
     transformOptions?: Jest26CacheKeyOptions,
   ): string {
-    // TODO(STENCIL-306): Remove support for earlier versions of Jest
     /**
      * As of Jest 27, jestConfigStr is no longer an accepted argument (as it's been moved into `transformOptions`). To
      * preserve backwards compatibility, we allow Jest to pass 4 arguments and check the shape of the third and fourth

--- a/src/testing/jest/jest-27-and-under/jest-runner.ts
+++ b/src/testing/jest/jest-27-and-under/jest-runner.ts
@@ -50,7 +50,6 @@ export async function runJest(config: d.ValidatedConfig, env: d.E2EProcessEnv) {
  * @returns the test runner
  */
 export function createTestRunner(): any {
-  // TODO(STENCIL-306): Remove support for earlier versions of Jest
   // The left hand side of the '??' is needed for Jest v27, the right hand side for Jest 26 and below
   const TestRunner = require('jest-runner').default ?? require('jest-runner');
 

--- a/src/testing/jest/jest-27-and-under/jest-setup-test-framework.ts
+++ b/src/testing/jest/jest-27-and-under/jest-setup-test-framework.ts
@@ -61,7 +61,6 @@ export function jestSetupTestFramework() {
     global.resourcesUrl = '/build';
   });
 
-  // TODO(STENCIL-307): Remove usage of the Jasmine global
   const jasmineEnv = (jasmine as any).getEnv();
   if (jasmineEnv != null) {
     jasmineEnv.addReporter({
@@ -79,7 +78,6 @@ export function jestSetupTestFramework() {
   if (typeof env.__STENCIL_DEFAULT_TIMEOUT__ === 'string') {
     const time = parseInt(env.__STENCIL_DEFAULT_TIMEOUT__, 10);
     jest.setTimeout(time * 1.5);
-    // TODO(STENCIL-307): Remove usage of the Jasmine global
     // eslint-disable-next-line jest/no-jasmine-globals -- these will be removed when we migrate to jest-circus
     jasmine.DEFAULT_TIMEOUT_INTERVAL = time;
   }


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When I copied Jest infrastructure in #4847, I failed to address/remove TODOs in the code that no longer applied
 
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
remove a handful of TODOs from the Jest 27 and under section of the codebase. these TODOs were originally written when we planned to have to continue to maintain the internally used version of Jest and the one users use, keeping them in sync. now that these two versions of jest are independent, we can remove these TODOs (as the Jest 27 and under code is not expected to be changed for Jest 28).


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I only removed comments, no testing applies (obviously CI should still pass)
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
