### PR TITLE
fix(compiler): normalize paths on windows

### DIFF
--- a/src/compiler/app-core/app-es5-disabled.ts
+++ b/src/compiler/app-core/app-es5-disabled.ts
@@ -1,5 +1,4 @@
-import { escapeHtml, generatePreamble } from '@utils';
-import { join } from 'path';
+import { escapeHtml, generatePreamble, join } from '@utils';
 
 import type * as d from '../../declarations';
 

--- a/src/compiler/app-core/app-polyfills.ts
+++ b/src/compiler/app-core/app-polyfills.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from '@utils';
 
 import type * as d from '../../declarations';
 

--- a/src/compiler/build/compiler-ctx.ts
+++ b/src/compiler/build/compiler-ctx.ts
@@ -1,5 +1,5 @@
-import { noop, normalizePath } from '@utils';
-import { basename, dirname, extname, join } from 'path';
+import { join, noop, normalizePath } from '@utils';
+import { basename, dirname, extname } from 'path';
 
 import type * as d from '../../declarations';
 import { buildEvents } from '../events';

--- a/src/compiler/build/watch-build.ts
+++ b/src/compiler/build/watch-build.ts
@@ -1,5 +1,5 @@
-import { isString } from '@utils';
-import { dirname, resolve } from 'path';
+import { isString, resolve } from '@utils';
+import { dirname } from 'path';
 import type ts from 'typescript';
 
 import type * as d from '../../declarations';

--- a/src/compiler/bundle/core-resolve-plugin.ts
+++ b/src/compiler/bundle/core-resolve-plugin.ts
@@ -1,5 +1,5 @@
-import { isRemoteUrl, normalizeFsPath, normalizePath } from '@utils';
-import { dirname, join } from 'path';
+import { isRemoteUrl, join, normalizeFsPath, normalizePath } from '@utils';
+import { dirname } from 'path';
 import type { Plugin } from 'rollup';
 
 import type * as d from '../../declarations';

--- a/src/compiler/bundle/dev-module.ts
+++ b/src/compiler/bundle/dev-module.ts
@@ -1,5 +1,5 @@
-import { generatePreamble } from '@utils';
-import { basename, dirname, join, relative } from 'path';
+import { generatePreamble, join, relative } from '@utils';
+import { basename, dirname } from 'path';
 import { OutputOptions, rollup } from 'rollup';
 
 import type * as d from '../../declarations';

--- a/src/compiler/bundle/dev-node-module-resolve.ts
+++ b/src/compiler/bundle/dev-node-module-resolve.ts
@@ -1,4 +1,5 @@
-import { basename, dirname, join, relative } from 'path';
+import { join, relative } from '@utils';
+import { basename, dirname } from 'path';
 import { ResolveIdResult } from 'rollup';
 
 import type * as d from '../../declarations';

--- a/src/compiler/bundle/ext-transforms-plugin.ts
+++ b/src/compiler/bundle/ext-transforms-plugin.ts
@@ -1,5 +1,4 @@
-import { hasError, isOutputTargetDistCollection, normalizeFsPath } from '@utils';
-import { join, relative } from 'path';
+import { hasError, isOutputTargetDistCollection, join, normalizeFsPath, relative } from '@utils';
 import type { Plugin } from 'rollup';
 
 import type * as d from '../../declarations';

--- a/src/compiler/bundle/plugin-helper.ts
+++ b/src/compiler/bundle/plugin-helper.ts
@@ -1,5 +1,4 @@
-import { buildError } from '@utils';
-import { relative } from 'path';
+import { buildError, relative } from '@utils';
 
 import type * as d from '../../declarations';
 

--- a/src/compiler/bundle/user-index-plugin.ts
+++ b/src/compiler/bundle/user-index-plugin.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from '@utils';
 import type { Plugin } from 'rollup';
 
 import type * as d from '../../declarations';

--- a/src/compiler/cache.ts
+++ b/src/compiler/cache.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from '@utils';
 
 import type * as d from '../declarations';
 import { InMemoryFileSystem } from './sys/in-memory-fs';

--- a/src/compiler/config/config-utils.ts
+++ b/src/compiler/config/config-utils.ts
@@ -1,5 +1,5 @@
-import { isBoolean } from '@utils';
-import { isAbsolute, join } from 'path';
+import { isBoolean, join } from '@utils';
+import { isAbsolute } from 'path';
 
 import type { ConfigFlags } from '../../cli/config-flags';
 import type * as d from '../../declarations';

