### PR TITLE
chore(snc): resolve (most) jest strictNullChecks

### DIFF
--- a/src/testing/jest/jest-27-and-under/jest-runner.ts
+++ b/src/testing/jest/jest-27-and-under/jest-runner.ts
@@ -60,7 +60,7 @@ export function createTestRunner(): any {
       // filter out only the tests the flags said we should run
       tests = tests.filter((t) => includeTestFile(t.path, env));
 
-      if (env.__STENCIL_SCREENSHOT__ === 'true') {
+      if (env.__STENCIL_SCREENSHOT__ === 'true' && env.__STENCIL_EMULATE_CONFIGS__) {
         // we're doing e2e screenshots, so let's loop through
         // each of the emulate configs for each test
 
@@ -105,8 +105,8 @@ export function includeTestFile(testPath: string, env: d.E2EProcessEnv) {
   return false;
 }
 
-export function getEmulateConfigs(testing: d.TestingConfig, flags: ConfigFlags) {
-  let emulateConfigs = testing.emulate.slice();
+export function getEmulateConfigs(testing: d.TestingConfig, flags: ConfigFlags): d.EmulateConfig[] {
+  let emulateConfigs = testing.emulate?.slice() ?? [];
 
   if (typeof flags.emulate === 'string') {
     const emulateFlag = flags.emulate.toLowerCase();

--- a/src/testing/jest/jest-27-and-under/jest-screenshot.ts
+++ b/src/testing/jest/jest-27-and-under/jest-screenshot.ts
@@ -6,7 +6,7 @@ import { runJest } from './jest-runner';
 export async function runJestScreenshot(config: d.ValidatedConfig, env: d.E2EProcessEnv) {
   config.logger.debug(`screenshot connector: ${config.testing.screenshotConnector}`);
 
-  const ScreenshotConnector = require(config.testing.screenshotConnector) as any;
+  const ScreenshotConnector = require(config.testing.screenshotConnector!) as any;
   const connector: d.ScreenshotConnector = new ScreenshotConnector();
 
   // for CI, let's wait a little longer than locally before taking the screenshot
@@ -22,7 +22,7 @@ export async function runJestScreenshot(config: d.ValidatedConfig, env: d.E2EPro
     rootDir: config.rootDir,
     cacheDir: config.cacheDir,
     packageDir: join(config.sys.getCompilerExecutingPath(), '..', '..'),
-    updateMaster: config.flags.updateScreenshot,
+    updateMaster: !!config.flags.updateScreenshot,
     logger: config.logger,
     allowableMismatchedPixels: config.testing.allowableMismatchedPixels,
     allowableMismatchedRatio: config.testing.allowableMismatchedRatio,

--- a/src/testing/jest/jest-27-and-under/jest-setup-test-framework.ts
+++ b/src/testing/jest/jest-27-and-under/jest-setup-test-framework.ts
@@ -93,7 +93,7 @@ export function jestSetupTestFramework() {
  *
  * @param node The mocked DOM node that will be removed from the DOM
  */
-export function removeDomNodes(node: MockNode) {
+export function removeDomNodes(node: MockNode | undefined | null) {
   if (node == null) {
     return;
   }

--- a/src/testing/jest/jest-27-and-under/test/jest-config.spec.ts
+++ b/src/testing/jest/jest-27-and-under/test/jest-config.spec.ts
@@ -148,7 +148,9 @@ describe('jest-config', () => {
     expect(config.flags.task).toBe('test');
 
     const jestArgv = buildJestArgv(config);
-    const parsedConfig = JSON.parse(jestArgv.config) as d.JestConfig;
+    // `buildJestArgv` is expected to place a `config` property on the returned `Config.Argv`, hence the use of the bang
+    // operator. if one wasn't on the object, `JSON.parse` is expected to throw (failing the test).
+    const parsedConfig = JSON.parse(jestArgv.config!) as d.JestConfig;
     expect(parsedConfig.testMatch).toEqual(['hello.spec.ts']);
   });
 
@@ -162,7 +164,9 @@ describe('jest-config', () => {
     config.flags = parseFlags(args);
 
     const jestArgv = buildJestArgv(config);
-    const parsedConfig = JSON.parse(jestArgv.config) as d.JestConfig;
+    // `buildJestArgv` is expected to place a `config` property on the returned `Config.Argv`, hence the use of the bang
+    // operator. if one wasn't on the object, `JSON.parse` is expected to throw (failing the test).
+    const parsedConfig = JSON.parse(jestArgv.config!) as d.JestConfig;
     expect(parsedConfig.reporters).toHaveLength(2);
     expect(parsedConfig.reporters[0]).toBe('default');
     expect(parsedConfig.reporters[1][0]).toBe('jest-junit');
@@ -176,7 +180,9 @@ describe('jest-config', () => {
     config.flags = parseFlags(args);
 
     const jestArgv = buildJestArgv(config);
-    const parsedConfig = JSON.parse(jestArgv.config) as d.JestConfig;
+    // `buildJestArgv` is expected to place a `config` property on the returned `Config.Argv`, hence the use of the bang
+    // operator. if one wasn't on the object, `JSON.parse` is expected to throw (failing the test).
+    const parsedConfig = JSON.parse(jestArgv.config!) as d.JestConfig;
     expect(parsedConfig.rootDir).toBe(rootDir);
   });
 
@@ -187,9 +193,11 @@ describe('jest-config', () => {
     config.flags = parseFlags(args);
 
     const jestArgv = buildJestArgv(config);
-    const parsedConfig = JSON.parse(jestArgv.config) as d.JestConfig;
+    // `buildJestArgv` is expected to place a `config` property on the returned `Config.Argv`, hence the use of the bang
+    // operator. if one wasn't on the object, `JSON.parse` is expected to throw (failing the test).
+    const parsedConfig = JSON.parse(jestArgv.config!) as d.JestConfig;
     expect(parsedConfig.collectCoverageFrom).toHaveLength(1);
-    expect(parsedConfig.collectCoverageFrom[0]).toBe('**/*.+(ts|tsx)');
+    expect(parsedConfig.collectCoverageFrom![0]).toBe('**/*.+(ts|tsx)');
   });
 
   it('passed flags should be respected over defaults', () => {

--- a/src/testing/jest/jest-27-and-under/test/jest-setup-test-framework.spec.ts
+++ b/src/testing/jest/jest-27-and-under/test/jest-setup-test-framework.spec.ts
@@ -15,7 +15,7 @@ describe('jest setup test framework', () => {
     });
 
     it('does nothing if there is no parent node', () => {
-      const parentNode: MockNode = undefined;
+      const parentNode: MockNode | undefined = undefined;
 
       removeDomNodes(parentNode);
 
@@ -33,7 +33,8 @@ describe('jest setup test framework', () => {
 
     it('does nothing if the parent node child array is `null`', () => {
       const parentNode = new MockHTMLElement(null, 'div');
-      parentNode.childNodes = null;
+      // the intent of this test is to guard against null-ish childNodes, hence the type assertion
+      parentNode.childNodes = null as unknown as MockNode[];
 
       removeDomNodes(parentNode);
 

--- a/src/testing/platform/testing-log.ts
+++ b/src/testing/platform/testing-log.ts
@@ -1,7 +1,7 @@
 import type * as d from '../../declarations';
 import { caughtErrors } from './testing-constants';
 
-let customError: d.ErrorHandler;
+let customError: d.ErrorHandler | undefined;
 
 const defaultConsoleError = (e: any) => {
   caughtErrors.push(e);
@@ -23,4 +23,4 @@ export const consoleDevInfo = (..._: any[]) => {
   /* noop for testing */
 };
 
-export const setErrorHandler = (handler: d.ErrorHandler) => (customError = handler);
+export const setErrorHandler = (handler: d.ErrorHandler | undefined) => (customError = handler);


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

there's a handful of strictNullChecks in the Jest v27 infra. before I start on the jest 28+ work, I'd like to sqaush these
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
resolve strictNullCheck violations in `src/testing/jest/jest-27-and-under` that only require updating the types on function/variable declarations, or a type assertion in the case of tests not understanding that a property will be added to an object

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Unit tests should continue to pass.

The updates in this PR _shouldn't_ cause a functional change, but let me know if something smells fishy to you!
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

I didn't squash all of the SNC violations for this directory - there are a handful of them in the matchers dir that require some additional investigation (which may require more work), so I'll put that in a separate PR
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
