### PR TITLE
feat(declarations): add popover attributes to JSX declarations

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -901,8 +901,8 @@ export namespace JSXBase {
     value?: string | string[] | number;
 
     // popover
-    popoverTargetAction?: 'hide' | 'show' | 'toggle';
-    popoverTargetElement?: Element;
+    popoverTargetAction?: string;
+    popoverTargetElement?: Element | null;
     popoverTarget?: string;
   }
 
@@ -1081,8 +1081,8 @@ export namespace JSXBase {
     width?: number | string;
 
     // popover
-    popoverTargetAction?: 'hide' | 'show' | 'toggle';
-    popoverTargetElement?: Element;
+    popoverTargetAction?: string;
+    popoverTargetElement?: Element | null;
     popoverTarget?: string;
   }
 
@@ -1374,7 +1374,7 @@ export namespace JSXBase {
     tabIndex?: number;
     tabindex?: number | string;
     title?: string;
-    popover?: 'auto' | 'manual';
+    popover?: string | null;
 
     // Unknown
     inputMode?: string;

--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -899,6 +899,11 @@ export namespace JSXBase {
     name?: string;
     type?: string;
     value?: string | string[] | number;
+
+    // popover
+    popoverTargetAction?: 'hide' | 'show' | 'toggle';
+    popoverTargetElement?: Element;
+    popoverTarget?: string;
   }
 
   export interface CanvasHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -1074,6 +1079,11 @@ export namespace JSXBase {
     webkitdirectory?: boolean;
     webkitEntries?: any;
     width?: number | string;
+
+    // popover
+    popoverTargetAction?: 'hide' | 'show' | 'toggle';
+    popoverTargetElement?: Element;
+    popoverTarget?: string;
   }
 
   export interface KeygenHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -1364,6 +1374,7 @@ export namespace JSXBase {
     tabIndex?: number;
     tabindex?: number | string;
     title?: string;
+    popover?: 'auto' | 'manual';
 
     // Unknown
     inputMode?: string;

--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1374,6 +1374,10 @@ export namespace JSXBase {
     tabIndex?: number;
     tabindex?: number | string;
     title?: string;
+    // These types don't allow you to use popover as a boolean attribute
+    // so you can't write HTML like `<div popover>` and get the default value.
+    // Developer must explicitly specify one of the valid popover values or it will fallback
+    // to `manual` (following the HTML spec).
     popover?: string | null;
 
     // Unknown


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Stencil's JSX declarations do not support `popover` or associated popover attributes

Closes: #4745 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds the `popover` attribute to the base `HTMLAttributes`
- Adds `popoverTargetAction`, `popoverTargetElement`, and `popoverTarget` to the declarations for button and input

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

**Automated testing**

Can't run automated tests because `popover` is not supported in all browsers we run e2e tests against via BrowserStack

**Manual testing**

Installed a build of this branch in a started project and was able to build a demo using popovers and triggers.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

`popover` is not yet supported in all browsers. It will be up to the developer to decide when they can leverage these APIs
