### PR TITLE
chore(snc): fix some boolean-related snc errors

### DIFF
--- a/src/cli/task-serve.ts
+++ b/src/cli/task-serve.ts
@@ -6,7 +6,7 @@ export const taskServe = async (config: ValidatedConfig) => {
   config.suppressLogs = true;
 
   config.flags.serve = true;
-  config.devServer.openBrowser = config.flags.open;
+  config.devServer.openBrowser = !!config.flags.open;
   config.devServer.reloadStrategy = null;
   config.devServer.initialLoadUrl = '/';
   config.devServer.websocket = false;

--- a/src/compiler/build/build-stats.ts
+++ b/src/compiler/build/build-stats.ts
@@ -36,11 +36,11 @@ export function generateBuildStats(
           outputs: getAppOutputs(config, buildResults),
         },
         options: {
-          minifyJs: config.minifyJs,
-          minifyCss: config.minifyCss,
-          hashFileNames: config.hashFileNames,
+          minifyJs: !!config.minifyJs,
+          minifyCss: !!config.minifyCss,
+          hashFileNames: !!config.hashFileNames,
           hashedFileNameLength: config.hashedFileNameLength,
-          buildEs5: config.buildEs5,
+          buildEs5: !!config.buildEs5,
         },
         formats: {
           esmBrowser: sanitizeBundlesForStats(buildCtx.esmBrowserComponentBundle),

--- a/src/compiler/bundle/bundle-output.ts
+++ b/src/compiler/bundle/bundle-output.ts
@@ -114,7 +114,7 @@ export const getRollupOptions = (
     },
 
     plugins: [
-      coreResolvePlugin(config, compilerCtx, bundleOpts.platform, bundleOpts.externalRuntime),
+      coreResolvePlugin(config, compilerCtx, bundleOpts.platform, !!bundleOpts.externalRuntime),
       appDataPlugin(config, compilerCtx, buildCtx, bundleOpts.conditionals, bundleOpts.platform),
       lazyComponentPlugin(buildCtx),
       loaderPlugin(bundleOpts.loader),

--- a/src/compiler/optimize/optimize-css.ts
+++ b/src/compiler/optimize/optimize-css.ts
@@ -17,7 +17,7 @@ export const optimizeCss = async (inputOpts: OptimizeCssInput): Promise<Optimize
     diagnostics: [],
   };
   if (inputOpts.autoprefixer !== false && inputOpts.autoprefixer !== null) {
-    result = await autoprefixCss(inputOpts.input, inputOpts.autoprefixer);
+    result = await autoprefixCss(inputOpts.input, inputOpts.autoprefixer ?? null);
     if (hasError(result.diagnostics)) {
       return result;
     }

--- a/src/compiler/optimize/optimize-module.ts
+++ b/src/compiler/optimize/optimize-module.ts
@@ -98,7 +98,7 @@ export const optimizeModule = async (
   }
 
   const shouldTranspile = opts.sourceTarget === 'es5';
-  const results = await compilerCtx.worker.prepareModule(code, minifyOpts, shouldTranspile, opts.inlineHelpers);
+  const results = await compilerCtx.worker.prepareModule(code, minifyOpts, shouldTranspile, !!opts.inlineHelpers);
   if (
     results != null &&
     typeof results.output === 'string' &&

--- a/src/compiler/output-targets/dist-lazy/generate-lazy-module.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-lazy-module.ts
@@ -26,7 +26,7 @@ export const generateLazyModules = async (
   if (!Array.isArray(destinations) || destinations.length === 0) {
     return [];
   }
-  const shouldMinify = config.minifyJs && isBrowserBuild;
+  const shouldMinify = !!(config.minifyJs && isBrowserBuild);
   const rollupResults = results.filter((r): r is d.RollupChunkResult => r.type === 'chunk');
   const entryComponentsResults = rollupResults.filter((rollupResult) => rollupResult.isComponent);
   const chunkResults = rollupResults.filter((rollupResult) => !rollupResult.isComponent && !rollupResult.isEntry);

--- a/src/compiler/output-targets/dist-lazy/generate-system.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-system.ts
@@ -69,7 +69,7 @@ const writeSystemLoader = async (
   if (outputTarget.systemLoaderFile) {
     const entryPointPath = join(outputTarget.systemDir, loaderFilename);
     const relativePath = relativeImport(outputTarget.systemLoaderFile, entryPointPath);
-    const loaderContent = await getSystemLoader(config, compilerCtx, relativePath, outputTarget.polyfills);
+    const loaderContent = await getSystemLoader(config, compilerCtx, relativePath, !!outputTarget.polyfills);
     await compilerCtx.fs.writeFile(outputTarget.systemLoaderFile, loaderContent, {
       outputTargetType: outputTarget.type,
     });

--- a/src/compiler/style/css-to-esm.ts
+++ b/src/compiler/style/css-to-esm.ts
@@ -116,7 +116,7 @@ const transformCssToEsmModule = (input: d.TransformCssToEsmInput): d.TransformCs
     if (isString(input.tag)) {
       if (input.encapsulation === 'scoped' || (input.encapsulation === 'shadow' && input.commentOriginalSelector)) {
         const scopeId = getScopeId(input.tag, input.mode);
-        results.styleText = scopeCss(results.styleText, scopeId, input.commentOriginalSelector);
+        results.styleText = scopeCss(results.styleText, scopeId, !!input.commentOriginalSelector);
       }
     }
 

--- a/src/compiler/transformers/static-to-meta/component.ts
+++ b/src/compiler/transformers/static-to-meta/component.ts
@@ -65,7 +65,7 @@ export const parseStaticComponentMeta = (
     componentClassName: cmpNode.name ? cmpNode.name.text : '',
     elementRef: parseStaticElementRef(staticMembers),
     encapsulation,
-    shadowDelegatesFocus: parseStaticShadowDelegatesFocus(encapsulation, staticMembers),
+    shadowDelegatesFocus: !!parseStaticShadowDelegatesFocus(encapsulation, staticMembers),
     properties: parseStaticProps(staticMembers),
     virtualProperties: parseVirtualProps(docs),
     states: parseStaticStates(staticMembers),

--- a/src/compiler/transformers/test/parse-encapsulation.spec.ts
+++ b/src/compiler/transformers/test/parse-encapsulation.spec.ts
@@ -67,7 +67,7 @@ describe('parse encapsulation', () => {
 
     expect(getStaticGetter(t.outputText, 'encapsulation')).toEqual('scoped');
     expect(t.cmp.encapsulation).toBe('scoped');
-    expect(t.cmp.shadowDelegatesFocus).toBe(null);
+    expect(t.cmp.shadowDelegatesFocus).toBe(false);
   });
 
   it('no encapsulation', () => {
@@ -80,6 +80,6 @@ describe('parse encapsulation', () => {
 
     expect(t.outputText).not.toContain(`static get encapsulation()`);
     expect(t.cmp.encapsulation).toBe('none');
-    expect(t.cmp.shadowDelegatesFocus).toBe(null);
+    expect(t.cmp.shadowDelegatesFocus).toBe(false);
   });
 });

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -825,8 +825,15 @@ export const serializeDocsSymbol = (checker: ts.TypeChecker, symbol: ts.Symbol) 
   }
 };
 
-export const isInternal = (jsDocs: d.CompilerJsDoc | undefined) => {
-  return jsDocs && jsDocs.tags.some((s) => s.name === 'internal');
+/**
+ * Given the JSDoc for a given bit of code, determine whether or not it is
+ * marked 'internal'
+ *
+ * @param jsDocs the JSDoc to examine
+ * @returns whether the JSDoc is marked 'internal' or not
+ */
+export const isInternal = (jsDocs: d.CompilerJsDoc | undefined): boolean => {
+  return !!(jsDocs && jsDocs.tags.some((s) => s.name === 'internal'));
 };
 
 export const isMethod = (member: ts.ClassElement, methodName: string): member is ts.MethodDeclaration => {

--- a/src/sys/node/logger/terminal-logger.ts
+++ b/src/sys/node/logger/terminal-logger.ts
@@ -210,7 +210,7 @@ export const createTerminalLogger = (loggerSys: TerminalLoggerSys): Logger => {
           }
         }
 
-        timespanFinish(finishMsg, time, colorName, textBold, newLineSuffix, debug, appendTo);
+        timespanFinish(finishMsg, time, colorName, !!textBold, !!newLineSuffix, debug, appendTo);
 
         return dur;
       },


### PR DESCRIPTION
This fixes a bunch of errors caused by passing `boolean | undefined` where a property or parameter is actually typed `boolean`. This isn't likely to actually cause too many issues at runtime since `undefined` is falsy, but it does cause `strictNullChecks` errors that we'd like to get rid of.

To fix the issues we can just do a `!!` coercion of the falsy `undefined` value to `false`.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
