### PR TITLE
feat: use globalThis as fallback if window is not available

### DIFF
--- a/src/client/client-window.ts
+++ b/src/client/client-window.ts
@@ -2,7 +2,7 @@ import { BUILD } from '@app-data';
 
 import type * as d from '../declarations';
 
-export const win = typeof window !== 'undefined' ? window : ({} as Window);
+export const win = typeof window !== 'undefined' ? window : ((globalThis || {}) as Window);
 
 export const doc = win.document || ({ head: {} } as Document);
 


### PR DESCRIPTION
## What is the current behavior?
Fixes: #4916


## What is the new behavior?
It is possible to provide server side needed functions (e.g. `customElements`) via `globalThis`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
