### PR TITLE
chore(build): build the dev-server module with esbuild

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5638,6 +5638,24 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
+    "node_modules/esbuild-plugin-replace": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esbuild-plugin-replace/-/esbuild-plugin-replace-1.4.0.tgz",
+      "integrity": "sha512-lP3ZAyzyRa5JXoOd59lJbRKNObtK8pJ/RO7o6vdjwLi71GfbL32NR22ZuS7/cLZkr10/L1lutoLma8E4DLngYg==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.25.7"
+      }
+    },
+    "node_modules/esbuild-plugin-replace/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -15779,6 +15797,26 @@
         "@esbuild/win32-arm64": "0.19.8",
         "@esbuild/win32-ia32": "0.19.8",
         "@esbuild/win32-x64": "0.19.8"
+      }
+    },
+    "esbuild-plugin-replace": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esbuild-plugin-replace/-/esbuild-plugin-replace-1.4.0.tgz",
+      "integrity": "sha512-lP3ZAyzyRa5JXoOd59lJbRKNObtK8pJ/RO7o6vdjwLi71GfbL32NR22ZuS7/cLZkr10/L1lutoLma8E4DLngYg==",
+      "dev": true,
+      "requires": {
+        "magic-string": "^0.25.7"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.25.9",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+          "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.8"
+          }
+        }
       }
     },
     "esbuild-plugin-replace": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5638,24 +5638,6 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
-    "node_modules/esbuild-plugin-replace": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esbuild-plugin-replace/-/esbuild-plugin-replace-1.4.0.tgz",
-      "integrity": "sha512-lP3ZAyzyRa5JXoOd59lJbRKNObtK8pJ/RO7o6vdjwLi71GfbL32NR22ZuS7/cLZkr10/L1lutoLma8E4DLngYg==",
-      "dev": true,
-      "dependencies": {
-        "magic-string": "^0.25.7"
-      }
-    },
-    "node_modules/esbuild-plugin-replace/node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dev": true,
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -15797,26 +15779,6 @@
         "@esbuild/win32-arm64": "0.19.8",
         "@esbuild/win32-ia32": "0.19.8",
         "@esbuild/win32-x64": "0.19.8"
-      }
-    },
-    "esbuild-plugin-replace": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esbuild-plugin-replace/-/esbuild-plugin-replace-1.4.0.tgz",
-      "integrity": "sha512-lP3ZAyzyRa5JXoOd59lJbRKNObtK8pJ/RO7o6vdjwLi71GfbL32NR22ZuS7/cLZkr10/L1lutoLma8E4DLngYg==",
-      "dev": true,
-      "requires": {
-        "magic-string": "^0.25.7"
-      },
-      "dependencies": {
-        "magic-string": {
-          "version": "0.25.9",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-          "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-          "dev": true,
-          "requires": {
-            "sourcemap-codec": "^1.4.8"
-          }
-        }
       }
     },
     "esbuild-plugin-replace": {

--- a/scripts/bundles/plugins/content-types-plugin.ts
+++ b/scripts/bundles/plugins/content-types-plugin.ts
@@ -22,7 +22,7 @@ export function contentTypesPlugin(opts: BuildOptions): Plugin {
   };
 }
 
