### PR TITLE
refactor(compiler): use doc const types

### DIFF
--- a/src/compiler/config/outputs/validate-docs.ts
+++ b/src/compiler/config/outputs/validate-docs.ts
@@ -1,5 +1,7 @@
 import {
   buildError,
+  DOCS_JSON,
+  DOCS_README,
   isFunction,
   isOutputTargetDocsCustom,
   isOutputTargetDocsJson,
@@ -19,7 +21,7 @@ export const validateDocs = (config: d.ValidatedConfig, diagnostics: d.Diagnosti
   if (isString(config.flags.docsJson)) {
     docsOutputs.push(
       validateJsonDocsOutputTarget(config, diagnostics, {
-        type: 'docs-json',
+        type: DOCS_JSON,
         file: config.flags.docsJson,
       }),
     );
@@ -35,7 +37,7 @@ export const validateDocs = (config: d.ValidatedConfig, diagnostics: d.Diagnosti
   if (config.flags.docs || config.flags.task === 'docs') {
     if (!userOutputs.some(isOutputTargetDocsReadme)) {
       // didn't provide a docs config, so let's add one
-      docsOutputs.push(validateReadmeOutputTarget(config, { type: 'docs-readme' }));
+      docsOutputs.push(validateReadmeOutputTarget(config, { type: DOCS_README }));
     }
   }
 


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We use string literals instead of their constant variable representations
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

use the const variables for validating docs-readme and docs-json instead of their string literal representation. this ought to aid in "finding" cases where stencil is doing "something" with documentation generation

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I didn't - this should be a straightforward swap
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
