### PR TITLE
fix(mock-doc): add inert to HTMLAttributes

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1358,6 +1358,7 @@ export namespace JSXBase {
     draggable?: boolean;
     hidden?: boolean;
     id?: string;
+    inert?: boolean;
     lang?: string;
     spellcheck?: 'true' | 'false' | any;
     style?: { [key: string]: string | undefined };


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `inert` attribute fails to type check:
![Screenshot 2023-11-14 at 9 10 35 AM](https://github.com/ionic-team/stencil/assets/1930213/0e6c5d4e-8eb4-4a5e-a814-882478317925)


fixes: #5071


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

add `inert` to the `HTMLAttributes` interface. this change only allows the attribute to properly type check in TSX. it does not polyfill the functionality for browsers that do not support `inert`.



## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Check out and build this branch: 
```
npm ci \
&& npm run clean \
&& npm run build \
&& npm pack
```
Install it in the output of creating a new stencil component library:

```bash
cd /tmp \
&& npm init stencil@latest component inert-test \
&& cd $_ \
&& npm i [PATH_TO_STENCIL]
```

Open `src/components/my-component/my-component.tsx` in your editor, and `inert` to a JSX element. It should not properly type check:

![Screenshot 2023-11-14 at 9 12 27 AM](https://github.com/ionic-team/stencil/assets/1930213/1dbb4bde-1b7f-474a-96de-4a4b0cf9c753)


<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
STENCIL-1011 bug: Property 'inert' does not exist on type 'HTMLAttributes<HTMLXElement>'
