### PR TITLE
docs(output-targets): document generateHashedCopy function

### DIFF
--- a/src/compiler/output-targets/copy/hashed-copy.ts
+++ b/src/compiler/output-targets/copy/hashed-copy.ts
@@ -2,7 +2,42 @@ import { dirname, extname, join } from 'path';
 
 import type * as d from '../../../declarations';
 
-export const generateHashedCopy = async (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx, path: string) => {
+/**
+ * Create a copy of a given file in its current directory but with a filename
+ * derived by hashing the file contents. This allows us to refer to a file by
+ * name and ensure that a given filename always refers to the same file
+ * contents.
+ *
+ * So for instance if you had a directory:
+ *
+ * ```
+ * build
+ * └── index.js
+ * ```
+ *
+ * and the contents of `build/index.js` hashed to `1234abcd` then write a
+ * file to `build/p-1234abcd.js` with the contents of `build/index.js`,
+ * giving:
+ *
+ * ```
+ * build
+ * ├── index.js
+ * └── p-1234abcd.js
+ * ```
+ *
+ * Assuming that the contents of `build/index.js` did not change re-running
+ * this function will produce the same output.
+ *
+ * @param config the current user-supplied config
+ * @param compilerCtx a compiler context
+ * @param path the path to read and hash from
+ * @returns the newly-written path or undefined if not written
+ */
+export const generateHashedCopy = async (
+  config: d.ValidatedConfig,
+  compilerCtx: d.CompilerCtx,
+  path: string,
+): Promise<string | undefined> => {
   try {
     const content = await compilerCtx.fs.readFile(path);
     const hash = await config.sys.generateContentHash(content, config.hashedFileNameLength);


### PR DESCRIPTION
This just adds some JSDoc to this function, which it was sorely lacking.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
