### PR TITLE
chore(repo): update cspell to ignore all node_modules

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -11,6 +11,7 @@
   "ignoreRegExpList": [
     "/`[a-zA-Z-_., /*']+`/g"
   ],
+  "ignorePaths": ["**/node_modules/**"],
   "includeRegExpList": [
     "CStyleComment"
   ]


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See 'new behavior' section
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
update the cspell configuration to ignore all node_modules directories. when we introduced new `jest`-version subdirectories in https://github.com/ionic-team/stencil/pull/4847, we failed to update cspell's configuration. as a result, cspell would run against the `node_modules` directory in
`src/testing/jest/jest-27-and-under` (e.g. `npm run spellcheck`). this change excludes _all_ `node_modules` cspell's eyes

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Prior to this commit, if you run `npm run spellcheck`, you get something like:
```
 npm run spellcheck

...
./src/testing/jest/jest-27-and-under/node_modules/xmlchars/xmlchars.d.ts:9:31 - Unknown word (Dubeau)
./src/testing/jest/jest-27-and-under/node_modules/xmlchars/xmlns/1.0/ed3.d.ts:4:28 - Unknown word (Dubeau)
./src/testing/jest/jest-27-and-under/node_modules/xmlchars/xmlns/1.0/ed3.d.ts:6:31 - Unknown word (Dubeau)
CSpell: Files checked: 1445, Issues found: 835 in 139 files
```
After this commit, `npm run spellcheck` gives you:
```
 npm run spellcheck

> @stencil/core@4.4.0 spellcheck
> cspell --no-progress "src/**/*.ts" "src/**/*.tsx" "scripts/**/*.ts" "*.md"

CSpell: Files checked: 774, Issues found: 0 in 0 files
```

I did also introduce an error locally to verify I hadn't broken this entirely:
```
npm run spellcheck

> @stencil/core@4.4.0 spellcheck
> cspell --no-progress "src/**/*.ts" "src/**/*.tsx" "scripts/**/*.ts" "*.md"

./src/cli/task-test.ts:37:13 - Unknown word (abcwe've)
CSpell: Files checked: 774, Issues found: 1 in 1 files

```

I also checked out the commit prior to #4847 (the PR that introduced these `node_modules/`) to verify that we were checking the right number of files:
```
git checkout cb3eac3a2b7795a5c8d3f9100812337d1a8d8a9d
rm -rf src/testing/jest/jest-27-and-under/node_modules
npm run spellcheck

> @stencil/core@4.3.0 spellcheck
> cspell --no-progress "src/**/*.ts" "src/**/*.tsx" "scripts/**/*.ts" "*.md"

CSpell: Files checked: 774, Issues found: 0 in 0 files

```
## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