--- a/src/compiler/config/outputs/validate-custom-element.ts
+++ b/src/compiler/config/outputs/validate-custom-element.ts
@@ -1,5 +1,4 @@
-import { COPY, DIST_TYPES, isBoolean, isOutputTargetDistCustomElements } from '@utils';
-import { join } from 'path';
+import { COPY, DIST_TYPES, isBoolean, isOutputTargetDistCustomElements, join } from '@utils';
 
 import type {
   OutputTarget,

--- a/src/compiler/config/outputs/validate-dist.ts
+++ b/src/compiler/config/outputs/validate-dist.ts
@@ -9,8 +9,10 @@ import {
   isBoolean,
   isOutputTargetDist,
   isString,
+  join,
+  resolve,
 } from '@utils';
-import { isAbsolute, join, resolve } from 'path';
+import { isAbsolute } from 'path';
 
 import type * as d from '../../../declarations';
 import { getAbsolutePath } from '../config-utils';

--- a/src/compiler/config/outputs/validate-docs.ts
+++ b/src/compiler/config/outputs/validate-docs.ts
@@ -8,8 +8,9 @@ import {
   isOutputTargetDocsReadme,
   isOutputTargetDocsVscode,
   isString,
+  join,
 } from '@utils';
-import { isAbsolute, join } from 'path';
+import { isAbsolute } from 'path';
 
 import type * as d from '../../../declarations';
 import { NOTE } from '../../docs/constants';

--- a/src/compiler/config/outputs/validate-hydrate-script.ts
+++ b/src/compiler/config/outputs/validate-hydrate-script.ts
@@ -5,8 +5,9 @@ import {
   isOutputTargetHydrate,
   isOutputTargetWww,
   isString,
+  join,
 } from '@utils';
-import { isAbsolute, join } from 'path';
+import { isAbsolute } from 'path';
 
 import type * as d from '../../../declarations';
 

--- a/src/compiler/config/outputs/validate-lazy.ts
+++ b/src/compiler/config/outputs/validate-lazy.ts
@@ -1,5 +1,4 @@
-import { DIST_LAZY, isBoolean, isOutputTargetDistLazy } from '@utils';
-import { join } from 'path';
+import { DIST_LAZY, isBoolean, isOutputTargetDistLazy, join } from '@utils';
 
 import type * as d from '../../../declarations';
 import { getAbsolutePath } from '../config-utils';

--- a/src/compiler/config/outputs/validate-stats.ts
+++ b/src/compiler/config/outputs/validate-stats.ts
@@ -1,5 +1,5 @@
-import { isOutputTargetStats, STATS } from '@utils';
-import { isAbsolute, join } from 'path';
+import { isOutputTargetStats, join, STATS } from '@utils';
+import { isAbsolute } from 'path';
 
 import type * as d from '../../../declarations';
 

--- a/src/compiler/config/outputs/validate-www.ts
+++ b/src/compiler/config/outputs/validate-www.ts
@@ -7,9 +7,10 @@ import {
   isOutputTargetDist,
   isOutputTargetWww,
   isString,
+  join,
   WWW,
 } from '@utils';
-import { isAbsolute, join } from 'path';
+import { isAbsolute } from 'path';
 
 import type * as d from '../../../declarations';
 import { getAbsolutePath } from '../config-utils';

--- a/src/compiler/config/test/validate-output-dist-collection.spec.ts
+++ b/src/compiler/config/test/validate-output-dist-collection.spec.ts
@@ -1,6 +1,6 @@
 import type * as d from '@stencil/core/declarations';
 import { mockConfig, mockLoadConfigInit } from '@stencil/core/testing';
-import { join, resolve } from 'path';
+import { join, resolve } from '@utils';
 
 import { validateConfig } from '../validate-config';
 

--- a/src/compiler/config/test/validate-output-dist-custom-element.spec.ts
+++ b/src/compiler/config/test/validate-output-dist-custom-element.spec.ts
@@ -1,14 +1,16 @@
 import type * as d from '@stencil/core/declarations';
 import { mockConfig, mockLoadConfigInit } from '@stencil/core/testing';
-import { COPY, DIST_CUSTOM_ELEMENTS, DIST_TYPES } from '@utils';
+import { COPY, DIST_CUSTOM_ELEMENTS, DIST_TYPES, join } from '@utils';
 import path from 'path';
 
 import { validateConfig } from '../validate-config';
 
 describe('validate-output-dist-custom-element', () => {
   describe('validateCustomElement', () => {
+    // use Node's resolve() here to simulate a user using either Win/Posix separators (depending on the platform these
+    // tests are run on)
     const rootDir = path.resolve('/');
-    const defaultDistDir = path.join(rootDir, 'dist', 'components');
+    const defaultDistDir = join(rootDir, 'dist', 'components');
     const distCustomElementsDir = 'my-dist-custom-elements';
     let userConfig: d.Config;
 
@@ -27,7 +29,7 @@ describe('validate-output-dist-custom-element', () => {
         {
           type: DIST_TYPES,
           dir: defaultDistDir,
-          typesDir: path.join(rootDir, 'dist', 'types'),
+          typesDir: join(rootDir, 'dist', 'types'),
         },
         {
           type: DIST_CUSTOM_ELEMENTS,
@@ -53,7 +55,7 @@ describe('validate-output-dist-custom-element', () => {
         {
           type: DIST_TYPES,
           dir: defaultDistDir,
-          typesDir: path.join(rootDir, 'dist', 'types'),
+          typesDir: join(rootDir, 'dist', 'types'),
         },
         {
           type: DIST_CUSTOM_ELEMENTS,
@@ -79,7 +81,7 @@ describe('validate-output-dist-custom-element', () => {
         {
           type: DIST_TYPES,
           dir: defaultDistDir,
-          typesDir: path.join(rootDir, 'dist', 'types'),
+          typesDir: join(rootDir, 'dist', 'types'),
         },
         {
           type: DIST_CUSTOM_ELEMENTS,
@@ -106,7 +108,7 @@ describe('validate-output-dist-custom-element', () => {
         {
           type: DIST_CUSTOM_ELEMENTS,
           copy: [],
-          dir: path.join(rootDir, distCustomElementsDir),
+          dir: join(rootDir, distCustomElementsDir),
           empty: true,
           externalRuntime: true,
           generateTypeDeclarations: false,
@@ -222,7 +224,7 @@ describe('validate-output-dist-custom-element', () => {
           {
             type: DIST_TYPES,
             dir: defaultDistDir,
-            typesDir: path.join(rootDir, 'dist', 'types'),
+            typesDir: join(rootDir, 'dist', 'types'),
           },
           {
             type: DIST_CUSTOM_ELEMENTS,
@@ -249,7 +251,7 @@ describe('validate-output-dist-custom-element', () => {
           {
             type: DIST_TYPES,
             dir: defaultDistDir,
-            typesDir: path.join(rootDir, 'dist', 'types'),
+            typesDir: join(rootDir, 'dist', 'types'),
           },
           {
             type: DIST_CUSTOM_ELEMENTS,
@@ -277,7 +279,7 @@ describe('validate-output-dist-custom-element', () => {
           {
             type: DIST_TYPES,
             dir: defaultDistDir,
-            typesDir: path.join(rootDir, 'dist', 'types'),
+            typesDir: join(rootDir, 'dist', 'types'),
           },
           {
             type: DIST_CUSTOM_ELEMENTS,
@@ -305,13 +307,13 @@ describe('validate-output-dist-custom-element', () => {
         expect(config.outputTargets).toEqual([
           {
             type: DIST_TYPES,
-            dir: path.join(rootDir, distCustomElementsDir),
-            typesDir: path.join(rootDir, 'dist', 'types'),
+            dir: join(rootDir, distCustomElementsDir),
+            typesDir: join(rootDir, 'dist', 'types'),
           },
           {
             type: DIST_CUSTOM_ELEMENTS,
             copy: [],
-            dir: path.join(rootDir, distCustomElementsDir),
+            dir: join(rootDir, distCustomElementsDir),
             empty: false,
             externalRuntime: false,
             generateTypeDeclarations: true,
@@ -375,7 +377,7 @@ describe('validate-output-dist-custom-element', () => {
           {
             type: DIST_CUSTOM_ELEMENTS,
             copy: [copyOutputTarget, copyOutputTarget2],
-            dir: path.join(rootDir, distCustomElementsDir),
+            dir: join(rootDir, distCustomElementsDir),
             empty: false,
             externalRuntime: false,
             generateTypeDeclarations: false,

--- a/src/compiler/config/test/validate-output-dist.spec.ts
+++ b/src/compiler/config/test/validate-output-dist.spec.ts
@@ -1,10 +1,13 @@
 import type * as d from '@stencil/core/declarations';
 import { mockConfig, mockLoadConfigInit } from '@stencil/core/testing';
+import { join } from '@utils';
 import path from 'path';
 
 import { validateConfig } from '../validate-config';
 
 describe('validateDistOutputTarget', () => {
+  // use Node's resolve() here to simulate a user using either Win/Posix separators (depending on the platform these
+  // tests are run on)
   const rootDir = path.resolve('/');
 
   let userConfig: d.Config;
@@ -24,23 +27,23 @@ describe('validateDistOutputTarget', () => {
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
     expect(config.outputTargets).toEqual([
       {
-        buildDir: path.join(rootDir, 'my-dist', 'my-build'),
-        collectionDir: path.join(rootDir, 'my-dist', 'collection'),
+        buildDir: join(rootDir, 'my-dist', 'my-build'),
+        collectionDir: join(rootDir, 'my-dist', 'collection'),
         copy: [],
-        dir: path.join(rootDir, 'my-dist'),
+        dir: join(rootDir, 'my-dist'),
         empty: false,
-        esmLoaderPath: path.join(rootDir, 'my-dist', 'loader'),
+        esmLoaderPath: join(rootDir, 'my-dist', 'loader'),
         type: 'dist',
         polyfills: false,
-        typesDir: path.join(rootDir, 'my-dist', 'types'),
+        typesDir: join(rootDir, 'my-dist', 'types'),
         transformAliasedImportPathsInCollection: true,
         isPrimaryPackageOutputTarget: false,
       },
       {
-        esmDir: path.join(rootDir, 'my-dist', 'my-build', 'testing'),
+        esmDir: join(rootDir, 'my-dist', 'my-build', 'testing'),
         empty: false,
         isBrowserBuild: true,
-        legacyLoaderFile: path.join(rootDir, 'my-dist', 'my-build', 'testing.js'),
+        legacyLoaderFile: join(rootDir, 'my-dist', 'my-build', 'testing.js'),
         polyfills: true,
         systemDir: undefined,
         systemLoaderFile: undefined,
@@ -49,21 +52,21 @@ describe('validateDistOutputTarget', () => {
       {
         copyAssets: 'dist',
         copy: [],
-        dir: path.join(rootDir, 'my-dist', 'my-build', 'testing'),
+        dir: join(rootDir, 'my-dist', 'my-build', 'testing'),
         type: 'copy',
       },
       {
-        file: path.join(rootDir, 'my-dist', 'my-build', 'testing', 'testing.css'),
+        file: join(rootDir, 'my-dist', 'my-build', 'testing', 'testing.css'),
         type: 'dist-global-styles',
       },
       {
-        dir: path.join(rootDir, 'my-dist'),
+        dir: join(rootDir, 'my-dist'),
         type: 'dist-types',
-        typesDir: path.join(rootDir, 'my-dist', 'types'),
+        typesDir: join(rootDir, 'my-dist', 'types'),
       },
       {
-        collectionDir: path.join(rootDir, 'my-dist', 'collection'),
-        dir: path.join(rootDir, '/my-dist'),
+        collectionDir: join(rootDir, 'my-dist', 'collection'),
+        dir: join(rootDir, '/my-dist'),
         empty: false,
         transformAliasedImportPaths: true,
         type: 'dist-collection',
@@ -71,25 +74,25 @@ describe('validateDistOutputTarget', () => {
       {
         copy: [{ src: '**/*.svg' }, { src: '**/*.js' }],
         copyAssets: 'collection',
-        dir: path.join(rootDir, 'my-dist', 'collection'),
+        dir: join(rootDir, 'my-dist', 'collection'),
         type: 'copy',
       },
       {
         type: 'dist-lazy',
-        cjsDir: path.join(rootDir, 'my-dist', 'cjs'),
-        cjsIndexFile: path.join(rootDir, 'my-dist', 'index.cjs.js'),
+        cjsDir: join(rootDir, 'my-dist', 'cjs'),
+        cjsIndexFile: join(rootDir, 'my-dist', 'index.cjs.js'),
         empty: false,
-        esmDir: path.join(rootDir, 'my-dist', 'esm'),
+        esmDir: join(rootDir, 'my-dist', 'esm'),
         esmEs5Dir: undefined,
-        esmIndexFile: path.join(rootDir, 'my-dist', 'index.js'),
+        esmIndexFile: join(rootDir, 'my-dist', 'index.js'),
         polyfills: true,
       },
       {
-        cjsDir: path.join(rootDir, 'my-dist', 'cjs'),
-        componentDts: path.join(rootDir, 'my-dist', 'types', 'components.d.ts'),
-        dir: path.join(rootDir, 'my-dist', 'loader'),
+        cjsDir: join(rootDir, 'my-dist', 'cjs'),
+        componentDts: join(rootDir, 'my-dist', 'types', 'components.d.ts'),
+        dir: join(rootDir, 'my-dist', 'loader'),
         empty: false,
-        esmDir: path.join(rootDir, 'my-dist', 'esm'),
+        esmDir: join(rootDir, 'my-dist', 'esm'),
         esmEs5Dir: undefined,
         type: 'dist-lazy-loader',
       },
@@ -101,8 +104,8 @@ describe('validateDistOutputTarget', () => {
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
     const outputTarget = config.outputTargets.find((o) => o.type === 'dist') as d.OutputTargetDist;
     expect(outputTarget).toBeDefined();
-    expect(outputTarget.dir).toBe(path.join(rootDir, 'dist'));
-    expect(outputTarget.buildDir).toBe(path.join(rootDir, '/dist'));
+    expect(outputTarget.dir).toBe(join(rootDir, 'dist'));
+    expect(outputTarget.buildDir).toBe(join(rootDir, '/dist'));
     expect(outputTarget.empty).toBe(true);
   });
 
@@ -127,23 +130,23 @@ describe('validateDistOutputTarget', () => {
 
     expect(config.outputTargets).toEqual([
       {
-        buildDir: path.join(rootDir, 'my-dist', 'my-build'),
-        collectionDir: path.join(rootDir, 'my-dist', 'collection'),
+        buildDir: join(rootDir, 'my-dist', 'my-build'),
+        collectionDir: join(rootDir, 'my-dist', 'collection'),
         copy: [],
-        dir: path.join(rootDir, 'my-dist'),
+        dir: join(rootDir, 'my-dist'),
         empty: false,
-        esmLoaderPath: path.join(rootDir, 'my-dist', 'loader'),
+        esmLoaderPath: join(rootDir, 'my-dist', 'loader'),
         type: 'dist',
         polyfills: false,
-        typesDir: path.join(rootDir, 'my-dist', 'types'),
+        typesDir: join(rootDir, 'my-dist', 'types'),
         transformAliasedImportPathsInCollection: true,
         isPrimaryPackageOutputTarget: false,
       },
       {
-        esmDir: path.join(rootDir, 'my-dist', 'my-build', 'testing'),
+        esmDir: join(rootDir, 'my-dist', 'my-build', 'testing'),
         empty: false,
         isBrowserBuild: true,
-        legacyLoaderFile: path.join(rootDir, 'my-dist', 'my-build', 'testing.js'),
+        legacyLoaderFile: join(rootDir, 'my-dist', 'my-build', 'testing.js'),
         polyfills: true,
         systemDir: undefined,
         systemLoaderFile: undefined,
@@ -152,21 +155,21 @@ describe('validateDistOutputTarget', () => {
       {
         copyAssets: 'dist',
         copy: [],
-        dir: path.join(rootDir, 'my-dist', 'my-build', 'testing'),
+        dir: join(rootDir, 'my-dist', 'my-build', 'testing'),
         type: 'copy',
       },
       {
-        file: path.join(rootDir, 'my-dist', 'my-build', 'testing', 'testing.css'),
+        file: join(rootDir, 'my-dist', 'my-build', 'testing', 'testing.css'),
         type: 'dist-global-styles',
       },
       {
-        dir: path.join(rootDir, 'my-dist'),
+        dir: join(rootDir, 'my-dist'),
         type: 'dist-types',
-        typesDir: path.join(rootDir, 'my-dist', 'types'),
+        typesDir: join(rootDir, 'my-dist', 'types'),
       },
       {
-        collectionDir: path.join(rootDir, 'my-dist', 'collection'),
-        dir: path.join(rootDir, '/my-dist'),
+        collectionDir: join(rootDir, 'my-dist', 'collection'),
+        dir: join(rootDir, '/my-dist'),
         empty: false,
         transformAliasedImportPaths: true,
         type: 'dist-collection',
@@ -174,25 +177,25 @@ describe('validateDistOutputTarget', () => {
       {
         copy: [{ src: '**/*.svg' }, { src: '**/*.js' }],
         copyAssets: 'collection',
-        dir: path.join(rootDir, 'my-dist', 'collection'),
+        dir: join(rootDir, 'my-dist', 'collection'),
         type: 'copy',
       },
       {
         type: 'dist-lazy',
-        cjsDir: path.join(rootDir, 'my-dist', 'cjs'),
-        cjsIndexFile: path.join(rootDir, 'my-dist', 'index.cjs.js'),
+        cjsDir: join(rootDir, 'my-dist', 'cjs'),
+        cjsIndexFile: join(rootDir, 'my-dist', 'index.cjs.js'),
         empty: false,
-        esmDir: path.join(rootDir, 'my-dist', 'esm'),
+        esmDir: join(rootDir, 'my-dist', 'esm'),
         esmEs5Dir: undefined,
-        esmIndexFile: path.join(rootDir, 'my-dist', 'index.js'),
+        esmIndexFile: join(rootDir, 'my-dist', 'index.js'),
         polyfills: true,
       },
       {
-        cjsDir: path.join(rootDir, 'my-dist', 'cjs'),
-        componentDts: path.join(rootDir, 'my-dist', 'types', 'components.d.ts'),
-        dir: path.join(rootDir, 'my-dist', 'loader'),
+        cjsDir: join(rootDir, 'my-dist', 'cjs'),
+        componentDts: join(rootDir, 'my-dist', 'types', 'components.d.ts'),
+        dir: join(rootDir, 'my-dist', 'loader'),
         empty: false,
-        esmDir: path.join(rootDir, 'my-dist', 'esm'),
+        esmDir: join(rootDir, 'my-dist', 'esm'),
         esmEs5Dir: undefined,
         type: 'dist-lazy-loader',
       },
@@ -214,23 +217,23 @@ describe('validateDistOutputTarget', () => {
 
     expect(config.outputTargets).toEqual([
       {
-        buildDir: path.join(rootDir, 'my-dist', 'my-build'),
-        collectionDir: path.join(rootDir, 'my-dist', 'collection'),
+        buildDir: join(rootDir, 'my-dist', 'my-build'),
+        collectionDir: join(rootDir, 'my-dist', 'collection'),
         copy: [],
-        dir: path.join(rootDir, 'my-dist'),
+        dir: join(rootDir, 'my-dist'),
         empty: false,
-        esmLoaderPath: path.join(rootDir, 'my-dist', 'loader'),
+        esmLoaderPath: join(rootDir, 'my-dist', 'loader'),
         type: 'dist',
         polyfills: false,
-        typesDir: path.join(rootDir, 'my-dist', 'types'),
+        typesDir: join(rootDir, 'my-dist', 'types'),
         transformAliasedImportPathsInCollection: true,
         isPrimaryPackageOutputTarget: true,
       },
       {
-        esmDir: path.join(rootDir, 'my-dist', 'my-build', 'testing'),
+        esmDir: join(rootDir, 'my-dist', 'my-build', 'testing'),
         empty: false,
         isBrowserBuild: true,
-        legacyLoaderFile: path.join(rootDir, 'my-dist', 'my-build', 'testing.js'),
+        legacyLoaderFile: join(rootDir, 'my-dist', 'my-build', 'testing.js'),
         polyfills: true,
         systemDir: undefined,
         systemLoaderFile: undefined,
@@ -239,21 +242,21 @@ describe('validateDistOutputTarget', () => {
       {
         copyAssets: 'dist',
         copy: [],
-        dir: path.join(rootDir, 'my-dist', 'my-build', 'testing'),
+        dir: join(rootDir, 'my-dist', 'my-build', 'testing'),
         type: 'copy',
       },
       {
-        file: path.join(rootDir, 'my-dist', 'my-build', 'testing', 'testing.css'),
+        file: join(rootDir, 'my-dist', 'my-build', 'testing', 'testing.css'),
         type: 'dist-global-styles',
       },
       {
-        dir: path.join(rootDir, 'my-dist'),
+        dir: join(rootDir, 'my-dist'),
         type: 'dist-types',
-        typesDir: path.join(rootDir, 'my-dist', 'types'),
+        typesDir: join(rootDir, 'my-dist', 'types'),
       },
       {
-        collectionDir: path.join(rootDir, 'my-dist', 'collection'),
-        dir: path.join(rootDir, '/my-dist'),
+        collectionDir: join(rootDir, 'my-dist', 'collection'),
+        dir: join(rootDir, '/my-dist'),
         empty: false,
         transformAliasedImportPaths: true,
         type: 'dist-collection',
@@ -261,25 +264,25 @@ describe('validateDistOutputTarget', () => {
       {
         copy: [{ src: '**/*.svg' }, { src: '**/*.js' }],
         copyAssets: 'collection',
-        dir: path.join(rootDir, 'my-dist', 'collection'),
+        dir: join(rootDir, 'my-dist', 'collection'),
         type: 'copy',
       },
       {
         type: 'dist-lazy',
-        cjsDir: path.join(rootDir, 'my-dist', 'cjs'),
-        cjsIndexFile: path.join(rootDir, 'my-dist', 'index.cjs.js'),
+        cjsDir: join(rootDir, 'my-dist', 'cjs'),
+        cjsIndexFile: join(rootDir, 'my-dist', 'index.cjs.js'),
         empty: false,
-        esmDir: path.join(rootDir, 'my-dist', 'esm'),
+        esmDir: join(rootDir, 'my-dist', 'esm'),
         esmEs5Dir: undefined,
-        esmIndexFile: path.join(rootDir, 'my-dist', 'index.js'),
+        esmIndexFile: join(rootDir, 'my-dist', 'index.js'),
         polyfills: true,
       },
       {
-        cjsDir: path.join(rootDir, 'my-dist', 'cjs'),
-        componentDts: path.join(rootDir, 'my-dist', 'types', 'components.d.ts'),
-        dir: path.join(rootDir, 'my-dist', 'loader'),
+        cjsDir: join(rootDir, 'my-dist', 'cjs'),
+        componentDts: join(rootDir, 'my-dist', 'types', 'components.d.ts'),
+        dir: join(rootDir, 'my-dist', 'loader'),
         empty: false,
-        esmDir: path.join(rootDir, 'my-dist', 'esm'),
+        esmDir: join(rootDir, 'my-dist', 'esm'),
         esmEs5Dir: undefined,
         type: 'dist-lazy-loader',
       },

--- a/src/compiler/config/test/validate-output-www.spec.ts
+++ b/src/compiler/config/test/validate-output-www.spec.ts
@@ -1,12 +1,14 @@
 import type * as d from '@stencil/core/declarations';
 import { mockLoadConfigInit } from '@stencil/core/testing';
-import { isOutputTargetCopy, isOutputTargetHydrate, isOutputTargetWww } from '@utils';
+import { isOutputTargetCopy, isOutputTargetHydrate, isOutputTargetWww, join } from '@utils';
 import path from 'path';
 
 import { ConfigFlags, createConfigFlags } from '../../../cli/config-flags';
 import { validateConfig } from '../validate-config';
 
 describe('validateOutputTargetWww', () => {
+  // use Node's resolve() here to simulate a user using either Win/Posix separators (depending on the platform these
+  // tests are run on)
   const rootDir = path.resolve('/');
   let userConfig: d.Config;
   let flags: ConfigFlags;
@@ -22,6 +24,8 @@ describe('validateOutputTargetWww', () => {
   it('should have default value', () => {
     const outputTarget: d.OutputTargetWww = {
       type: 'www',
+      // use Node's join() here to simulate a user using either Win/Posix separators (depending on the platform these
+      // tests are run on) for their input
       dir: path.join('www', 'docs'),
     };
     userConfig.outputTargets = [outputTarget];
@@ -30,16 +34,16 @@ describe('validateOutputTargetWww', () => {
 
     expect(config.outputTargets).toEqual([
       {
-        appDir: path.join(rootDir, 'www', 'docs'),
+        appDir: join(rootDir, 'www', 'docs'),
         baseUrl: '/',
-        buildDir: path.join(rootDir, 'www', 'docs', 'build'),
-        dir: path.join(rootDir, 'www', 'docs'),
+        buildDir: join(rootDir, 'www', 'docs', 'build'),
+        dir: join(rootDir, 'www', 'docs'),
         empty: true,
-        indexHtml: path.join(rootDir, 'www', 'docs', 'index.html'),
+        indexHtml: join(rootDir, 'www', 'docs', 'index.html'),
         polyfills: true,
         serviceWorker: {
           dontCacheBustURLsMatching: /p-\w{8}/,
-          globDirectory: path.join(rootDir, 'www', 'docs'),
+          globDirectory: join(rootDir, 'www', 'docs'),
           globIgnores: [
             '**/host.config.json',
             '**/*.system.entry.js',
@@ -49,13 +53,13 @@ describe('validateOutputTargetWww', () => {
             '**/app.css',
           ],
           globPatterns: ['*.html', '**/*.{js,css,json}'],
-          swDest: path.join(rootDir, 'www', 'docs', 'sw.js'),
+          swDest: join(rootDir, 'www', 'docs', 'sw.js'),
         },
         type: 'www',
       },
       {
-        dir: path.join(rootDir, 'www', 'docs', 'build'),
-        esmDir: path.join(rootDir, 'www', 'docs', 'build'),
+        dir: join(rootDir, 'www', 'docs', 'build'),
+        esmDir: join(rootDir, 'www', 'docs', 'build'),
         isBrowserBuild: true,
         polyfills: true,
         systemDir: undefined,
@@ -64,7 +68,7 @@ describe('validateOutputTargetWww', () => {
       },
       {
         copyAssets: 'dist',
-        dir: path.join(rootDir, 'www', 'docs', 'build'),
+        dir: join(rootDir, 'www', 'docs', 'build'),
         type: 'copy',
       },
       {
@@ -78,11 +82,11 @@ describe('validateOutputTargetWww', () => {
             warn: false,
           },
         ],
-        dir: path.join(rootDir, 'www', 'docs'),
+        dir: join(rootDir, 'www', 'docs'),
         type: 'copy',
       },
       {
-        file: path.join(rootDir, 'www', 'docs', 'build', 'app.css'),
+        file: join(rootDir, 'www', 'docs', 'build', 'app.css'),
         type: 'dist-global-styles',
       },
     ]);
@@ -91,16 +95,18 @@ describe('validateOutputTargetWww', () => {
   it('should www with sub directory', () => {
     const outputTarget: d.OutputTargetWww = {
       type: 'www',
+      // use Node's join() here to simulate a user using either Win/Posix separators (depending on the platform these
+      // tests are run on) for their input
       dir: path.join('www', 'docs'),
     };
     userConfig.outputTargets = [outputTarget];
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
     const www = config.outputTargets.find(isOutputTargetWww) as d.OutputTargetWww;
 
-    expect(www.dir).toBe(path.join(rootDir, 'www', 'docs'));
-    expect(www.appDir).toBe(path.join(rootDir, 'www', 'docs'));
-    expect(www.buildDir).toBe(path.join(rootDir, 'www', 'docs', 'build'));
-    expect(www.indexHtml).toBe(path.join(rootDir, 'www', 'docs', 'index.html'));
+    expect(www.dir).toBe(join(rootDir, 'www', 'docs'));
+    expect(www.appDir).toBe(join(rootDir, 'www', 'docs'));
+    expect(www.buildDir).toBe(join(rootDir, 'www', 'docs', 'build'));
+    expect(www.indexHtml).toBe(join(rootDir, 'www', 'docs', 'index.html'));
   });
 
   it('should set www values', () => {
@@ -116,9 +122,9 @@ describe('validateOutputTargetWww', () => {
     const www = config.outputTargets.find(isOutputTargetWww) as d.OutputTargetWww;
 
     expect(www.type).toBe('www');
-    expect(www.dir).toBe(path.join(rootDir, 'my-www'));
-    expect(www.buildDir).toBe(path.join(rootDir, 'my-www', 'my-build'));
-    expect(www.indexHtml).toBe(path.join(rootDir, 'my-www', 'my-index.htm'));
+    expect(www.dir).toBe(join(rootDir, 'my-www'));
+    expect(www.buildDir).toBe(join(rootDir, 'my-www', 'my-build'));
+    expect(www.indexHtml).toBe(join(rootDir, 'my-www', 'my-index.htm'));
     expect(www.empty).toBe(false);
   });
 
@@ -127,9 +133,9 @@ describe('validateOutputTargetWww', () => {
     expect(config.outputTargets).toHaveLength(5);
 
     const outputTarget = config.outputTargets.find(isOutputTargetWww) as d.OutputTargetWww;
-    expect(outputTarget.dir).toBe(path.join(rootDir, 'www'));
-    expect(outputTarget.buildDir).toBe(path.join(rootDir, 'www', 'build'));
-    expect(outputTarget.indexHtml).toBe(path.join(rootDir, 'www', 'index.html'));
+    expect(outputTarget.dir).toBe(join(rootDir, 'www'));
+    expect(outputTarget.buildDir).toBe(join(rootDir, 'www', 'build'));
+    expect(outputTarget.indexHtml).toBe(join(rootDir, 'www', 'index.html'));
     expect(outputTarget.empty).toBe(true);
   });
 
@@ -145,12 +151,12 @@ describe('validateOutputTargetWww', () => {
       const www = config.outputTargets.find(isOutputTargetWww) as d.OutputTargetWww;
 
       expect(www.type).toBe('www');
-      expect(www.dir).toBe(path.join(rootDir, 'my-www'));
+      expect(www.dir).toBe(join(rootDir, 'my-www'));
       expect(www.baseUrl).toBe('/docs/');
-      expect(www.appDir).toBe(path.join(rootDir, 'my-www/docs'));
+      expect(www.appDir).toBe(join(rootDir, 'my-www/docs'));
 
-      expect(www.buildDir).toBe(path.join(rootDir, 'my-www', 'docs', 'build'));
-      expect(www.indexHtml).toBe(path.join(rootDir, 'my-www', 'docs', 'index.html'));
+      expect(www.buildDir).toBe(join(rootDir, 'my-www', 'docs', 'build'));
+      expect(www.indexHtml).toBe(join(rootDir, 'my-www', 'docs', 'index.html'));
     });
 
     it('baseUrl does not end with /', () => {
@@ -163,12 +169,12 @@ describe('validateOutputTargetWww', () => {
       const www = config.outputTargets.find(isOutputTargetWww) as d.OutputTargetWww;
 
       expect(www.type).toBe('www');
-      expect(www.dir).toBe(path.join(rootDir, 'www'));
+      expect(www.dir).toBe(join(rootDir, 'www'));
       expect(www.baseUrl).toBe('/docs/');
-      expect(www.appDir).toBe(path.join(rootDir, 'www/docs'));
+      expect(www.appDir).toBe(join(rootDir, 'www/docs'));
 
-      expect(www.buildDir).toBe(path.join(rootDir, 'www', 'docs', 'build'));
-      expect(www.indexHtml).toBe(path.join(rootDir, 'www', 'docs', 'index.html'));
+      expect(www.buildDir).toBe(join(rootDir, 'www', 'docs', 'build'));
+      expect(www.indexHtml).toBe(join(rootDir, 'www', 'docs', 'index.html'));
     });
 
     it('baseUrl is a full url', () => {
@@ -181,12 +187,12 @@ describe('validateOutputTargetWww', () => {
       const www = config.outputTargets.find(isOutputTargetWww) as d.OutputTargetWww;
 
       expect(www.type).toBe('www');
-      expect(www.dir).toBe(path.join(rootDir, 'www'));
+      expect(www.dir).toBe(join(rootDir, 'www'));
       expect(www.baseUrl).toBe('https://example.com/docs/');
-      expect(www.appDir).toBe(path.join(rootDir, 'www/docs'));
+      expect(www.appDir).toBe(join(rootDir, 'www/docs'));
 
-      expect(www.buildDir).toBe(path.join(rootDir, 'www', 'docs', 'build'));
-      expect(www.indexHtml).toBe(path.join(rootDir, 'www', 'docs', 'index.html'));
+      expect(www.buildDir).toBe(join(rootDir, 'www', 'docs', 'build'));
+      expect(www.indexHtml).toBe(join(rootDir, 'www', 'docs', 'index.html'));
     });
   });
 
@@ -194,6 +200,8 @@ describe('validateOutputTargetWww', () => {
     it('should add copy tasks', () => {
       const outputTarget: d.OutputTargetWww = {
         type: 'www',
+        // use Node's join() here to simulate a user using either Win/Posix separators (depending on the platform these
+        // tests are run on) for their input
         dir: path.join('www', 'docs'),
         copy: [
           {
@@ -209,7 +217,7 @@ describe('validateOutputTargetWww', () => {
       expect(copyTargets).toEqual([
         {
           copyAssets: 'dist',
-          dir: path.join(rootDir, 'www', 'docs', 'build'),
+          dir: join(rootDir, 'www', 'docs', 'build'),
           type: 'copy',
         },
         {
@@ -227,7 +235,7 @@ describe('validateOutputTargetWww', () => {
               warn: false,
             },
           ],
-          dir: path.join(rootDir, 'www', 'docs'),
+          dir: join(rootDir, 'www', 'docs'),
           type: 'copy',
         },
       ]);
@@ -236,6 +244,8 @@ describe('validateOutputTargetWww', () => {
     it('should replace copy tasks', () => {
       const outputTarget: d.OutputTargetWww = {
         type: 'www',
+        // use Node's join() here to simulate a user using either Win/Posix separators (depending on the platform these
+        // tests are run on) for their input
         dir: path.join('www', 'docs'),
         copy: [
           {
@@ -251,7 +261,7 @@ describe('validateOutputTargetWww', () => {
       expect(copyTargets).toEqual([
         {
           copyAssets: 'dist',
-          dir: path.join(rootDir, 'www', 'docs', 'build'),
+          dir: join(rootDir, 'www', 'docs', 'build'),
           type: 'copy',
         },
         {
@@ -265,7 +275,7 @@ describe('validateOutputTargetWww', () => {
               warn: false,
             },
           ],
-          dir: path.join(rootDir, 'www', 'docs'),
+          dir: join(rootDir, 'www', 'docs'),
           type: 'copy',
         },
       ]);
@@ -274,6 +284,8 @@ describe('validateOutputTargetWww', () => {
     it('should disable copy tasks', () => {
       const outputTarget: d.OutputTargetWww = {
         type: 'www',
+        // use Node's join() here to simulate a user using either Win/Posix separators (depending on the platform these
+        // tests are run on) for their input
         dir: path.join('www', 'docs'),
         copy: null,
       };
@@ -284,12 +296,12 @@ describe('validateOutputTargetWww', () => {
       expect(copyTargets).toEqual([
         {
           copyAssets: 'dist',
-          dir: path.join(rootDir, 'www', 'docs', 'build'),
+          dir: join(rootDir, 'www', 'docs', 'build'),
           type: 'copy',
         },
         {
           copy: [],
-          dir: path.join(rootDir, 'www', 'docs'),
+          dir: join(rootDir, 'www', 'docs'),
           type: 'copy',
         },
       ]);

--- a/src/compiler/config/test/validate-paths.spec.ts
+++ b/src/compiler/config/test/validate-paths.spec.ts
@@ -1,5 +1,6 @@
 import type * as d from '@stencil/core/declarations';
 import { mockCompilerSystem, mockLoadConfigInit, mockLogger } from '@stencil/core/testing';
+import { join } from '@utils';
 import path from 'path';
 
 import { validateConfig } from '../validate-config';
@@ -9,32 +10,38 @@ describe('validatePaths', () => {
   const logger = mockLogger();
   const sys = mockCompilerSystem();
 
+  // use Node's resolve() here to simulate a user using either Win/Posix separators (depending on the platform these
+  // tests are run on)
   const ROOT = path.resolve('/');
 
   beforeEach(() => {
     userConfig = {
       sys: sys as any,
       logger: logger,
+      // use Node's join() here to simulate a user using either Win/Posix separators (depending on the platform these
+      // tests are run on) for their input
       rootDir: path.join(ROOT, 'User', 'my-app'),
       namespace: 'Testing',
     };
   });
 
   it('should set absolute cacheDir', () => {
+    // use Node's join() here to simulate a user using either Win/Posix separators (depending on the platform these
+    // tests are run on) for their input
     userConfig.cacheDir = path.join(ROOT, 'some', 'custom', 'cache');
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
-    expect(config.cacheDir).toBe(path.join(ROOT, 'some', 'custom', 'cache'));
+    expect(config.cacheDir).toBe(join(ROOT, 'some', 'custom', 'cache'));
   });
 
   it('should set relative cacheDir', () => {
     userConfig.cacheDir = 'custom-cache';
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
-    expect(config.cacheDir).toBe(path.join(ROOT, 'User', 'my-app', 'custom-cache'));
+    expect(config.cacheDir).toBe(join(ROOT, 'User', 'my-app', 'custom-cache'));
   });
 
   it('should set default cacheDir', () => {
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
-    expect(config.cacheDir).toBe(path.join(ROOT, 'User', 'my-app', '.stencil'));
+    expect(config.cacheDir).toBe(join(ROOT, 'User', 'my-app', '.stencil'));
   });
 
   it('should set default wwwIndexHtml and convert to absolute path', () => {
@@ -47,6 +54,8 @@ describe('validatePaths', () => {
     userConfig.outputTargets = [
       {
         type: 'www',
+        // use Node's join() here to simulate a user using either Win/Posix separators (depending on the platform these
+        // tests are run on) for their input
         indexHtml: path.join('assets', 'custom-index.html'),
       },
     ] as d.OutputTargetWww[];
@@ -112,8 +121,8 @@ describe('validatePaths', () => {
 
   it('should set default build dir and convert to absolute path', () => {
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
-    const normalizedPathSep = path.sep;
-    const parts = (config.outputTargets as d.OutputTargetDist[])[0].buildDir.split(normalizedPathSep);
+    // the path will be normalized by Stencil us use '/', split on that regardless of platform
+    const parts = (config.outputTargets as d.OutputTargetDist[])[0].buildDir.split('/');
     expect(parts[parts.length - 1]).toBe('build');
     expect(parts[parts.length - 2]).toBe('www');
     expect(path.isAbsolute((config.outputTargets as d.OutputTargetDist[])[0].buildDir)).toBe(true);
@@ -127,8 +136,8 @@ describe('validatePaths', () => {
       },
     ] as d.OutputTargetWww[];
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
-    const normalizedPathSep = path.sep;
-    const parts = (config.outputTargets as d.OutputTargetDist[])[0].buildDir.split(normalizedPathSep);
+    // the path will be normalized by Stencil us use '/', split on that regardless of platform
+    const parts = (config.outputTargets as d.OutputTargetDist[])[0].buildDir.split('/');
     expect(parts[parts.length - 1]).toBe('build');
     expect(parts[parts.length - 2]).toBe('custom-www');
     expect(path.isAbsolute((config.outputTargets as d.OutputTargetDist[])[0].buildDir)).toBe(true);
@@ -148,6 +157,8 @@ describe('validatePaths', () => {
   });
 
   it('should convert globalScript to absolute path, if a globalScript property was provided', () => {
+    // use Node's join() here to simulate a user using either Win/Posix separators (depending on the platform these
+    // tests are run on) for their input
     userConfig.globalScript = path.join('src', 'global', 'index.ts');
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
     expect(path.basename(config.globalScript)).toBe('index.ts');
@@ -155,6 +166,8 @@ describe('validatePaths', () => {
   });
 
   it('should convert globalStyle string to absolute path array, if a globalStyle property was provided', () => {
+    // use Node's join() here to simulate a user using either Win/Posix separators (depending on the platform these
+    // tests are run on) for their input
     userConfig.globalStyle = path.join('src', 'global', 'styles.css');
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
     expect(path.basename(config.globalStyle)).toBe('styles.css');

--- a/src/compiler/config/test/validate-testing.spec.ts
+++ b/src/compiler/config/test/validate-testing.spec.ts
@@ -1,11 +1,14 @@
 import type * as d from '@stencil/core/declarations';
 import { mockCompilerSystem, mockLoadConfigInit, mockLogger } from '@stencil/core/testing';
+import { join } from '@utils';
 import path from 'path';
 
 import { ConfigFlags, createConfigFlags } from '../../../cli/config-flags';
 import { validateConfig } from '../validate-config';
 
 describe('validateTesting', () => {
+  // use Node's resolve() here to simulate a user using either Win/Posix separators (depending on the platform these
+  // tests are run on)
   const ROOT = path.resolve('/');
   const sys = mockCompilerSystem();
   const logger = mockLogger();
@@ -17,15 +20,21 @@ describe('validateTesting', () => {
     userConfig = {
       sys: sys as any,
       logger: logger,
+      // use Node's join() here to simulate a user using either Win/Posix separators (depending on the platform these
+      // tests are run on) for their input
       rootDir: path.join(ROOT, 'User', 'some', 'path'),
       srcDir: path.join(ROOT, 'User', 'some', 'path', 'src'),
       flags,
       namespace: 'Testing',
+      // use Node's join() here to simulate a user using either Win/Posix separators (depending on the platform these
+      // tests are run on) for their input
       configPath: path.join(ROOT, 'User', 'some', 'path', 'stencil.config.ts'),
     };
     userConfig.outputTargets = [
       {
         type: 'www',
+        // use Node's join() here to simulate a user using either Win/Posix separators (depending on the platform these
+        // tests are run on) for their input
         dir: path.join(ROOT, 'www'),
       } as any as d.OutputTargetStats,
     ];
@@ -195,21 +204,25 @@ describe('validateTesting', () => {
 
   describe('screenshotConnector', () => {
     it('assigns the screenshotConnector value from the provided flags', () => {
+      // use Node's join() here to simulate a user using either Win/Posix separators (depending on the platform these
+      // tests are run on) for their input
       userConfig.flags = { ...flags, e2e: true, screenshotConnector: path.join(ROOT, 'mock', 'path') };
       userConfig.testing = { screenshotConnector: path.join(ROOT, 'another', 'mock', 'path') };
 
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
 
-      expect(config.testing.screenshotConnector).toBe(path.join(ROOT, 'mock', 'path'));
+      expect(config.testing.screenshotConnector).toBe(join(ROOT, 'mock', 'path'));
     });
 
     it("uses the config's root dir to make the screenshotConnector path absolute", () => {
+      // use Node's join() here to simulate a user using either Win/Posix separators (depending on the platform these
+      // tests are run on) for their input
       userConfig.flags = { ...flags, e2e: true, screenshotConnector: path.join('mock', 'path') };
       userConfig.testing = { screenshotConnector: path.join('another', 'mock', 'path') };
 
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
 
-      expect(config.testing.screenshotConnector).toBe(path.join(ROOT, 'User', 'some', 'path', 'mock', 'path'));
+      expect(config.testing.screenshotConnector).toBe(join(ROOT, 'User', 'some', 'path', 'mock', 'path'));
     });
 
     it('sets screenshotConnector if a non-string is provided', () => {
@@ -219,7 +232,7 @@ describe('validateTesting', () => {
 
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
 
-      expect(config.testing.screenshotConnector).toBe(path.join('screenshot', 'local-connector.js'));
+      expect(config.testing.screenshotConnector).toBe(join('screenshot', 'local-connector.js'));
     });
   });
 
@@ -227,6 +240,8 @@ describe('validateTesting', () => {
     it('does not alter a provided testPathIgnorePatterns', () => {
       userConfig.flags = { ...flags, e2e: true };
 
+      // use Node's join() here to simulate a user using either Win/Posix separators (depending on the platform these
+      // tests are run on) for their input
       const mockPath1 = path.join('this', 'is', 'a', 'mock', 'path');
       const mockPath2 = path.join('this', 'is', 'another', 'mock', 'path');
       userConfig.testing = { testPathIgnorePatterns: [mockPath1, mockPath2] };
@@ -236,15 +251,16 @@ describe('validateTesting', () => {
       expect(config.testing.testPathIgnorePatterns).toEqual([mockPath1, mockPath2]);
     });
 
-    it('sets the default testPathIgnorePatterns if not array is provided', () => {
+    it('sets the default testPathIgnorePatterns if no array is provided', () => {
       userConfig.flags = { ...flags, e2e: true };
 
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
 
       expect(config.testing.testPathIgnorePatterns).toEqual([
-        path.join(ROOT, 'User', 'some', 'path', '.vscode'),
-        path.join(ROOT, 'User', 'some', 'path', '.stencil'),
-        path.join(ROOT, 'User', 'some', 'path', 'node_modules'),
+        join(ROOT, 'User', 'some', 'path', '.vscode'),
+        join(ROOT, 'User', 'some', 'path', '.stencil'),
+        join(ROOT, 'User', 'some', 'path', 'node_modules'),
+        // use Node's join() here as the normalization process doesn't necessarily occur for this field
         path.join(ROOT, 'www'),
       ]);
     });
@@ -260,11 +276,11 @@ describe('validateTesting', () => {
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
 
       expect(config.testing.testPathIgnorePatterns).toEqual([
-        path.join(ROOT, 'User', 'some', 'path', '.vscode'),
-        path.join(ROOT, 'User', 'some', 'path', '.stencil'),
-        path.join(ROOT, 'User', 'some', 'path', 'node_modules'),
-        path.join(ROOT, 'User', 'some', 'path', 'www-folder'),
-        path.join(ROOT, 'User', 'some', 'path', 'dist-folder'),
+        join(ROOT, 'User', 'some', 'path', '.vscode'),
+        join(ROOT, 'User', 'some', 'path', '.stencil'),
+        join(ROOT, 'User', 'some', 'path', 'node_modules'),
+        join(ROOT, 'User', 'some', 'path', 'www-folder'),
+        join(ROOT, 'User', 'some', 'path', 'dist-folder'),
       ]);
     });
   });
@@ -286,17 +302,21 @@ describe('validateTesting', () => {
     it('forces a provided preset path to be absolute', () => {
       userConfig.flags = { ...flags, e2e: true };
       userConfig.testing = {
+        // use Node's join() here to simulate a user using either Win/Posix separators (depending on the platform these
+        // tests are run on) for their input
         preset: path.join('mock', 'path'),
       };
 
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
 
-      expect(config.testing.preset).toEqual(path.join(ROOT, 'User', 'some', 'path', 'mock', 'path'));
+      expect(config.testing.preset).toEqual(join(ROOT, 'User', 'some', 'path', 'mock', 'path'));
     });
 
     it('does not change an already absolute preset path', () => {
       userConfig.flags = { ...flags, e2e: true };
 
+      // use Node's join() here to simulate a user using either Win/Posix separators (depending on the platform these
+      // tests are run on) for their input
       const presetPath = path.join(ROOT, 'mock', 'path');
       userConfig.testing = {
         preset: presetPath,
@@ -304,6 +324,8 @@ describe('validateTesting', () => {
 
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
 
+      // per the test name, we should not change an already absolute path - assert against the preset path that was
+      // generated using Node's join()
       expect(config.testing.preset).toEqual(presetPath);
     });
   });
@@ -319,7 +341,7 @@ describe('validateTesting', () => {
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
 
       // 'testing' is the internal directory where the default setup file can be found
-      expect(config.testing.setupFilesAfterEnv).toEqual([path.join('testing', 'jest-setuptestframework.js')]);
+      expect(config.testing.setupFilesAfterEnv).toEqual([join('testing', 'jest-setuptestframework.js')]);
     });
 
     it.each([[[]], [['mock-setup-file.js']]])(
@@ -334,7 +356,7 @@ describe('validateTesting', () => {
 
         expect(config.testing.setupFilesAfterEnv).toEqual([
           // 'testing' is the internal directory where the default setup file can be found
-          path.join('testing', 'jest-setuptestframework.js'),
+          join('testing', 'jest-setuptestframework.js'),
           ...setupFilesAfterEnv,
         ]);
       },
@@ -672,7 +694,7 @@ describe('validateTesting', () => {
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
 
       // 'testing' is the internal directory where the default runner file can be found
-      expect(config.testing.runner).toEqual(path.join('testing', 'jest-runner.js'));
+      expect(config.testing.runner).toEqual(join('testing', 'jest-runner.js'));
     });
   });
 

--- a/src/compiler/config/validate-dev-server.ts
+++ b/src/compiler/config/validate-dev-server.ts
@@ -1,5 +1,5 @@
-import { buildError, isBoolean, isNumber, isOutputTargetWww, isString, normalizePath } from '@utils';
-import { isAbsolute, join } from 'path';
+import { buildError, isBoolean, isNumber, isOutputTargetWww, isString, join, normalizePath } from '@utils';
+import { isAbsolute } from 'path';
 
 import type * as d from '../../declarations';
 

--- a/src/compiler/config/validate-paths.ts
+++ b/src/compiler/config/validate-paths.ts
@@ -1,4 +1,5 @@
-import { isAbsolute, join } from 'path';
+import { join } from '@utils';
+import { isAbsolute } from 'path';
 
 import type * as d from '../../declarations';
 

--- a/src/compiler/config/validate-paths.ts
+++ b/src/compiler/config/validate-paths.ts
@@ -1,4 +1,4 @@
-import { join } from '@utils';
+import { join, normalizePath } from '@utils';
 import { isAbsolute } from 'path';
 
 import type * as d from '../../declarations';
@@ -39,6 +39,8 @@ export const validatePaths = (config: d.Config): ConfigPaths => {
 
   if (!isAbsolute(cacheDir)) {
     cacheDir = join(rootDir, cacheDir);
+  } else {
+    cacheDir = normalizePath(cacheDir);
   }
 
   let srcIndexHtml = typeof config.srcIndexHtml !== 'string' ? join(srcDir, DEFAULT_INDEX_HTML) : config.srcIndexHtml;

--- a/src/compiler/config/validate-prerender.ts
+++ b/src/compiler/config/validate-prerender.ts
@@ -1,5 +1,5 @@
-import { buildError, isString, normalizePath } from '@utils';
-import { isAbsolute, join } from 'path';
+import { buildError, isString, join, normalizePath } from '@utils';
+import { isAbsolute } from 'path';
 
 import type * as d from '../../declarations';
 

--- a/src/compiler/config/validate-service-worker.ts
+++ b/src/compiler/config/validate-service-worker.ts
@@ -1,5 +1,5 @@
-import { isString } from '@utils';
-import { isAbsolute, join } from 'path';
+import { isString, join } from '@utils';
+import { isAbsolute } from 'path';
 
 import type * as d from '../../declarations';
 

--- a/src/compiler/config/validate-testing.ts
+++ b/src/compiler/config/validate-testing.ts
@@ -1,4 +1,4 @@
-import { buildError, isOutputTargetDist, isOutputTargetWww, isString, join } from '@utils';
+import { buildError, isOutputTargetDist, isOutputTargetWww, isString, join, normalizePath } from '@utils';
 import { basename, dirname, isAbsolute } from 'path';
 
 import type * as d from '../../declarations';
@@ -59,6 +59,8 @@ export const validateTesting = (config: d.ValidatedConfig, diagnostics: d.Diagno
   if (typeof testing.screenshotConnector === 'string') {
     if (!isAbsolute(testing.screenshotConnector)) {
       testing.screenshotConnector = join(config.rootDir!, testing.screenshotConnector);
+    } else {
+      testing.screenshotConnector = normalizePath(testing.screenshotConnector);
     }
   } else {
     testing.screenshotConnector = join(

--- a/src/compiler/config/validate-testing.ts
+++ b/src/compiler/config/validate-testing.ts
@@ -1,5 +1,5 @@
-import { buildError, isOutputTargetDist, isOutputTargetWww, isString } from '@utils';
-import { basename, dirname, isAbsolute, join } from 'path';
+import { buildError, isOutputTargetDist, isOutputTargetWww, isString, join } from '@utils';
+import { basename, dirname, isAbsolute } from 'path';
 
 import type * as d from '../../declarations';
 import { isLocalModule } from '../sys/resolve/resolve-utils';

--- a/src/compiler/docs/generate-doc-data.ts
+++ b/src/compiler/docs/generate-doc-data.ts
@@ -1,5 +1,5 @@
-import { flatOne, isOutputTargetDocsJson, normalizePath, sortBy, unique } from '@utils';
-import { basename, dirname, join, relative } from 'path';
+import { flatOne, isOutputTargetDocsJson, join, normalizePath, relative, sortBy, unique } from '@utils';
+import { basename, dirname } from 'path';
 
 import type * as d from '../../declarations';
 import { JsonDocsValue } from '../../declarations';

--- a/src/compiler/docs/json/index.ts
+++ b/src/compiler/docs/json/index.ts
@@ -1,5 +1,4 @@
-import { isOutputTargetDocsJson } from '@utils';
-import { join } from 'path';
+import { isOutputTargetDocsJson, join } from '@utils';
 
 import type * as d from '../../../declarations';
 

--- a/src/compiler/docs/readme/markdown-dependencies.ts
+++ b/src/compiler/docs/readme/markdown-dependencies.ts
@@ -1,5 +1,4 @@
-import { normalizePath } from '@utils';
-import { relative } from 'path';
+import { normalizePath, relative } from '@utils';
 
 import type * as d from '../../../declarations';
 

--- a/src/compiler/docs/readme/output-docs.ts
+++ b/src/compiler/docs/readme/output-docs.ts
@@ -1,4 +1,4 @@
-import { join, relative } from 'path';
+import { join, relative } from '@utils';
 
 import type * as d from '../../../declarations';
 import { AUTO_GENERATE_COMMENT } from '../constants';

--- a/src/compiler/docs/vscode/index.ts
+++ b/src/compiler/docs/vscode/index.ts
@@ -1,5 +1,4 @@
-import { isOutputTargetDocsVscode } from '@utils';
-import { join } from 'path';
+import { isOutputTargetDocsVscode, join } from '@utils';
 
 import type * as d from '../../../declarations';
 import { getNameText } from '../generate-doc-data';

--- a/src/compiler/html/add-script-attr.ts
+++ b/src/compiler/html/add-script-attr.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from '@utils';
 
 import type * as d from '../../declarations';
 import { getAbsoluteBuildDir } from './html-utils';

--- a/src/compiler/html/html-utils.ts
+++ b/src/compiler/html/html-utils.ts
@@ -1,4 +1,4 @@
-import { join, relative } from 'path';
+import { join, relative } from '@utils';
 
 import type * as d from '../../declarations';
 

--- a/src/compiler/html/inject-module-preloads.ts
+++ b/src/compiler/html/inject-module-preloads.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from '@utils';
 
 import type * as d from '../../declarations';
 import { getAbsoluteBuildDir } from './html-utils';

--- a/src/compiler/html/inline-esm-import.ts
+++ b/src/compiler/html/inline-esm-import.ts
@@ -1,5 +1,4 @@
-import { isString } from '@utils';
-import { join } from 'path';
+import { isString, join } from '@utils';
 import ts from 'typescript';
 
 import type * as d from '../../declarations';

--- a/src/compiler/html/inline-style-sheets.ts
+++ b/src/compiler/html/inline-style-sheets.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from '@utils';
 
 import type * as d from '../../declarations';
 

--- a/src/compiler/html/update-global-styles-link.ts
+++ b/src/compiler/html/update-global-styles-link.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from '@utils';
 
 import type * as d from '../../declarations';
 import { getAbsoluteBuildDir } from './html-utils';

--- a/src/compiler/html/validate-manifest-json.ts
+++ b/src/compiler/html/validate-manifest-json.ts
@@ -1,5 +1,5 @@
-import { buildError, buildJsonFileError, isOutputTargetWww } from '@utils';
-import { dirname, join } from 'path';
+import { buildError, buildJsonFileError, isOutputTargetWww, join } from '@utils';
+import { dirname } from 'path';
 
 import type * as d from '../../declarations';
 

--- a/src/compiler/output-targets/copy/assets-copy-tasks.ts
+++ b/src/compiler/output-targets/copy/assets-copy-tasks.ts
@@ -1,5 +1,5 @@
-import { normalizePath } from '@utils';
-import { dirname, join, relative } from 'path';
+import { join, normalizePath, relative } from '@utils';
+import { dirname } from 'path';
 
 import type * as d from '../../../declarations';
 

--- a/src/compiler/output-targets/copy/hashed-copy.ts
+++ b/src/compiler/output-targets/copy/hashed-copy.ts
@@ -1,4 +1,5 @@
-import { dirname, extname, join } from 'path';
+import { join } from '@utils';
+import { dirname, extname } from 'path';
 
 import type * as d from '../../../declarations';
 

--- a/src/compiler/output-targets/copy/local-copy-tasks.ts
+++ b/src/compiler/output-targets/copy/local-copy-tasks.ts
@@ -1,4 +1,5 @@
-import { isAbsolute, join } from 'path';
+import { join } from '@utils';
+import { isAbsolute } from 'path';
 
 import type * as d from '../../../declarations';
 

--- a/src/compiler/output-targets/copy/output-copy.ts
+++ b/src/compiler/output-targets/copy/output-copy.ts
@@ -1,6 +1,5 @@
-import { buildError, isGlob, isOutputTargetCopy, normalizePath } from '@utils';
+import { buildError, isGlob, isOutputTargetCopy, join, normalizePath } from '@utils';
 import minimatch from 'minimatch';
-import { join } from 'path';
 
 import type * as d from '../../../declarations';
 import { canSkipAssetsCopy, getComponentAssetsCopyTasks } from './assets-copy-tasks';

--- a/src/compiler/output-targets/dist-custom-elements/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements/index.ts
@@ -6,9 +6,9 @@ import {
   hasError,
   isOutputTargetDistCustomElements,
   isString,
+  join,
   rollupToStencilSourceMap,
 } from '@utils';
-import { join } from 'path';
 import ts from 'typescript';
 
 import type * as d from '../../../declarations';

--- a/src/compiler/output-targets/dist-hydrate-script/generate-hydrate-app.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/generate-hydrate-app.ts
@@ -1,6 +1,5 @@
-import { catchError, createOnWarnFn, generatePreamble, loadRollupDiagnostics } from '@utils';
+import { catchError, createOnWarnFn, generatePreamble, join, loadRollupDiagnostics } from '@utils';
 import MagicString from 'magic-string';
-import { join } from 'path';
 import { RollupOptions } from 'rollup';
 import { rollup } from 'rollup';
 

--- a/src/compiler/output-targets/dist-hydrate-script/write-hydrate-outputs.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/write-hydrate-outputs.ts
@@ -1,4 +1,5 @@
-import { basename, join } from 'path';
+import { join } from '@utils';
+import { basename } from 'path';
 import type { RollupOutput } from 'rollup';
 
 import type * as d from '../../../declarations';

--- a/src/compiler/output-targets/dist-lazy/generate-cjs.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-cjs.ts
@@ -1,5 +1,4 @@
-import { generatePreamble, relativeImport } from '@utils';
-import { join } from 'path';
+import { generatePreamble, join, relativeImport } from '@utils';
 import type { OutputOptions, RollupBuild } from 'rollup';
 
 import type * as d from '../../../declarations';

--- a/src/compiler/output-targets/dist-lazy/generate-lazy-module.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-lazy-module.ts
@@ -2,10 +2,10 @@ import {
   formatComponentRuntimeMeta,
   getSourceMappingUrlForEndOfFile,
   hasDependency,
+  join,
   rollupToStencilSourceMap,
   stringifyRuntimeData,
 } from '@utils';
-import { join } from 'path';
 import type { SourceMap as RollupSourceMap } from 'rollup';
 
 import type * as d from '../../../declarations';

--- a/src/compiler/output-targets/dist-lazy/generate-system.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-system.ts
@@ -1,5 +1,4 @@
-import { generatePreamble, relativeImport } from '@utils';
-import { join } from 'path';
+import { generatePreamble, join, relativeImport } from '@utils';
 import type { OutputOptions, RollupBuild } from 'rollup';
 
 import type * as d from '../../../declarations';

--- a/src/compiler/output-targets/dist-lazy/write-lazy-entry-module.ts
+++ b/src/compiler/output-targets/dist-lazy/write-lazy-entry-module.ts
@@ -1,5 +1,4 @@
-import { getSourceMappingUrlForEndOfFile } from '@utils';
-import { join } from 'path';
+import { getSourceMappingUrlForEndOfFile, join } from '@utils';
 
 import type * as d from '../../../declarations';
 

--- a/src/compiler/plugin/plugin.ts
+++ b/src/compiler/plugin/plugin.ts
@@ -1,5 +1,5 @@
-import { buildError, catchError, isFunction, isOutputTargetDocs, isString } from '@utils';
-import { basename, relative } from 'path';
+import { buildError, catchError, isFunction, isOutputTargetDocs, isString, relative } from '@utils';
+import { basename } from 'path';
 
 import type * as d from '../../declarations';
 import { PluginCtx, PluginTransformResults } from '../../declarations';

--- a/src/compiler/prerender/prerender-main.ts
+++ b/src/compiler/prerender/prerender-main.ts
@@ -1,5 +1,5 @@
-import { buildError, catchError, hasError, isOutputTargetWww, isString } from '@utils';
-import { isAbsolute, join } from 'path';
+import { buildError, catchError, hasError, isOutputTargetWww, isString, join } from '@utils';
+import { isAbsolute } from 'path';
 
 import type * as d from '../../declarations';
 import { createHydrateBuildId } from '../../hydrate/runner/render-utils';

--- a/src/compiler/prerender/prerender-optimize.ts
+++ b/src/compiler/prerender/prerender-optimize.ts
@@ -1,5 +1,4 @@
-import { catchError, flatOne, isString, unique } from '@utils';
-import { join } from 'path';
+import { catchError, flatOne, isString, join, unique } from '@utils';
 
 import type * as d from '../../declarations';
 import { injectModulePreloads } from '../html/inject-module-preloads';

--- a/src/compiler/prerender/prerender-worker.ts
+++ b/src/compiler/prerender/prerender-worker.ts
@@ -1,5 +1,5 @@
-import { catchError, isFunction, isPromise, isRootPath, normalizePath } from '@utils';
-import { dirname, join } from 'path';
+import { catchError, isFunction, isPromise, isRootPath, join, normalizePath } from '@utils';
+import { dirname } from 'path';
 
 import type * as d from '../../declarations';
 import { crawlAnchorsForNextUrls } from './crawl-urls';

--- a/src/compiler/prerender/prerendered-write-path.ts
+++ b/src/compiler/prerender/prerendered-write-path.ts
@@ -1,3 +1,4 @@
+import { join } from '@utils';
 import path from 'path';
 
 import type * as d from '../../declarations';
@@ -46,5 +47,5 @@ export const getWriteFilePathFromUrlPath = (manager: d.PrerenderManager, inputHr
   pathParts.push(fileName);
 
   // figure out the directory where this file will be saved
-  return path.join(manager.outputTarget.appDir, ...pathParts);
+  return join(manager.outputTarget.appDir, ...pathParts);
 };

--- a/src/compiler/prerender/robots-txt.ts
+++ b/src/compiler/prerender/robots-txt.ts
@@ -1,5 +1,4 @@
-import { catchError } from '@utils';
-import { join } from 'path';
+import { catchError, join } from '@utils';
 
 import type * as d from '../../declarations';
 import { getSitemapUrls } from './sitemap-xml';

--- a/src/compiler/prerender/sitemap-xml.ts
+++ b/src/compiler/prerender/sitemap-xml.ts
@@ -1,5 +1,4 @@
-import { catchError } from '@utils';
-import { join } from 'path';
+import { catchError, join } from '@utils';
 
 import type * as d from '../../declarations';
 

--- a/src/compiler/prerender/test/prerendered-write-path.spec.ts
+++ b/src/compiler/prerender/test/prerendered-write-path.spec.ts
@@ -1,5 +1,5 @@
 import { mockValidatedConfig } from '@stencil/core/testing';
-import { join, resolve } from 'path';
+import { join, resolve } from '@utils';
 
 import type * as d from '../../../declarations';
 import { validateWww } from '../../config/outputs/validate-www';

--- a/src/compiler/style/css-imports.ts
+++ b/src/compiler/style/css-imports.ts
@@ -1,5 +1,5 @@
-import { buildError, normalizePath } from '@utils';
-import { basename, dirname, isAbsolute, join } from 'path';
+import { buildError, join, normalizePath } from '@utils';
+import { basename, dirname, isAbsolute } from 'path';
 
 import type * as d from '../../declarations';
 import { parseStyleDocs } from '../docs/style-docs';

--- a/src/compiler/style/css-to-esm.ts
+++ b/src/compiler/style/css-to-esm.ts
@@ -1,4 +1,4 @@
-import { catchError, createJsVarName, DEFAULT_STYLE_MODE, hasError, isString, normalizePath } from '@utils';
+import { catchError, createJsVarName, DEFAULT_STYLE_MODE, hasError, isString, normalizePath, resolve } from '@utils';
 import MagicString from 'magic-string';
 import path from 'path';
 
@@ -243,7 +243,7 @@ const getCssToEsmImports = (
       cssImportData.filePath = normalizePath(cssImportData.url);
     } else {
       // relative path
-      cssImportData.filePath = normalizePath(path.resolve(dir, cssImportData.url));
+      cssImportData.filePath = normalizePath(resolve(dir, cssImportData.url));
     }
 
     cssImportData.varName = createCssVarName(cssImportData.filePath, modeName);

--- a/src/compiler/style/normalize-styles.ts
+++ b/src/compiler/style/normalize-styles.ts
@@ -1,5 +1,5 @@
-import { DEFAULT_STYLE_MODE, normalizePath } from '@utils';
-import { dirname, isAbsolute, join, relative } from 'path';
+import { DEFAULT_STYLE_MODE, join, normalizePath, relative } from '@utils';
+import { dirname, isAbsolute } from 'path';
 
 import type * as d from '../../declarations';
 

--- a/src/compiler/sys/in-memory-fs.ts
+++ b/src/compiler/sys/in-memory-fs.ts
@@ -1,6 +1,6 @@
 import type * as d from '@stencil/core/internal';
-import { isIterable, isString, normalizePath } from '@utils';
-import { basename, dirname, relative } from 'path';
+import { isIterable, isString, normalizePath, relative } from '@utils';
+import { basename, dirname } from 'path';
 
 /**
  * An in-memory FS which proxies the underlying OS filesystem using a simple

--- a/src/compiler/sys/stencil-sys.ts
+++ b/src/compiler/sys/stencil-sys.ts
@@ -1,7 +1,7 @@
 import { createNodeLogger } from '@sys-api-node';
-import { isRootPath, normalizePath } from '@utils';
+import { isRootPath, join, normalizePath } from '@utils';
 import * as os from 'os';
-import path, { basename, dirname, join } from 'path';
+import path, { basename, dirname } from 'path';
 import * as process from 'process';
 
 import type {

--- a/src/compiler/sys/typescript/typescript-config.ts
+++ b/src/compiler/sys/typescript/typescript-config.ts
@@ -1,5 +1,14 @@
-import { buildError, buildWarn, catchError, isString, loadTypeScriptDiagnostic, normalizePath } from '@utils';
-import { isAbsolute, join, relative } from 'path';
+import {
+  buildError,
+  buildWarn,
+  catchError,
+  isString,
+  join,
+  loadTypeScriptDiagnostic,
+  normalizePath,
+  relative,
+} from '@utils';
+import { isAbsolute } from 'path';
 import ts from 'typescript';
 
 import type * as d from '../../../declarations';

--- a/src/compiler/sys/typescript/typescript-resolve-module.ts
+++ b/src/compiler/sys/typescript/typescript-resolve-module.ts
@@ -1,5 +1,5 @@
-import { isString, normalizePath } from '@utils';
-import { basename, dirname, join, resolve } from 'path';
+import { isString, join, normalizePath, resolve } from '@utils';
+import { basename, dirname } from 'path';
 import ts from 'typescript';
 
 import type * as d from '../../../declarations';

--- a/src/compiler/sys/typescript/typescript-sys.ts
+++ b/src/compiler/sys/typescript/typescript-sys.ts
@@ -1,5 +1,5 @@
-import { isRemoteUrl, isString, noop, normalizePath } from '@utils';
-import { basename, resolve } from 'path';
+import { isRemoteUrl, isString, noop, normalizePath, resolve } from '@utils';
+import { basename } from 'path';
 import ts from 'typescript';
 
 import type * as d from '../../../declarations';

--- a/src/compiler/transformers/collections/parse-collection-components.ts
+++ b/src/compiler/transformers/collections/parse-collection-components.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from '@utils';
 import ts from 'typescript';
 
 import type * as d from '../../../declarations';

--- a/src/compiler/transformers/collections/parse-collection-manifest.ts
+++ b/src/compiler/transformers/collections/parse-collection-manifest.ts
@@ -1,5 +1,4 @@
-import { normalizePath } from '@utils';
-import { join } from 'path';
+import { join, normalizePath } from '@utils';
 
 import type * as d from '../../../declarations';
 import { parseCollectionComponents, transpileCollectionModule } from './parse-collection-components';

--- a/src/compiler/transformers/decorators-to-static/style-to-static.ts
+++ b/src/compiler/transformers/decorators-to-static/style-to-static.ts
@@ -1,5 +1,5 @@
-import { DEFAULT_STYLE_MODE } from '@utils';
-import { basename, dirname, extname, join } from 'path';
+import { DEFAULT_STYLE_MODE, join } from '@utils';
+import { basename, dirname, extname } from 'path';
 import ts from 'typescript';
 
 import type * as d from '../../../declarations';

--- a/src/compiler/transformers/static-to-meta/import.ts
+++ b/src/compiler/transformers/static-to-meta/import.ts
@@ -1,5 +1,5 @@
-import { normalizePath } from '@utils';
-import { isAbsolute, resolve } from 'path';
+import { normalizePath, resolve } from '@utils';
+import { isAbsolute } from 'path';
 import ts from 'typescript';
 
 import type * as d from '../../../declarations';

--- a/src/compiler/transformers/static-to-meta/parse-static.ts
+++ b/src/compiler/transformers/static-to-meta/parse-static.ts
@@ -1,5 +1,5 @@
-import { normalizePath } from '@utils';
-import { basename, dirname, join } from 'path';
+import { join, normalizePath } from '@utils';
+import { basename, dirname } from 'path';
 import ts from 'typescript';
 
 import type * as d from '../../../declarations';

--- a/src/compiler/types/generate-app-types.ts
+++ b/src/compiler/types/generate-app-types.ts
@@ -1,5 +1,5 @@
-import { addDocBlock, GENERATED_DTS, getComponentsDtsSrcFilePath, normalizePath } from '@utils';
-import { isAbsolute, relative, resolve } from 'path';
+import { addDocBlock, GENERATED_DTS, getComponentsDtsSrcFilePath, normalizePath, relative, resolve } from '@utils';
+import { isAbsolute } from 'path';
 
 import type * as d from '../../declarations';
 import { generateComponentTypes } from './generate-component-types';

--- a/src/compiler/types/generate-types.ts
+++ b/src/compiler/types/generate-types.ts
@@ -1,5 +1,4 @@
-import { isDtsFile } from '@utils';
-import { join, relative } from 'path';
+import { isDtsFile, join, relative } from '@utils';
 
 import type * as d from '../../declarations';
 import { generateCustomElementsTypes } from '../output-targets/dist-custom-elements/custom-elements-types';

--- a/src/compiler/types/stencil-types.ts
+++ b/src/compiler/types/stencil-types.ts
@@ -1,5 +1,5 @@
-import { isOutputTargetDistTypes, normalizePath } from '@utils';
-import { dirname, join, relative, resolve } from 'path';
+import { isOutputTargetDistTypes, join, normalizePath, relative, resolve } from '@utils';
+import { dirname } from 'path';
 
 import type * as d from '../../declarations';
 import { FsWriteResults } from '../sys/in-memory-fs';

--- a/src/compiler/types/tests/stencil-types.spec.ts
+++ b/src/compiler/types/tests/stencil-types.spec.ts
@@ -1,6 +1,15 @@
 import * as d from '@stencil/core/declarations';
 import path from 'path';
 
+jest.mock('@utils', () => {
+  const originalUtils = jest.requireActual('@utils');
+  return {
+    __esModule: true,
+    ...originalUtils,
+    resolve: (...pathSegments: string[]) => pathSegments.pop(),
+  };
+});
+
 import { updateTypeIdentifierNames } from '../stencil-types';
 import { stubComponentCompilerMeta } from './ComponentCompilerMeta.stub';
 import { stubComponentCompilerTypeReference } from './ComponentCompilerTypeReference.stub';
@@ -9,19 +18,14 @@ import { stubTypesImportData } from './TypesImportData.stub';
 describe('stencil-types', () => {
   describe('updateTypeMemberNames', () => {
     let dirnameSpy: jest.SpyInstance<ReturnType<typeof path.dirname>, Parameters<typeof path.dirname>>;
-    let resolveSpy: jest.SpyInstance<ReturnType<typeof path.resolve>, Parameters<typeof path.resolve>>;
 
     beforeEach(() => {
       dirnameSpy = jest.spyOn(path, 'dirname');
       dirnameSpy.mockImplementation((path: string) => path);
-
-      resolveSpy = jest.spyOn(path, 'resolve');
-      resolveSpy.mockImplementation((...pathSegments: string[]) => pathSegments.pop());
     });
 
     afterEach(() => {
       dirnameSpy.mockRestore();
-      resolveSpy.mockRestore();
     });
 
     describe('no type transformations', () => {

--- a/src/compiler/types/update-import-refs.ts
+++ b/src/compiler/types/update-import-refs.ts
@@ -1,4 +1,5 @@
-import { dirname, resolve } from 'path';
+import { resolve } from '@utils';
+import { dirname } from 'path';
 import ts from 'typescript';
 
 import type * as d from '../../declarations';

--- a/src/compiler/types/validate-build-package-json.ts
+++ b/src/compiler/types/validate-build-package-json.ts
@@ -1,5 +1,13 @@
-import { COLLECTION_MANIFEST_FILE_NAME, isGlob, isOutputTargetDistCollection, isString, normalizePath } from '@utils';
-import { dirname, join, relative } from 'path';
+import {
+  COLLECTION_MANIFEST_FILE_NAME,
+  isGlob,
+  isOutputTargetDistCollection,
+  isString,
+  join,
+  normalizePath,
+  relative,
+} from '@utils';
+import { dirname } from 'path';
 
 import type * as d from '../../declarations';
 import { packageJsonError, packageJsonWarn } from './package-json-log-utils';

--- a/src/compiler/types/validate-primary-package-output-target.ts
+++ b/src/compiler/types/validate-primary-package-output-target.ts
@@ -1,5 +1,4 @@
-import { buildWarn, isEligiblePrimaryPackageOutputTarget, isString, normalizePath } from '@utils';
-import { join, relative } from 'path';
+import { buildWarn, isEligiblePrimaryPackageOutputTarget, isString, join, normalizePath, relative } from '@utils';
 
 import type * as d from '../../declarations';
 import { packageJsonError, packageJsonWarn } from './package-json-log-utils';

--- a/src/utils/output-target.ts
+++ b/src/utils/output-target.ts
@@ -1,5 +1,6 @@
 import { flatOne, normalizePath, sortBy } from '@utils';
-import { basename, dirname, join, relative } from 'path';
+import { join } from '@utils';
+import { basename, dirname, relative } from 'path';
 
 import type * as d from '../declarations';
 import {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
See 'New Behavior' section


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this patch ensures that paths are properly normalized by the compiler.
this ensures that regardless of the platform (operating system) that a
project is compiled on, paths are uniformly treated internally by
stencil. this has system-wide reaching effects - from the in-memory
filesystem, to configuration/output target validation, and file
generation.

previously, stencil's in-browser compilation support included a polyfill
for the following NodeJS `path` module functions: `join`, `normalize`,
`relative` & `resolve`. this polyfill did the following:
- it wrapped each of the aforementioned functions in a `normalizePath`
  function to convert Windows-style path separators (`\\`) to
  Unix/POSIX-style path separators (`/`)
- it overwrote the standard NodeJS `path` implementations for each of
  these functions.

as a result, calling `join` or any of the other three methods, even when
importing the method from `path` like below would result in the polyfill
being called:
```ts
import { join } from 'path'; // this imports the polyfilled `join`

// runs the native `path.join`, then normalizes the returned path
const filePath = join(part1, part2);
```

while this was 'nice' in that stencil engineers didn't need to think
about which implementation of `path` functions they were using, this
polyfill made some behavior of the compiler hard to understand.

the polyfills were removed in https://github.com/ionic-team/stencil/pull/4317 (https://github.com/ionic-team/stencil/commit/b042d8b6e02c2df09a920db14abe551879cde5a2). this led to calls to the
aforementioned functions to call their original implementations, rather
than the wrapped implementations:
```ts
import { join } from 'path'; // imports Node's `join`

// run the native `path.join`, without any normalization
const filePath = join(part1, part2);
```

discrepencies arose where parts of the code would explicitly wrap a
call to `join()` (or one of its ilk) around a path normalization
function. this caused paths to not be uniformly normalized throughout
the codebase, leading to errors.

since the removal of in-browser compilation, additional pull requests
to fix path-related issues on windows have landed in the codebase:
- https://github.com/ionic-team/stencil/pull/4545 (cd58d9c)
- https://github.com/ionic-team/stencil/pull/4932 (https://github.com/ionic-team/stencil/commit/b97dadc967b1fde892cb75a544b1eecd2361b194)

this commit builds on the previous commits by attempting to move
stencil's compiler completely over to polyfilled versions of the
mentioned `path` functions that are explicitly imported/called.



## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

A dev build of Stencil containing the changes in this commit was built, and is available under `@stencil/core@4.7.1-dev.1699535671.a4c3950`

Reproduction cases for the issues that this pull requests closes have been combined into a single repository/reproduction case. This reproduction project can be [found here](https://github.com/rwaskiewicz/stencil-path-testing). It uses the aforementioned dev build of Stencil.

The following sections assume that the reproduction repo linked above has been cloned locally and dependencies installed (`npm ci`). Note that manual testing should occur on a Windows based machine.

### Copy Tasks

GitHub Issue: https://github.com/ionic-team/stencil/issues/4980

1. Start the dev server of the reproduction case with `npm start`
2. Observe the contents of `src/dev/worksonmymachine.html` have been copied to `www/dev/worksonmymachine.html` (open the both to confirm that they match).
3. Edit `src/dev/worksonmymachine.html` - add text, write a blog, add non-sense - whatever feels right. We only need one character of difference here.
4. Open `www/dev/worksonmymachine.html`, observe your changes made to `src/dev/worksonmymachine.html` have been propagated to the copied file under `www/dev/`

### Global Styles

GitHub Issue: https://github.com/ionic-team/stencil/issues/4961

1. Start the dev server of the reproduction case with `npm start`
2. Observe that the background of the 'Hello World' message is blue. This is controlled by a CSS variable that is defined in a global style for the project.
3. In your favorite (or least favorite) text editor, open `src/global.css`. This file contains the CSS variable that is currently set to blue.
4. Modify the value to be a valid CSS color (`red`, `green`, etc.)
5. Observe the background of the 'Hello World' message now properly changes to reflect the changes found in that global CSS file.

### CacheDir

The cache directory setting (`cacheDir`) is now unconditionally normalized.
Previously, absolute paths would not get transformed.
To evaluate this, update the project's `stencil.config.ts` as follows:
```diff
--- a/stencil.config.ts  
+++ b/stencil.config.ts  
@@ -3,6 +3,7 @@ import { Config } from '@stencil/core';  
 export const config: Config = {  
   namespace: 'path-test',  
   globalStyle: 'src/global.css',  
+  cacheDir: 'ABSOLUTE_PATH_TO_THIS_PROJECT\\.stencil',
```
Running the build `npm run build` should result in cached files being placed in a `.stencil` directory in this project's root.

### Test Paths

Some test cases associated with `validate-testing` were updated in the associated pull request/dev build. These changes are believed to be correct/validated by running `npm t` in the reproduction repository (and are equally exercised by Stencil's CI) - specifically, these ensure that the Jest infrastructure is found on disk and loaded properly. If it weren't tests would fall over/fail!

### Ionic Framework

For additional testing, a one-off build of the Ionic Framework "Stencil Nightly Build" with the aforementioned dev build related to this PR was [run and passed](https://github.com/ionic-team/ionic-framework/actions/runs/6812681112)
	
## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->


Some of the changes found herein were created/validated using Alice's
codemod branch, https://github.com/ionic-team/stencil/pull/4996
Co-authored-by: alicewriteswrongs <alicewriteswrongs@users.noreply.github.com>

STENCIL-975 Determine Scope of Path Polyfill Bug, Fix

Fixes: https://github.com/ionic-team/stencil/issues/4980
Fixes: https://github.com/ionic-team/stencil/issues/4961

Spun Off: https://github.com/ionic-team/stencil/pull/5036, https://github.com/ionic-team/stencil/pull/5032, https://github.com/ionic-team/stencil/pull/5029