### PR TITLE
chore(repo): add package.json jest install script

### DIFF
--- a/.github/workflows/actions/get-core-dependencies/action.yml
+++ b/.github/workflows/actions/get-core-dependencies/action.yml
@@ -15,6 +15,6 @@ runs:
     - name: Install Dependencies
       run: |
         npm ci \
-        && ./src/testing/jest/install-dependencies.sh
+        && npm run install.jest
 
       shell: bash

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "clean": "rm -rf build/ cli/ compiler/ dev-server/ internal/ mock-doc/ sys/ testing/ && npm run clean-scripts",
     "clean-scripts": "rm -rf scripts/build",
     "lint": "eslint 'bin/*' 'scripts/*.ts' 'scripts/**/*.ts' 'src/*.ts' 'src/**/*.ts' 'src/**/*.tsx'",
+    "install.jest": "bash ./src/testing/jest/install-dependencies.sh",
     "prettier": "npm run prettier.base -- --write",
     "prettier.base": "prettier --cache \"./({bin,scripts,src,test}/**/*.{ts,tsx,js,jsx})|bin/stencil|.github/(**/)?*.(yml|yaml)|*.js\"",
     "prettier.dry-run": "npm run prettier.base -- --list-different",

--- a/src/testing/jest/README.md
+++ b/src/testing/jest/README.md
@@ -6,7 +6,8 @@ This directory contains support for the Jest testing library.
 
 To be able to work on the sub-projects in this directory, Jest dependencies are required to be installed explicitly.
 To do so, one may either:
-1. (Recommended) Run the `install-dependencies.sh` script found in this directory to install _all_ Jest dependencies
+1. (Recommended) Run `npm run install.jest` from the root of the repository to install _all_ Jest dependencies
+1. Run the `install-dependencies.sh` script found in this directory to install _all_ Jest dependencies
 1. Run `npm ci` in the Jest version-specific directory you plan on working in
 
 ## Adding Support for a New Version of Jest


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Knowing where the shell script for jest scripts shouldn't necessarily be on one's mind when trying to develop for Stencil + Jest

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

add an `install.jest` script to `package.json` to make it easier to install jest dependencies within the project. the motivator for this change is the following suggestion in a pull request that was a child PR of the one that implemented this functionality - https://github.com/ionic-team/stencil/pull/5068#pullrequestreview-1732217554

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

### Manual testing

I was able to run `npm run install.jest` locally 

### CI

I tailed the logs and found the command still runs:
```Run npm ci \
  npm ci \
  && npm run install.jest
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}

added 947 packages, and audited 948 packages in 11s

131 packages are looking for funding
  run `npm fund` for details

1 moderate severity vulnerability

To address all issues, run:
  npm audit fix

Run `npm audit` for details.

> @stencil/core@4.7.2 install.jest
> bash ./src/testing/jest/install-dependencies.sh

Installing dependencies in jest-27-and-under
npm WARN deprecated w3c-hr-time@1.0.2: Use your platform's native performance.now() and performance.timeOrigin.

added 342 packages, and audited 343 packages in 2s

30 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

/home/runner/work/stencil/stencil/src/testing/jest
Installing dependencies in jest-28

added 289 packages, and audited 290 packages in 2s

32 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

/home/runner/work/stencil/stencil/src/testing/jest
Installing dependencies in jest-29

added 291 packages, and audited 292 packages in 2s

32 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

/home/runner/work/stencil/stencil/src/testing/jest
```

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
