### PR TITLE
chore(test): document dynamic import of testing submodule

### DIFF
--- a/src/cli/task-test.ts
+++ b/src/cli/task-test.ts
@@ -42,7 +42,15 @@ export const taskTest = async (config: ValidatedConfig): Promise<void> => {
   }
 
   try {
-    // let's test!
+    /**
+     * We dynamically import the testing submodule here in order for Stencil's lazy module checking to work properly.
+     *
+     * Prior to this call, we create a collection of string-based node module names and ensure that they're installed &
+     * on disk. The testing submodule includes `jest` (amongst other) testing libraries in its dependency chain. We need
+     * to run the lazy module check _before_ we include `jest` et al. in our dependency chain otherwise, the lazy module
+     * checking would fail to run properly (because we'd import `jest`, which wouldn't exist, before we even checked if
+     * it was installed).
+     */
     const { createTesting } = await import('@stencil/core/testing');
     const testing = await createTesting(config);
     const passed = await testing.run(testingRunOpts);


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

this behavior isn't the clearest, and as a part of working on #4883, I now have an answer as to _why_ we do this 

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

add a comment explains why we need to dynamically import the testing submodule at runtime.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

comment only change, N/A
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

