### PR TITLE
fix(runtime): support "capture" style events

### DIFF
--- a/src/runtime/vdom/set-accessor.ts
+++ b/src/runtime/vdom/set-accessor.ts
@@ -113,12 +113,9 @@ export const setAccessor = (
         // Need to account for "capture" events.
         // If the event name ends with "Capture", we'll update the name to remove
         // the "Capture" suffix and make sure the event listener is setup to handle the capture event.
-        let capture = false;
-        if (memberName.endsWith(CAPTURE_EVENT_SUFFIX)) {
-          capture = true;
-          // Make sure we only replace the last instance of "Capture"
-          memberName = memberName.replace(new RegExp(CAPTURE_EVENT_SUFFIX + '$'), '');
-        }
+        const capture = memberName.endsWith(CAPTURE_EVENT_SUFFIX);
+        // Make sure we only replace the last instance of "Capture"
+        memberName = memberName.replace(CAPTURE_EVENT_REGEX, '');
 
         if (oldValue) {
           plt.rel(elm, memberName, oldValue, capture);
@@ -183,3 +180,4 @@ export const setAccessor = (
 const parseClassListRegex = /\s/;
 const parseClassList = (value: string | undefined | null): string[] => (!value ? [] : value.split(parseClassListRegex));
 const CAPTURE_EVENT_SUFFIX = 'Capture';
+const CAPTURE_EVENT_REGEX = new RegExp(CAPTURE_EVENT_SUFFIX + '$');

--- a/src/runtime/vdom/set-accessor.ts
+++ b/src/runtime/vdom/set-accessor.ts
@@ -110,11 +110,14 @@ export const setAccessor = (
         memberName = ln[2] + memberName.slice(3);
       }
       if (oldValue || newValue) {
-        // Need to account for "capture" events
+        // Need to account for "capture" events.
+        // If the event name ends with "Capture", we'll update the name to remove
+        // the "Capture" suffix and make sure the event listener is setup to handle the capture event.
         let capture = false;
         if (memberName.endsWith(CAPTURE_EVENT_SUFFIX)) {
           capture = true;
-          memberName = memberName.replace(CAPTURE_EVENT_SUFFIX, '');
+          // Make sure we only replace the last instance of "Capture"
+          memberName = memberName.replace(new RegExp(CAPTURE_EVENT_SUFFIX + '$'), '');
         }
 
         if (oldValue) {

--- a/src/runtime/vdom/set-accessor.ts
+++ b/src/runtime/vdom/set-accessor.ts
@@ -109,11 +109,20 @@ export const setAccessor = (
         // except for the first character, we keep the event name case
         memberName = ln[2] + memberName.slice(3);
       }
-      if (oldValue) {
-        plt.rel(elm, memberName, oldValue, false);
-      }
-      if (newValue) {
-        plt.ael(elm, memberName, newValue, false);
+      if (oldValue || newValue) {
+        // Need to account for "capture" events
+        let capture = false;
+        if (memberName.endsWith(CAPTURE_EVENT_SUFFIX)) {
+          capture = true;
+          memberName = memberName.replace(CAPTURE_EVENT_SUFFIX, '');
+        }
+
+        if (oldValue) {
+          plt.rel(elm, memberName, oldValue, capture);
+        }
+        if (newValue) {
+          plt.ael(elm, memberName, newValue, capture);
+        }
       }
     } else if (BUILD.vdomPropOrAttr) {
       // Set property if it exists and it's not a SVG
@@ -170,3 +179,4 @@ export const setAccessor = (
 };
 const parseClassListRegex = /\s/;
 const parseClassList = (value: string | undefined | null): string[] => (!value ? [] : value.split(parseClassListRegex));
+const CAPTURE_EVENT_SUFFIX = 'Capture';

--- a/src/runtime/vdom/test/set-accessor.spec.ts
+++ b/src/runtime/vdom/test/set-accessor.spec.ts
@@ -127,6 +127,22 @@ describe('setAccessor for custom elements', () => {
       expect(addEventSpy).toHaveBeenCalledWith('click', newValue, true);
       expect(removeEventSpy).not.toHaveBeenCalled();
     });
+
+    it('should remove a capture style event listener', () => {
+      const addEventSpy = jest.spyOn(elm, 'addEventListener');
+      const removeEventSpy = jest.spyOn(elm, 'removeEventListener');
+
+      const orgValue = () => {
+        /**/
+      };
+
+      setAccessor(elm, 'onClickCapture', undefined, orgValue, false, 0);
+      setAccessor(elm, 'onClickCapture', orgValue, undefined, false, 0);
+
+      expect(addEventSpy).toHaveBeenCalledTimes(1);
+      expect(addEventSpy).toHaveBeenCalledWith('click', orgValue, true);
+      expect(removeEventSpy).toHaveBeenCalledWith('click', orgValue, true);
+    });
   });
 
   it('should set object property to child', () => {

--- a/src/runtime/vdom/test/set-accessor.spec.ts
+++ b/src/runtime/vdom/test/set-accessor.spec.ts
@@ -113,6 +113,20 @@ describe('setAccessor for custom elements', () => {
       expect(addEventSpy).toHaveBeenCalledWith('click', newValue, false);
       expect(removeEventSpy).not.toHaveBeenCalled();
     });
+
+    it('should add a capture style event listener', () => {
+      const addEventSpy = jest.spyOn(elm, 'addEventListener');
+      const removeEventSpy = jest.spyOn(elm, 'removeEventListener');
+
+      const newValue = () => {
+        /**/
+      };
+
+      setAccessor(elm, 'onClickCapture', undefined, newValue, false, 0);
+
+      expect(addEventSpy).toHaveBeenCalledWith('click', newValue, true);
+      expect(removeEventSpy).not.toHaveBeenCalled();
+    });
   });
 
   it('should set object property to child', () => {

--- a/test/karma/test-app/components.d.ts
+++ b/test/karma/test-app/components.d.ts
@@ -131,6 +131,8 @@ export namespace Components {
     }
     interface EventCustomType {
     }
+    interface EventListenerCapture {
+    }
     interface ExternalImportA {
     }
     interface ExternalImportB {
@@ -675,6 +677,12 @@ declare global {
     var HTMLEventCustomTypeElement: {
         prototype: HTMLEventCustomTypeElement;
         new (): HTMLEventCustomTypeElement;
+    };
+    interface HTMLEventListenerCaptureElement extends Components.EventListenerCapture, HTMLStencilElement {
+    }
+    var HTMLEventListenerCaptureElement: {
+        prototype: HTMLEventListenerCaptureElement;
+        new (): HTMLEventListenerCaptureElement;
     };
     interface HTMLExternalImportAElement extends Components.ExternalImportA, HTMLStencilElement {
     }
@@ -1355,6 +1363,7 @@ declare global {
         "esm-import": HTMLEsmImportElement;
         "event-basic": HTMLEventBasicElement;
         "event-custom-type": HTMLEventCustomTypeElement;
+        "event-listener-capture": HTMLEventListenerCaptureElement;
         "external-import-a": HTMLExternalImportAElement;
         "external-import-b": HTMLExternalImportBElement;
         "external-import-c": HTMLExternalImportCElement;
@@ -1574,6 +1583,8 @@ declare namespace LocalJSX {
     }
     interface EventCustomType {
         "onTestEvent"?: (event: EventCustomTypeCustomEvent<TestEventDetail>) => void;
+    }
+    interface EventListenerCapture {
     }
     interface ExternalImportA {
     }
@@ -1856,6 +1867,7 @@ declare namespace LocalJSX {
         "esm-import": EsmImport;
         "event-basic": EventBasic;
         "event-custom-type": EventCustomType;
+        "event-listener-capture": EventListenerCapture;
         "external-import-a": ExternalImportA;
         "external-import-b": ExternalImportB;
         "external-import-c": ExternalImportC;
@@ -2002,6 +2014,7 @@ declare module "@stencil/core" {
             "esm-import": LocalJSX.EsmImport & JSXBase.HTMLAttributes<HTMLEsmImportElement>;
             "event-basic": LocalJSX.EventBasic & JSXBase.HTMLAttributes<HTMLEventBasicElement>;
             "event-custom-type": LocalJSX.EventCustomType & JSXBase.HTMLAttributes<HTMLEventCustomTypeElement>;
+            "event-listener-capture": LocalJSX.EventListenerCapture & JSXBase.HTMLAttributes<HTMLEventListenerCaptureElement>;
             "external-import-a": LocalJSX.ExternalImportA & JSXBase.HTMLAttributes<HTMLExternalImportAElement>;
             "external-import-b": LocalJSX.ExternalImportB & JSXBase.HTMLAttributes<HTMLExternalImportBElement>;
             "external-import-c": LocalJSX.ExternalImportC & JSXBase.HTMLAttributes<HTMLExternalImportCElement>;

--- a/test/karma/test-app/event-listener-capture/cmp.tsx
+++ b/test/karma/test-app/event-listener-capture/cmp.tsx
@@ -1,0 +1,21 @@
+import { Component, h, State } from '@stencil/core';
+
+@Component({
+  tag: 'event-listener-capture',
+})
+export class EventListenerCapture {
+  @State() counter = 0;
+
+  render() {
+    return (
+      <div>
+        <p>Click the text below to trigger a capture style event</p>
+        <div>
+          <p id="incrementer" onClickCapture={() => this.counter++}>
+            Clicked: <span id="counter">{this.counter}</span> time(s)
+          </p>
+        </div>
+      </div>
+    );
+  }
+}

--- a/test/karma/test-app/event-listener-capture/index.html
+++ b/test/karma/test-app/event-listener-capture/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<meta charset="utf8" />
+<script src="./build/testapp.esm.js" type="module"></script>
+<script src="./build/testapp.js" nomodule></script>
+
+<event-listener-capture></event-listener-capture>

--- a/test/karma/test-app/event-listener-capture/karma.spec.ts
+++ b/test/karma/test-app/event-listener-capture/karma.spec.ts
@@ -1,0 +1,31 @@
+import { setupDomTests, waitForChanges } from '../util';
+
+describe('event-listener-capture', function () {
+  const { setupDom, tearDownDom } = setupDomTests(document);
+
+  let app: HTMLElement | undefined;
+  let host: HTMLElement | undefined;
+
+  beforeEach(async () => {
+    app = await setupDom('/event-listener-capture/index.html');
+    host = app.querySelector('event-listener-capture');
+  });
+
+  afterEach(tearDownDom);
+
+  it('should render', () => {
+    expect(host).toBeDefined();
+  });
+
+  it('should increment counter on click', async () => {
+    const counter = host.querySelector('#counter');
+    expect(counter.textContent).toBe('0');
+
+    const p = host.querySelector('#incrementer') as HTMLParagraphElement;
+    expect(p).toBeDefined();
+    p.click();
+    await waitForChanges();
+
+    expect(counter.textContent).toBe('1');
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Our element interfaces include capture type events (like `onClickCapture`, `onInputCapture`, etc.), but our runtime does not correctly bind the event listeners for these types. So, currently, nothing happens when using these attributes since they were bound like this:

```ts
el.addEventListener('clickCapture', <handler>, false)`
```

but should be bound like this:

```ts
el.addEventListener('click', <handler>, true)`
```

Fixes: #4955 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The runtime has been updated to correctly bind the listeners for capture events based on the "Capture" suffix in the event attribute

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

**Manual testing**
1. Add an `onClickCapture` to any element in a Stencil component starter that just logs out the event. Notice nothing gets logged clicking the element.
2. Build and install this branch into the starter
3. Event gets logged correctly when clicking the element

**Automated testing**
- All existing tests continue to pass.
- Added a unit test for `setAccessor` to ensure the call to bind the event listeners is getting the correct args
- Added a e2e test to test the actual event handlers for capture events

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
