### PR TITLE
chore(repo): tmp pin unit test node version

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -11,7 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['16', '18', '20']
+        # TODO(STENCIL-964): Use latest Node minor version (remove '.7' from v20 entry)
+        node: ['16', '18', '20.7']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Unit tests in CI started to fail sporadically earlier this week for both
Windows and Ubuntu on Node 20. Hoping this was sporadic, we did not
investigate immediately. Starting this morning, no CI workflows
containing our unit tests on Node 20 were passing, blocking us from landing
code.

Looking across all CI workflows that ran in the past week/week and a
half, splitting them by those that passed and those that failed
It appears the issues that plagued us during the Node 20.5 upgrade
where Jest fails when finding a file on disk (or writing it) are back

In our unit tests, we always pull the latest minor of the LTS versions of
Node we support (16. 18, 20). We’ve started getting Node 20.8 in CI,
hence the failure.

In so far as I can tell, this is only Jest test related, and does not
affect the functionality of Stencil. Pin our unit tests to 20.7 for now.

Relates to: https://github.com/ionic-team/stencil/commit/dd1fe1d0b01723ef4d88f5eb24d34eae0cf7ac1c

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

CI passes again

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

We'll fix the root issue and revert this PR next sprint