### PR TITLE
fix(vite): resolve PURE comment warnings

### DIFF
--- a/src/client/client-task-queue.ts
+++ b/src/client/client-task-queue.ts
@@ -96,7 +96,7 @@ const flush = () => {
   }
 };
 
-export const nextTick = /*@__PURE__*/ (cb: () => void) => promiseResolve().then(cb);
+export const nextTick = (cb: () => void) => promiseResolve().then(cb);
 
 export const readTask = /*@__PURE__*/ queueTask(queueDomReads, false);
 

--- a/src/hydrate/platform/index.ts
+++ b/src/hydrate/platform/index.ts
@@ -72,7 +72,7 @@ export const writeTask = (cb: Function) => {
 };
 
 const resolved = /*@__PURE__*/ Promise.resolve();
-export const nextTick = /*@__PURE__*/ (cb: () => void) => resolved.then(cb);
+export const nextTick = (cb: () => void) => resolved.then(cb);
 
 const defaultConsoleError = (e: any) => {
   if (e != null) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
prior to this fix, building a stencil/ionic project using stencil would result in a warning in the console similar to the following:
```
vite v5.0.0-beta.14 building for production...
node_modules/.pnpm/@stencil+core@4.7.0/node_modules/@stencil/core/internal/client/index.js (3800:17) A comment

"/*@__PURE__*/"

in "node_modules/.pnpm/@stencil+core@4.7.0/node_modules/@stencil/core/internal/client/index.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.
```
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

remove `/*@__PURE__*/` comment pragma warnings from vite v5/rollup v4 from a pragma that was applied to a variable assignment that rollup can't understand.



## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

### Manual

1. Check out this branch and build it (`npm run clean && npm ci && npm run build`)
2. Navigate to line 3800 in the generated `internal/client/index.js`
3. Observe the pragma is gone
4. Pull down the reproduction case associated with the issue for this PR
5. Run `pnpm i` within the reproduction case, and build `pnpm run build`
6. Observe the error reported
7. Open the `client/index.js` file in the reproduction case to line 3800
8. Manually remove the pragma (reaching parity with the locally built file)
9. `pnpm run build` - observe no errors

### Dev Build

1. Pull down the reproduction case associated with the issue
2. Run `pnpm i && pnpm build` from the root of the repo
3. Observe the error
4. Install the following dev builds of `@ionic/react`, `@ionic/react-router` and `ionicons`
```
pnpm i @ionic/react@7.5.4-dev.11699023297.172bb30f  @ionic/react-router@7.5.4-dev.11699023297.172bb30f ionicons@7.2.2-dev.11699022363.15a70775
```
(these packages are build with a Stencil dev build `4.7.0-dev.1699016641.733d6c5`)
5. `pnpm build` again, this time, no error!
6. 
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

Stencil-996 bug: vite v5 warning

fixes: #5008
