### PR TITLE
refactor(test): resolve typing import issues

### DIFF
--- a/src/testing/jest/jest-apis.ts
+++ b/src/testing/jest/jest-apis.ts
@@ -14,6 +14,7 @@
 
 import type { TransformedSource } from '@jest/transform';
 import type { Config } from '@jest/types';
+import * as d from '@stencil/core/internal';
 import { getVersion } from 'jest';
 
 // TODO(STENCIL-959): Improve this typing by narrowing it
@@ -37,6 +38,30 @@ export type JestTestRunner = {
  * Helper type for describing a function that returns a {@link JestTestRunner}.
  */
 export type JestTestRunnerConstructor = new (...args: any[]) => JestTestRunner;
+
+/**
+ * This type serves as an alias for a function that invokes the Jest CLI.
+ *
+ * This alias serves two purposes:
+ * 1. It allows Stencil to have a single source of truth for the return type(s) on {@link JestFacade} (and its
+ *    implementations)
+ * 2. It prevents TypeScript from expanding Stencil type declarations in the generated `.d.ts` file. This is necessary
+ *    as TypeScript will make assumptions about where it can dynamically resolve Stencil typings from, which are not
+ *    always necessarily true when `tsconfig#paths` are used.
+ */
+export type JestCliRunner = (config: d.ValidatedConfig, e2eEnv: d.E2EProcessEnv) => Promise<boolean>;
+
+/**
+ * This type serves as an alias for a function that invokes Stencil's Screenshot runner.
+ *
+ * This alias serves two purposes:
+ * 1. It allows Stencil to have a single source of truth for the return type(s) on {@link JestFacade} (and its
+ *    implementations)
+ * 2. It prevents TypeScript from expanding Stencil type declarations in the generated `.d.ts` file. This is necessary
+ *    as TypeScript will make assumptions about where it can dynamically resolve Stencil typings from, which are not
+ *   always necessarily true when `tsconfig#paths` are used.
+ */
+export type JestScreenshotRunner = (config: d.ValidatedConfig, e2eEnv: d.E2EProcessEnv) => Promise<boolean>;
 
 /**
  * This type serves as an alias for the type representing the initial configuration for Jest.

--- a/src/testing/jest/jest-facade.ts
+++ b/src/testing/jest/jest-facade.ts
@@ -1,4 +1,11 @@
-import { JestPreprocessor, JestPresetConfig, JestPuppeteerEnvironment, JestTestRunnerConstructor } from './jest-apis';
+import {
+  JestCliRunner,
+  JestPreprocessor,
+  JestPresetConfig,
+  JestPuppeteerEnvironment,
+  JestScreenshotRunner,
+  JestTestRunnerConstructor,
+} from './jest-apis';
 
 /**
  * Interface for Jest-version specific code implementations that interact with Stencil.
@@ -7,7 +14,6 @@ import { JestPreprocessor, JestPresetConfig, JestPuppeteerEnvironment, JestTestR
  * directory Stencil supports.
  */
 export interface JestFacade {
-  // TODO(STENCIL-961): Fix build validation when types are pulled in from `@stencil/core/declarations`
   /**
    * Retrieve a function that invokes the Jest CLI.
    *
@@ -16,9 +22,8 @@ export interface JestFacade {
    *
    * @returns A function that invokes the Jest CLI.
    */
-  getJestCliRunner(): (config: any, e2eEnv: any) => Promise<boolean>;
+  getJestCliRunner(): JestCliRunner;
 
-  // TODO(STENCIL-961): Fix build validation when types are pulled in from `@stencil/core/declarations`
   /**
    * Retrieve a function that invokes Stencil's Screenshot runner.
    *
@@ -27,7 +32,7 @@ export interface JestFacade {
    *
    * @returns A function that invokes the Screenshot runner.
    */
-  getRunJestScreenshot(): (config: any, e2eEnv: any) => Promise<boolean>;
+  getRunJestScreenshot(): JestScreenshotRunner;
 
   /**
    * Retrieve the default Jest runner name prescribed by Stencil.

--- a/src/testing/jest/jest-stencil-connector.ts
+++ b/src/testing/jest/jest-stencil-connector.ts
@@ -12,7 +12,7 @@ import semverMajor from 'semver/functions/major';
 import { Jest27Stencil } from './jest-27-and-under/jest-facade';
 import { Jest28Stencil } from './jest-28/jest-facade';
 import { Jest29Stencil } from './jest-29/jest-facade';
-import { getJestMajorVersion, JestPresetConfig } from './jest-apis';
+import { getJestMajorVersion, JestCliRunner, JestPresetConfig, JestScreenshotRunner } from './jest-apis';
 import { JestFacade } from './jest-facade';
 
 /**
@@ -69,7 +69,7 @@ export const getDefaultJestRunner = (): string => {
  *
  * @returns a test runner for Stencil tests, based on the version of Jest that's detected
  */
-export const getRunner = () => {
+export const getRunner = (): JestCliRunner => {
   return getJestFacade().getJestCliRunner();
 };
 
@@ -78,7 +78,7 @@ export const getRunner = () => {
  *
  * @returns a screenshot facade implementation for Stencil tests, based on the version of Jest that's detected
  */
-export const getScreenshot = () => {
+export const getScreenshot = (): JestScreenshotRunner => {
   return getJestFacade().getRunJestScreenshot();
 };
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We have a handful of types in our `jest/` submodule that use `any` due to some issues with reconciling Stencil declarations.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

resolves an issue where adding typings from `@stencil/core/internal` were causing failures of the build validation step in CI (`npm run test.dist`). this had caused argument types for a handful of functions to be typed as `any` as opposed to known types provided by stencil.

previous to this change, naively adding types to use stencil declarations in `./src/testing/jest/jest-facade.ts` would cause the following error when running the build validation step against a build of stencil:
```
> node scripts/build --validate-build

🐡  Validated packages
Error: 🧨  testing/jest/jest-stencil-connector.d.ts(29,55): error TS2307: Cannot find module '../../declarations' or its corresponding type declarations.
testing/jest/jest-stencil-connector.d.ts(29,109): error TS2307: Cannot find module '../../declarations' or its corresponding type declarations.
```

with this change, we can safely type `jest-facade.ts` and have a uniform type used throughout the directory/jest supporting submodules.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

First, build the project with this branch:
```
./src/testing/jest/install-dependencies.sh && npm ci && npm run clean && npm run build && npm pack
```

Then, verify the build validation works: `npm run test.dist`.

Then install it in the output of creating a new stencil component library:

```bash
cd /tmp \
&& npm init stencil@latest component jest-test \
&& cd $_ \
&& npm i [PATH_TO_STENCIL]
```
Run tests for all versions of Jest:
```
npm i jest@24 jest-cli@24 @types/jest@24 && npm t -- --no-cache && \
npm i jest@25 jest-cli@25 @types/jest@25 && npm t -- --no-cache && \
npm i jest@26 jest-cli@26 @types/jest@26 && npm t -- --no-cache && \
npm i jest@27 jest-cli@27 @types/jest@27 && npm t -- --no-cache && \
npm i jest@28 jest-cli@28 @types/jest@28 && npm t -- --no-cache && \
npm i jest@29 jest-cli@29 @types/jest@29 && npm t -- --no-cache
```

## Other information
STENCIL-961: Fix type resolutions from declarations

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
