### PR TITLE
chore(repo): ensure jest packages have installed deps

### DIFF
--- a/.github/workflows/test-component-starter.yml
+++ b/.github/workflows/test-component-starter.yml
@@ -82,7 +82,7 @@ jobs:
         shell: bash
 
       - name: Install Stencil Eval
-        run: npm i ../stencil-eval.tgz
+        run: npm i --ignore-scripts ../stencil-eval.tgz
         working-directory: ./tmp-component-starter
         shell: bash
 

--- a/install-jest.sh
+++ b/install-jest.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -e
+
+# Directory path
+TARGET_DIR="src/testing/jest"
+
+# Change to the specified directory
+cd "$TARGET_DIR" || {
+    echo "Error: Cannot enter $TARGET_DIR"
+    exit 1
+}
+
+# Flag to check if any jest-[SOME_NUMBER] directories were found and processed
+found=false
+
+# Loop through directories that seem to match the pattern jest-*
+# e.g. `jest-27-and-under`, `jest-28`, etc.
+for dir in jest-*; do
+    if [[ -d "$dir" ]]; then
+        found=true
+
+        if cd "$dir"; then
+            npm ci || {
+                echo "Error: npm ci failed in directory $dir"
+                exit 1
+            }
+        else
+            echo "Error: Cannot enter directory $dir"
+            exit 1
+        fi
+
+        # go back to where we started
+        cd - > /dev/null || {
+            echo "Error: Unable to leave $dir"
+            exit 1
+        }
+    fi
+done
+
+# If no directories were found and processed, print an error and exit
+if [[ $found == false ]]; then
+    echo "Error: No jest-[SOME_NUMBER] directories found"
+    exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "clean-scripts": "rm -rf scripts/build",
     "license": "node scripts/build --license",
     "lint": "eslint 'bin/*' 'scripts/*.ts' 'scripts/**/*.ts' 'src/*.ts' 'src/**/*.ts' 'src/**/*.tsx'",
-    "postinstall": "./install-jest.sh",
+    "postinstall": "sh install-jest.sh",
     "prettier": "npm run prettier.base -- --write",
     "prettier.base": "prettier --cache \"./({bin,scripts,src,test}/**/*.{ts,tsx,js,jsx})|bin/stencil|.github/(**/)?*.(yml|yaml)|*.js\"",
     "prettier.dry-run": "npm run prettier.base -- --list-different",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "clean-scripts": "rm -rf scripts/build",
     "license": "node scripts/build --license",
     "lint": "eslint 'bin/*' 'scripts/*.ts' 'scripts/**/*.ts' 'src/*.ts' 'src/**/*.ts' 'src/**/*.tsx'",
+    "postinstall": "./install-jest.sh",
     "prettier": "npm run prettier.base -- --write",
     "prettier.base": "prettier --cache \"./({bin,scripts,src,test}/**/*.{ts,tsx,js,jsx})|bin/stencil|.github/(**/)?*.(yml|yaml)|*.js\"",
     "prettier.dry-run": "npm run prettier.base -- --list-different",


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

one consequence of moving to the design laid out in https://github.com/ionic-team/stencil/pull/4847 is that there are now `package.json` file(s) that:
- define jest dependencies that are not used by stencil's own internal testing
- do not have their dependencies installed when we run `npm ci` (or equivalent)

as a result, it's entirely possible for a stencil engineer to work on the project without having
the right dependencies!

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->


this commit introduces a small shell script that iterates over all jest subdirectories (currently just one, `jest-27-and-under`) and runs `npm ci`. this ensures that these dependencies are installed/up to date when working with stencil


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

1. Pull this branch
2. Manually remove `src/testing/jest/jest-27-and-under/node_modules` if they exist
3. Run `npm ci` from the root of this project
4. See that `node_modules` have been recreated

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
