### PR TITLE
refactor(jest): remove version qualifiers in v27 facade impl

### DIFF
--- a/src/testing/jest/jest-27-and-under/jest-facade.ts
+++ b/src/testing/jest/jest-27-and-under/jest-facade.ts
@@ -1,22 +1,22 @@
 import { JestFacade } from '../jest-facade';
-import { createJestPuppeteerEnvironment as createJestPuppeteerEnvironment27 } from './jest-environment';
-import { jestPreprocessor as jestPreprocessor27 } from './jest-preprocessor';
-import { preset as jestPreset27 } from './jest-preset';
-import { createTestRunner as createTestRunner27 } from './jest-runner';
-import { runJest as runJest27 } from './jest-runner';
-import { runJestScreenshot as runJestScreenshot27 } from './jest-screenshot';
-import { jestSetupTestFramework as jestSetupTestFramework27 } from './jest-setup-test-framework';
+import { createJestPuppeteerEnvironment } from './jest-environment';
+import { jestPreprocessor } from './jest-preprocessor';
+import { preset } from './jest-preset';
+import { createTestRunner } from './jest-runner';
+import { runJest } from './jest-runner';
+import { runJestScreenshot } from './jest-screenshot';
+import { jestSetupTestFramework } from './jest-setup-test-framework';
 
 /**
  * `JestFacade` implementation for communicating between this directory's version of Jest and Stencil
  */
 export class Jest27Stencil implements JestFacade {
   getJestCliRunner() {
-    return runJest27;
+    return runJest;
   }
 
   getRunJestScreenshot() {
-    return runJestScreenshot27;
+    return runJestScreenshot;
   }
 
   getDefaultJestRunner() {
@@ -24,22 +24,22 @@ export class Jest27Stencil implements JestFacade {
   }
 
   getCreateJestPuppeteerEnvironment() {
-    return createJestPuppeteerEnvironment27;
+    return createJestPuppeteerEnvironment;
   }
 
   getJestPreprocessor() {
-    return jestPreprocessor27;
+    return jestPreprocessor;
   }
 
   getCreateJestTestRunner() {
-    return createTestRunner27;
+    return createTestRunner;
   }
 
   getJestSetupTestFramework() {
-    return jestSetupTestFramework27;
+    return jestSetupTestFramework;
   }
 
   getJestPreset() {
-    return jestPreset27;
+    return preset;
   }
 }


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See 'new behavior' section

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

remove the import aliases used in `jest-facade.ts`. the aliases were renaming the imports to be '27-specific'. however, we're already in a 'jest-27' directory and working on the `Jest27Stencil` class (which is kept with the '27' to help differentiate this class further). having these extra import aliases made the instructions for adding a new version of jest more onerous than it needed to be

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

These aliases were internal only to this file - I don't expect them to affect any other parts of the code. 
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
