### PR TITLE
chore(renovate): fix volta karma node management

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -101,16 +101,23 @@
     {
       // We intentionally run the karma tests against the oldest LTS of Node we support.
       // Prevent renovate from trying to bump node
-      matchFileNames: ['./test/karma/package.json'],
-      matchPackageNames: ['node', '@types/node'],
+      matchFileNames: ['test/karma/package.json'],
+      matchDepNames: ['node'],
+      allowedVersions: '<=16'
+    },
+    {
+      // We intentionally run the karma tests against the oldest LTS of Node we support.
+      // Prevent renovate from trying to bump node
+      matchFileNames: ['test/karma/package.json'],
+      matchPackageNames: ['@types/node'],
       allowedVersions: '<=16'
     },
     {
       // We intentionally run the karma tests against the oldest LTS of Node we support.
       // Prevent renovate from trying to bump npm and keep it in sync with a version that's supported by the version of
       // Node we run against.
-      matchFileNames: ['./test/karma/package.json'],
-      matchPackageNames: ['npm'],
+      matchFileNames: ['test/karma/package.json'],
+      matchDepNames: ['npm'],
       allowedVersions: '<=8'
     }
   ],


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See 'new behavior' section
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit attempts to fix a renovate configuration issue where we wish
to ignore npm, node and `@types/node` from getting bumped in the karma
subdirectory of the project. currently, renovate is trying to bump
these. update `matchPackageNames` to `matchDepNames` and the path to
`package.json` for node/npm to see if that picks up correctly. the node
typings will continue to use `matchPackageNames`, and have therefore
been moved to their own package rule

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

We can't run renovate based on a non-base branch (non-`main`). I've validated the syntax is OK with their offline validator (`renovate-config-validator`), but that more-or-less type checks the config file. We won't know for sure until this merges and renovate runs again :-(
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
