### PR TITLE
refactor(jest): narrow getJestPreset typings

### DIFF
--- a/src/testing/jest/jest-apis.ts
+++ b/src/testing/jest/jest-apis.ts
@@ -27,7 +27,16 @@ export type JestPreprocessor = {
 // TODO(STENCIL-960): Improve this typing by narrowing it
 export type JestTestRunner = any;
 
-export type JestConfig = Config.InitialOptions;
+/**
+ * This type serves as an alias for the type representing the initial configuration for Jest.
+ * This alias serves two purposes:
+ * 1. It allows Stencil to have a single source of truth for the return type(s) on {@link JestFacade} (and its
+ *    implementations)
+ * 2. It prevents TypeScript from expanding Jest typings in the generated `.d.ts` file. This is necessary as TypeScript
+ *    will make assumptions about where it can dynamically resolve Jest typings from, which do not necessarily hold
+ *    true for every type of Stencil project directory structure.
+ */
+export type JestPresetConfig = Config.InitialOptions;
 
 /**
  * Get the current major version of Jest that Stencil reconciles

--- a/src/testing/jest/jest-facade.ts
+++ b/src/testing/jest/jest-facade.ts
@@ -1,4 +1,4 @@
-import { JestConfig, JestPreprocessor, JestPuppeteerEnvironment, JestTestRunner } from './jest-apis';
+import { JestPreprocessor, JestPresetConfig, JestPuppeteerEnvironment, JestTestRunner } from './jest-apis';
 
 /**
  * Interface for Jest-version specific code implementations that interact with Stencil.
@@ -80,5 +80,5 @@ export interface JestFacade {
    *
    * @returns the Jest preset object to be used for a particular version of Jest.
    */
-  getJestPreset(): JestConfig;
+  getJestPreset(): JestPresetConfig;
 }

--- a/src/testing/jest/jest-stencil-connector.ts
+++ b/src/testing/jest/jest-stencil-connector.ts
@@ -12,7 +12,7 @@ import semverMajor from 'semver/functions/major';
 import { Jest27Stencil } from './jest-27-and-under/jest-facade';
 import { Jest28Stencil } from './jest-28/jest-facade';
 import { Jest29Stencil } from './jest-29/jest-facade';
-import { getJestMajorVersion } from './jest-apis';
+import { getJestMajorVersion, JestPresetConfig } from './jest-apis';
 import { JestFacade } from './jest-facade';
 
 /**
@@ -118,12 +118,11 @@ export const getJestSetupTestFramework = () => {
   return getJestFacade().getJestSetupTestFramework();
 };
 
-// TODO(STENCIL-1003): Fix typing resolution bug where dynamic type imports would result in build failures for Jest 28/29
 /**
  * Retrieve Stencil's Jest presets for the detected version of Jest
  *
  * @returns an object representing a Jest preset
  */
-export const getJestPreset = (): any => {
+export const getJestPreset = (): JestPresetConfig => {
   return getJestFacade().getJestPreset();
 };


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We have a small piece of technical debt introduced in #5031 where we use an `any` type for the Jest infrastructure. This PR fixes it!

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit is a follow up to #5031 (5df16e6). it narrows the return type of the `JestFacade#getJestPreset` function from `any` to an alias to Jest's `Config.InitialOptions`.

prior to #5031, the return type of `getJestPreset` would be inferred by the TypeScript compiler, and a dynamic import to an internal Jest type declaration file would be generated for the typing of the function:
```ts
// a snippet of what was generated in `jest-stencil-connector.d.ts
export declare const getJestPreset: () => Partial<{
    coverageReporters: import("@jest/types/build/Config").CoverageReporters;
    // other fields omitted
}>;
```
however, stencil cannot/should not make assumptions about the location of this file. by placing an alias, the dyanmic import is removed from the output `.d.ts` file (having the same effect as #5031).

pr #5031 eliminated this by using `any` as an explicit return type, which would generate:
```ts
export declare const getJestPreset: () => any;
```

with this commit, we now generate:
```ts
export declare const getJestPreset: () => JestPresetConfig;
```
which no longer inlines dynamic imports for typings.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

1. Pull down the repo that is associated with #5030 
2. Run `yarn` to install dependencies
3. Run `yarn build` to build the project, observe the error
4. Add the following dev build to the project: `yarn add @stencil/core@4.7.1-dev.1699565413.1847940`
5. Run `yarn build` to build the project, observe no error occurs
## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
STENCIL-1003 Dynamic Import Type Resolution Fails for Jest 28, 29