### PR TITLE
chore(ci): unpin node minor version

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -16,8 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO(STENCIL-964): Use latest Node minor version (remove '.7' from v20 entry)
-        node: ['16', '18', '20.7']
+        node: ['16', '18', '20']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See 'new behavior'
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

revert the changes from #4900 (9bb1994a). with node 20.8+ unblocked as of #4897 (e1858ea), we no longer need to pin to v20.7.



## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Verified the correct version of Node runs our unit tests (and doesn't fail!)
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

I'll need to change our CI gate checks after this lands
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
STENCIL-964