### PR TITLE
fix(compiler): persist polyfills on build

### DIFF
--- a/src/compiler/output-targets/dist-lazy/generate-esm.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-esm.ts
@@ -1,5 +1,4 @@
-import { generatePreamble, relativeImport } from '@utils';
-import { join } from 'path';
+import { generatePreamble, join, relativeImport } from '@utils';
 import type { OutputOptions, RollupBuild } from 'rollup';
 
 import type * as d from '../../../declarations';


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

A `polyfills` directory disappears on every other build on Windows.

Fixes: https://github.com/ionic-team/stencil/issues/4661


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
in #4317 (b042d8b), a polyfill for node's `path.join` was [removed](https://github.com/ionic-team/stencil/pull/4317/files#diff-734f69edf83052dfd5ce6df10429550680537c6da66ef9b7cfbda11efdff5117L36), but wasn't backfilled with stencil's `@utils` package version in `generate-esm.ts`. without this change, the destination computed for the polyfills is not normalized for users of Windows OS's.

when the destination path is not normalized here (but is normalized in other parts of the code), it creates a situation where stencil's in memory-fs both:
1. marks the polyfills to be copied
2. marks the _previous_ polyfills to be removed

normally, if we're performing a copy operation, we don't bother with the deletion (as the copy overwrites the existing polyfills). this is important, as stencil performs its copy operations before it performs its deletions. to ensure that a recently copied file is not subsequently deleted, stencil performs a [check on the files it will delete and removes them from the 'to delete' list](https://github.com/ionic-team/stencil/blob/15a7f89f677bad012dd82a088ce64149a7e48a61/src/compiler/sys/in-memory-fs.ts#L1250-L1253) based on the destination filename.

since the destination filename on windows is not normalized and the filename for the same file to delete is (normalized), the check fails to acknowledge we're going to copy this file. this causes the following behavior on a stencil build:
- if the polyfills directory exists, mark it to be copied, but subsequently delete it
- if the polyfills directory does not exist, mark it to be copied. it will not be marked to be deleted because it does not exist on disk when the list of files to delete is calculated (prior to the copy)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I tested this on a Windows machine, one where I had a build of this branch:  `@stencil/core@4.4.1-dev.1697459952.0a1efbd`

Then installed it in the output of creating a new stencil component library:

```bash
cd /tmp \
&& npm init stencil@latest component jest-test \
&& cd $_ \
&& npm i @stencil/core@4.4.1-dev.1697459952.0a1efbd
```

Once installed, I ran `npm run build`, and ensured that `dist/esm/polyfills` was populated. Rerunning the build shows the directory is still populated.

Running this with `@stencil/core@4.4.1` will show an alternating pattern - the polyfills directory will always exists, but it's contents will disappear
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

I also gave a dev build to the folks who were encountering this issue (see issue comments), and had one report over the weekend of this fixing the issue.
## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
STENCIL-918
