### PR TITLE
chore(snc): fix instances of config.flag ref

### DIFF
--- a/src/compiler/config/test/validate-dev-server.spec.ts
+++ b/src/compiler/config/test/validate-dev-server.spec.ts
@@ -205,7 +205,8 @@ describe('validateDevServer', () => {
   });
 
   it('should set openBrowser from flag', () => {
-    inputConfig.flags.open = false;
+    // the flags field should have been set up in the `beforeEach` block for this test, hence the bang operator
+    inputConfig.flags!.open = false;
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.openBrowser).toBe(false);
   });

--- a/src/compiler/config/test/validate-docs.spec.ts
+++ b/src/compiler/config/test/validate-docs.spec.ts
@@ -11,7 +11,9 @@ describe('validateDocs', () => {
   });
 
   it('readme docs dir', () => {
-    userConfig.flags.docs = true;
+    // the flags field is expected to have been set by the mock creation function for unvalidated configs, hence the
+    // bang operator
+    userConfig.flags!.docs = true;
     userConfig.outputTargets = [
       {
         type: 'docs-readme',

--- a/src/compiler/config/test/validate-stats.spec.ts
+++ b/src/compiler/config/test/validate-stats.spec.ts
@@ -11,7 +11,9 @@ describe('validateStats', () => {
   });
 
   it('adds stats from flags, w/ no outputTargets', () => {
-    userConfig.flags.stats = true;
+    // the flags field is expected to have been set by the mock creation function for unvalidated configs, hence the
+    // bang operator
+    userConfig.flags!.stats = true;
 
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
     const o = config.outputTargets.find((o) => o.type === 'stats') as d.OutputTargetStats;


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We have >1000 strict null check violations

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit fixes a few minor strictNullChecks violations related to accessing the `flag` field on unvalidated configs

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

N/A, only the bang operator was added to a few (three) existing tests. They still pass 😆 
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
