### PR TITLE
fix(compiler): ignore TS diagnostics on builds where typedef file changes

### DIFF
--- a/src/compiler/transpile/run-program.ts
+++ b/src/compiler/transpile/run-program.ts
@@ -132,7 +132,10 @@ export const runTsProgram = async (
     await Promise.all(srcRootDtsFiles);
   }
 
-  if (config.validateTypes) {
+  // TODO(STENCIL-540): remove `hasTypesChanged` check and figure out how to generate types before
+  // executing the TS build program so we don't get semantic diagnostic errors about referencing the
+  // auto-generated `components.d.ts` file.
+  if (config.validateTypes && !hasTypesChanged) {
     const tsSemantic = loadTypeScriptDiagnostics(tsBuilder.getSemanticDiagnostics());
     if (config.devMode) {
       tsSemantic.forEach((semanticDiagnostic) => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Building a Stencil project that uses the component starter template can result in build errors if the `src/components.d.ts` file doesn't already exist. This is because the TS program used for the build generates the semantic error diagnostics before we generate the typedef file. This bug was introduced by #4938 since we no longer early-abort before the TS diagnostics are pushed into our own diagnostics. 

Fixes: #4999 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This is a temporary fix to prevent the build errors without needing to early abort and revert all the changes from #4938. If the typedef file was changed, we ignore the TS diagnostics.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Tested in a component starter by deleting the `src/components.d.ts` file before running a build.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
