### PR TITLE
refactor(jest): detect jest version for testing

### DIFF
--- a/scripts/bundles/helpers/jest/jest-environment.js
+++ b/scripts/bundles/helpers/jest/jest-environment.js
@@ -1,3 +1,3 @@
-const { createJestPuppeteerEnvironment } = require('./index.js');
-
+const { getCreateJestPuppeteerEnvironment } = require('./index.js');
+const createJestPuppeteerEnvironment = getCreateJestPuppeteerEnvironment();
 module.exports = createJestPuppeteerEnvironment();

--- a/scripts/bundles/helpers/jest/jest-preprocessor.js
+++ b/scripts/bundles/helpers/jest/jest-preprocessor.js
@@ -1,3 +1,3 @@
-const { jestPreprocessor } = require('./index.js');
-
+const { getJestPreprocessor } = require('./index.js');
+const jestPreprocessor = getJestPreprocessor();
 module.exports = jestPreprocessor;

--- a/scripts/bundles/helpers/jest/jest-runner.js
+++ b/scripts/bundles/helpers/jest/jest-runner.js
@@ -1,3 +1,3 @@
-const { createTestRunner } = require('./index.js');
-
+const { getCreateJestTestRunner } = require('./index.js');
+const createTestRunner = getCreateJestTestRunner();
 module.exports = createTestRunner();

