### PR TITLE
chore(ci): adjust component start test name to include jest version

### DIFF
--- a/.github/workflows/test-component-starter.yml
+++ b/.github/workflows/test-component-starter.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   analysis_test:
-    name: (${{ matrix.os }}.${{ matrix.node }})
+    name: (${{ matrix.os }}.node-${{ matrix.node }}.jest-${{ matrix.jest }})
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
We added the Jest version to the matrix for the component starter test in #4851 which increases the number of tests being run for the component starter but the names of the tests don't signify which version of jest is being installed in each one.

Here we just adjust the name to include the node and jest versions directly, just so it's easier to see what's up if something is failing.


## What is the current behavior?

<img width="325" alt="Screenshot 2023-09-28 at 10 03 18 AM" src="https://github.com/ionic-team/stencil/assets/6207644/86238980-4e95-4322-98ae-03f0c9e7b711">


## What is the new behavior?

The names should be different!

<img width="310" alt="Screenshot 2023-09-28 at 10 51 52 AM" src="https://github.com/ionic-team/stencil/assets/6207644/5930e629-5c8d-48ec-953b-339615469e4c">


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
