### PR TITLE
chore(esbuild): port screenshot bundle to esbuild

### DIFF
--- a/scripts/esbuild/build.ts
+++ b/scripts/esbuild/build.ts
@@ -1,5 +1,6 @@
 import { getOptions } from '../utils/options';
 import { buildCli } from './cli';
+import { buildScreenshot } from './screenshot';
 import { buildSysNode } from './sys-node';
 
 // the main entry point for the Esbuild-based build
@@ -10,7 +11,7 @@ async function main() {
     isWatch: !!process.argv.includes('--watch'),
   });
 
-  await Promise.all([buildCli(opts), buildSysNode(opts)]);
+  await Promise.all([buildCli(opts), buildSysNode(opts), buildScreenshot(opts)]);
 }
 
 main();

--- a/scripts/esbuild/screenshot.ts
+++ b/scripts/esbuild/screenshot.ts
@@ -1,0 +1,67 @@
+import type { BuildOptions as ESBuildOptions } from 'esbuild';
+import fs from 'fs-extra';
+import { join } from 'path';
+
+import { getBanner } from '../utils/banner';
+import { BuildOptions } from '../utils/options';
+import { writePkgJson } from '../utils/write-pkg-json';
+import { getBaseEsbuildOptions, getEsbuildAliases, getEsbuildExternalModules, runBuilds } from './util';
+
+export async function buildScreenshot(opts: BuildOptions) {
+  const inputScreenshotDir = join(opts.buildDir, 'screenshot');
+  const inputScreenshotSrcDir = join(opts.srcDir, 'screenshot');
+
+  // copy @stencil/core/screenshot/index.d.ts
+  await fs.copy(inputScreenshotDir, opts.output.screenshotDir, {
+    filter: (f) => {
+      if (f.endsWith('.d.ts')) {
+        return true;
+      }
+      try {
+        return fs.statSync(f).isDirectory();
+      } catch (e) {}
+      return false;
+    },
+  });
+
+  // write @stencil/core/screenshot/package.json
+  writePkgJson(opts, opts.output.screenshotDir, {
+    description: 'Stencil Screenshot.',
+    files: ['compare/', 'index.js', 'connector.js', 'local-connector.js', 'pixel-match.js'],
+    main: 'index.js',
+    name: '@stencil/core/screenshot',
+    types: 'index.d.ts',
+  });
+
+  const aliases = getEsbuildAliases();
+
+  const external = getEsbuildExternalModules(opts, opts.output.screenshotDir);
+
+  const baseScreenshotOptions = {
+    ...getBaseEsbuildOptions(),
+    alias: aliases,
+    external,
+    format: 'cjs',
+    platform: 'node',
+  } satisfies ESBuildOptions;
+
+  const screenshotEsbuildOptions = {
+    ...baseScreenshotOptions,
+    banner: {
+      js: getBanner(opts, 'Stencil Screenshot'),
+    },
+    entryPoints: [join(inputScreenshotSrcDir, 'index.ts')],
+    outfile: join(opts.output.screenshotDir, 'index.js'),
+  } satisfies ESBuildOptions;
+
+  const pixelmatchEsbuildOptions = {
+    ...baseScreenshotOptions,
+    banner: {
+      js: getBanner(opts, 'Stencil Screenshot Pixel Match'),
+    },
+    entryPoints: [join(inputScreenshotSrcDir, 'index.ts')],
+    outfile: join(opts.output.screenshotDir, 'pixel-match.js'),
+  } satisfies ESBuildOptions;
+
+  return runBuilds([screenshotEsbuildOptions, pixelmatchEsbuildOptions], opts);
+}


### PR DESCRIPTION
This adds a new, Esbuild-based build script which handles the built
files for `screenshot/`.


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I will fully admit to not really knowing what I'm doing with the screenshot functionality! _However_ what I did to confirm that this is at least working was:

- I started a new example project (`npm init stencil@latest...`) and installed `@stencil/core@latest` in it
- I then followed the steps here to add a basic screenshot test to my project: https://stenciljs.com/docs/screenshot-visual-diff
- then I built and packed this branch locally:

  ```sh
  npm run clean && npm run build.esbuild && npm pack
  ```
- I then installed that in the project and confirmed that the screenshot test passed

and it looks like everything is working - if anyone has more expertise with how this works please let me know how I can better test it!

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
