### PR TITLE
chore(snc): resolve SNC for stencil-types.ts

### DIFF
--- a/src/compiler/types/stencil-types.ts
+++ b/src/compiler/types/stencil-types.ts
@@ -70,9 +70,9 @@ export const updateTypeIdentifierNames = (
  * @param sourceFilePath the component source file path to resolve against
  * @returns the path of the type import
  */
-const getTypeImportPath = (importResolvedFile: string | undefined, sourceFilePath: string): string => {
-  const isPathRelative = importResolvedFile && importResolvedFile.startsWith('.');
-  if (isPathRelative) {
+const getTypeImportPath = (importResolvedFile: string | undefined, sourceFilePath: string): string | undefined => {
+  if (importResolvedFile && importResolvedFile.startsWith('.')) {
+    // the path to the type reference is relative, resolve it relative to the provided source path
     importResolvedFile = resolve(dirname(sourceFilePath), importResolvedFile);
   }
 

--- a/src/compiler/types/stencil-types.ts
+++ b/src/compiler/types/stencil-types.ts
@@ -53,6 +53,10 @@ export const updateTypeIdentifierNames = (
   for (const typeReference of Object.values(typeReferences)) {
     const importResolvedFile = getTypeImportPath(typeReference.path, sourceFilePath);
 
+    if (typeof importResolvedFile !== 'string') {
+      continue;
+    }
+
     if (!typeImportData.hasOwnProperty(importResolvedFile)) {
       continue;
     }

--- a/src/compiler/types/tests/stencil-types.spec.ts
+++ b/src/compiler/types/tests/stencil-types.spec.ts
@@ -71,6 +71,24 @@ describe('stencil-types', () => {
         expect(actualTypeName).toBe(expectedTypeName);
       });
 
+      it('returns the provided type for imports without the resolved file', () => {
+        const expectedTypeName = 'CustomType';
+        const typeReferences: d.ComponentCompilerTypeReferences = {
+          // we're testing the `path` value doesn't exist on the type import data.
+          // in practice this should never happen, but let's ensure that we cover this case explicitly in tests
+          [expectedTypeName]: stubComponentCompilerTypeReference({ location: 'import',  path: 'some/mock/unknown/path'}),
+        };
+
+        const actualTypeName = updateTypeIdentifierNames(
+          typeReferences,
+          {},
+          stubComponentCompilerMeta().sourceFilePath,
+          expectedTypeName,
+        );
+
+        expect(actualTypeName).toBe(expectedTypeName);
+      });
+
       it("does not change a simple type when there's no import name to alias", () => {
         const initialType = 'InitialType';
         const basePath = '~/some/stubbed/path';

--- a/src/compiler/types/tests/stencil-types.spec.ts
+++ b/src/compiler/types/tests/stencil-types.spec.ts
@@ -76,7 +76,10 @@ describe('stencil-types', () => {
         const typeReferences: d.ComponentCompilerTypeReferences = {
           // we're testing the `path` value doesn't exist on the type import data.
           // in practice this should never happen, but let's ensure that we cover this case explicitly in tests
-          [expectedTypeName]: stubComponentCompilerTypeReference({ location: 'import',  path: 'some/mock/unknown/path'}),
+          [expectedTypeName]: stubComponentCompilerTypeReference({
+            location: 'import',
+            path: 'some/mock/unknown/path',
+          }),
         };
 
         const actualTypeName = updateTypeIdentifierNames(


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We have a handful of SNC's in `stencil-types.ts`

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

resolves two strictNullChecks violations that were caused
by improperly handling a variable that was of type `string|undefined`
and assuming that it was of type `string`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I ran the unit tests with coverage, and verified the [new/existing branches](https://github.com/ionic-team/stencil/pull/5026/files#diff-9520ec3dc9b12aac1a3735d5bc8a2808c1cf32a7c560ab81874b9e6aa10b9f37R56-R62) were covered. I ran the tests in the debugger with breakpoints in each conditional body, to verify they were actually called when I expected them to be.

I also repeated the same steps above without the code changes applied (but with the new test) to verify that the behavior for `undefined` being returned by our little helper method functionally did "the same thing".

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