-async function createContentTypeData(opts: BuildOptions) {
+export async function createContentTypeData(opts: BuildOptions) {
   // create a focused content-type lookup object from
   // the mime db json file
   const mimeDbSrcPath = join(opts.nodeModulesDir, 'mime-db', 'db.json');

--- a/scripts/bundles/sys-node.ts
+++ b/scripts/bundles/sys-node.ts
@@ -95,8 +95,9 @@ export async function sysNode(opts: BuildOptions) {
   return [sysNodeBundle, sysNodeWorkerBundle];
 }
 
+export const sysNodeBundleCacheDir = 'sys-node-bundle-cache';
 export async function sysNodeExternalBundles(opts: BuildOptions) {
-  const cachedDir = join(opts.scriptsBuildDir, 'sys-node-bundle-cache');
+  const cachedDir = join(opts.scriptsBuildDir, sysNodeBundleCacheDir);
 
   await fs.ensureDir(cachedDir);
 
@@ -106,22 +107,25 @@ export async function sysNodeExternalBundles(opts: BuildOptions) {
     bundleExternal(opts, opts.output.sysNodeDir, cachedDir, 'graceful-fs.js'),
     bundleExternal(opts, opts.output.sysNodeDir, cachedDir, 'node-fetch.js'),
     bundleExternal(opts, opts.output.sysNodeDir, cachedDir, 'prompts.js'),
+    // TODO(STENCIL-1052): remove next two entries once Rollup -> esbuild migration is complete
     bundleExternal(opts, opts.output.devServerDir, cachedDir, 'open-in-editor-api.js'),
     bundleExternal(opts, opts.output.devServerDir, cachedDir, 'ws.js'),
   ]);
 
   // open-in-editor's visualstudio.vbs file
+  // TODO(STENCIL-1052): remove once Rollup -> esbuild migration is complete
   const visualstudioVbsSrc = join(opts.nodeModulesDir, 'open-in-editor', 'lib', 'editors', 'visualstudio.vbs');
   const visualstudioVbsDesc = join(opts.output.devServerDir, 'visualstudio.vbs');
   await fs.copy(visualstudioVbsSrc, visualstudioVbsDesc);
 
   // copy open's xdg-open file
+  // TODO(STENCIL-1052): remove once Rollup -> esbuild migration is complete
   const xdgOpenSrcPath = join(opts.nodeModulesDir, 'open', 'xdg-open');
   const xdgOpenDestPath = join(opts.output.devServerDir, 'xdg-open');
   await fs.copy(xdgOpenSrcPath, xdgOpenDestPath);
 }
 
-function bundleExternal(opts: BuildOptions, outputDir: string, cachedDir: string, entryFileName: string) {
+export function bundleExternal(opts: BuildOptions, outputDir: string, cachedDir: string, entryFileName: string) {
   return new Promise<void>(async (resolveBundle, rejectBundle) => {
     const outputFile = join(outputDir, entryFileName);
     const cachedFile = join(cachedDir, entryFileName) + (opts.isProd ? '.min.js' : '');

--- a/scripts/esbuild/build.ts
+++ b/scripts/esbuild/build.ts
@@ -1,6 +1,7 @@
 import { getOptions } from '../utils/options';
 import { buildCli } from './cli';
 import { buildCompiler } from './compiler';
+import { buildDevServer } from './dev-server';
 import { buildMockDoc } from './mock-doc';
 import { buildScreenshot } from './screenshot';
 import { buildSysNode } from './sys-node';
@@ -16,6 +17,7 @@ async function main() {
   await Promise.all([
     buildCli(opts),
     buildCompiler(opts),
+    buildDevServer(opts),
     buildMockDoc(opts),
     buildScreenshot(opts),
     buildSysNode(opts),

--- a/scripts/esbuild/dev-server.ts
+++ b/scripts/esbuild/dev-server.ts
@@ -1,0 +1,305 @@
+import { builtinModules } from 'node:module';
+import { join } from 'node:path';
+
+import type { BuildOptions as ESBuildOptions, Plugin } from 'esbuild';
+import { replace } from 'esbuild-plugin-replace';
+import fs from 'fs-extra';
+import ts from 'typescript';
+
+import { createContentTypeData } from '../bundles/plugins/content-types-plugin';
+import { bundleExternal, sysNodeBundleCacheDir } from '../bundles/sys-node';
+import { getBanner } from '../utils/banner';
+import { type BuildOptions, createReplaceData } from '../utils/options';
+import { writePkgJson } from '../utils/write-pkg-json';
+import { getBaseEsbuildOptions, getEsbuildAliases, runBuilds } from './util';
+
+const CONNECTOR_NAME = 'connector.html';
+
+/**
+ * Runs esbuild to bundle the `dev-server` submodule
+ *
+ * @param opts build options
+ * @returns a promise for this bundle's build output
+ */
+export async function buildDevServer(opts: BuildOptions) {
+  // create dir of not existing already
+  await fs.ensureDir(opts.output.devServerDir);
+  // clear out rollup stuff
+  await fs.emptyDir(opts.output.devServerDir);
+
+  const inputDir = join(opts.buildDir, 'dev-server');
+
+  // create public d.ts
+  let dts = await fs.readFile(join(opts.buildDir, 'dev-server', 'index.d.ts'), 'utf8');
+  dts = dts.replace('../declarations', '../internal/index');
+  await fs.writeFile(join(opts.output.devServerDir, 'index.d.ts'), dts);
+
+  // write package.json
+  writePkgJson(opts, opts.output.devServerDir, {
+    name: '@stencil/core/dev-server',
+    description: 'Stencil Development Server which communicates with the Stencil Compiler.',
+    main: 'index.js',
+    types: 'index.d.ts',
+  });
+
+  // copy static files
+  await fs.copy(join(opts.srcDir, 'dev-server', 'static'), join(opts.output.devServerDir, 'static'));
+
+  // copy server-worker-thread.js
+  await fs.copy(
+    join(opts.srcDir, 'dev-server', 'server-worker-thread.js'),
+    join(opts.output.devServerDir, 'server-worker-thread.js'),
+  );
+
+  // copy template files
+  await fs.copy(join(opts.srcDir, 'dev-server', 'templates'), join(opts.output.devServerDir, 'templates'));
+
+  // open-in-editor's visualstudio.vbs file
+  const visualstudioVbsSrc = join(opts.nodeModulesDir, 'open-in-editor', 'lib', 'editors', 'visualstudio.vbs');
+  const visualstudioVbsDesc = join(opts.output.devServerDir, 'visualstudio.vbs');
+  await fs.copy(visualstudioVbsSrc, visualstudioVbsDesc);
+
+  // copy open's xdg-open file
+  const xdgOpenSrcPath = join(opts.nodeModulesDir, 'open', 'xdg-open');
+  const xdgOpenDestPath = join(opts.output.devServerDir, 'xdg-open');
+  await fs.copy(xdgOpenSrcPath, xdgOpenDestPath);
+
+  const cachedDir = join(opts.scriptsBuildDir, sysNodeBundleCacheDir);
+  await Promise.all([
+    bundleExternal(opts, opts.output.devServerDir, cachedDir, 'ws.js'),
+    bundleExternal(opts, opts.output.devServerDir, cachedDir, 'open-in-editor-api.js'),
+  ]);
+
+  const devServerAliases = getEsbuildAliases();
+  const external = [...builtinModules, './ws.js', './open-in-editor-api'];
+
+  const devServerIndexEsbuildOptions = {
+    ...getBaseEsbuildOptions(),
+    alias: devServerAliases,
+    entryPoints: [join(inputDir, 'index.js')],
+    outfile: join(opts.output.devServerDir, 'index.js'),
+    external: ['@dev-server-process', ...external],
+    format: 'cjs',
+    platform: 'node',
+    write: false,
+    plugins: [serverProcessAliasPlugin(), replace(createReplaceData(opts))],
+    banner: {
+      js: getBanner(opts, `Stencil Dev Server`, true),
+    },
+  } satisfies ESBuildOptions;
+
+  const devServerProcessEsbuildOptions = {
+    ...getBaseEsbuildOptions(),
+    alias: {
+      ...devServerAliases,
+      '@sys-api-node': '../sys/node/index.js',
+    },
+    entryPoints: [join(inputDir, 'server-process.js')],
+    outfile: join(opts.output.devServerDir, 'server-process.js'),
+    external: [...external, '../sys/node/index.js'],
+    format: 'cjs',
+    platform: 'node',
+    write: false,
+    plugins: [esm2CJSPlugin(), contentTypesPlugin(opts), replace(createReplaceData(opts))],
+    banner: {
+      js: getBanner(opts, `Stencil Dev Server Process`, true),
+    },
+  } satisfies ESBuildOptions;
+
+  const connectorAlias = {
+    '@stencil/core/dev-server/client': join(inputDir, 'client', 'index.js'),
+  };
+  const connectorEsbuildOptions = {
+    ...getBaseEsbuildOptions(),
+    alias: connectorAlias,
+    entryPoints: [join(inputDir, 'dev-server-client', 'index.js')],
+    outfile: join(opts.output.devServerDir, CONNECTOR_NAME),
+    format: 'cjs',
+    platform: 'node',
+    write: false,
+    plugins: [appErrorCssPlugin(opts), clientConnectorPlugin(opts), replace(createReplaceData(opts))],
+  } satisfies ESBuildOptions;
+
+  await fs.ensureDir(join(opts.output.devServerDir, 'client'));
+  // copy dev server client dts files
+  await fs.copy(join(opts.buildDir, 'dev-server', 'client'), join(opts.output.devServerDir, 'client'), {
+    filter: (src) => {
+      if (src.endsWith('.d.ts')) {
+        return true;
+      }
+      const stats = fs.statSync(src);
+      if (stats.isDirectory()) {
+        return true;
+      }
+      return false;
+    },
+  });
+
+  // write package.json
+  writePkgJson(opts, join(opts.output.devServerDir, 'client'), {
+    name: '@stencil/core/dev-server/client',
+    description: 'Stencil Dev Server Client.',
+    main: 'index.js',
+    types: 'index.d.ts',
+  });
+
+  const devServerClientEsbuildOptions = {
+    ...getBaseEsbuildOptions(),
+    entryPoints: [join(opts.buildDir, 'dev-server', 'client', 'index.js')],
+    outfile: join(opts.output.devServerDir, 'client', 'index.js'),
+    format: 'esm',
+    platform: 'node',
+    sourcemap: false,
+    plugins: [appErrorCssPlugin(opts), replace(createReplaceData(opts))],
+    banner: {
+      js: getBanner(opts, `Stencil Dev Server Client`, true),
+    },
+  } satisfies ESBuildOptions;
+
+  return runBuilds(
+    [
+      devServerIndexEsbuildOptions,
+      devServerProcessEsbuildOptions,
+      connectorEsbuildOptions,
+      devServerClientEsbuildOptions,
+    ],
+    opts,
+  );
+}
+
+/**
+ * Load CSS files and export them as a string
+ * @param opts build options
+ * @returns an esbuild plugin
+ */
+function appErrorCssPlugin(opts: BuildOptions): Plugin {
+  return {
+    name: 'appErrorCss',
+    setup(build) {
+      build.onResolve({ filter: /app-error\.css$/ }, () => ({
+        path: join(opts.srcDir, 'dev-server', 'client', 'app-error.css'),
+      }));
+      build.onLoad({ filter: /app-error\.css$/ }, async (args) => {
+        const code = await fs.readFile(args.path, 'utf8');
+        const css = code.replace(/\n/g, ' ').trim();
+        const minified = css.replace(/  /g, ' ');
+        return { contents: `export default ${JSON.stringify(minified)};` };
+      });
+    },
+  };
+}
+
+/**
+ * Transform connector client script into a HTML file
+ * @param opts build options
+ * @returns an esbuild plugin
+ */
+function clientConnectorPlugin(opts: BuildOptions): Plugin {
+  return {
+    name: 'clientConnectorPlugin',
+    setup(build) {
+      build.onEnd(async (buildResult) => {
+        const bundle = buildResult.outputFiles.find((b) => b.path.endsWith(CONNECTOR_NAME));
+        let code = Buffer.from(bundle.contents).toString();
+
+        const tsResults = ts.transpileModule(code, {
+          compilerOptions: {
+            target: ts.ScriptTarget.ES5,
+          },
+        });
+
+        if (tsResults.diagnostics.length > 0) {
+          throw new Error(tsResults.diagnostics as any);
+        }
+
+        code = tsResults.outputText;
+        code = intro + code + outro;
+
+        if (opts.isProd) {
+          const { minify } = await import('terser');
+          const minifyResults = await minify(code, {
+            compress: { hoist_vars: true, hoist_funs: true, ecma: 5 },
+            format: { ecma: 5 },
+          });
+          code = minifyResults.code;
+        }
+
+        code = banner + code + footer;
+        code = code.replace(/__VERSION:STENCIL__/g, opts.version);
+        return fs.writeFile(bundle.path, code);
+      });
+    },
+  };
+}
+
+/**
+ * esbuild plugin to support alias of dynamic import. Transforming a path within a dynamic import
+ * does not seem to be supported yet.
+ * @see https://github.com/evanw/esbuild/issues/700
+ * @returns an esbuild plugin
+ */
+function serverProcessAliasPlugin(): Plugin {
+  return {
+    name: 'serverProcessAlias',
+    setup(build) {
+      build.onEnd(async (buildResult) => {
+        const bundle = buildResult.outputFiles[0];
+        let code = Buffer.from(bundle.contents).toString();
+        code = code.replace('await import("@dev-server-process")', '(await import("./server-process.js")).default');
+        return fs.writeFile(bundle.path, code);
+      });
+    },
+  };
+}
+
+/**
+ * The `open` NPM package is build as ESM module and uses ESM runtime features like `import.meta.url`.
+ * This plugin transforms this into CJS compliant code.
+ * @returns an esbuild plugin
+ */
+function esm2CJSPlugin(): Plugin {
+  return {
+    name: 'esm2CJS',
+    setup(build) {
+      build.onEnd(async (buildResult) => {
+        const bundle = buildResult.outputFiles[0];
+        let code = Buffer.from(bundle.contents).toString();
+        code = code.replace('import_meta.url', 'new (require("url").URL)("file:" + __filename).href');
+        return fs.writeFile(bundle.path, code);
+      });
+    },
+  };
+}
+
+/**
+ * Populates the `content-types-db.json` file with the content types of the `mime-db` package.
+ * @param opts build options
+ * @returns an esbuild plugin
+ */
+function contentTypesPlugin(opts) {
+  return {
+    name: 'contentTypesPlugin',
+    setup(build) {
+      build.onLoad({ filter: /content-types-db\.json$/ }, async () => {
+        const contents = await createContentTypeData(opts);
+        return { contents };
+      });
+    },
+  };
+}
+
+const banner = `<!doctype html><html><head><meta charset="utf-8"><title>Stencil Dev Server Connector __VERSION:STENCIL__ &#9889</title><style>body{background:black;color:white;font:18px monospace;text-align:center}</style></head><body>
+
+Stencil Dev Server Connector __VERSION:STENCIL__ &#9889;
+
+<script>`;
+
+const intro = `(function(iframeWindow, appWindow, config, exports) {
+"use strict";
+`;
+
+const outro = `
+})(window, window.parent, window.__DEV_CLIENT_CONFIG__, {});
+`;
+
+const footer = `\n</script></body></html>`;

--- a/scripts/esbuild/util.ts
+++ b/scripts/esbuild/util.ts
@@ -31,6 +31,9 @@ export function getEsbuildAliases(): Record<string, string> {
     prompts: './sys/node/prompts.js',
     glob: './sys/node/glob.js',
     'graceful-fs': './sys/node/graceful-fs.js',
+
+    // dev server related aliases
+    ws: './ws.js',
   };
 }
 

--- a/src/dev-server/server-web-socket.ts
+++ b/src/dev-server/server-web-socket.ts
@@ -1,6 +1,6 @@
 import { noop } from '@utils';
 import type { Server } from 'http';
-import * as ws from 'ws';
+import ws from 'ws';
 
 import type * as d from '../declarations';
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?

This patch adds an esbuild step for compiling the `dev-server` package. Some note worthy comments:

- I've found some required build steps, e.g. for creating `open-in-editor-api.js`, `ws.js`, `visualstudio.vbs` and `xdg-open` in sys-node bundle and migrated them over. They only seem to be connected to `dev-server` features.
- because of that I moved the `buildSysNode` step as pre-requisite of other the CLI and dev-server build scripts as I discovered race conditions (e.g. `@sys-api-node` -> `./sys/node/index.js` not being able to get resolved by `dev-server.js`
- there were some esbuild plugins necessary to transpile the source code in a similar way as we have done with rollup, rollup was a bit better compiling down from ESM to CJS

GitHub Issue Number: N/A

## What is the new behavior?

- The dev server works the same way, just gets compiled by esbuild than rollup.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

There are already some tests in place verifying that files are created successfully. I will do some further manual testing tomorrow.

## Other information

n/a
