### PR TITLE
test(path): add additional tests to normalize

### DIFF
--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -249,6 +249,10 @@ export function join(...paths: string[]): string {
  * @returns a resolved path!
  */
 export function resolve(...paths: string[]): string {
+  /**
+   * When normalizing, we should _not_ attempt to relativize the path returned by the native Node `resolve` method. When
+   * calculating the path from each of the string-based parts, Node does not prepend './' to the calculated path.
+   */
   return normalizePath(path.resolve(...paths), false);
 }
 
@@ -263,5 +267,9 @@ export function resolve(...paths: string[]): string {
  * @returns a normalized path!
  */
 export function normalize(toNormalize: string): string {
+  /**
+   * When normalizing, we should _not_ attempt to relativize the path returned by the native Node `normalize` method.
+   * When calculating the path from each of the string-based parts, Node does not prepend './' to the calculated path.
+   */
   return normalizePath(path.normalize(toNormalize), false);
 }

--- a/src/utils/test/path.spec.ts
+++ b/src/utils/test/path.spec.ts
@@ -164,6 +164,11 @@ describe('normalizeFsPathQuery', () => {
     });
 
     it('normalize should always return a POSIX path', () => {
+      expect(normalize('')).toBe('.');
+      expect(normalize('.')).toBe('.');
+      expect(normalize('..')).toBe('..');
+      expect(normalize('/')).toBe('/');
+      expect(normalize('\\')).toBe('/');
       // these examples taken from
       // https://nodejs.org/api/path.html#pathnormalizepath
       expect(normalize('\\temp\\\\foo\\bar\\..\\')).toBe('/temp/foo');


### PR DESCRIPTION





<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
I was questioning how this function behaves/should behave was the impetus for this change - I didn't understand what I was seeing at first when debugging some Stencil 4.x related path related bugs. this commit is spun out from that work.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

add additional tests to stencil's wrapped version of `path.normalize`, adding additional documentation to how the wrapped function works. specifically, add tests to verify the following behavior:
1. how an empty string behaves
2. how relative paths ('.', '..') behave
3. how absolute paths ('/' for POSIX and '\\' for Windows) behave

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

No functional changes - added unit tests only
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

related to: #5029, #5032