### PR TITLE
chore(utils): add path utils for 'resolve' and 'normalize'

### DIFF
--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -218,3 +218,31 @@ export function relative(from: string, to: string): string {
 export function join(...paths: string[]): string {
   return normalizePath(path.join(...paths), false);
 }
+
+/**
+ * A wrapped version of node.js' {@link path.resolve} which adds our custom
+ * normalization logic. This resolves a path to a given (relative or absolute)
+ * path.
+ *
+ * @throws the underlying node function will throw if any argument is not a
+ * string
+ * @param paths a path or path fragments to resolve
+ * @returns a resolved path!
+ */
+export function resolve(...paths: string[]): string {
+  return normalizePath(path.resolve(...paths), false);
+}
+
+/**
+ * A wrapped version of node.js' {@link path.normalize} which adds our custom
+ * normalization logic. This normalizes a path, de-duping repeated segment
+ * separators and resolving `'..'` segments.
+ *
+ * @throws the underlying node function will throw if the argument is not a
+ * string
+ * @param toNormalize a path to normalize
+ * @returns a normalized path!
+ */
+export function normalize(toNormalize: string): string {
+  return normalizePath(path.normalize(toNormalize), false);
+}

--- a/src/utils/test/path.spec.ts
+++ b/src/utils/test/path.spec.ts
@@ -1,4 +1,4 @@
-import { join, normalizeFsPathQuery, normalizePath, relative } from '../path';
+import { join, normalize, normalizeFsPathQuery, normalizePath, relative, resolve } from '../path';
 
 describe('normalizePath', () => {
   it('node module', () => {
@@ -147,6 +147,20 @@ describe('normalizeFsPathQuery', () => {
       expect(relative('foo/bar', '..')).toBe('../../..');
       expect(relative('foo/bar/baz', 'foo/bar/boz')).toBe('../boz');
       expect(relative('.', '../foo/bar')).toBe('../foo/bar');
+    });
+
+    it('resolve should always return a POSIX path', () => {
+      expect(resolve('.')).toBe(normalizePath(process.cwd()));
+      expect(resolve('foo/bar/baz')).toBe(join(normalizePath(process.cwd()), 'foo/bar/baz'));
+      expect(resolve('foo\\bar\\baz')).toBe(join(normalizePath(process.cwd()), 'foo/bar/baz'));
+    });
+
+    it('normalize should always return a POSIX path', () => {
+      // these examples taken from
+      // https://nodejs.org/api/path.html#pathnormalizepath
+      expect(normalize('\\temp\\\\foo\\bar\\..\\')).toBe('/temp/foo');
+      expect(normalize('/temp/foo//bar/../')).toBe('/temp/foo');
+      expect(normalize('/foo/bar//baz/asdf/quux/..')).toBe('/foo/bar/baz/asdf');
     });
   });
 });


### PR DESCRIPTION
This adds two new wrapped / patched path utils to our `@utils/path` module.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

As part of addressing our ongoing woes with `path` we want to make sure we have all the utils we'll need here.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
