### PR TITLE
fix(test): don't fail build when jest typings can't be resolved

### DIFF
--- a/src/testing/jest/jest-stencil-connector.ts
+++ b/src/testing/jest/jest-stencil-connector.ts
@@ -118,11 +118,12 @@ export const getJestSetupTestFramework = () => {
   return getJestFacade().getJestSetupTestFramework();
 };
 
+// TODO(STENCIL-1003): Fix typing resolution bug where dynamic type imports would result in build failures for Jest 28/29
 /**
  * Retrieve Stencil's Jest presets for the detected version of Jest
  *
  * @returns an object representing a Jest preset
  */
-export const getJestPreset = () => {
+export const getJestPreset = (): any => {
   return getJestFacade().getJestPreset();
 };


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
prior to this fix, building a stencil project with jest 29 installed could lead to an error such as:
```
TypeScript: node_modules/@stencil/core/testing/jest/jest-stencil-connector.d.ts:81:31
       Could not find a declaration file for module '@jest/types/build/Config'.
       '/PROJECT_DIRECTORY/node_modules/@jest/types/build/Config.js' implicitly
       has an 'any' type.If the '@jest/types' package actually exposes this module, try adding a new declaration
       (.d.ts) file containing `declare module '@jest/types/build/Config';`
```

GitHub Issue Number: #5030 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

patch `getJestPreset` in the jest-stencil connector to return `any` instead of an inferred type for the function. 

Explicitly setting this return type to `any` is a temporary measure to unblock adopters. A TODO for STENCIL-1003 has been added to resolve this fully.



## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

1. Pull down the repo that is associated with #5030 
2. Run `yarn` to install dependencies
3. Run `yarn build` to build the project, observe the error
4. Add the following dev build to the project: `yarn add @stencil/core@4.7.1-dev.1699392001.733589`
5. Run `yarn build` to build the project, observe no error occurs

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
STENCIL-1002: bug: Stencil 4.7.x & Jest 29.5.7 TypeScript error
fixes: #5030