### PR TITLE
test(path): add additional tests to join

### DIFF
--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -210,12 +210,22 @@ export function relative(from: string, to: string): string {
  * normalization logic. This joins all the arguments (path fragments) into a
  * single path.
  *
+ * The calculation of the returned path follows that of Node's logic, with one exception - any trailing slashes will
+ * be removed from the calculated path.
+ *
  * @throws the underlying node function will throw if any argument is not a
  * string
  * @param paths the paths to join together
  * @returns a joined path!
  */
 export function join(...paths: string[]): string {
+  /**
+   * When normalizing, we should _not_ attempt to relativize the path returned by the native Node `join` method. When
+   * calculating the path from each of the string-based parts, Node does not prepend './' to any calculated path.
+   *
+   * Note that our algorithm does differ from Node's, as described in this function's JSDoc regarding trailing
+   * slashes.
+   */
   return normalizePath(path.join(...paths), false);
 }
 

--- a/src/utils/test/path.spec.ts
+++ b/src/utils/test/path.spec.ts
@@ -137,8 +137,13 @@ describe('normalizeFsPathQuery', () => {
   describe('wrapped nodejs path functions', () => {
     it('join should always return a POSIX path', () => {
       expect(join('foo')).toBe('foo');
+      expect(join('foo/')).toBe('foo');
       expect(join('foo', 'bar')).toBe('foo/bar');
+      expect(join('foo', 'bar', '/')).toBe('foo/bar');
+      expect(join('foo', '/', 'bar')).toBe('foo/bar');
+      expect(join('foo', '/', '/', 'bar')).toBe('foo/bar');
       expect(join('..', 'foo', 'bar.ts')).toBe('../foo/bar.ts');
+      expect(join('foo', '..', 'bar.ts')).toBe('bar.ts');
       expect(join('.', 'foo', 'bar.ts')).toBe('foo/bar.ts');
     });
 


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
I was questioning some divergent behavior between our `path.join` wrapper and the underlying Node call with respect to trailing slashes. This led to adding additional tests/docs

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

add additional tests to stencil's wrapped version of `path.join`, adding additional documentation to how the wrapped function works. specifically, add tests to verify the following behavior:
1. how trailing slashes are treated by the function
2. how 1+ string arguments of '/' are handled
3. how relative paths going 'up' one directory level are handled such that only a file is resolved


## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

No functional changes have occurred - only adding unit tests. I did track the execution of the tests in a debugger and walked through `normalizePath` to verify they were hitting the code points that I expected them to.
## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

the first case of trailing slashes is documented in JSDoc as well to signify a divergence from `path.join`. this behavior was the impetus for this change - I didn't understand what I was seeing at first when debugging some Stencil 4.x related path related bugs. this commit is spun out from that work.


related to: #5029