### PR TITLE
chore(snc): fix violations in update-element.spec

### DIFF
--- a/src/runtime/vdom/test/update-element.spec.ts
+++ b/src/runtime/vdom/test/update-element.spec.ts
@@ -71,7 +71,7 @@ describe('updateElement', () => {
 
   it('should add new class when no oldVNode', () => {
     const elm = document.createElement('my-tag') as HTMLElement;
-    const oldVNode: d.VNode = null;
+    const oldVNode: d.VNode | null = null;
     const newVnode = createTestNode({
       $flags$: 0,
       $elm$: elm,
@@ -84,7 +84,7 @@ describe('updateElement', () => {
   it('should do nothing when no newVnode attrs', () => {
     expect(() => {
       const elm = document.createElement('my-tag') as HTMLElement;
-      const oldVNode: d.VNode = null;
+      const oldVNode: d.VNode | null = null;
       const newVnode = createTestNode({
         $flags$: 0,
         $elm$: elm,
@@ -98,7 +98,7 @@ describe('updateElement', () => {
       host: document.createElement('div') as HTMLElement,
       nodeType: NODE_TYPE.DocumentFragment,
     };
-    const oldVNode: d.VNode = null;
+    const oldVNode: d.VNode | null = null;
     const newVnode = createTestNode({
       $flags$: 0,
       $elm$: elm,
@@ -115,7 +115,7 @@ describe('updateElement', () => {
   it('should use host element when using an element with a "host" property', () => {
     const elm: any = document.createElement('a') as HTMLElement;
     elm.host = 'localhost:8888';
-    const oldVNode: d.VNode = null;
+    const oldVNode: d.VNode | null = null;
     const newVnode = createTestNode({
       $flags$: 0,
       $elm$: elm,
@@ -131,7 +131,7 @@ describe('updateElement', () => {
 
   it('should use host element when not shadow dom', () => {
     const elm = document.createElement('my-tag') as HTMLElement;
-    const oldVNode: d.VNode = null;
+    const oldVNode: d.VNode | null = null;
     const newVnode = createTestNode({
       $flags$: 0,
       $elm$: elm,
@@ -148,7 +148,7 @@ describe('updateElement', () => {
   it('max test', () => {
     const spy = jest.spyOn(setAccessor, 'setAccessor');
     const elm = document.createElement('section') as HTMLElement;
-    const initialVNode: d.VNode = null;
+    const initialVNode: d.VNode | null = null;
     const firstVNode = createTestNode({
       $flags$: 0,
       $elm$: elm,

--- a/src/runtime/vdom/test/update-element.spec.ts
+++ b/src/runtime/vdom/test/update-element.spec.ts
@@ -71,7 +71,7 @@ describe('updateElement', () => {
 
   it('should add new class when no oldVNode', () => {
     const elm = document.createElement('my-tag') as HTMLElement;
-    const oldVNode: d.VNode | null = null;
+    const oldVNode: null = null;
     const newVnode = createTestNode({
       $flags$: 0,
       $elm$: elm,
@@ -84,7 +84,7 @@ describe('updateElement', () => {
   it('should do nothing when no newVnode attrs', () => {
     expect(() => {
       const elm = document.createElement('my-tag') as HTMLElement;
-      const oldVNode: d.VNode | null = null;
+      const oldVNode: null = null;
       const newVnode = createTestNode({
         $flags$: 0,
         $elm$: elm,
@@ -98,7 +98,7 @@ describe('updateElement', () => {
       host: document.createElement('div') as HTMLElement,
       nodeType: NODE_TYPE.DocumentFragment,
     };
-    const oldVNode: d.VNode | null = null;
+    const oldVNode: null = null;
     const newVnode = createTestNode({
       $flags$: 0,
       $elm$: elm,
@@ -115,7 +115,7 @@ describe('updateElement', () => {
   it('should use host element when using an element with a "host" property', () => {
     const elm: any = document.createElement('a') as HTMLElement;
     elm.host = 'localhost:8888';
-    const oldVNode: d.VNode | null = null;
+    const oldVNode: null = null;
     const newVnode = createTestNode({
       $flags$: 0,
       $elm$: elm,
@@ -131,7 +131,7 @@ describe('updateElement', () => {
 
   it('should use host element when not shadow dom', () => {
     const elm = document.createElement('my-tag') as HTMLElement;
-    const oldVNode: d.VNode | null = null;
+    const oldVNode: null = null;
     const newVnode = createTestNode({
       $flags$: 0,
       $elm$: elm,
@@ -148,7 +148,7 @@ describe('updateElement', () => {
   it('max test', () => {
     const spy = jest.spyOn(setAccessor, 'setAccessor');
     const elm = document.createElement('section') as HTMLElement;
-    const initialVNode: d.VNode | null = null;
+    const initialVNode: null = null;
     const firstVNode = createTestNode({
       $flags$: 0,
       $elm$: elm,

--- a/src/runtime/vdom/test/update-element.spec.ts
+++ b/src/runtime/vdom/test/update-element.spec.ts
@@ -61,8 +61,8 @@ describe('updateElement', () => {
 
   it('should add new classes when no oldVNode.vattrs', () => {
     const elm = document.createElement('my-tag') as HTMLElement;
-    const oldVNode: d.VNode = newVNode(null, null);
-    const newVnode: d.VNode = newVNode(null, null);
+    const oldVNode: d.VNode = newVNode('my-component', 'text value');
+    const newVnode: d.VNode = newVNode('my-component', 'text value');
     newVnode.$elm$ = elm;
     newVnode.$attrs$ = { class: 'mr fusion' };
     updateElement(oldVNode, newVnode, false);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We have quite a few SNCs! This is today's 15 minutes of work to drive these down

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the types of multiple VNode variable instances to
`null` from `VNode`. in each of these usages, an old VNode
instance is instantiated as `null` for testing purposes to call
`updateElement`. since the old VNode can be `null` according to the
`updateElement` function signature, this is considered to by a safe
operation (i.e. does not adversely affect the tests).

for one test in particular, this commit updates VNode init by providing
the VNode with non-null values. the test that initializes these VNodes
doesn't use these values stored on the VNode, making this a safe
operation in terms of the test

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Unit tests continue to pass - reading through the code and tests, I don't have any reason to believe we've changed their actual behavior in the second commit (the first acts solely on the type system)
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->



<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
