### PR TITLE
refactor(build): remove whitespace edit from parse5Plugin

### DIFF
--- a/scripts/bundles/plugins/parse5-plugin.ts
+++ b/scripts/bundles/plugins/parse5-plugin.ts
@@ -2,8 +2,7 @@ import rollupCommonjs from '@rollup/plugin-commonjs';
 import rollupResolve from '@rollup/plugin-node-resolve';
 import fs from 'fs-extra';
 import { join } from 'path';
-import type { NormalizedOutputOptions, OutputBundle } from 'rollup';
-import { OutputChunk, Plugin, rollup } from 'rollup';
+import { Plugin, rollup } from 'rollup';
 
 import type { BuildOptions } from '../../utils/options';
 import { aliasPlugin } from './alias-plugin';
@@ -37,20 +36,6 @@ export function parse5Plugin(opts: BuildOptions): Plugin {
         return await bundleParse5(opts);
       }
       return null;
-    },
-    /**
-     * Output generation hook used to reduce the amount of whitespace in the bundle
-     * @param _ unused output options
-     * @param bundle the bundle to minify
-     */
-    generateBundle(_: NormalizedOutputOptions, bundle: OutputBundle): void {
-      Object.keys(bundle).forEach((fileName) => {
-        // not minifying, but we are reducing whitespace
-        const chunk = bundle[fileName] as OutputChunk;
-        if (chunk.type === 'chunk') {
-          chunk.code = chunk.code.replace(/    /g, '  ');
-        }
-      });
     },
   };
 }

