### PR TITLE
fix(mock-doc): add `getAttributeNode` to mock elements

### DIFF
--- a/src/mock-doc/node.ts
+++ b/src/mock-doc/node.ts
@@ -380,6 +380,14 @@ Testing components with ElementInternals is fully supported in e2e tests.`,
     return null;
   }
 
+  getAttributeNode(attrName: string): MockAttr | null {
+    if (!this.hasAttribute(attrName)) {
+      return null;
+    }
+
+    return new MockAttr(attrName, this.getAttribute(attrName));
+  }
+
   getBoundingClientRect() {
     return { bottom: 0, height: 0, left: 0, right: 0, top: 0, width: 0, x: 0, y: 0 };
   }

--- a/src/mock-doc/test/attribute.spec.ts
+++ b/src/mock-doc/test/attribute.spec.ts
@@ -165,6 +165,24 @@ describe('attributes', () => {
     expect(img.draggable).toEqual(false);
   });
 
+  describe('getAttributeNode', () => {
+    it('should return an attribute node if the attribute exists', () => {
+      const div = doc.createElement('div');
+      div.setAttribute('draggable', 'true');
+      expect(div.getAttributeNode('draggable')).toEqual({
+        _name: 'draggable',
+        _namespaceURI: null,
+        _value: 'true',
+      });
+    });
+
+    it('should return `null` if the attribute does not exist', () => {
+      const div = doc.createElement('div');
+      div.setAttribute('draggable', 'true');
+      expect(div.getAttributeNode('test')).toEqual(null);
+    });
+  });
+
   function testNsAttributes(element: MockHTMLElement) {
     element.setAttributeNS('tEst', 'viewBox', '1');
     element.setAttributeNS('tEst', 'viewbox', '2');


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Use of pseudo selectors in Stencil tests can result in errors due to mock elements not having the `getAttributeNode` method used by Sizzle

Closes: #3043, #3588 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Adds a definition for `getAttributeNode` to Mock Doc's `MockElement`

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

**Manual testing**

Verified fix via reproduction case for #3588 

**Automated testing**

Added unit tests to Mock Doc's test suite for the new method

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
