### PR TITLE
chore(client): remove performance.mark and performance.measure polyfill

### DIFF
--- a/src/client/client-patch-browser.ts
+++ b/src/client/client-patch-browser.ts
@@ -14,19 +14,6 @@ export const patchBrowser = (): Promise<d.CustomElementsDefineOptions> => {
     patchCloneNodeFix((H as any).prototype);
   }
 
-  if (BUILD.profile && !performance.mark) {
-    // not all browsers support performance.mark/measure (Safari 10)
-    // because the mark/measure APIs are designed to write entries to a buffer in the browser that does not exist,
-    // simply stub the implementations out.
-    // TODO(STENCIL-323): Remove this patch when support for older browsers is removed (breaking)
-    // @ts-ignore
-    performance.mark = performance.measure = () => {
-      /*noop*/
-    };
-    performance.getEntriesByName = () => [];
-  }
-
-  // @ts-ignore
   const scriptElm = BUILD.scriptDataOpts
     ? Array.from(doc.querySelectorAll('script')).find(
         (s) =>


### PR DESCRIPTION
## What is the current behavior?
We polyfill `performance.mark` and `performance.measure` in case it is not supported. After taking a look into MDN it seems that support for these primitives is way advanced and pretty much given across all environments:

__`performance.mark`__
<img width="769" alt="Screenshot 2023-09-29 at 12 54 10 PM" src="https://github.com/ionic-team/stencil/assets/731337/31997728-49fd-4bb3-8a16-fa38ad93f533">

__`performance.measure`__
<img width="768" alt="Screenshot 2023-09-29 at 12 54 00 PM" src="https://github.com/ionic-team/stencil/assets/731337/ef207b96-aeb6-46f4-ad9a-60579db0b232">

## What is the new behavior?
Removing the polyfill and reduce some bytes in bundle size.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Looking at Stencils [browser support policy](https://stenciljs.com/docs/support-policy#browser-support) non of the browser we marked as supported miss these web platform features.

## Testing

n/a

## Other information

n/a
