### PR TITLE
test(vdom): setting readonly props is ignored

### DIFF
--- a/src/mock-doc/document.ts
+++ b/src/mock-doc/document.ts
@@ -198,7 +198,6 @@ export class MockDocument extends MockHTMLElement {
 
   createElementNS(namespaceURI: string, tagName: string) {
     const elmNs = createElementNS(this, namespaceURI, tagName);
-    elmNs.namespaceURI = namespaceURI;
     return elmNs;
   }
 

--- a/src/mock-doc/element.ts
+++ b/src/mock-doc/element.ts
@@ -88,7 +88,7 @@ export function createElementNS(ownerDocument: any, namespaceURI: string, tagNam
         return new MockSVGElement(ownerDocument, tagName);
     }
   } else {
-    return new MockElement(ownerDocument, tagName);
+    return new MockElement(ownerDocument, tagName, namespaceURI);
   }
 }
 
@@ -377,6 +377,8 @@ export class MockStyleElement extends MockHTMLElement {
   }
 }
 export class MockSVGElement extends MockElement {
+  override __namespaceURI = 'http://www.w3.org/2000/svg';
+
   // SVGElement properties and methods
   get ownerSVGElement(): SVGSVGElement {
     return null;

--- a/src/mock-doc/node.ts
+++ b/src/mock-doc/node.ts
@@ -226,7 +226,7 @@ export class MockNodeList {
 type MockElementInternals = Record<keyof ElementInternals, null>;
 
 export class MockElement extends MockNode {
-  #namespaceURI: string | null;
+  __namespaceURI: string | null;
   __attributeMap: MockAttributeMap | null | undefined;
   __shadowRoot: ShadowRoot | null | undefined;
   __style: MockCSSStyleDeclaration | null | undefined;
@@ -242,9 +242,9 @@ Testing components with ElementInternals is fully supported in e2e tests.`,
     });
   }
 
-  constructor(ownerDocument: any, nodeName: string | null) {
+  constructor(ownerDocument: any, nodeName: string | null, namespaceURI: string | null = null) {
     super(ownerDocument, NODE_TYPES.ELEMENT_NODE, typeof nodeName === 'string' ? nodeName : null, null);
-    this.#namespaceURI = null;
+    this.__namespaceURI = namespaceURI;
     this.__shadowRoot = null;
     this.__attributeMap = null;
   }
@@ -267,7 +267,7 @@ Testing components with ElementInternals is fully supported in e2e tests.`,
   }
 
   get namespaceURI() {
-    return this.#namespaceURI;
+    return this.__namespaceURI;
   }
 
   get shadowRoot() {

--- a/src/mock-doc/node.ts
+++ b/src/mock-doc/node.ts
@@ -1088,9 +1088,7 @@ function insertBefore(parentNode: MockNode, newNode: MockNode, referenceNode: Mo
 }
 
 export class MockHTMLElement extends MockElement {
-  override get namespaceURI() {
-    return 'http://www.w3.org/1999/xhtml';
-  }
+  override __namespaceURI = 'http://www.w3.org/1999/xhtml';
 
   constructor(ownerDocument: any, nodeName: string) {
     super(ownerDocument, typeof nodeName === 'string' ? nodeName.toUpperCase() : null);

--- a/src/mock-doc/node.ts
+++ b/src/mock-doc/node.ts
@@ -226,7 +226,7 @@ export class MockNodeList {
 type MockElementInternals = Record<keyof ElementInternals, null>;
 
 export class MockElement extends MockNode {
-  namespaceURI: string | null;
+  #namespaceURI: string | null;
   __attributeMap: MockAttributeMap | null | undefined;
   __shadowRoot: ShadowRoot | null | undefined;
   __style: MockCSSStyleDeclaration | null | undefined;
@@ -244,7 +244,7 @@ Testing components with ElementInternals is fully supported in e2e tests.`,
 
   constructor(ownerDocument: any, nodeName: string | null) {
     super(ownerDocument, NODE_TYPES.ELEMENT_NODE, typeof nodeName === 'string' ? nodeName : null, null);
-    this.namespaceURI = null;
+    this.#namespaceURI = null;
     this.__shadowRoot = null;
     this.__attributeMap = null;
   }
@@ -264,6 +264,10 @@ Testing components with ElementInternals is fully supported in e2e tests.`,
       this,
       new MockFocusEvent('blur', { relatedTarget: null, bubbles: true, cancelable: true, composed: true }),
     );
+  }
+
+  get namespaceURI() {
+    return this.#namespaceURI;
   }
 
   get shadowRoot() {
@@ -1084,7 +1088,9 @@ function insertBefore(parentNode: MockNode, newNode: MockNode, referenceNode: Mo
 }
 
 export class MockHTMLElement extends MockElement {
-  override namespaceURI = 'http://www.w3.org/1999/xhtml';
+  override get namespaceURI() {
+    return 'http://www.w3.org/1999/xhtml';
+  }
 
   constructor(ownerDocument: any, nodeName: string) {
     super(ownerDocument, typeof nodeName === 'string' ? nodeName.toUpperCase() : null);

--- a/src/runtime/vdom/set-accessor.ts
+++ b/src/runtime/vdom/set-accessor.ts
@@ -141,7 +141,11 @@ export const setAccessor = (
           } else {
             (elm as any)[memberName] = newValue;
           }
-        } catch (e) {}
+        } catch (e) {
+          /**
+           * in case someone tries to set a read-only property, e.g. "namespaceURI", we just ignore it
+           */
+        }
       }
 
       /**
@@ -177,7 +181,13 @@ export const setAccessor = (
     }
   }
 };
+
 const parseClassListRegex = /\s/;
+/**
+ * Parsed a string of classnames into an array
+ * @param value className string, e.g. "foo bar baz"
+ * @returns list of classes, e.g. ["foo", "bar", "baz"]
+ */
 const parseClassList = (value: string | undefined | null): string[] => (!value ? [] : value.split(parseClassListRegex));
 const CAPTURE_EVENT_SUFFIX = 'Capture';
 const CAPTURE_EVENT_REGEX = new RegExp(CAPTURE_EVENT_SUFFIX + '$');

--- a/src/runtime/vdom/test/set-accessor.spec.ts
+++ b/src/runtime/vdom/test/set-accessor.spec.ts
@@ -322,6 +322,13 @@ describe('setAccessor for custom elements', () => {
     expect(elm.myprop).toBeUndefined();
     expect(elm).toEqualAttributes({ myprop: 'stringval' });
   });
+
+  it('ignore when updating readonly properties', () => {
+    const readOnlyProp = 'namespaceURI';
+    const oldReadOnlyVal = 'http://www.w3.org/1999/xhtml';
+    setAccessor(elm, readOnlyProp, oldReadOnlyVal, 'foobar', false, 0);
+    expect(elm[readOnlyProp]).toBe(oldReadOnlyVal);
+  });
 });
 
 describe('setAccessor for inputs', () => {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -121,7 +121,7 @@ export const DEFAULT_STYLE_MODE = '$';
  * Reusable empty obj/array
  * Don't add values to these!!
  */
-export const EMPTY_OBJ: any = {};
+export const EMPTY_OBJ: Record<never, never> = {};
 
 /**
  * Namespaces


### PR DESCRIPTION
## What is the new behavior?
While going through `set-accessor.ts` I was wondering why we would try/catch the prop setting part. My assumption is for cases where we set readonly properties like e.g. `namespaceURI`. This actually is compliant with what the browser does:

<img width="313" alt="Screenshot 2023-09-28 at 4 28 18 PM" src="https://github.com/ionic-team/stencil/assets/731337/a911f34f-330b-48bd-a35b-8fe948e59518">

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

This patch adds a test for this case.

## Other information

n/a
