### PR TITLE
test(path): add additional tests to relative

### DIFF
--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -195,6 +195,9 @@ const enum CharacterCodes {
  * A wrapped version of node.js' {@link path.relative} which adds our custom
  * normalization logic. This solves the relative path between `from` and `to`!
  *
+ * The calculation of the returned path follows that of Node's logic, with one exception - if the calculated path
+ * results in an empty string, a string of length one with a period (`'.'`) is returned.
+ *
  * @throws the underlying node.js function can throw if either path is not a
  * string
  * @param from the path where relative resolution starts
@@ -202,6 +205,12 @@ const enum CharacterCodes {
  * @returns the resolved relative path
  */
 export function relative(from: string, to: string): string {
+  /**
+   * When normalizing, we should _not_ attempt to relativize the path returned by the native Node `relative` method.
+   * When finding the relative path between `from` and `to`, Node does not prepend './' a non-zero length calculated
+   * path. However, our algorithm does differ from that of Node's, as described in this function's JSDoc when an zero
+   * length string is encountered.
+   */
   return normalizePath(path.relative(from, to), false);
 }
 

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -207,8 +207,8 @@ const enum CharacterCodes {
 export function relative(from: string, to: string): string {
   /**
    * When normalizing, we should _not_ attempt to relativize the path returned by the native Node `relative` method.
-   * When finding the relative path between `from` and `to`, Node does not prepend './' a non-zero length calculated
-   * path. However, our algorithm does differ from that of Node's, as described in this function's JSDoc when an zero
+   * When finding the relative path between `from` and `to`, Node does not prepend './' to a non-zero length calculated
+   * path. However, our algorithm does differ from that of Node's, as described in this function's JSDoc when a zero
    * length string is encountered.
    */
   return normalizePath(path.relative(from, to), false);

--- a/src/utils/test/path.spec.ts
+++ b/src/utils/test/path.spec.ts
@@ -145,7 +145,10 @@ describe('normalizeFsPathQuery', () => {
     it('relative should always return a POSIX path', () => {
       expect(relative('.', 'foo/bar')).toBe('foo/bar');
       expect(relative('foo/bar', '..')).toBe('../../..');
+      expect(relative('foo', 'foo/bar/file.js')).toBe('bar/file.js');
+      expect(relative('foo/bar', 'foo/bar/file.js')).toBe('file.js');
       expect(relative('foo/bar/baz', 'foo/bar/boz')).toBe('../boz');
+      expect(relative('foo/bar/file.js', 'foo/bar/file.js')).toBe('.');
       expect(relative('.', '../foo/bar')).toBe('../foo/bar');
     });
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I was questioning some divergent behavior between our `path.resolve` wrapper and the underlying Node call. Specifically:
```
// Node.JS console
> path.relative('foo/bar/file.js', 'foo/bar/file.js')
'' // empty string
```
```js
// Our code
import { relative } from '@utils';
// ...
const foo = path.relative('foo/bar/file.js', 'foo/bar/file.js');
console.log(foo); // print '.'
```
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

add additional tests to stencil's wrapped version of `path.relative`, adding additional documentation to how the wrapped function work. specifically, add tests to verify the following behavior:
1. when there is a single directory of overlap between `from` and `to`
2. when there is multiple directory overlap, but no divergences between `from` and `to`
3. when there is complete overlap between `from` and `to`

the latter case of complete overlap is documented in JSDoc as well to signify a divergence from `path.resolve`. 


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

No functional changes have occurred - only adding unit tests. I did track the execution of the tests in a debugger and walked through `normalizePath` to verify they were hitting the code points that I expected them to.

## Other information

the case where we have complete overlap between `from` and `to` was the impetus for this change - I didn't understand what I was seeing at first when debugging some Stencil 4.x related path related bugs. this commit is spun out from that work

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