--- a/src/compiler/docs/json/index.ts
+++ b/src/compiler/docs/json/index.ts
@@ -18,7 +18,7 @@ export const generateJsonDocs = async (
   // indentation. Instead, let's replace those with spaces!
   docsDts = docsDts
     .split('\n')
-    .map((line) => line.replace(/\t/g, '    '))
+    .map((line) => line.replace(/\t/g, '  '))
     .join('\n');
 
   const typesContent = `

--- a/src/compiler/types/generate-app-types.ts
+++ b/src/compiler/types/generate-app-types.ts
@@ -130,9 +130,9 @@ const generateComponentTypesFile = (
 
   c.push(...modules.map((m) => m.element));
 
-  c.push(`        interface HTMLElementTagNameMap {`);
-  c.push(...modules.map((m) => `                "${m.tagName}": ${m.htmlElementName};`));
-  c.push(`        }`);
+  c.push(`    interface HTMLElementTagNameMap {`);
+  c.push(...modules.map((m) => `        "${m.tagName}": ${m.htmlElementName};`));
+  c.push(`    }`);
 
   c.push(`}`);
 
@@ -140,34 +140,34 @@ const generateComponentTypesFile = (
   c.push(
     ...modules.map((m) => {
       const docs = components.find((c) => c.tagName === m.tagName).docs;
-      return addDocBlock(`  ${m.jsx}`, docs, 4);
+      return addDocBlock(m.jsx, docs, 4);
     }),
   );
 
-  c.push(`        interface IntrinsicElements {`);
-  c.push(...modules.map((m) => `              "${m.tagName}": ${m.tagNameAsPascal};`));
-  c.push(`        }`);
+  c.push(`    interface IntrinsicElements {`);
+  c.push(...modules.map((m) => `        "${m.tagName}": ${m.tagNameAsPascal};`));
+  c.push(`    }`);
 
   c.push(`}`);
 
   c.push(`export { LocalJSX as JSX };`);
 
   c.push(`declare module "@stencil/core" {`);
-  c.push(`        export namespace JSX {`);
-  c.push(`                interface IntrinsicElements {`);
+  c.push(`    export namespace JSX {`);
+  c.push(`        interface IntrinsicElements {`);
   c.push(
     ...modules.map((m) => {
       const docs = components.find((c) => c.tagName === m.tagName).docs;
 
       return addDocBlock(
-        `                        "${m.tagName}": LocalJSX.${m.tagNameAsPascal} & JSXBase.HTMLAttributes<${m.htmlElementName}>;`,
+        `            "${m.tagName}": LocalJSX.${m.tagNameAsPascal} & JSXBase.HTMLAttributes<${m.htmlElementName}>;`,
         docs,
         12,
       );
     }),
   );
-  c.push(`                }`);
   c.push(`        }`);
+  c.push(`    }`);
   c.push(`}`);
 
   return c.join(`\n`) + `\n`;

--- a/src/compiler/types/generate-component-types.ts
+++ b/src/compiler/types/generate-component-types.ts
@@ -38,24 +38,24 @@ export const generateComponentTypes = (
   const element = [
     ...htmlElementEventMap,
     addDocBlock(
-      `        interface ${htmlElementName} extends Components.${tagNameAsPascal}, HTMLStencilElement {`,
+      `    interface ${htmlElementName} extends Components.${tagNameAsPascal}, HTMLStencilElement {`,
       cmp.docs,
       4,
     ),
     ...htmlElementEventListenerProperties,
-    `        }`,
-    `        var ${htmlElementName}: {`,
-    `                prototype: ${htmlElementName};`,
-    `                new (): ${htmlElementName};`,
-    `        };`,
+    `    }`,
+    `    var ${htmlElementName}: {`,
+    `        prototype: ${htmlElementName};`,
+    `        new (): ${htmlElementName};`,
+    `    };`,
   ];
   return {
     isDep,
     tagName,
     tagNameAsPascal,
     htmlElementName,
-    component: addDocBlock(`        interface ${tagNameAsPascal} {\n${componentAttributes}        }`, cmp.docs, 4),
-    jsx: `    interface ${tagNameAsPascal} {\n${jsxAttributes}        }`,
+    component: addDocBlock(`    interface ${tagNameAsPascal} {\n${componentAttributes}    }`, cmp.docs, 4),
+    jsx: `    interface ${tagNameAsPascal} {\n${jsxAttributes}    }`,
     element: element.join(`\n`),
   };
 };
@@ -70,12 +70,12 @@ const attributesToMultiLineString = (attributes: d.TypeInfo, jsxAttributes: bool
     })
     .reduce((fullList, type) => {
       if (type.jsdoc) {
-        fullList.push(`                /**`);
-        fullList.push(...type.jsdoc.split('\n').map((line) => '                  * ' + line));
-        fullList.push(`                 */`);
+        fullList.push(`        /**`);
+        fullList.push(...type.jsdoc.split('\n').map((line) => '          * ' + line));
+        fullList.push(`         */`);
       }
       const optional = jsxAttributes ? !type.required : type.optional;
-      fullList.push(`                "${type.name}"${optional ? '?' : ''}: ${type.type};`);
+      fullList.push(`        "${type.name}"${optional ? '?' : ''}: ${type.type};`);
       return fullList;
     }, [] as string[])
     .join(`\n`);

--- a/src/compiler/types/generate-event-detail-types.ts
+++ b/src/compiler/types/generate-event-detail-types.ts
@@ -22,8 +22,8 @@ export const generateEventDetailTypes = (cmp: d.ComponentCompilerMeta): d.TypesM
   const cmpEventInterface = `${tagNameAsPascal}CustomEvent`;
   const cmpInterface = [
     `export interface ${cmpEventInterface}<T> extends CustomEvent<T> {`,
-    `        detail: T;`,
-    `        target: ${htmlElementName};`,
+    `    detail: T;`,
+    `    target: ${htmlElementName};`,
     `}`,
   ];
   return {

--- a/src/compiler/types/generate-event-listener-types.ts
+++ b/src/compiler/types/generate-event-listener-types.ts
@@ -27,14 +27,14 @@ export const generateEventListenerTypes = (
   return {
     htmlElementEventMap: getHtmlElementEventMap(cmpEvents, typeImportData, cmp.sourceFilePath, htmlElementEventMapName),
     htmlElementEventListenerProperties: [
-      `                addEventListener<K extends keyof ${htmlElementEventMapName}>(type: K, listener: (this: ${htmlElementName}, ev: ${cmpEventInterface}<${htmlElementEventMapName}[K]>) => any, options?: boolean | AddEventListenerOptions): void;`,
-      '                addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
-      '                addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
-      '                addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;',
-      `                removeEventListener<K extends keyof ${htmlElementEventMapName}>(type: K, listener: (this: ${htmlElementName}, ev: ${cmpEventInterface}<${htmlElementEventMapName}[K]>) => any, options?: boolean | EventListenerOptions): void;`,
-      '                removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;',
-      '                removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;',
-      '                removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;',
+      `        addEventListener<K extends keyof ${htmlElementEventMapName}>(type: K, listener: (this: ${htmlElementName}, ev: ${cmpEventInterface}<${htmlElementEventMapName}[K]>) => any, options?: boolean | AddEventListenerOptions): void;`,
+      '        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
+      '        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
+      '        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;',
+      `        removeEventListener<K extends keyof ${htmlElementEventMapName}>(type: K, listener: (this: ${htmlElementName}, ev: ${cmpEventInterface}<${htmlElementEventMapName}[K]>) => any, options?: boolean | EventListenerOptions): void;`,
+      '        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;',
+      '        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;',
+      '        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;',
     ],
   };
 };
@@ -57,9 +57,9 @@ const getHtmlElementEventMap = (
 ): string[] => {
   const eventMapProperties = cmpEvents.map((cmpEvent) => {
     const type = getEventGenericType(cmpEvent, typeImportData, sourceFilePath);
-    return `                "${cmpEvent.name}": ${type};`;
+    return `        "${cmpEvent.name}": ${type};`;
   });
-  return [`        interface ${htmlElementEventMapName} {`, ...eventMapProperties, `        }`];
+  return [`    interface ${htmlElementEventMapName} {`, ...eventMapProperties, `    }`];
 };
 
 /**

--- a/src/compiler/types/tests/generate-app-types.spec.ts
+++ b/src/compiler/types/tests/generate-app-types.spec.ts
@@ -58,43 +58,43 @@ export namespace Components {
     /**
      * docs
      */
-        interface MyComponent {
-        }
+    interface MyComponent {
+    }
 }
 declare global {
     /**
      * docs
      */
-        interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
-        }
-        var HTMLMyComponentElement: {
-                prototype: HTMLMyComponentElement;
-                new (): HTMLMyComponentElement;
-        };
-        interface HTMLElementTagNameMap {
-                "my-component": HTMLMyComponentElement;
-        }
+    interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
+    }
+    var HTMLMyComponentElement: {
+        prototype: HTMLMyComponentElement;
+        new (): HTMLMyComponentElement;
+    };
+    interface HTMLElementTagNameMap {
+        "my-component": HTMLMyComponentElement;
+    }
 }
 declare namespace LocalJSX {
     /**
      * docs
      */
-      interface MyComponent {
-        }
-        interface IntrinsicElements {
-              "my-component": MyComponent;
-        }
+    interface MyComponent {
+    }
+    interface IntrinsicElements {
+        "my-component": MyComponent;
+    }
 }
 export { LocalJSX as JSX };
 declare module "@stencil/core" {
-        export namespace JSX {
-                interface IntrinsicElements {
+    export namespace JSX {
+        interface IntrinsicElements {
             /**
              * docs
              */
-                        "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
-                }
+            "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
         }
+    }
 }
 `,
       {
@@ -130,59 +130,59 @@ export namespace Components {
     /**
      * docs
      */
-        interface MyComponent {
-        }
+    interface MyComponent {
+    }
 }
 export interface MyComponentCustomEvent<T> extends CustomEvent<T> {
-        detail: T;
-        target: HTMLMyComponentElement;
+    detail: T;
+    target: HTMLMyComponentElement;
 }
 declare global {
-        interface HTMLMyComponentElementEventMap {
-                "myEvent": UserImplementedEventType;
-        }
+    interface HTMLMyComponentElementEventMap {
+        "myEvent": UserImplementedEventType;
+    }
     /**
      * docs
      */
-        interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
-                addEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-                removeEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-        }
-        var HTMLMyComponentElement: {
-                prototype: HTMLMyComponentElement;
-                new (): HTMLMyComponentElement;
-        };
-        interface HTMLElementTagNameMap {
-                "my-component": HTMLMyComponentElement;
-        }
+    interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLMyComponentElement: {
+        prototype: HTMLMyComponentElement;
+        new (): HTMLMyComponentElement;
+    };
+    interface HTMLElementTagNameMap {
+        "my-component": HTMLMyComponentElement;
+    }
 }
 declare namespace LocalJSX {
     /**
      * docs
      */
-      interface MyComponent {
-                "onMyEvent"?: (event: MyComponentCustomEvent<UserImplementedEventType>) => void;
-        }
-        interface IntrinsicElements {
-              "my-component": MyComponent;
-        }
+    interface MyComponent {
+        "onMyEvent"?: (event: MyComponentCustomEvent<UserImplementedEventType>) => void;
+    }
+    interface IntrinsicElements {
+        "my-component": MyComponent;
+    }
 }
 export { LocalJSX as JSX };
 declare module "@stencil/core" {
-        export namespace JSX {
-                interface IntrinsicElements {
+    export namespace JSX {
+        interface IntrinsicElements {
             /**
              * docs
              */
-                        "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
-                }
+            "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
         }
+    }
 }
 `,
         {
@@ -234,61 +234,61 @@ export namespace Components {
     /**
      * docs
      */
-        interface MyComponent {
-        }
+    interface MyComponent {
+    }
 }
 export interface MyComponentCustomEvent<T> extends CustomEvent<T> {
-        detail: T;
-        target: HTMLMyComponentElement;
+    detail: T;
+    target: HTMLMyComponentElement;
 }
 declare global {
-        interface HTMLMyComponentElementEventMap {
-                "myEvent": UserImplementedEventType;
-                "mySecondEvent": SecondUserImplementedEventType;
-        }
+    interface HTMLMyComponentElementEventMap {
+        "myEvent": UserImplementedEventType;
+        "mySecondEvent": SecondUserImplementedEventType;
+    }
     /**
      * docs
      */
-        interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
-                addEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-                removeEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-        }
-        var HTMLMyComponentElement: {
-                prototype: HTMLMyComponentElement;
-                new (): HTMLMyComponentElement;
-        };
-        interface HTMLElementTagNameMap {
-                "my-component": HTMLMyComponentElement;
-        }
+    interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLMyComponentElement: {
+        prototype: HTMLMyComponentElement;
+        new (): HTMLMyComponentElement;
+    };
+    interface HTMLElementTagNameMap {
+        "my-component": HTMLMyComponentElement;
+    }
 }
 declare namespace LocalJSX {
     /**
      * docs
      */
-      interface MyComponent {
-                "onMyEvent"?: (event: MyComponentCustomEvent<UserImplementedEventType>) => void;
-                "onMySecondEvent"?: (event: MyComponentCustomEvent<SecondUserImplementedEventType>) => void;
-        }
-        interface IntrinsicElements {
-              "my-component": MyComponent;
-        }
+    interface MyComponent {
+        "onMyEvent"?: (event: MyComponentCustomEvent<UserImplementedEventType>) => void;
+        "onMySecondEvent"?: (event: MyComponentCustomEvent<SecondUserImplementedEventType>) => void;
+    }
+    interface IntrinsicElements {
+        "my-component": MyComponent;
+    }
 }
 export { LocalJSX as JSX };
 declare module "@stencil/core" {
-        export namespace JSX {
-                interface IntrinsicElements {
+    export namespace JSX {
+        interface IntrinsicElements {
             /**
              * docs
              */
-                        "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
-                }
+            "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
         }
+    }
 }
 `,
         {
@@ -360,100 +360,100 @@ export namespace Components {
     /**
      * docs
      */
-        interface MyComponent {
-        }
+    interface MyComponent {
+    }
     /**
      * docs
      */
-        interface MyNewComponent {
-        }
+    interface MyNewComponent {
+    }
 }
 export interface MyComponentCustomEvent<T> extends CustomEvent<T> {
-        detail: T;
-        target: HTMLMyComponentElement;
+    detail: T;
+    target: HTMLMyComponentElement;
 }
 export interface MyNewComponentCustomEvent<T> extends CustomEvent<T> {
-        detail: T;
-        target: HTMLMyNewComponentElement;
+    detail: T;
+    target: HTMLMyNewComponentElement;
 }
 declare global {
-        interface HTMLMyComponentElementEventMap {
-                "myEvent": UserImplementedEventType;
-        }
+    interface HTMLMyComponentElementEventMap {
+        "myEvent": UserImplementedEventType;
+    }
     /**
      * docs
      */
-        interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
-                addEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-                removeEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-        }
-        var HTMLMyComponentElement: {
-                prototype: HTMLMyComponentElement;
-                new (): HTMLMyComponentElement;
-        };
-        interface HTMLMyNewComponentElementEventMap {
-                "myEvent": UserImplementedEventType;
-        }
+    interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLMyComponentElement: {
+        prototype: HTMLMyComponentElement;
+        new (): HTMLMyComponentElement;
+    };
+    interface HTMLMyNewComponentElementEventMap {
+        "myEvent": UserImplementedEventType;
+    }
     /**
      * docs
      */
-        interface HTMLMyNewComponentElement extends Components.MyNewComponent, HTMLStencilElement {
-                addEventListener<K extends keyof HTMLMyNewComponentElementEventMap>(type: K, listener: (this: HTMLMyNewComponentElement, ev: MyNewComponentCustomEvent<HTMLMyNewComponentElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-                removeEventListener<K extends keyof HTMLMyNewComponentElementEventMap>(type: K, listener: (this: HTMLMyNewComponentElement, ev: MyNewComponentCustomEvent<HTMLMyNewComponentElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-        }
-        var HTMLMyNewComponentElement: {
-                prototype: HTMLMyNewComponentElement;
-                new (): HTMLMyNewComponentElement;
-        };
-        interface HTMLElementTagNameMap {
-                "my-component": HTMLMyComponentElement;
-                "my-new-component": HTMLMyNewComponentElement;
-        }
+    interface HTMLMyNewComponentElement extends Components.MyNewComponent, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLMyNewComponentElementEventMap>(type: K, listener: (this: HTMLMyNewComponentElement, ev: MyNewComponentCustomEvent<HTMLMyNewComponentElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLMyNewComponentElementEventMap>(type: K, listener: (this: HTMLMyNewComponentElement, ev: MyNewComponentCustomEvent<HTMLMyNewComponentElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLMyNewComponentElement: {
+        prototype: HTMLMyNewComponentElement;
+        new (): HTMLMyNewComponentElement;
+    };
+    interface HTMLElementTagNameMap {
+        "my-component": HTMLMyComponentElement;
+        "my-new-component": HTMLMyNewComponentElement;
+    }
 }
 declare namespace LocalJSX {
     /**
      * docs
      */
-      interface MyComponent {
-                "onMyEvent"?: (event: MyComponentCustomEvent<UserImplementedEventType>) => void;
-        }
+    interface MyComponent {
+        "onMyEvent"?: (event: MyComponentCustomEvent<UserImplementedEventType>) => void;
+    }
     /**
      * docs
      */
-      interface MyNewComponent {
-                "onMyEvent"?: (event: MyNewComponentCustomEvent<UserImplementedEventType>) => void;
-        }
-        interface IntrinsicElements {
-              "my-component": MyComponent;
-              "my-new-component": MyNewComponent;
-        }
+    interface MyNewComponent {
+        "onMyEvent"?: (event: MyNewComponentCustomEvent<UserImplementedEventType>) => void;
+    }
+    interface IntrinsicElements {
+        "my-component": MyComponent;
+        "my-new-component": MyNewComponent;
+    }
 }
 export { LocalJSX as JSX };
 declare module "@stencil/core" {
-        export namespace JSX {
-                interface IntrinsicElements {
+    export namespace JSX {
+        interface IntrinsicElements {
             /**
              * docs
              */
-                        "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
+            "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
             /**
              * docs
              */
-                        "my-new-component": LocalJSX.MyNewComponent & JSXBase.HTMLAttributes<HTMLMyNewComponentElement>;
-                }
+            "my-new-component": LocalJSX.MyNewComponent & JSXBase.HTMLAttributes<HTMLMyNewComponentElement>;
         }
+    }
 }
 `,
         {
@@ -530,100 +530,100 @@ export namespace Components {
     /**
      * docs
      */
-        interface MyComponent {
-        }
+    interface MyComponent {
+    }
     /**
      * docs
      */
-        interface MyNewComponent {
-        }
+    interface MyNewComponent {
+    }
 }
 export interface MyComponentCustomEvent<T> extends CustomEvent<T> {
-        detail: T;
-        target: HTMLMyComponentElement;
+    detail: T;
+    target: HTMLMyComponentElement;
 }
 export interface MyNewComponentCustomEvent<T> extends CustomEvent<T> {
-        detail: T;
-        target: HTMLMyNewComponentElement;
+    detail: T;
+    target: HTMLMyNewComponentElement;
 }
 declare global {
-        interface HTMLMyComponentElementEventMap {
-                "myEvent": UserImplementedEventType;
-        }
+    interface HTMLMyComponentElementEventMap {
+        "myEvent": UserImplementedEventType;
+    }
     /**
      * docs
      */
-        interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
-                addEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-                removeEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-        }
-        var HTMLMyComponentElement: {
-                prototype: HTMLMyComponentElement;
-                new (): HTMLMyComponentElement;
-        };
-        interface HTMLMyNewComponentElementEventMap {
-                "myEvent": UserImplementedEventType1;
-        }
+    interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLMyComponentElement: {
+        prototype: HTMLMyComponentElement;
+        new (): HTMLMyComponentElement;
+    };
+    interface HTMLMyNewComponentElementEventMap {
+        "myEvent": UserImplementedEventType1;
+    }
     /**
      * docs
      */
-        interface HTMLMyNewComponentElement extends Components.MyNewComponent, HTMLStencilElement {
-                addEventListener<K extends keyof HTMLMyNewComponentElementEventMap>(type: K, listener: (this: HTMLMyNewComponentElement, ev: MyNewComponentCustomEvent<HTMLMyNewComponentElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-                removeEventListener<K extends keyof HTMLMyNewComponentElementEventMap>(type: K, listener: (this: HTMLMyNewComponentElement, ev: MyNewComponentCustomEvent<HTMLMyNewComponentElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-        }
-        var HTMLMyNewComponentElement: {
-                prototype: HTMLMyNewComponentElement;
-                new (): HTMLMyNewComponentElement;
-        };
-        interface HTMLElementTagNameMap {
-                "my-component": HTMLMyComponentElement;
-                "my-new-component": HTMLMyNewComponentElement;
-        }
+    interface HTMLMyNewComponentElement extends Components.MyNewComponent, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLMyNewComponentElementEventMap>(type: K, listener: (this: HTMLMyNewComponentElement, ev: MyNewComponentCustomEvent<HTMLMyNewComponentElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLMyNewComponentElementEventMap>(type: K, listener: (this: HTMLMyNewComponentElement, ev: MyNewComponentCustomEvent<HTMLMyNewComponentElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLMyNewComponentElement: {
+        prototype: HTMLMyNewComponentElement;
+        new (): HTMLMyNewComponentElement;
+    };
+    interface HTMLElementTagNameMap {
+        "my-component": HTMLMyComponentElement;
+        "my-new-component": HTMLMyNewComponentElement;
+    }
 }
 declare namespace LocalJSX {
     /**
      * docs
      */
-      interface MyComponent {
-                "onMyEvent"?: (event: MyComponentCustomEvent<UserImplementedEventType>) => void;
-        }
+    interface MyComponent {
+        "onMyEvent"?: (event: MyComponentCustomEvent<UserImplementedEventType>) => void;
+    }
     /**
      * docs
      */
-      interface MyNewComponent {
-                "onMyEvent"?: (event: MyNewComponentCustomEvent<UserImplementedEventType1>) => void;
-        }
-        interface IntrinsicElements {
-              "my-component": MyComponent;
-              "my-new-component": MyNewComponent;
-        }
+    interface MyNewComponent {
+        "onMyEvent"?: (event: MyNewComponentCustomEvent<UserImplementedEventType1>) => void;
+    }
+    interface IntrinsicElements {
+        "my-component": MyComponent;
+        "my-new-component": MyNewComponent;
+    }
 }
 export { LocalJSX as JSX };
 declare module "@stencil/core" {
-        export namespace JSX {
-                interface IntrinsicElements {
+    export namespace JSX {
+        interface IntrinsicElements {
             /**
              * docs
              */
-                        "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
+            "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
             /**
              * docs
              */
-                        "my-new-component": LocalJSX.MyNewComponent & JSXBase.HTMLAttributes<HTMLMyNewComponentElement>;
-                }
+            "my-new-component": LocalJSX.MyNewComponent & JSXBase.HTMLAttributes<HTMLMyNewComponentElement>;
         }
+    }
 }
 `,
         {
@@ -700,100 +700,100 @@ export namespace Components {
     /**
      * docs
      */
-        interface MyComponent {
-        }
+    interface MyComponent {
+    }
     /**
      * docs
      */
-        interface MyNewComponent {
-        }
+    interface MyNewComponent {
+    }
 }
 export interface MyComponentCustomEvent<T> extends CustomEvent<T> {
-        detail: T;
-        target: HTMLMyComponentElement;
+    detail: T;
+    target: HTMLMyComponentElement;
 }
 export interface MyNewComponentCustomEvent<T> extends CustomEvent<T> {
-        detail: T;
-        target: HTMLMyNewComponentElement;
+    detail: T;
+    target: HTMLMyNewComponentElement;
 }
 declare global {
-        interface HTMLMyComponentElementEventMap {
-                "myEvent": UserImplementedEventType;
-        }
+    interface HTMLMyComponentElementEventMap {
+        "myEvent": UserImplementedEventType;
+    }
     /**
      * docs
      */
-        interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
-                addEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-                removeEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-        }
-        var HTMLMyComponentElement: {
-                prototype: HTMLMyComponentElement;
-                new (): HTMLMyComponentElement;
-        };
-        interface HTMLMyNewComponentElementEventMap {
-                "myEvent": UserImplementedEventType1;
-        }
+    interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLMyComponentElement: {
+        prototype: HTMLMyComponentElement;
+        new (): HTMLMyComponentElement;
+    };
+    interface HTMLMyNewComponentElementEventMap {
+        "myEvent": UserImplementedEventType1;
+    }
     /**
      * docs
      */
-        interface HTMLMyNewComponentElement extends Components.MyNewComponent, HTMLStencilElement {
-                addEventListener<K extends keyof HTMLMyNewComponentElementEventMap>(type: K, listener: (this: HTMLMyNewComponentElement, ev: MyNewComponentCustomEvent<HTMLMyNewComponentElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-                removeEventListener<K extends keyof HTMLMyNewComponentElementEventMap>(type: K, listener: (this: HTMLMyNewComponentElement, ev: MyNewComponentCustomEvent<HTMLMyNewComponentElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-        }
-        var HTMLMyNewComponentElement: {
-                prototype: HTMLMyNewComponentElement;
-                new (): HTMLMyNewComponentElement;
-        };
-        interface HTMLElementTagNameMap {
-                "my-component": HTMLMyComponentElement;
-                "my-new-component": HTMLMyNewComponentElement;
-        }
+    interface HTMLMyNewComponentElement extends Components.MyNewComponent, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLMyNewComponentElementEventMap>(type: K, listener: (this: HTMLMyNewComponentElement, ev: MyNewComponentCustomEvent<HTMLMyNewComponentElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLMyNewComponentElementEventMap>(type: K, listener: (this: HTMLMyNewComponentElement, ev: MyNewComponentCustomEvent<HTMLMyNewComponentElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLMyNewComponentElement: {
+        prototype: HTMLMyNewComponentElement;
+        new (): HTMLMyNewComponentElement;
+    };
+    interface HTMLElementTagNameMap {
+        "my-component": HTMLMyComponentElement;
+        "my-new-component": HTMLMyNewComponentElement;
+    }
 }
 declare namespace LocalJSX {
     /**
      * docs
      */
-      interface MyComponent {
-                "onMyEvent"?: (event: MyComponentCustomEvent<UserImplementedEventType>) => void;
-        }
+    interface MyComponent {
+        "onMyEvent"?: (event: MyComponentCustomEvent<UserImplementedEventType>) => void;
+    }
     /**
      * docs
      */
-      interface MyNewComponent {
-                "onMyEvent"?: (event: MyNewComponentCustomEvent<UserImplementedEventType1>) => void;
-        }
-        interface IntrinsicElements {
-              "my-component": MyComponent;
-              "my-new-component": MyNewComponent;
-        }
+    interface MyNewComponent {
+        "onMyEvent"?: (event: MyNewComponentCustomEvent<UserImplementedEventType1>) => void;
+    }
+    interface IntrinsicElements {
+        "my-component": MyComponent;
+        "my-new-component": MyNewComponent;
+    }
 }
 export { LocalJSX as JSX };
 declare module "@stencil/core" {
-        export namespace JSX {
-                interface IntrinsicElements {
+    export namespace JSX {
+        interface IntrinsicElements {
             /**
              * docs
              */
-                        "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
+            "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
             /**
              * docs
              */
-                        "my-new-component": LocalJSX.MyNewComponent & JSXBase.HTMLAttributes<HTMLMyNewComponentElement>;
-                }
+            "my-new-component": LocalJSX.MyNewComponent & JSXBase.HTMLAttributes<HTMLMyNewComponentElement>;
         }
+    }
 }
 `,
         {
@@ -845,45 +845,45 @@ export namespace Components {
     /**
      * docs
      */
-        interface MyComponent {
-                "name": UserImplementedPropType;
-        }
+    interface MyComponent {
+        "name": UserImplementedPropType;
+    }
 }
 declare global {
     /**
      * docs
      */
-        interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
-        }
-        var HTMLMyComponentElement: {
-                prototype: HTMLMyComponentElement;
-                new (): HTMLMyComponentElement;
-        };
-        interface HTMLElementTagNameMap {
-                "my-component": HTMLMyComponentElement;
-        }
+    interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
+    }
+    var HTMLMyComponentElement: {
+        prototype: HTMLMyComponentElement;
+        new (): HTMLMyComponentElement;
+    };
+    interface HTMLElementTagNameMap {
+        "my-component": HTMLMyComponentElement;
+    }
 }
 declare namespace LocalJSX {
     /**
      * docs
      */
-      interface MyComponent {
-                "name"?: UserImplementedPropType;
-        }
-        interface IntrinsicElements {
-              "my-component": MyComponent;
-        }
+    interface MyComponent {
+        "name"?: UserImplementedPropType;
+    }
+    interface IntrinsicElements {
+        "my-component": MyComponent;
+    }
 }
 export { LocalJSX as JSX };
 declare module "@stencil/core" {
-        export namespace JSX {
-                interface IntrinsicElements {
+    export namespace JSX {
+        interface IntrinsicElements {
             /**
              * docs
              */
-                        "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
-                }
+            "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
         }
+    }
 }
 `,
         {
@@ -947,47 +947,47 @@ export namespace Components {
     /**
      * docs
      */
-        interface MyComponent {
-                "email": SecondUserImplementedPropType;
-                "name": UserImplementedPropType;
-        }
+    interface MyComponent {
+        "email": SecondUserImplementedPropType;
+        "name": UserImplementedPropType;
+    }
 }
 declare global {
     /**
      * docs
      */
-        interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
-        }
-        var HTMLMyComponentElement: {
-                prototype: HTMLMyComponentElement;
-                new (): HTMLMyComponentElement;
-        };
-        interface HTMLElementTagNameMap {
-                "my-component": HTMLMyComponentElement;
-        }
+    interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
+    }
+    var HTMLMyComponentElement: {
+        prototype: HTMLMyComponentElement;
+        new (): HTMLMyComponentElement;
+    };
+    interface HTMLElementTagNameMap {
+        "my-component": HTMLMyComponentElement;
+    }
 }
 declare namespace LocalJSX {
     /**
      * docs
      */
-      interface MyComponent {
-                "email"?: SecondUserImplementedPropType;
-                "name"?: UserImplementedPropType;
-        }
-        interface IntrinsicElements {
-              "my-component": MyComponent;
-        }
+    interface MyComponent {
+        "email"?: SecondUserImplementedPropType;
+        "name"?: UserImplementedPropType;
+    }
+    interface IntrinsicElements {
+        "my-component": MyComponent;
+    }
 }
 export { LocalJSX as JSX };
 declare module "@stencil/core" {
-        export namespace JSX {
-                interface IntrinsicElements {
+    export namespace JSX {
+        interface IntrinsicElements {
             /**
              * docs
              */
-                        "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
-                }
+            "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
         }
+    }
 }
 `,
         {
@@ -1061,72 +1061,72 @@ export namespace Components {
     /**
      * docs
      */
-        interface MyComponent {
-                "name": UserImplementedPropType;
-        }
+    interface MyComponent {
+        "name": UserImplementedPropType;
+    }
     /**
      * docs
      */
-        interface MyNewComponent {
-                "fullName": UserImplementedPropType;
-        }
+    interface MyNewComponent {
+        "fullName": UserImplementedPropType;
+    }
 }
 declare global {
     /**
      * docs
      */
-        interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
-        }
-        var HTMLMyComponentElement: {
-                prototype: HTMLMyComponentElement;
-                new (): HTMLMyComponentElement;
-        };
+    interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
+    }
+    var HTMLMyComponentElement: {
+        prototype: HTMLMyComponentElement;
+        new (): HTMLMyComponentElement;
+    };
     /**
      * docs
      */
-        interface HTMLMyNewComponentElement extends Components.MyNewComponent, HTMLStencilElement {
-        }
-        var HTMLMyNewComponentElement: {
-                prototype: HTMLMyNewComponentElement;
-                new (): HTMLMyNewComponentElement;
-        };
-        interface HTMLElementTagNameMap {
-                "my-component": HTMLMyComponentElement;
-                "my-new-component": HTMLMyNewComponentElement;
-        }
+    interface HTMLMyNewComponentElement extends Components.MyNewComponent, HTMLStencilElement {
+    }
+    var HTMLMyNewComponentElement: {
+        prototype: HTMLMyNewComponentElement;
+        new (): HTMLMyNewComponentElement;
+    };
+    interface HTMLElementTagNameMap {
+        "my-component": HTMLMyComponentElement;
+        "my-new-component": HTMLMyNewComponentElement;
+    }
 }
 declare namespace LocalJSX {
     /**
      * docs
      */
-      interface MyComponent {
-                "name"?: UserImplementedPropType;
-        }
+    interface MyComponent {
+        "name"?: UserImplementedPropType;
+    }
     /**
      * docs
      */
-      interface MyNewComponent {
-                "fullName"?: UserImplementedPropType;
-        }
-        interface IntrinsicElements {
-              "my-component": MyComponent;
-              "my-new-component": MyNewComponent;
-        }
+    interface MyNewComponent {
+        "fullName"?: UserImplementedPropType;
+    }
+    interface IntrinsicElements {
+        "my-component": MyComponent;
+        "my-new-component": MyNewComponent;
+    }
 }
 export { LocalJSX as JSX };
 declare module "@stencil/core" {
-        export namespace JSX {
-                interface IntrinsicElements {
+    export namespace JSX {
+        interface IntrinsicElements {
             /**
              * docs
              */
-                        "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
+            "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
             /**
              * docs
              */
-                        "my-new-component": LocalJSX.MyNewComponent & JSXBase.HTMLAttributes<HTMLMyNewComponentElement>;
-                }
+            "my-new-component": LocalJSX.MyNewComponent & JSXBase.HTMLAttributes<HTMLMyNewComponentElement>;
         }
+    }
 }
 `,
         {
@@ -1205,72 +1205,72 @@ export namespace Components {
     /**
      * docs
      */
-        interface MyComponent {
-                "name": UserImplementedPropType;
-        }
+    interface MyComponent {
+        "name": UserImplementedPropType;
+    }
     /**
      * docs
      */
-        interface MyNewComponent {
-                "newName": UserImplementedPropType1;
-        }
+    interface MyNewComponent {
+        "newName": UserImplementedPropType1;
+    }
 }
 declare global {
     /**
      * docs
      */
-        interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
-        }
-        var HTMLMyComponentElement: {
-                prototype: HTMLMyComponentElement;
-                new (): HTMLMyComponentElement;
-        };
+    interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
+    }
+    var HTMLMyComponentElement: {
+        prototype: HTMLMyComponentElement;
+        new (): HTMLMyComponentElement;
+    };
     /**
      * docs
      */
-        interface HTMLMyNewComponentElement extends Components.MyNewComponent, HTMLStencilElement {
-        }
-        var HTMLMyNewComponentElement: {
-                prototype: HTMLMyNewComponentElement;
-                new (): HTMLMyNewComponentElement;
-        };
-        interface HTMLElementTagNameMap {
-                "my-component": HTMLMyComponentElement;
-                "my-new-component": HTMLMyNewComponentElement;
-        }
+    interface HTMLMyNewComponentElement extends Components.MyNewComponent, HTMLStencilElement {
+    }
+    var HTMLMyNewComponentElement: {
+        prototype: HTMLMyNewComponentElement;
+        new (): HTMLMyNewComponentElement;
+    };
+    interface HTMLElementTagNameMap {
+        "my-component": HTMLMyComponentElement;
+        "my-new-component": HTMLMyNewComponentElement;
+    }
 }
 declare namespace LocalJSX {
     /**
      * docs
      */
-      interface MyComponent {
-                "name"?: UserImplementedPropType;
-        }
+    interface MyComponent {
+        "name"?: UserImplementedPropType;
+    }
     /**
      * docs
      */
-      interface MyNewComponent {
-                "newName"?: UserImplementedPropType1;
-        }
-        interface IntrinsicElements {
-              "my-component": MyComponent;
-              "my-new-component": MyNewComponent;
-        }
+    interface MyNewComponent {
+        "newName"?: UserImplementedPropType1;
+    }
+    interface IntrinsicElements {
+        "my-component": MyComponent;
+        "my-new-component": MyNewComponent;
+    }
 }
 export { LocalJSX as JSX };
 declare module "@stencil/core" {
-        export namespace JSX {
-                interface IntrinsicElements {
+    export namespace JSX {
+        interface IntrinsicElements {
             /**
              * docs
              */
-                        "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
+            "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
             /**
              * docs
              */
-                        "my-new-component": LocalJSX.MyNewComponent & JSXBase.HTMLAttributes<HTMLMyNewComponentElement>;
-                }
+            "my-new-component": LocalJSX.MyNewComponent & JSXBase.HTMLAttributes<HTMLMyNewComponentElement>;
         }
+    }
 }
 `,
         {
@@ -1349,72 +1349,72 @@ export namespace Components {
     /**
      * docs
      */
-        interface MyComponent {
-                "name": UserImplementedPropType;
-        }
+    interface MyComponent {
+        "name": UserImplementedPropType;
+    }
     /**
      * docs
      */
-        interface MyNewComponent {
-                "name": UserImplementedPropType1;
-        }
+    interface MyNewComponent {
+        "name": UserImplementedPropType1;
+    }
 }
 declare global {
     /**
      * docs
      */
-        interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
-        }
-        var HTMLMyComponentElement: {
-                prototype: HTMLMyComponentElement;
-                new (): HTMLMyComponentElement;
-        };
+    interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
+    }
+    var HTMLMyComponentElement: {
+        prototype: HTMLMyComponentElement;
+        new (): HTMLMyComponentElement;
+    };
     /**
      * docs
      */
-        interface HTMLMyNewComponentElement extends Components.MyNewComponent, HTMLStencilElement {
-        }
-        var HTMLMyNewComponentElement: {
-                prototype: HTMLMyNewComponentElement;
-                new (): HTMLMyNewComponentElement;
-        };
-        interface HTMLElementTagNameMap {
-                "my-component": HTMLMyComponentElement;
-                "my-new-component": HTMLMyNewComponentElement;
-        }
+    interface HTMLMyNewComponentElement extends Components.MyNewComponent, HTMLStencilElement {
+    }
+    var HTMLMyNewComponentElement: {
+        prototype: HTMLMyNewComponentElement;
+        new (): HTMLMyNewComponentElement;
+    };
+    interface HTMLElementTagNameMap {
+        "my-component": HTMLMyComponentElement;
+        "my-new-component": HTMLMyNewComponentElement;
+    }
 }
 declare namespace LocalJSX {
     /**
      * docs
      */
-      interface MyComponent {
-                "name"?: UserImplementedPropType;
-        }
+    interface MyComponent {
+        "name"?: UserImplementedPropType;
+    }
     /**
      * docs
      */
-      interface MyNewComponent {
-                "name"?: UserImplementedPropType1;
-        }
-        interface IntrinsicElements {
-              "my-component": MyComponent;
-              "my-new-component": MyNewComponent;
-        }
+    interface MyNewComponent {
+        "name"?: UserImplementedPropType1;
+    }
+    interface IntrinsicElements {
+        "my-component": MyComponent;
+        "my-new-component": MyNewComponent;
+    }
 }
 export { LocalJSX as JSX };
 declare module "@stencil/core" {
-        export namespace JSX {
-                interface IntrinsicElements {
+    export namespace JSX {
+        interface IntrinsicElements {
             /**
              * docs
              */
-                        "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
+            "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
             /**
              * docs
              */
-                        "my-new-component": LocalJSX.MyNewComponent & JSXBase.HTMLAttributes<HTMLMyNewComponentElement>;
-                }
+            "my-new-component": LocalJSX.MyNewComponent & JSXBase.HTMLAttributes<HTMLMyNewComponentElement>;
         }
+    }
 }
 `,
         {
@@ -1470,61 +1470,61 @@ export namespace Components {
     /**
      * docs
      */
-        interface MyComponent {
-                "name": UserImplementedPropType;
-        }
+    interface MyComponent {
+        "name": UserImplementedPropType;
+    }
 }
 export interface MyComponentCustomEvent<T> extends CustomEvent<T> {
-        detail: T;
-        target: HTMLMyComponentElement;
+    detail: T;
+    target: HTMLMyComponentElement;
 }
 declare global {
-        interface HTMLMyComponentElementEventMap {
-                "myEvent": UserImplementedEventType;
-        }
+    interface HTMLMyComponentElementEventMap {
+        "myEvent": UserImplementedEventType;
+    }
     /**
      * docs
      */
-        interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
-                addEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-                addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-                removeEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-                removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-        }
-        var HTMLMyComponentElement: {
-                prototype: HTMLMyComponentElement;
-                new (): HTMLMyComponentElement;
-        };
-        interface HTMLElementTagNameMap {
-                "my-component": HTMLMyComponentElement;
-        }
+    interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLMyComponentElementEventMap>(type: K, listener: (this: HTMLMyComponentElement, ev: MyComponentCustomEvent<HTMLMyComponentElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLMyComponentElement: {
+        prototype: HTMLMyComponentElement;
+        new (): HTMLMyComponentElement;
+    };
+    interface HTMLElementTagNameMap {
+        "my-component": HTMLMyComponentElement;
+    }
 }
 declare namespace LocalJSX {
     /**
      * docs
      */
-      interface MyComponent {
-                "name"?: UserImplementedPropType;
-                "onMyEvent"?: (event: MyComponentCustomEvent<UserImplementedEventType>) => void;
-        }
-        interface IntrinsicElements {
-              "my-component": MyComponent;
-        }
+    interface MyComponent {
+        "name"?: UserImplementedPropType;
+        "onMyEvent"?: (event: MyComponentCustomEvent<UserImplementedEventType>) => void;
+    }
+    interface IntrinsicElements {
+        "my-component": MyComponent;
+    }
 }
 export { LocalJSX as JSX };
 declare module "@stencil/core" {
-        export namespace JSX {
-                interface IntrinsicElements {
+    export namespace JSX {
+        interface IntrinsicElements {
             /**
              * docs
              */
-                        "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
-                }
+            "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
         }
+    }
 }
 `,
       {
@@ -1588,45 +1588,45 @@ export namespace Components {
     /**
      * docs
      */
-        interface MyComponent {
-                "name": UserImplementedPropType;
-        }
+    interface MyComponent {
+        "name": UserImplementedPropType;
+    }
 }
 declare global {
     /**
      * docs
      */
-        interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
-        }
-        var HTMLMyComponentElement: {
-                prototype: HTMLMyComponentElement;
-                new (): HTMLMyComponentElement;
-        };
-        interface HTMLElementTagNameMap {
-                "my-component": HTMLMyComponentElement;
-        }
+    interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
+    }
+    var HTMLMyComponentElement: {
+        prototype: HTMLMyComponentElement;
+        new (): HTMLMyComponentElement;
+    };
+    interface HTMLElementTagNameMap {
+        "my-component": HTMLMyComponentElement;
+    }
 }
 declare namespace LocalJSX {
     /**
      * docs
      */
-      interface MyComponent {
-                "name"?: UserImplementedPropType;
-        }
-        interface IntrinsicElements {
-              "my-component": MyComponent;
-        }
+    interface MyComponent {
+        "name"?: UserImplementedPropType;
+    }
+    interface IntrinsicElements {
+        "my-component": MyComponent;
+    }
 }
 export { LocalJSX as JSX };
 declare module "@stencil/core" {
-        export namespace JSX {
-                interface IntrinsicElements {
+    export namespace JSX {
+        interface IntrinsicElements {
             /**
              * docs
              */
-                        "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
-                }
+            "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
         }
+    }
 }
 `,
       {
@@ -1680,45 +1680,45 @@ export namespace Components {
     /**
      * docs
      */
-        interface MyComponent {
-                "name": UserImplementedPropType;
-        }
+    interface MyComponent {
+        "name": UserImplementedPropType;
+    }
 }
 declare global {
     /**
      * docs
      */
-        interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
-        }
-        var HTMLMyComponentElement: {
-                prototype: HTMLMyComponentElement;
-                new (): HTMLMyComponentElement;
-        };
-        interface HTMLElementTagNameMap {
-                "my-component": HTMLMyComponentElement;
-        }
+    interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
+    }
+    var HTMLMyComponentElement: {
+        prototype: HTMLMyComponentElement;
+        new (): HTMLMyComponentElement;
+    };
+    interface HTMLElementTagNameMap {
+        "my-component": HTMLMyComponentElement;
+    }
 }
 declare namespace LocalJSX {
     /**
      * docs
      */
-      interface MyComponent {
-                "name"?: UserImplementedPropType;
-        }
-        interface IntrinsicElements {
-              "my-component": MyComponent;
-        }
+    interface MyComponent {
+        "name"?: UserImplementedPropType;
+    }
+    interface IntrinsicElements {
+        "my-component": MyComponent;
+    }
 }
 export { LocalJSX as JSX };
 declare module "@stencil/core" {
-        export namespace JSX {
-                interface IntrinsicElements {
+    export namespace JSX {
+        interface IntrinsicElements {
             /**
              * docs
              */
-                        "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
-                }
+            "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
         }
+    }
 }
 `,
       {

--- a/src/compiler/types/tests/generate-event-detail-types.spec.ts
+++ b/src/compiler/types/tests/generate-event-detail-types.spec.ts
@@ -9,8 +9,8 @@ describe('generate-event-detail-types', () => {
       const tagNameAsPascal = 'EventDetailTestTag';
 
       const expectedTypeInfo = `export interface ${tagNameAsPascal}CustomEvent<T> extends CustomEvent<T> {
-        detail: T;
-        target: HTML${tagNameAsPascal}Element;
+    detail: T;
+    target: HTML${tagNameAsPascal}Element;
 }`;
       const componentMeta = stubComponentCompilerMeta({
         tagName,

--- a/src/compiler/types/tests/generate-event-listener-types.spec.ts
+++ b/src/compiler/types/tests/generate-event-listener-types.spec.ts
@@ -47,9 +47,9 @@ describe('generate-event-listener-types', () => {
       });
 
       const expectedHtmlElementEventMap = [
-        '        interface HTMLStubCmpElementEventMap {',
-        '                "myEvent": UserImplementedEventType;',
-        '        }',
+        '    interface HTMLStubCmpElementEventMap {',
+        '        "myEvent": UserImplementedEventType;',
+        '    }',
       ];
 
       const { htmlElementEventMap } = generateEventListenerTypes(componentMeta, stubImportTypes);
@@ -75,9 +75,9 @@ describe('generate-event-listener-types', () => {
       });
 
       const expectedHtmlElementEventMap = [
-        '        interface HTMLStubCmpElementEventMap {',
-        `                "${expectedEventMapKey}": UserImplementedEventType;`,
-        '        }',
+        '    interface HTMLStubCmpElementEventMap {',
+        `        "${expectedEventMapKey}": UserImplementedEventType;`,
+        '    }',
       ];
 
       const { htmlElementEventMap } = generateEventListenerTypes(componentMeta, stubImportTypes);
@@ -92,14 +92,14 @@ describe('generate-event-listener-types', () => {
       });
 
       const expectedHtmlElementEventListenerProperties = [
-        '                addEventListener<K extends keyof HTMLStubCmpElementEventMap>(type: K, listener: (this: HTMLStubCmpElement, ev: StubCmpCustomEvent<HTMLStubCmpElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;',
-        '                addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
-        '                addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
-        '                addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;',
-        '                removeEventListener<K extends keyof HTMLStubCmpElementEventMap>(type: K, listener: (this: HTMLStubCmpElement, ev: StubCmpCustomEvent<HTMLStubCmpElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;',
-        '                removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;',
-        '                removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;',
-        '                removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;',
+        '        addEventListener<K extends keyof HTMLStubCmpElementEventMap>(type: K, listener: (this: HTMLStubCmpElement, ev: StubCmpCustomEvent<HTMLStubCmpElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;',
+        '        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
+        '        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
+        '        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;',
+        '        removeEventListener<K extends keyof HTMLStubCmpElementEventMap>(type: K, listener: (this: HTMLStubCmpElement, ev: StubCmpCustomEvent<HTMLStubCmpElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;',
+        '        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;',
+        '        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;',
+        '        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;',
       ];
 
       const { htmlElementEventListenerProperties } = generateEventListenerTypes(componentMeta, stubImportTypes);
@@ -117,9 +117,9 @@ describe('generate-event-listener-types', () => {
       });
 
       const expectedHtmlElementEventMap = [
-        '        interface HTMLStubCmpElementEventMap {',
-        `                "myEvent": ${updatedTypeName};`,
-        '        }',
+        '    interface HTMLStubCmpElementEventMap {',
+        `        "myEvent": ${updatedTypeName};`,
+        '    }',
       ];
 
       const { htmlElementEventMap } = generateEventListenerTypes(componentMeta, stubImportTypes);
@@ -135,19 +135,19 @@ describe('generate-event-listener-types', () => {
 
       const expectedEventListenerTypes = {
         htmlElementEventMap: [
-          '        interface HTMLStubCmpElementEventMap {',
-          '                "myEvent": UserImplementedEventType;',
-          '        }',
+          '    interface HTMLStubCmpElementEventMap {',
+          '        "myEvent": UserImplementedEventType;',
+          '    }',
         ],
         htmlElementEventListenerProperties: [
-          '                addEventListener<K extends keyof HTMLStubCmpElementEventMap>(type: K, listener: (this: HTMLStubCmpElement, ev: StubCmpCustomEvent<HTMLStubCmpElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;',
-          '                addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
-          '                addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
-          '                addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;',
-          '                removeEventListener<K extends keyof HTMLStubCmpElementEventMap>(type: K, listener: (this: HTMLStubCmpElement, ev: StubCmpCustomEvent<HTMLStubCmpElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;',
-          '                removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;',
-          '                removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;',
-          '                removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;',
+          '        addEventListener<K extends keyof HTMLStubCmpElementEventMap>(type: K, listener: (this: HTMLStubCmpElement, ev: StubCmpCustomEvent<HTMLStubCmpElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;',
+          '        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
+          '        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
+          '        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;',
+          '        removeEventListener<K extends keyof HTMLStubCmpElementEventMap>(type: K, listener: (this: HTMLStubCmpElement, ev: StubCmpCustomEvent<HTMLStubCmpElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;',
+          '        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;',
+          '        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;',
+          '        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;',
         ],
       };
 
@@ -175,20 +175,20 @@ describe('generate-event-listener-types', () => {
 
       const expectedEventListenerTypes = {
         htmlElementEventMap: [
-          '        interface HTMLStubCmpElementEventMap {',
-          '                "myEvent": UserImplementedEventType;',
-          '                "anotherEvent": AnotherUserImplementedEventType;',
-          '        }',
+          '    interface HTMLStubCmpElementEventMap {',
+          '        "myEvent": UserImplementedEventType;',
+          '        "anotherEvent": AnotherUserImplementedEventType;',
+          '    }',
         ],
         htmlElementEventListenerProperties: [
-          '                addEventListener<K extends keyof HTMLStubCmpElementEventMap>(type: K, listener: (this: HTMLStubCmpElement, ev: StubCmpCustomEvent<HTMLStubCmpElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;',
-          '                addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
-          '                addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
-          '                addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;',
-          '                removeEventListener<K extends keyof HTMLStubCmpElementEventMap>(type: K, listener: (this: HTMLStubCmpElement, ev: StubCmpCustomEvent<HTMLStubCmpElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;',
-          '                removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;',
-          '                removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;',
-          '                removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;',
+          '        addEventListener<K extends keyof HTMLStubCmpElementEventMap>(type: K, listener: (this: HTMLStubCmpElement, ev: StubCmpCustomEvent<HTMLStubCmpElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;',
+          '        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
+          '        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
+          '        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;',
+          '        removeEventListener<K extends keyof HTMLStubCmpElementEventMap>(type: K, listener: (this: HTMLStubCmpElement, ev: StubCmpCustomEvent<HTMLStubCmpElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;',
+          '        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;',
+          '        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;',
+          '        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;',
         ],
       };
 
@@ -213,19 +213,19 @@ describe('generate-event-listener-types', () => {
 
       const expectedEventListenerTypes = {
         htmlElementEventMap: [
-          '        interface HTMLStubCmpElementEventMap {',
-          '                "myEvent": UserImplementedEventType;',
-          '        }',
+          '    interface HTMLStubCmpElementEventMap {',
+          '        "myEvent": UserImplementedEventType;',
+          '    }',
         ],
         htmlElementEventListenerProperties: [
-          '                addEventListener<K extends keyof HTMLStubCmpElementEventMap>(type: K, listener: (this: HTMLStubCmpElement, ev: StubCmpCustomEvent<HTMLStubCmpElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;',
-          '                addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
-          '                addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
-          '                addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;',
-          '                removeEventListener<K extends keyof HTMLStubCmpElementEventMap>(type: K, listener: (this: HTMLStubCmpElement, ev: StubCmpCustomEvent<HTMLStubCmpElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;',
-          '                removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;',
-          '                removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;',
-          '                removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;',
+          '        addEventListener<K extends keyof HTMLStubCmpElementEventMap>(type: K, listener: (this: HTMLStubCmpElement, ev: StubCmpCustomEvent<HTMLStubCmpElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;',
+          '        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
+          '        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
+          '        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;',
+          '        removeEventListener<K extends keyof HTMLStubCmpElementEventMap>(type: K, listener: (this: HTMLStubCmpElement, ev: StubCmpCustomEvent<HTMLStubCmpElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;',
+          '        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;',
+          '        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;',
+          '        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;',
         ],
       };
 


### PR DESCRIPTION
This removes a strange bit of code from our `parse5Plugin`, which bundles `parse5` for inclusion in the compiler and mock-doc bundles.

That code is here:

https://github.com/ionic-team/stencil/blob/bb0b1d46f63175dc09d0a23445be4d4a0d891a01/scripts/bundles/plugins/parse5-plugin.ts#L41-L54

Essentially what this does is any place in the bundled code where there are four space characters it convert it into two space characters instead.

This produces the weird behavior where when we're generating files like `components.d.ts` somewhat 'by hand' we have code that looks like this:

https://github.com/ionic-team/stencil/blob/bb0b1d46f63175dc09d0a23445be4d4a0d891a01/src/compiler/types/generate-app-types.ts#L133-L135

One would think that this would produce lines indented by 8 spaces, but actually when this file is written to disk it looks like this:

https://github.com/ionic-team/stencil/blob/ce06708e9666c69c162eb6f100a7d925b3e14344/test/todo-app/src/components.d.ts#L68-L72

In other words it's now indented 4 spaces instead of 8! What!

This is because the template literal is rewritten by the rollup plugin from 8 spaces to four. 

This isn't good! It creates a situation where (contrary to any reasonable explanation) the behavior of Stencil doesn't obviously follow from the source code.

So this changes things to that the re-writing behavior is removed and the source code is adjusted in order to keep the same output as before (so that it has, for the example cited above, 4 spaces in the source code and 4 spaces of indentation in the `components.d.ts` written to disk).

Making this change required edits to a few functions that generate the typedef strings and corresponding edits to a lot of unit tests.

## What is the current behavior?

We have this weird source code / behavior mis-match!

GitHub Issue Number: I started doing this when working on #5027 where this thing was producing different behavior when the compiler is built with rollup or with esbuild.


## What is the new behavior?

Now the indentation for `components.d.ts` comes from the source code and not from a weird build-time confusing things.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

When making the change I first adjusted the indentation in `generate-app-types.ts` and friends until I stopped seeing any changes in the `components.d.ts` files written to disk when running `npm run test.analysis`. Then I adjusted the unit tests to pass with the new code.