--- a/scripts/bundles/helpers/jest/jest-setuptestframework.js
+++ b/scripts/bundles/helpers/jest/jest-setuptestframework.js
@@ -1,3 +1,3 @@
-const { jestSetupTestFramework } = require('./index.js');
-
+const { getJestSetupTestFramework } = require('./index.js');
+const jestSetupTestFramework = getJestSetupTestFramework();
 jestSetupTestFramework();

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,7 +1,9 @@
-export { createJestPuppeteerEnvironment } from './jest/jest-27-and-under/jest-environment';
-export { jestPreprocessor } from './jest/jest-27-and-under/jest-preprocessor';
-export { createTestRunner } from './jest/jest-27-and-under/jest-runner';
-export { jestSetupTestFramework } from './jest/jest-27-and-under/jest-setup-test-framework';
+export {
+  getCreateJestPuppeteerEnvironment,
+  getCreateJestTestRunner,
+  getJestPreprocessor,
+  getJestSetupTestFramework,
+} from './jest/jest-stencil-connector';
 export {
   mockFetch,
   MockHeaders,

--- a/src/testing/jest/jest-27-and-under/jest-config.ts
+++ b/src/testing/jest/jest-27-and-under/jest-config.ts
@@ -2,6 +2,8 @@ import type { Config } from '@jest/types';
 import type * as d from '@stencil/core/internal';
 import { isString } from '@utils';
 
+import { Jest27Stencil } from './jest-facade';
+
 /**
  * Helper function for retrieving legacy Jest options. These options have been provided as defaults to Stencil users
  * by Jest + yargs for all users using Jest versions 24 through 26 (inclusively). Between Jest v26 and v27, a few
@@ -145,7 +147,7 @@ export function buildJestConfig(config: d.ValidatedConfig): string {
     jestConfig.verbose = stencilConfigTesting.verbose;
   }
 
-  jestConfig.testRunner = 'jest-jasmine2';
+  jestConfig.testRunner = new Jest27Stencil().getDefaultJestRunner();
 
   return JSON.stringify(jestConfig);
 }

--- a/src/testing/jest/jest-27-and-under/jest-facade.ts
+++ b/src/testing/jest/jest-27-and-under/jest-facade.ts
@@ -1,0 +1,40 @@
+import { JestFacade } from '../jest-facade';
+import { createJestPuppeteerEnvironment as createJestPuppeteerEnvironment27 } from './jest-environment';
+import { jestPreprocessor as jestPreprocessor27 } from './jest-preprocessor';
+import { createTestRunner as createTestRunner27 } from './jest-runner';
+import { runJest as runJest27 } from './jest-runner';
+import { runJestScreenshot as runJestScreenshot27 } from './jest-screenshot';
+import { jestSetupTestFramework as jestSetupTestFramework27 } from './jest-setup-test-framework';
+
+/**
+ * `JestFacade` implementation for communicating between this directory's version of Jest and Stencil
+ */
+export class Jest27Stencil implements JestFacade {
+  getJestCliRunner() {
+    return runJest27;
+  }
+
+  getRunJestScreenshot() {
+    return runJestScreenshot27;
+  }
+
+  getDefaultJestRunner() {
+    return 'jest-jasmine2';
+  }
+
+  getCreateJestPuppeteerEnvironment() {
+    return createJestPuppeteerEnvironment27;
+  }
+
+  getJestPreprocessor() {
+    return jestPreprocessor27;
+  }
+
+  getCreateJestTestRunner() {
+    return createTestRunner27;
+  }
+
+  getJestSetupTestFramework() {
+    return jestSetupTestFramework27;
+  }
+}

--- a/src/testing/jest/jest-27-and-under/jest-runner.ts
+++ b/src/testing/jest/jest-27-and-under/jest-runner.ts
@@ -3,6 +3,7 @@ import type * as d from '@stencil/core/internal';
 
 import type { ConfigFlags } from '../../../cli/config-flags';
 import { setScreenshotEmulateData } from '../../puppeteer/puppeteer-emulate';
+import type { JestTestRunner } from '../jest-apis';
 import { buildJestArgv, getProjectListFromCLIArgs } from './jest-config';
 
 export async function runJest(config: d.ValidatedConfig, env: d.E2EProcessEnv) {
@@ -49,7 +50,7 @@ export async function runJest(config: d.ValidatedConfig, env: d.E2EProcessEnv) {
  * Creates a Stencil test runner
  * @returns the test runner
  */
-export function createTestRunner(): any {
+export function createTestRunner(): JestTestRunner {
   // The left hand side of the '??' is needed for Jest v27, the right hand side for Jest 26 and below
   const TestRunner = require('jest-runner').default ?? require('jest-runner');
 

--- a/src/testing/jest/jest-27-and-under/test/jest-config.spec.ts
+++ b/src/testing/jest/jest-27-and-under/test/jest-config.spec.ts
@@ -273,4 +273,10 @@ describe('jest-config', () => {
       expect(jestArgv[fullArgument]).toBe(true);
     });
   });
+
+  it('sets the default runner', () => {
+    const jestArgv = buildJestArgv(mockValidatedConfig());
+    const config = JSON.parse(jestArgv.config!);
+    expect(config.testRunner).toBe('jest-jasmine2');
+  });
 });

--- a/src/testing/jest/jest-apis.ts
+++ b/src/testing/jest/jest-apis.ts
@@ -1,0 +1,48 @@
+/*!
+ * This file contains Jest API usages for situations where it is difficult to determine which API should be used.
+ *
+ * An example of this is determining the version of Jest, which is retrieved via the `getVersion` API.
+ * It's difficult at compile & runtime to determine:
+ * 1. If such an API exists
+ * 2. If it's typings are the same across all versions of Jest
+ * 3. If there are variants of this API, which one to use and when
+ *
+ * Short of probing the directory where a user keeps their modules (e.g. `node_modules/`), we need to make a "best
+ * guess" at things. This file is meant to only contain functions for these types of scenarios. It is expected that this
+ * file be added to sparingly.
+ */
+
+import { getVersion } from 'jest';
+
+// TODO(STENCIL-959): Improve this typing by narrowing it
+export type JestPuppeteerEnvironment = any;
+
+type Jest26CacheKeyOptions = { instrument: boolean; rootDir: string };
+type Jest26Config = { instrument: boolean; rootDir: string };
+type Jest27TransformOptions = { config: Jest26Config };
+export type JestPreprocessor = {
+  process(
+    sourceText: string,
+    sourcePath: string,
+    jestConfig: Jest26Config | Jest27TransformOptions,
+    transformOptions?: Jest26Config,
+  ): string;
+  getCacheKey(
+    sourceText: string,
+    sourcePath: string,
+    jestConfigStr: string | Jest27TransformOptions,
+    transformOptions?: Jest26CacheKeyOptions,
+  ): string;
+};
+
+// TODO(STENCIL-960): Improve this typing by narrowing it
+export type JestTestRunner = any;
+
+/**
+ * Get the current major version of Jest that Stencil reconciles
+ *
+ * @returns the major version of Jest.
+ */
+export const getJestMajorVersion = (): string => {
+  return getVersion();
+};

--- a/src/testing/jest/jest-facade.ts
+++ b/src/testing/jest/jest-facade.ts
@@ -1,0 +1,74 @@
+import { JestPreprocessor, JestPuppeteerEnvironment, JestTestRunner } from './jest-apis';
+
+/**
+ * Interface for Jest-version specific code implementations that interact with Stencil.
+ *
+ * It is expected that there exists a Jest version-specific implementation for this interface in each version-specific
+ * directory Stencil supports.
+ */
+export interface JestFacade {
+  // TODO(STENCIL-961): Fix build validation when types are pulled in from `@stencil/core/declarations`
+  /**
+   * Retrieve a function that invokes the Jest CLI.
+   *
+   * This function does not perform the invocation itself. Rather, it expects the caller to prepare a Stencil
+   * configuration object and environment for tests to run and invoke the returned value itself.
+   *
+   * @returns A function that invokes the Jest CLI.
+   */
+  getJestCliRunner(): (config: any, e2eEnv: any) => Promise<boolean>;
+
+  // TODO(STENCIL-961): Fix build validation when types are pulled in from `@stencil/core/declarations`
+  /**
+   * Retrieve a function that invokes Stencil's Screenshot runner.
+   *
+   * This function does not start screenshot tests themselves. Rather, it expects the caller to prepare a Stencil
+   * configuration object and environment for tests to run and invoke the screenshot runner itself.
+   *
+   * @returns A function that invokes the Screenshot runner.
+   */
+  getRunJestScreenshot(): (config: any, e2eEnv: any) => Promise<boolean>;
+
+  /**
+   * Retrieve the default Jest runner name prescribed by Stencil.
+   *
+   * Examples of valid return values include 'jest-jasmine2' and 'jest-circus'.
+   *
+   * @returns the stringified name of the test runner, based on the currently detected version of Stencil
+   */
+  getDefaultJestRunner(): string;
+
+  /**
+   * Retrieve a function that builds an E2E (puppeteer) testing environment that uses Jest as its test runner.
+   *
+   * @returns A function that builds an E2E testing environment.
+   */
+  getCreateJestPuppeteerEnvironment(): () => JestPuppeteerEnvironment;
+
+  /**
+   * Create an object used to transform files as a part of running Jest.
+   *
+   * The object returned by this function is expected to conform to the interface/guide laid out by Jest for
+   * [writing custom transformers](https://jestjs.io/docs/code-transformation#writing-custom-transformers).
+   *
+   * @returns the object used to transform files at test time
+   */
+  getJestPreprocessor(): JestPreprocessor;
+
+  /**
+   * Retrieve a custom Stencil-Jest test runner
+   *
+   * @returns the test runner
+   */
+  getCreateJestTestRunner(): JestTestRunner;
+
+  /**
+   * Retrieve a function that returns the setup configuration code to run between tests.
+   *
+   * The value returned by said function is expected to be used in a
+   * [setupFilesAfterEnv](https://jestjs.io/docs/configuration#setupfilesafterenv-array) context.
+   *
+   * @returns a function that runs a setup configuration between tests.
+   */
+  getJestSetupTestFramework(): () => void;
+}

--- a/src/testing/jest/jest-stencil-connector.ts
+++ b/src/testing/jest/jest-stencil-connector.ts
@@ -1,0 +1,114 @@
+/*!
+ * This file acts as the connector/bridge between Stencil and Jest.
+ *
+ * It defines/caches a `JestFacade` implementation to dispatch Jest-related configuration calls to the correct section
+ * of the Stencil codebase.
+ *
+ * It contains the APIs that are designed to be used by the Jest pre-configurations supplied by Stencil.
+ */
+
+import semverMajor from 'semver/functions/major';
+
+import { Jest27Stencil } from './jest-27-and-under/jest-facade';
+import { getJestMajorVersion } from './jest-apis';
+import { JestFacade } from './jest-facade';
+
+/**
+ * Store a reference to the Jest version-specific facade implementation used to get pieces of testing infrastructure
+ */
+let JEST_STENCIL_FACADE: JestFacade | null = null;
+
+/**
+ * Retrieve the numeric representation of the major version of Jest being used.
+ *
+ * If a user has Jest v27.1.0 installed, `27` will be returned.
+ *
+ * @returns the major version of Jest detected
+ */
+export const getVersion = (): number => {
+  return semverMajor(getJestMajorVersion());
+};
+
+/**
+ * Retrieve the cached local variable containing a Jest facade implementation, based on the version of Jest detected.
+ * If no Jest facade implementation is cached, set it.
+ *
+ * @returns the cached Jest facade implementation.
+ */
+const getJestFacade = (): JestFacade => {
+  if (!JEST_STENCIL_FACADE) {
+    const version = getVersion();
+    if (version <= 27) {
+      JEST_STENCIL_FACADE = new Jest27Stencil();
+    } else {
+      // in Stencil 4.X, defaulting to jest 27 infrastructure is the default behavior.
+      // when Jest 28+ is supported, this will likely change.
+      JEST_STENCIL_FACADE = new Jest27Stencil();
+    }
+  }
+
+  return JEST_STENCIL_FACADE;
+};
+
+/**
+ * Retrieve the default Jest runner name prescribed by Stencil
+ *
+ * @returns the stringified name of the test runner, based on the currently detected version of Stencil
+ */
+export const getDefaultJestRunner = (): string => {
+  return getJestFacade().getDefaultJestRunner();
+};
+
+/**
+ * Retrieve the Stencil-Jest test runner based on the version of Jest that's installed.
+ *
+ * @returns a test runner for Stencil tests, based on the version of Jest that's detected
+ */
+export const getRunner = () => {
+  return getJestFacade().getJestCliRunner();
+};
+
+/**
+ * Retrieve the Stencil-Jest screenshot facade implementation based on the version of Jest that's installed.
+ *
+ * @returns a screenshot facade implementation for Stencil tests, based on the version of Jest that's detected
+ */
+export const getScreenshot = () => {
+  return getJestFacade().getRunJestScreenshot();
+};
+
+/**
+ * Retrieve the Jest-Puppeteer Environment, based on the version of Jest that is installed
+ *
+ * @returns a function capable of creating a Jest-Puppeteer environment
+ */
+export const getCreateJestPuppeteerEnvironment = () => {
+  return getJestFacade().getCreateJestPuppeteerEnvironment();
+};
+
+/**
+ * Retrieve the Jest preprocessor, based on the version of Jest that is installed
+ *
+ * @returns a Jest preprocessor to transform code at test time
+ */
+export const getJestPreprocessor = () => {
+  return getJestFacade().getJestPreprocessor();
+};
+
+/**
+ * Retrieve the Jest-Runner, based on the version of Jest that is installed
+ *
+ * @returns a function capable of creating a Jest test runner
+ */
+export const getCreateJestTestRunner = () => {
+  return getJestFacade().getCreateJestTestRunner();
+};
+
+/**
+ * Retrieve the Jest-setup function, based on the version of Jest that is installed
+ *
+ * @returns a function capable of setting up Jest
+ */
+export const getJestSetupTestFramework = () => {
+  return getJestFacade().getJestSetupTestFramework();
+};

--- a/src/testing/jest/test/jest-stencil-connector.spec.ts
+++ b/src/testing/jest/test/jest-stencil-connector.spec.ts
@@ -1,0 +1,48 @@
+import * as JestVersion from '../jest-apis';
+import { getDefaultJestRunner, getVersion } from '../jest-stencil-connector';
+
+describe('jest-stencil-connector', () => {
+  let getJestMajorVersionSpy: jest.SpyInstance<
+    ReturnType<typeof JestVersion.getJestMajorVersion>,
+    Parameters<typeof JestVersion.getJestMajorVersion>
+  >;
+
+  beforeEach(() => {
+    getJestMajorVersionSpy = jest.spyOn(JestVersion, 'getJestMajorVersion');
+  });
+
+  afterEach(() => {
+    getJestMajorVersionSpy.mockRestore();
+  });
+
+  describe('getVersion', () => {
+    it.each([
+      ['27.0.0', 27],
+      ['28.1.0', 28],
+      ['29.1.2', 29],
+      ['29.1.2-3', 29],
+      ['29.1.2-alpha.0', 29],
+      ['29.1.2-beta.1', 29],
+      ['29.1.2-rc.2', 29],
+    ])('transforms semver string %s into major version %d', (semverStr, majorVersion) => {
+      getJestMajorVersionSpy.mockImplementation(() => semverStr);
+      expect(getVersion()).toBe(majorVersion);
+    });
+  });
+
+  describe('getDefaultJestRunner()', () => {
+    it.each([
+      ['24.0.0', 'jest-jasmine2'],
+      ['25.0.0', 'jest-jasmine2'],
+      ['26.0.0', 'jest-jasmine2'],
+      ['27.0.0', 'jest-jasmine2'],
+      ['28.0.0', 'jest-jasmine2'],
+      ['29.0.0', 'jest-jasmine2'],
+      ['30.0.0', 'jest-jasmine2'],
+    ])('returns the correct module names for jest %s', (jestMajorVersion, runnerName) => {
+      getJestMajorVersionSpy.mockImplementation(() => jestMajorVersion);
+
+      expect(getDefaultJestRunner()).toEqual(runnerName);
+    });
+  });
+});

--- a/src/testing/testing.ts
+++ b/src/testing/testing.ts
@@ -13,8 +13,7 @@ import type {
 import { hasError } from '@utils';
 import type * as puppeteer from 'puppeteer';
 
-import { runJest } from './jest/jest-27-and-under/jest-runner';
-import { runJestScreenshot } from './jest/jest-27-and-under/jest-screenshot';
+import { getRunner, getScreenshot } from './jest/jest-stencil-connector';
 import { startPuppeteerBrowser } from './puppeteer/puppeteer-browser';
 import { getAppScriptUrl, getAppStyleUrl } from './testing-utils';
 
@@ -144,8 +143,10 @@ export const createTesting = async (config: ValidatedConfig): Promise<Testing> =
 
     try {
       if (doScreenshots) {
+        const runJestScreenshot = getScreenshot();
         passed = await runJestScreenshot(config, env);
       } else {
+        const runJest = getRunner();
         passed = await runJest(config, env);
       }
       config.logger.info('');


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

stencil will always assume that jest v27 is being used for testing.
this is a result of years  of using the same files for all jest infrastructure for end users.
while this pr does not do away with always picking jest v27, it gets us one step closer

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

add a new abstraction layer to stencil's jest testing configuration/running such that the version of jest is detected when jest is run. based on the version that is detected, defer to the correct piece of versioned infrastructure to setup and run tests.

in https://github.com/ionic-team/stencil/pull/4847, the directory structure of the testing submodule was updated to look something like:
```
├── src/testing/jest/
│   └── jest-27-and-under
│       ├── jest-config.ts                 
│       ├── jest-environment.ts
│       ├── jest-preprocessor.ts
│       ├── jest-runner.ts
│       ├── jest-screenshot.ts
│       ├── jest-serializer.ts
│       ├── jest-setup-test-framework.ts
│       ├── node_modules/
│       ├── package.json                   
│       └── test
└── package.json                            
```

this commit introduces the following infrastructue to dispatch to jest-27-and-under at runtime:

```diff
  ├── src/testing/jest/
  │   └── jest-27-and-under
  │       ├── jest-config.ts                
  │       ├── jest-environment.ts
+ │       ├── jest-facade.ts                  <- Implements base class in `jest-adapter.ts`
  │       ├── jest-preprocessor.ts
  │       ├── jest-runner.ts
  │       ├── jest-screenshot.ts
  │       ├── jest-serializer.ts
  │       ├── jest-setup-test-framework.ts
  │       ├── node_modules/
  │       ├── package.json                    
  │       └── test
+ ├── jest-apis.ts                            <- Interactions with Jest prior to knowing the version
+ ├── jest-facade.ts                         <- Base class all `jest-facade` implementations should follow
+ ├── jest-stencil-connector.ts               <- Routes Jest logic through the correct `jest-facade` implementation
  └── package.json                            
```
Where:
- `jest-stencil-connector` - performs the detection of the current version of jest - dispatching to the correct infrastructure via `jest-facade` implementations
- `jest-facade` - a file containing a base class to define the API by which version-specific implementations can be loaded. a jest v27-specific implementation is included as well in `jest-27-and-under/`
- `jest-apis` - a file containing typings for cases where the jest typings are ambiguous, particularly for when we do not know what the current version of jest is (yet)

the end result of this commit should be nothing to the end user (for now). this work shall be used to help support jest v28+ in the near future (dispatching the the correct version)


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Pull down this branch and build it. Make note of the location of the generated tarball:
```bash
npm run clean \                   
&& npm ci \
&& npm run build \
&& npm pack
```
Next, create a new stencil component library with that tarball:
```bash
cd /tmp \
&& npm init stencil@latest component jest-test \
&& cd $_ \
&& npm i [PATH_TO_TARBALL]
```
Stencil Testing should continue to pass for Jest [24,27]:
```bash
npm i jest@24 jest-cli@24 @types/jest@24 && npm t -- --no-cache && \
npm i jest@25 jest-cli@25 @types/jest@25 && npm t -- --no-cache && \
npm i jest@26 jest-cli@26 @types/jest@26 && npm t -- --no-cache && \
npm i jest@27 jest-cli@27 @types/jest@27 && npm t -- --no-cache
```
Next, Stencil should continue to warn if a testing module is not installed:
```
npm uninstall jest \
&& npm t -- --no-cache # expect error
```

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
