### PR TITLE
fix(compiler): consistently generate additional type files

### DIFF
--- a/src/compiler/transpile/run-program.ts
+++ b/src/compiler/transpile/run-program.ts
@@ -109,10 +109,6 @@ export const runTsProgram = async (
 
   // create the components.d.ts file and write to disk
   const hasTypesChanged = await generateAppTypes(config, compilerCtx, buildCtx, 'src');
-  if (hasTypesChanged) {
-    return true;
-  }
-
   if (typesOutputTarget.length > 0) {
     // copy src dts files that do not get emitted by the compiler
     // but we still want to ship them in the dist directory
@@ -149,7 +145,7 @@ export const runTsProgram = async (
     buildCtx.diagnostics.push(...tsSemantic);
   }
 
-  return false;
+  return hasTypesChanged;
 };
 
 /**


### PR DESCRIPTION
## What is the current behavior?

The if statement doesn't really make sense to me as I would assume you would return early in case no types have changed. However this is causing an interesting side effect where the filesystem in memory determines to delete the directory because the directory and the file in it is not being written. A second execution actually re-creates the file.

It it has hard to determine the origin of this change. Likely this wasn't causing any harm until the memory FS logic started to clear out directories that had no files written to them.

This has potentially a small performance impact since types are now always generated which they would have been before too except the first time. However if we are not writing the file to memory, the directory will be cleaned up by the memfs system when we commit changes in [`writeBuild`](https://github.com/ionic-team/stencil/blob/b91f94a122dc9add876f0277f99afc92c96e66dd/src/compiler/build/write-build.ts#L24).

Fixes #4716

GitHub Issue Number: #4716

## What is the new behavior?

With this patch, we always generate additional type files for the component, including for the first type generation.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

No tests added to verify this new behavior given there aren't any tests for part of the code base already. Given that we don't really know the expected behavior for a lot of these parts I am not sure about the value of adding unit tests for the current state. Happy to do so if you think it does make sense.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->