### PR TITLE
fix: use defineProperty to overwrite observedAttributes

### DIFF
--- a/src/runtime/proxy-component.ts
+++ b/src/runtime/proxy-component.ts
@@ -171,22 +171,26 @@ export const proxyComponent = (
       // on a component as well as any Stencil-specific "members" (`@Prop()`s and `@State()`s).
       // As such, there is no way to guarantee type-safety here that a user hasn't entered
       // an invalid attribute.
-      Cstr.observedAttributes = Array.from(
-        new Set([
-          ...Object.keys(cmpMeta.$watchers$ ?? {}),
-          ...members
-            .filter(([_, m]) => m[0] & MEMBER_FLAGS.HasAttribute)
-            .map(([propName, m]) => {
-              const attrName = m[1] || propName;
-              attrNameToPropName.set(attrName, propName);
-              if (BUILD.reflect && m[0] & MEMBER_FLAGS.ReflectAttr) {
-                cmpMeta.$attrsToReflect$.push([propName, attrName]);
-              }
+      Object.defineProperty(Cstr, 'observedAttributes', {
+        get: function () {
+          return Array.from(
+            new Set([
+              ...Object.keys(cmpMeta.$watchers$ ?? {}),
+              ...members
+                .filter(([_, m]) => m[0] & MEMBER_FLAGS.HasAttribute)
+                .map(([propName, m]) => {
+                  const attrName = m[1] || propName;
+                  attrNameToPropName.set(attrName, propName);
+                  if (BUILD.reflect && m[0] & MEMBER_FLAGS.ReflectAttr) {
+                    cmpMeta.$attrsToReflect$.push([propName, attrName]);
+                  }
 
-              return attrName;
-            }),
-        ]),
-      );
+                  return attrName;
+                }),
+            ]),
+          );
+        },
+      });
     }
   }
 


### PR DESCRIPTION
## What is the current behavior?
Fixes: #4914


## What is the new behavior?
Is the same without an TypeError. 😏 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

Difficult to reproduce since I'm using some self made stuff and [luwes/wesc](https://github.com/luwes/wesc) to render stencil components within an Next.js app.
