### PR TITLE
refactor(runtime): remove unused s-hmr-load callback

### DIFF
--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -1082,11 +1082,6 @@ export interface HostElement extends HTMLElement {
    */
   ['s-hmr']?: (versionId: string) => void;
 
-  /**
-   * Callback method for when HMR finishes
-   */
-  ['s-hmr-load']?: () => void;
-
   ['s-p']?: Promise<void>[];
 
   componentOnReady?: () => Promise<this>;

--- a/src/runtime/hmr-component.ts
+++ b/src/runtime/hmr-component.ts
@@ -16,17 +16,6 @@ export const hmrStart = (elm: d.HostElement, cmpMeta: d.ComponentRuntimeMeta, hm
   // because we're not passing an exact event name it'll
   // remove all of this element's event, which is good
 
-  // create a callback for when this component finishes hmr
-  elm['s-hmr-load'] = () => {
-    // finished hmr for this element
-    delete elm['s-hmr-load'];
-    hmrFinish(elm, cmpMeta);
-  };
-
   // re-initialize the component
   initializeComponent(elm, hostRef, cmpMeta, hmrVersionId);
-};
-
-export const hmrFinish = (_elm: d.HostElement, _cmpMeta: d.ComponentRuntimeMeta) => {
-  // TODO
 };

--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -341,10 +341,6 @@ export const postUpdateComponent = (hostRef: d.HostRef) => {
     endPostUpdate();
   }
 
-  if (BUILD.hotModuleReplacement) {
-    elm['s-hmr-load'] && elm['s-hmr-load']();
-  }
-
   if (BUILD.method && BUILD.lazyLoad) {
     hostRef.$onInstanceResolve$(elm);
   }


### PR DESCRIPTION
This has been present in the hmr related runtime code for quite a while but does not appear to do anything.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
