### PR TITLE
chore(snc): resolve dist-lazy violations

### DIFF
--- a/src/compiler/output-targets/dist-lazy/generate-cjs.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-cjs.ts
@@ -27,7 +27,9 @@ export const generateCjs = async (
     };
     const results = await generateRollupOutput(rollupBuild, esmOpts, config, buildCtx.entryModules);
     if (results != null) {
-      const destinations = cjsOutputs.map((o) => o.cjsDir);
+      const destinations = cjsOutputs
+        .map((o) => o.cjsDir)
+        .filter((cjsDir): cjsDir is string => typeof cjsDir === 'string');
 
       buildCtx.commonJsComponentBundle = await generateLazyModules(
         config,

--- a/src/compiler/output-targets/dist-lazy/generate-esm-browser.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-esm-browser.ts
@@ -28,7 +28,9 @@ export const generateEsmBrowser = async (
     const output = await generateRollupOutput(rollupBuild, esmOpts, config, buildCtx.entryModules);
 
     if (output != null) {
-      const es2017destinations = esmOutputs.map((o) => o.esmDir);
+      const es2017destinations = esmOutputs
+        .map((o) => o.esmDir)
+        .filter((esmDir): esmDir is string => typeof esmDir === 'string');
       buildCtx.esmBrowserComponentBundle = await generateLazyModules(
         config,
         compilerCtx,

--- a/src/compiler/output-targets/dist-lazy/generate-esm.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-esm.ts
@@ -28,7 +28,9 @@ export const generateEsm = async (
     const output = await generateRollupOutput(rollupBuild, esmOpts, config, buildCtx.entryModules);
 
     if (output != null) {
-      const es2017destinations = esmOutputs.map((o) => o.esmDir);
+      const es2017destinations = esmOutputs
+        .map((o) => o.esmDir)
+        .filter((esmDir): esmDir is string => typeof esmDir === 'string');
       buildCtx.esmComponentBundle = await generateLazyModules(
         config,
         compilerCtx,
@@ -41,7 +43,9 @@ export const generateEsm = async (
         '',
       );
 
-      const es5destinations = esmEs5Outputs.map((o) => o.esmEs5Dir);
+      const es5destinations = esmEs5Outputs
+        .map((o) => o.esmEs5Dir)
+        .filter((esmEs5Dir): esmEs5Dir is string => typeof esmEs5Dir === 'string');
       buildCtx.es5ComponentBundle = await generateLazyModules(
         config,
         compilerCtx,
@@ -67,7 +71,10 @@ const copyPolyfills = async (
   compilerCtx: d.CompilerCtx,
   outputTargets: d.OutputTargetDistLazy[],
 ): Promise<void> => {
-  const destinations = outputTargets.filter((o) => o.polyfills).map((o) => o.esmDir);
+  const destinations = outputTargets
+    .filter((o) => o.polyfills)
+    .map((o) => o.esmDir)
+    .filter((esmDir): esmDir is string => typeof esmDir === 'string');
   if (destinations.length === 0) {
     return;
   }

--- a/src/compiler/output-targets/dist-lazy/generate-system.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-system.ts
@@ -28,7 +28,9 @@ export const generateSystem = async (
     };
     const results = await generateRollupOutput(rollupBuild, esmOpts, config, buildCtx.entryModules);
     if (results != null) {
-      const destinations = systemOutputs.map((o) => o.esmDir);
+      const destinations = systemOutputs
+        .map((o) => o.esmDir)
+        .filter((esmDir): esmDir is string => typeof esmDir === 'string');
       buildCtx.systemComponentBundle = await generateLazyModules(
         config,
         compilerCtx,


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We have ~1400 SNC failures

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
resolve a handful of dist-lazy strictNullChecks violations where `undefined` values were not properly being filtered out of the arrays being passed to `generate-lazy-module`.

in all code paths, this code would be failing if `undefined` were in these arrays in practice, as the values are used in `path.join` calls (which error in the event of `undefined` being provided as an arg)

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I'm relying on existing tests/the assumption that I'm correct in that all code paths would result in an `Error` being thrown if `undefined` actually made it in to these data structs
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
