### PR TITLE
fix(runtime): add height, width Source attrs

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1259,11 +1259,13 @@ export namespace JSXBase {
   }
 
   export interface SourceHTMLAttributes<T> extends HTMLAttributes<T> {
+    height?: number;
     media?: string;
     sizes?: string;
     src?: string;
     srcSet?: string;
     type?: string;
+    width?: number;
   }
 
   export interface StyleHTMLAttributes<T> extends HTMLAttributes<T> {


### PR DESCRIPTION




<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

prior to this commit, users attempting to properly type a `<source/>` element in JSX would run into TypeScript errors:
```tsx
render() {
  return <picture><source height={100} width={100}/></picture>;
}
```
```
[ ERROR ]  TypeScript: src/components/my-component/my-component.tsx:31:29
           Type '{ height: number; width: number; }' is not assignable to type
           'SourceHTMLAttributes<HTMLSourceElement>'.Property 'height' does not exist on type
           'SourceHTMLAttributes<HTMLSourceElement>'.

     L30:  render() {
     L31:    return <picture><source height={100} width={100}/></picture>;
     L32:  }

[26:05.7]  build failed in 1.12 s
```

fixes: #4942

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

add the height and width properties for the `SourceHTMLAttributes`. 

adding these typings as optional numbers resolves these types of compile-time errors

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
I created a dev build of Stencil: `@stencil/core@4.5.0-dev.1697632445.c2d195e`

Then I created a new stencil component library with the latest version of Stencil:

```bash
cd /tmp \
&& npm init stencil@latest component jsx-test \
&& cd $_ \
&& npm i
```

Then updated `my-component.tsx` and ran `npm run build` to get errors:
```diff
diff --git a/src/components/my-component/my-component.tsx b/src/components/my-component/my-component.tsx
index 56d51d9..aef1d67 100644
--- a/src/components/my-component/my-component.tsx
+++ b/src/components/my-component/my-component.tsx
@@ -22,11 +22,12 @@ export class MyComponent {
    */
   @Prop() last: string;
 
+  // @ts-ignore - we won't use this in the repro
   private getText(): string {
     return format(this.first, this.middle, this.last);
   }
 
   render() {
-    return <div>Hello, World! I'm {this.getText()}</div>;
+    return <picture><source height={23} width={2}/></picture>;
   }
```
```bash
$ npm run build

> jsx-test@0.0.1 build
> stencil build --docs

[42:31.9]  @stencil/core
[42:32.1]  v4.5.0 📢
[42:33.0]  build, jsx-test, prod mode, started ...
[42:33.0]  transpile started ...
[42:34.1]  transpile finished in 1.08 s

[ ERROR ]  TypeScript: src/components/my-component/my-component.tsx:31:29
           Type '{ height: number; width: number; }' is not assignable to type
           'SourceHTMLAttributes<HTMLSourceElement>'.Property 'height' does not exist on type
           'SourceHTMLAttributes<HTMLSourceElement>'.

     L30:  render() {
     L31:    return <picture><source height={23} width={2}/></picture>;
     L32:  }

[42:34.1]  build failed in 1.09 s

```

I then installed my dev build, verified that errors didn't occur on build:
```bash
npm i @stencil/core@ && npm run build && echo $?
```
## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

STENCIL-977