### PR TITLE
chore(esbuild): build mock-doc with esbuild

### DIFF
--- a/scripts/esbuild/build.ts
+++ b/scripts/esbuild/build.ts
@@ -1,6 +1,7 @@
 import { getOptions } from '../utils/options';
 import { buildCli } from './cli';
 import { buildCompiler } from './compiler';
+import { buildMockDoc } from './mock-doc';
 import { buildScreenshot } from './screenshot';
 import { buildSysNode } from './sys-node';
 
@@ -12,7 +13,13 @@ async function main() {
     isWatch: !!process.argv.includes('--watch'),
   });
 
-  await Promise.all([buildCli(opts), buildCompiler(opts), buildSysNode(opts), buildScreenshot(opts)]);
+  await Promise.all([
+    buildCli(opts),
+    buildCompiler(opts),
+    buildMockDoc(opts),
+    buildScreenshot(opts),
+    buildSysNode(opts),
+  ]);
 }
 
 main();

--- a/scripts/esbuild/mock-doc.ts
+++ b/scripts/esbuild/mock-doc.ts
@@ -1,0 +1,93 @@
+import type { BuildOptions as ESBuildOptions } from 'esbuild';
+import fs from 'fs-extra';
+import { join } from 'path';
+
+import { bundleParse5 } from '../bundles/plugins/parse5-plugin';
+import { writeSizzleBundle } from '../bundles/plugins/sizzle-plugin';
+import { getBanner } from '../utils/banner';
+import { bundleDts } from '../utils/bundle-dts';
+import { BuildOptions, createReplaceData } from '../utils/options';
+import { writePkgJson } from '../utils/write-pkg-json';
+import { getBaseEsbuildOptions, getEsbuildAliases, runBuilds } from './util';
+
+/**
+ * Use esbuild to bundle the `mock-doc` submodule
+ *
+ * @param opts build options
+ * @returns a promise for this bundle's build output
+ */
+export async function buildMockDoc(opts: BuildOptions) {
+  const inputDir = join(opts.buildDir, 'mock-doc');
+  const srcDir = join(opts.srcDir, 'mock-doc');
+  const outputDir = opts.output.mockDocDir;
+
+  // bundle d.ts
+  await bundleMockDocDts(opts, inputDir, outputDir);
+
+  writePkgJson(opts, outputDir, {
+    name: '@stencil/core/mock-doc',
+    description: 'Mock window, document and DOM outside of a browser environment.',
+    main: 'index.cjs',
+    module: 'index.js',
+    types: 'index.d.ts',
+    sideEffects: false,
+  });
+
+  // we need to call `createReplaceData` here not because we plan to use the
+  // replace data in this bundle but because the function has some side-effects
+  // that we need here. in particular, it sets the version of `parse5` on
+  // `opts` and the `bundleParse5` function has an implicit dependency on this
+  // value being already set.
+  createReplaceData(opts);
+
+  const mockDocAliases = getEsbuildAliases();
+
+  const sizzlePath = await writeSizzleBundle(opts);
+  mockDocAliases['sizzle'] = sizzlePath;
+
+  const [, parse5Path] = await bundleParse5(opts);
+  mockDocAliases['parse5'] = parse5Path;
+
+  const mockDocBuildOptions: ESBuildOptions = {
+    ...getBaseEsbuildOptions(),
+    entryPoints: [join(srcDir, 'index.ts')],
+    bundle: true,
+    alias: mockDocAliases,
+    logLevel: 'info',
+    target: 'node16',
+  };
+
+  const esmOptions: ESBuildOptions = {
+    ...mockDocBuildOptions,
+    format: 'esm',
+    outfile: join(outputDir, 'index.js'),
+    banner: { js: getBanner(opts, `Stencil Mock Doc`, true) },
+  };
+
+  const cjsOptions: ESBuildOptions = {
+    ...mockDocBuildOptions,
+    format: 'cjs',
+    outfile: join(outputDir, 'index.cjs'),
+    banner: { js: getBanner(opts, `Stencil Mock Doc (CommonJS)`, true) },
+  };
+
+  return runBuilds([esmOptions, cjsOptions], opts);
+}
+
+async function bundleMockDocDts(opts: BuildOptions, inputDir: string, outputDir: string) {
+  const bundled = await bundleDts(
+    opts,
+    join(inputDir, 'index.ts'),
+    {
+      // we want to suppress the `dts-bundle-generator` banner here because we do
+      // our own later on
+      noBanner: true,
+      // we also don't want the types which are inlined into our bundled file to
+      // be re-exported, which will change the 'surface' of the module
+      exportReferencedTypes: false,
+    },
+    false,
+  );
+
+  await fs.writeFile(join(outputDir, 'index.d.ts'), bundled);
+}

--- a/scripts/utils/bundle-dts.ts
+++ b/scripts/utils/bundle-dts.ts
@@ -13,12 +13,18 @@ import { BuildOptions } from './options';
  * @param opts an object holding information about the current build of Stencil
  * @param inputFile the path to the file which should be bundled
  * @param outputOptions options for bundling the file
+ * @param useCache whether or not the bundled file should be cached to disk
  * @returns a string containing the bundled typedef
  */
-export async function bundleDts(opts: BuildOptions, inputFile: string, outputOptions?: OutputOptions): Promise<string> {
+export async function bundleDts(
+  opts: BuildOptions,
+  inputFile: string,
+  outputOptions?: OutputOptions,
+  useCache = true,
+): Promise<string> {
   const cachedDtsOutput = inputFile + '-bundled.d.ts';
 
-  if (!opts.isProd) {
+  if (!opts.isProd && useCache) {
     try {
       return await fs.readFile(cachedDtsOutput, 'utf8');
     } catch (e) {}
@@ -34,7 +40,9 @@ export async function bundleDts(opts: BuildOptions, inputFile: string, outputOpt
 
   const outputCode = cleanDts(generateDtsBundle([config]).join('\n'));
 
-  await fs.writeFile(cachedDtsOutput, outputCode);
+  if (useCache) {
+    await fs.writeFile(cachedDtsOutput, outputCode);
+  }
 
   return outputCode;
 }


### PR DESCRIPTION
This adds support for building the mock-doc top-level-module using esbuild.


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

CI passing with both the Rollup- and Esbuild-based builds is a good signal that things are alright here. I also build and packed the project locally and then installed it in a sample project, ensuring that I could then run a basic `stencil test --e2e --spec` without issues.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
