### PR TITLE
chore(ci): install jest dependencies script

### DIFF
--- a/.github/workflows/actions/get-core-dependencies/action.yml
+++ b/.github/workflows/actions/get-core-dependencies/action.yml
@@ -13,5 +13,8 @@ runs:
         cache: 'npm'
 
     - name: Install Dependencies
-      run: npm ci
+      run: |
+        npm ci \
+        && ./src/testing/jest/install-dependencies.sh
+
       shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,8 @@ Please see our [Contributor Code of Conduct](https://github.com/ionic-team/stenc
    [Install it](https://docs.volta.sh/guide/getting-started) before proceeding.
    1. There's no need to install a specific version of npm or Node right now, it shall be done automatically for you in
       the next step
-5. Run `npm install`
+5. Run `npm ci`
+6. (Optional) If you are working on [Jest support](./src/testing/jest), [see the installation steps in that directory's README](./src/testing/jest/README.md#installing-dependencies).
 
 
 ### Updates

--- a/src/testing/jest/README.md
+++ b/src/testing/jest/README.md
@@ -2,6 +2,13 @@
 
 This directory contains support for the Jest testing library.
 
+## Installing Dependencies
+
+To be able to work on the sub-projects in this directory, Jest dependencies are required to be installed explicitly.
+To do so, one may either:
+1. (Recommended) Run the `install-dependencies.sh` script found in this directory to install _all_ Jest dependencies
+1. Run `npm ci` in the Jest version-specific directory you plan on working in
+
 ## Adding Support for a New Version of Jest
 
 The steps for adding support for a new version of Jest can be found below.

--- a/src/testing/jest/install-dependencies.sh
+++ b/src/testing/jest/install-dependencies.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
+# Get the directory where this script is located - doing so will allow us to run the script from anywhere in the
+# project. Since we retrieve the directory this script lives in via a subshell, we'll need to `cd` to in explicitly in
+# a separate command.
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+cd "$SCRIPT_DIR"
+
+# Flag to check if any jest-[SOME_NUMBER] directories were found and processed
+found=false
+
+# Loop through directories start with 'jest-', e.g. `jest-27-and-under`, `jest-28`, etc.
+for dir in jest-*; do
+    if [[ -d "$dir" ]]; then
+        found=true
+
+        cd "$dir"
+        echo "Installing dependencies in $dir"
+        npm ci
+        # print a newline to separate sequential installs
+        echo ""
+
+        # go back to where we started
+        cd -
+    fi
+done
+
+# If no directories were found and processed, print an error and exit
+if [[ $found == false ]]; then
+    echo "Error: No jest directories were found"
+    exit 1
+fi


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

until now, all jest-related types in `src/testing/jest/jest-*` have resolved to stencil's root-level `node_modules/jest*` directories (jest-27) in ci. this hasn't been an issue, as many of the types were effectively typed as `any` (or something nearly equally as wide). as we begin to narrow the typings in `src/testing/jest`, we will need these typings to be available to us (otherwise ci will fail).

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

add a shell script for installing jest-related dependencies for the `src/testing/jest/jest-*` subdirectories. this allows a developer to install all dependencies in one command, rather than chaining N number of directory changes and `npm ci` commands for every N directories.

this script has been wired up to the `get-core-dependencies` github action as well. this ensures that all jest dependencies are available during ci. 

this route was taken over an npm `postinstall` script, as a such a script will run when installing a packed tarball (and fail), breaking the existing `npm pack && npm install` workflow for testing stencil.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

### Verify this script can run anywhere
Start from the root of the repo with this branch checked out and run:
```bash
./src/testing/jest/install-dependencies.sh \
&& cd src \
&& ./testing/jest/install-dependencies.sh \
&& cd ./testing \
&& ./jest/install-dependencies.sh \
&& cd jest \
&& ./install-dependencies.sh
```


### Verify this Runs in CI
From [the logs](https://github.com/ionic-team/stencil/actions/runs/6855129064/job/18639601742?pr=5069)
```
 Installing dependencies in jest-27-and-under
npm WARN deprecated w3c-hr-time@1.0.2: Use your platform's native performance.now() and performance.timeOrigin.

added 342 packages, and audited 343 packages in 2s

30 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

Installing dependencies in jest-28

added 289 packages, and audited 290 packages in 2s

32 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

Installing dependencies in jest-29

added 291 packages, and audited 292 packages in 2s

32 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```
## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

Technically, I didn't add the `strictNullChecks` here. They've always been there, just hidden by the fact that we weren't resolving to the correct versions of Jest.

STENCIL-994 Improve Local Dev Experience for Jest Work