### PR TITLE
fix(runtime): slotted content order with sibling elements

### DIFF
--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -989,7 +989,7 @@ render() {
           //
           // If there is no node immediately following the slot reference node, then we will just
           // end up appending the node as the last child of the parent.
-          let insertBeforeNode = slotRefNode.nextSibling as d.RenderNode;
+          let insertBeforeNode = slotRefNode.nextSibling as d.RenderNode | null;
 
           // If the node we're currently planning on inserting the new node before is an element,
           // we need to do some additional checks to make sure we're inserting the node in the correct order.
@@ -1001,10 +1001,11 @@ render() {
             !BUILD.experimentalSlotFixes ||
             (insertBeforeNode && insertBeforeNode.nodeType === NODE_TYPE.ElementNode)
           ) {
-            let orgLocationNode = nodeToRelocate['s-ol'];
-            let refNode: d.RenderNode;
-            while ((orgLocationNode = orgLocationNode.previousSibling as d.RenderNode)) {
-              refNode = orgLocationNode['s-nr'];
+            let orgLocationNode = nodeToRelocate['s-ol']?.previousSibling as d.RenderNode | null;
+
+            while (orgLocationNode) {
+              let refNode = orgLocationNode['s-nr'] ?? null;
+
               if (refNode && refNode['s-sn'] === nodeToRelocate['s-sn'] && parentNodeRef === refNode.parentNode) {
                 refNode = refNode.nextSibling as any;
                 if (!refNode || !refNode['s-nr']) {
@@ -1012,6 +1013,8 @@ render() {
                   break;
                 }
               }
+
+              orgLocationNode = orgLocationNode.previousSibling as d.RenderNode | null;
             }
           }
 

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -995,7 +995,12 @@ render() {
           // we need to do some additional checks to make sure we're inserting the node in the correct order.
           // The use case here would be that we have multiple nodes being relocated to the same slot. So, we want
           // to make sure they get inserted into their new how in the same order they were declared in their original location.
-          if (insertBeforeNode && insertBeforeNode.nodeType === NODE_TYPE.ElementNode) {
+          //
+          // TODO(STENCIL-914): Remove `experimentalSlotFixes` check
+          if (
+            !BUILD.experimentalSlotFixes ||
+            (insertBeforeNode && insertBeforeNode.nodeType === NODE_TYPE.ElementNode)
+          ) {
             let orgLocationNode = nodeToRelocate['s-ol'];
             let refNode: d.RenderNode;
             while ((orgLocationNode = orgLocationNode.previousSibling as d.RenderNode)) {

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -986,7 +986,7 @@ render() {
           // TODO(NOW): document the behavior around determining where to insert the content
           let insertBeforeNode = slotRefNode.nextSibling as unknown as d.RenderNode;
 
-          if (insertBeforeNode) {
+          if (insertBeforeNode && insertBeforeNode.nodeType === NODE_TYPE.ElementNode) {
             let orgLocationNode = nodeToRelocate['s-ol'];
             let refNode: d.RenderNode;
             while ((orgLocationNode = orgLocationNode.previousSibling as any)) {

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -982,14 +982,13 @@ render() {
 
         if (slotRefNode) {
           const parentNodeRef = slotRefNode.parentNode;
-          // TODO(NOW): type
           // TODO(NOW): document the behavior around determining where to insert the content
-          let insertBeforeNode = slotRefNode.nextSibling as unknown as d.RenderNode;
+          let insertBeforeNode = slotRefNode.nextSibling as d.RenderNode;
 
           if (insertBeforeNode && insertBeforeNode.nodeType === NODE_TYPE.ElementNode) {
             let orgLocationNode = nodeToRelocate['s-ol'];
             let refNode: d.RenderNode;
-            while ((orgLocationNode = orgLocationNode.previousSibling as any)) {
+            while ((orgLocationNode = orgLocationNode.previousSibling as d.RenderNode)) {
               refNode = orgLocationNode['s-nr'];
               if (refNode && refNode['s-sn'] === nodeToRelocate['s-sn'] && parentNodeRef === refNode.parentNode) {
                 refNode = refNode.nextSibling as any;

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -962,10 +962,6 @@ render() {
 
       let relocateData: RelocateNodeData;
       let nodeToRelocate: d.RenderNode;
-      let orgLocationNode: d.RenderNode;
-      let parentNodeRef: Node;
-      let insertBeforeNode: Node;
-      let refNode: d.RenderNode;
       let i = 0;
 
       for (; i < relocateNodes.length; i++) {
@@ -975,7 +971,7 @@ render() {
         if (!nodeToRelocate['s-ol']) {
           // add a reference node marking this node's original location
           // keep a reference to this node for later lookups
-          orgLocationNode =
+          const orgLocationNode =
             BUILD.isDebug || BUILD.hydrateServerSide
               ? originalLocationDebugNode(nodeToRelocate)
               : (doc.createTextNode('') as any);
@@ -991,19 +987,20 @@ render() {
         const slotRefNode = relocateData.$slotRefNode$;
 
         if (slotRefNode) {
-          // by default we're just going to insert it directly
-          // after the slot reference node
-          parentNodeRef = slotRefNode.parentNode;
-          insertBeforeNode = slotRefNode.nextSibling;
-          orgLocationNode = nodeToRelocate['s-ol'] as any;
+          const parentNodeRef = slotRefNode.parentNode;
 
-          while ((orgLocationNode = orgLocationNode.previousSibling as any)) {
-            refNode = orgLocationNode['s-nr'];
-            if (refNode && refNode['s-sn'] === nodeToRelocate['s-sn'] && parentNodeRef === refNode.parentNode) {
-              refNode = refNode.nextSibling as any;
-              if (!refNode || !refNode['s-nr']) {
-                insertBeforeNode = refNode;
-                break;
+          let insertBeforeNode = slotRefNode.nextSibling as unknown as d.RenderNode;
+          if (insertBeforeNode) {
+            let orgLocationNode = nodeToRelocate['s-ol'];
+            let refNode: d.RenderNode;
+            while ((orgLocationNode = orgLocationNode.previousSibling as any)) {
+              refNode = orgLocationNode['s-nr'];
+              if (refNode && refNode['s-sn'] === nodeToRelocate['s-sn'] && parentNodeRef === refNode.parentNode) {
+                refNode = refNode.nextSibling as any;
+                if (!refNode || !refNode['s-nr']) {
+                  insertBeforeNode = refNode;
+                  break;
+                }
               }
             }
           }

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -982,8 +982,10 @@ render() {
 
         if (slotRefNode) {
           const parentNodeRef = slotRefNode.parentNode;
-
+          // TODO(NOW): type
+          // TODO(NOW): document the behavior around determining where to insert the content
           let insertBeforeNode = slotRefNode.nextSibling as unknown as d.RenderNode;
+
           if (insertBeforeNode) {
             let orgLocationNode = nodeToRelocate['s-ol'];
             let refNode: d.RenderNode;

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -982,9 +982,19 @@ render() {
 
         if (slotRefNode) {
           const parentNodeRef = slotRefNode.parentNode;
-          // TODO(NOW): document the behavior around determining where to insert the content
+          // When determining where to insert content, the most simple case would be
+          // to relocate the node immediately following the slot reference node. We do this
+          // by getting a reference to the node immediately following the slot reference node
+          // since we will use `insertBefore` to manipulate the DOM.
+          //
+          // If there is no node immediately following the slot reference node, then we will just
+          // end up appending the node as the last child of the parent.
           let insertBeforeNode = slotRefNode.nextSibling as d.RenderNode;
 
+          // If the node we're currently planning on inserting the new node before is an element,
+          // we need to do some additional checks to make sure we're inserting the node in the correct order.
+          // The use case here would be that we have multiple nodes being relocated to the same slot. So, we want
+          // to make sure they get inserted into their new how in the same order they were declared in their original location.
           if (insertBeforeNode && insertBeforeNode.nodeType === NODE_TYPE.ElementNode) {
             let orgLocationNode = nodeToRelocate['s-ol'];
             let refNode: d.RenderNode;
@@ -1034,7 +1044,10 @@ render() {
                 }
               }
 
-              // add it back to the dom but in its new home
+              // Add it back to the dom but in its new home
+              // If we get to this point and `insertBeforeNode` is `null`, that means
+              // we're just going to append the node as the last child of the parent. Passing
+              // `null` as the second arg here will trigger that behavior.
               parentNodeRef.insertBefore(nodeToRelocate, insertBeforeNode);
             }
           }

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -960,13 +960,8 @@ render() {
     if (checkSlotRelocate) {
       markSlotContentForRelocation(rootVnode.$elm$);
 
-      let relocateData: RelocateNodeData;
-      let nodeToRelocate: d.RenderNode;
-      let i = 0;
-
-      for (; i < relocateNodes.length; i++) {
-        relocateData = relocateNodes[i];
-        nodeToRelocate = relocateData.$nodeToRelocate$;
+      for (const relocateData of relocateNodes) {
+        const nodeToRelocate = relocateData.$nodeToRelocate$;
 
         if (!nodeToRelocate['s-ol']) {
           // add a reference node marking this node's original location
@@ -981,9 +976,8 @@ render() {
         }
       }
 
-      for (i = 0; i < relocateNodes.length; i++) {
-        relocateData = relocateNodes[i];
-        nodeToRelocate = relocateData.$nodeToRelocate$;
+      for (const relocateData of relocateNodes) {
+        const nodeToRelocate = relocateData.$nodeToRelocate$;
         const slotRefNode = relocateData.$slotRefNode$;
 
         if (slotRefNode) {

--- a/test/karma/test-app/components.d.ts
+++ b/test/karma/test-app/components.d.ts
@@ -333,6 +333,11 @@ export namespace Components {
     }
     interface SlotMapOrderRoot {
     }
+    interface SlotNestedDefaultOrderChild {
+        "state": boolean;
+    }
+    interface SlotNestedDefaultOrderParent {
+    }
     interface SlotNestedNameChange {
     }
     interface SlotNestedNameChangeChild {
@@ -1253,6 +1258,18 @@ declare global {
         prototype: HTMLSlotMapOrderRootElement;
         new (): HTMLSlotMapOrderRootElement;
     };
+    interface HTMLSlotNestedDefaultOrderChildElement extends Components.SlotNestedDefaultOrderChild, HTMLStencilElement {
+    }
+    var HTMLSlotNestedDefaultOrderChildElement: {
+        prototype: HTMLSlotNestedDefaultOrderChildElement;
+        new (): HTMLSlotNestedDefaultOrderChildElement;
+    };
+    interface HTMLSlotNestedDefaultOrderParentElement extends Components.SlotNestedDefaultOrderParent, HTMLStencilElement {
+    }
+    var HTMLSlotNestedDefaultOrderParentElement: {
+        prototype: HTMLSlotNestedDefaultOrderParentElement;
+        new (): HTMLSlotNestedDefaultOrderParentElement;
+    };
     interface HTMLSlotNestedNameChangeElement extends Components.SlotNestedNameChange, HTMLStencilElement {
     }
     var HTMLSlotNestedNameChangeElement: {
@@ -1513,6 +1530,8 @@ declare global {
         "slot-list-light-scoped-root": HTMLSlotListLightScopedRootElement;
         "slot-map-order": HTMLSlotMapOrderElement;
         "slot-map-order-root": HTMLSlotMapOrderRootElement;
+        "slot-nested-default-order-child": HTMLSlotNestedDefaultOrderChildElement;
+        "slot-nested-default-order-parent": HTMLSlotNestedDefaultOrderParentElement;
         "slot-nested-name-change": HTMLSlotNestedNameChangeElement;
         "slot-nested-name-change-child": HTMLSlotNestedNameChangeChildElement;
         "slot-nested-order-child": HTMLSlotNestedOrderChildElement;
@@ -1867,6 +1886,11 @@ declare namespace LocalJSX {
     }
     interface SlotMapOrderRoot {
     }
+    interface SlotNestedDefaultOrderChild {
+        "state"?: boolean;
+    }
+    interface SlotNestedDefaultOrderParent {
+    }
     interface SlotNestedNameChange {
     }
     interface SlotNestedNameChangeChild {
@@ -2042,6 +2066,8 @@ declare namespace LocalJSX {
         "slot-list-light-scoped-root": SlotListLightScopedRoot;
         "slot-map-order": SlotMapOrder;
         "slot-map-order-root": SlotMapOrderRoot;
+        "slot-nested-default-order-child": SlotNestedDefaultOrderChild;
+        "slot-nested-default-order-parent": SlotNestedDefaultOrderParent;
         "slot-nested-name-change": SlotNestedNameChange;
         "slot-nested-name-change-child": SlotNestedNameChangeChild;
         "slot-nested-order-child": SlotNestedOrderChild;
@@ -2197,6 +2223,8 @@ declare module "@stencil/core" {
             "slot-list-light-scoped-root": LocalJSX.SlotListLightScopedRoot & JSXBase.HTMLAttributes<HTMLSlotListLightScopedRootElement>;
             "slot-map-order": LocalJSX.SlotMapOrder & JSXBase.HTMLAttributes<HTMLSlotMapOrderElement>;
             "slot-map-order-root": LocalJSX.SlotMapOrderRoot & JSXBase.HTMLAttributes<HTMLSlotMapOrderRootElement>;
+            "slot-nested-default-order-child": LocalJSX.SlotNestedDefaultOrderChild & JSXBase.HTMLAttributes<HTMLSlotNestedDefaultOrderChildElement>;
+            "slot-nested-default-order-parent": LocalJSX.SlotNestedDefaultOrderParent & JSXBase.HTMLAttributes<HTMLSlotNestedDefaultOrderParentElement>;
             "slot-nested-name-change": LocalJSX.SlotNestedNameChange & JSXBase.HTMLAttributes<HTMLSlotNestedNameChangeElement>;
             "slot-nested-name-change-child": LocalJSX.SlotNestedNameChangeChild & JSXBase.HTMLAttributes<HTMLSlotNestedNameChangeChildElement>;
             "slot-nested-order-child": LocalJSX.SlotNestedOrderChild & JSXBase.HTMLAttributes<HTMLSlotNestedOrderChildElement>;

--- a/test/karma/test-app/slot-nested-default-order/cmp-child.tsx
+++ b/test/karma/test-app/slot-nested-default-order/cmp-child.tsx
@@ -1,0 +1,17 @@
+import { Component, h, Host, Prop } from '@stencil/core';
+
+@Component({
+  tag: 'slot-nested-default-order-child',
+})
+export class SlotNestedDefaultOrderChild {
+  @Prop() state: boolean;
+
+  render() {
+    return (
+      <Host>
+        <div>State: {this.state.toString()}</div>
+        <slot />
+      </Host>
+    );
+  }
+}

--- a/test/karma/test-app/slot-nested-default-order/cmp-parent.tsx
+++ b/test/karma/test-app/slot-nested-default-order/cmp-parent.tsx
@@ -1,0 +1,18 @@
+import { Component, h, Host } from '@stencil/core';
+
+@Component({
+  tag: 'slot-nested-default-order-parent',
+})
+export class SlotNestedDefaultOrderParent {
+  render() {
+    return (
+      <Host>
+        <div>
+          <slot-nested-default-order-child state={true}>
+            <slot />
+          </slot-nested-default-order-child>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/test/karma/test-app/slot-nested-default-order/index.html
+++ b/test/karma/test-app/slot-nested-default-order/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset="utf8" />
+<script src="./build/testapp.esm.js" type="module"></script>
+<script src="./build/testapp.js" nomodule></script>
+
+<slot-nested-default-order-parent>
+  <p>Hello</p>
+</slot-nested-default-order-parent>

--- a/test/karma/test-app/slot-nested-default-order/karma.spec.ts
+++ b/test/karma/test-app/slot-nested-default-order/karma.spec.ts
@@ -1,0 +1,32 @@
+import { setupDomTests } from '../util';
+
+describe('slot-nested-default-order', function () {
+  const { setupDom, tearDownDom } = setupDomTests(document);
+  let app: HTMLElement | undefined;
+  let host: HTMLElement | undefined;
+
+  beforeEach(async () => {
+    app = await setupDom('/slot-nested-default-order/index.html');
+    host = app.querySelector('slot-nested-default-order-parent');
+  });
+
+  afterEach(tearDownDom);
+
+  it('should render', () => {
+    expect(host).toBeDefined();
+  });
+
+  it('should render the slot content after the div', () => {
+    const childCmp = host.querySelector('slot-nested-default-order-child');
+
+    expect(childCmp.children.length).toBe(2);
+
+    const firstChild = childCmp.children[0];
+    expect(firstChild.tagName).toBe('DIV');
+    expect(firstChild.textContent.trim()).toBe('State: true');
+
+    const secondChild = childCmp.children[1];
+    expect(secondChild.tagName).toBe('P');
+    expect(secondChild.textContent.trim()).toBe('Hello');
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

It is possible for slot content that gets relocated to a nested component to appear in the wrong order with the nested component's other non-slotted elements. This was due to logic we had for keeping relocated content in the correct order _within_ a slot executing when it shouldn't and changing our relocation node. 

Fixes: #2997 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The culprit code has been wrapped in a check to only execute in certain situations that make sense (i.e. when the slot has other relocated elements)
- Documented the code responsible for determining where to insert the relocated node for posterity
- Cleaned up some of the code to make things more readable

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

All existing unit and e2e tests continue to pass. Added an e2e test for the reproduction case from the linked issue

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

This is only available with the `experimentalSlotFixes` extra config flag is active
