### PR TITLE
chore(repo): group rollup in renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -119,6 +119,11 @@
       matchFileNames: ['test/karma/package.json'],
       matchDepNames: ['npm'],
       allowedVersions: '<=8'
+    },
+    {
+      matchPackageNames: ['rollup'],
+      matchPackagePrefixes: ['@rollup'],
+      groupName: 'rollup,'
     }
   ],
   // Never rebase the branch or update it unless manually requested to avoid noisy PR emails


### PR DESCRIPTION
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We get >1 PR when rollup upgrades

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

add rollup and `@rollup` prefixed packages to one pull request when a release goes out, to minimize the noise associated with a release


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Tested in the create stencil repo to verify this works

Ran the `renovate-config-validator` locally
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
I _assume_ that the ignore list for rollup will supersede this. This is just for "future us" while we work through the pain of renovate creating so many PRs for us today 😆 
