### PR TITLE
refactor(test): narrow jest/puppeteer environment

### DIFF
--- a/scripts/bundles/testing.ts
+++ b/scripts/bundles/testing.ts
@@ -43,6 +43,7 @@ export async function testing(opts: BuildOptions) {
     'jest',
     'expect',
     '@jest/reporters',
+    'jest-environment-node',
     'jest-message-id',
     'jest-runner',
     'net',

--- a/src/testing/jest/jest-28/jest-environment.ts
+++ b/src/testing/jest/jest-28/jest-environment.ts
@@ -1,11 +1,14 @@
 import type { Circus } from '@jest/types';
 import type { E2EProcessEnv, JestEnvironmentGlobal } from '@stencil/core/internal';
+import { TestEnvironment as NodeEnvironment } from 'jest-environment-node';
 
 import { connectBrowser, disconnectBrowser, newBrowserPage } from '../../puppeteer/puppeteer-browser';
+import { JestPuppeteerEnvironmentConstructor } from '../jest-apis';
 
-export function createJestPuppeteerEnvironment() {
-  const NodeEnvironment = require('jest-environment-node').TestEnvironment;
+export function createJestPuppeteerEnvironment(): JestPuppeteerEnvironmentConstructor {
   const JestEnvironment = class extends NodeEnvironment {
+    // TODO(STENCIL-1023): Remove this @ts-expect-error
+    // @ts-expect-error - Stencil's Jest environment adds additional properties to the Jest global, but does not extend it
     global: JestEnvironmentGlobal;
     browser: any = null;
     pages: any[] = [];
@@ -16,7 +19,7 @@ export function createJestPuppeteerEnvironment() {
       this.testPath = context.testPath;
     }
 
-    async setup() {
+    override async setup() {
       if ((process.env as E2EProcessEnv).__STENCIL_E2E_TESTS__ === 'true') {
         this.global.__NEW_TEST_PAGE__ = this.newPuppeteerPage.bind(this);
         this.global.__CLOSE_OPEN_PAGES__ = this.closeOpenPages.bind(this);
@@ -82,14 +85,14 @@ export function createJestPuppeteerEnvironment() {
       this.pages.length = 0;
     }
 
-    async teardown() {
+    override async teardown() {
       await super.teardown();
       await this.closeOpenPages();
       await disconnectBrowser(this.browser);
       this.browser = null;
     }
 
-    getVmContext() {
+    override getVmContext() {
       return super.getVmContext();
     }
   };

--- a/src/testing/jest/jest-29/jest-environment.ts
+++ b/src/testing/jest/jest-29/jest-environment.ts
@@ -1,11 +1,14 @@
 import type { Circus } from '@jest/types';
 import type { E2EProcessEnv, JestEnvironmentGlobal } from '@stencil/core/internal';
+import { TestEnvironment as NodeEnvironment } from 'jest-environment-node';
 
 import { connectBrowser, disconnectBrowser, newBrowserPage } from '../../puppeteer/puppeteer-browser';
+import { JestPuppeteerEnvironmentConstructor } from '../jest-apis';
 
-export function createJestPuppeteerEnvironment() {
-  const NodeEnvironment = require('jest-environment-node').TestEnvironment;
+export function createJestPuppeteerEnvironment(): JestPuppeteerEnvironmentConstructor {
   const JestEnvironment = class extends NodeEnvironment {
+    // TODO(STENCIL-1023): Remove this @ts-expect-error
+    // @ts-expect-error - Stencil's Jest environment adds additional properties to the Jest global, but does not extend it
     global: JestEnvironmentGlobal;
     browser: any = null;
     pages: any[] = [];
@@ -16,7 +19,7 @@ export function createJestPuppeteerEnvironment() {
       this.testPath = context.testPath;
     }
 
-    async setup() {
+    override async setup() {
       if ((process.env as E2EProcessEnv).__STENCIL_E2E_TESTS__ === 'true') {
         this.global.__NEW_TEST_PAGE__ = this.newPuppeteerPage.bind(this);
         this.global.__CLOSE_OPEN_PAGES__ = this.closeOpenPages.bind(this);
@@ -82,14 +85,14 @@ export function createJestPuppeteerEnvironment() {
       this.pages.length = 0;
     }
 
-    async teardown() {
+    override async teardown() {
       await super.teardown();
       await this.closeOpenPages();
       await disconnectBrowser(this.browser);
       this.browser = null;
     }
 
-    getVmContext() {
+    override getVmContext() {
       return super.getVmContext();
     }
   };

--- a/src/testing/jest/jest-apis.ts
+++ b/src/testing/jest/jest-apis.ts
@@ -17,8 +17,22 @@ import type { Config } from '@jest/types';
 import * as d from '@stencil/core/internal';
 import { getVersion } from 'jest';
 
-// TODO(STENCIL-959): Improve this typing by narrowing it
-export type JestPuppeteerEnvironment = any;
+/**
+ * For Stencil's purposes, an instance of a Jest/Puppeteer environment only needs to have a handful of functions.
+ * This does not mean that Jest does not require additional functions on an environment. However, those requirements may
+ * change from version-to-version of Jest. Stencil overrides the functions below, and with our current design of
+ * integrating with Jest, require them to be overridden.
+ */
+export type JestPuppeteerEnvironment = {
+  setup(): Promise<void>;
+  teardown(): Promise<void>;
+  getVmContext(): any | null;
+};
+
+/**
+ * Helper type for describing a function that returns a {@link JestPuppeteerEnvironment}.
+ */
+export type JestPuppeteerEnvironmentConstructor = new (...args: any[]) => JestPuppeteerEnvironment;
 
 export type JestPreprocessor = {
   process(sourceText: string, sourcePath: string, ...args: any[]): string | TransformedSource;

--- a/src/testing/jest/jest-facade.ts
+++ b/src/testing/jest/jest-facade.ts
@@ -2,7 +2,7 @@ import {
   JestCliRunner,
   JestPreprocessor,
   JestPresetConfig,
-  JestPuppeteerEnvironment,
+  JestPuppeteerEnvironmentConstructor,
   JestScreenshotRunner,
   JestTestRunnerConstructor,
 } from './jest-apis';
@@ -48,7 +48,7 @@ export interface JestFacade {
    *
    * @returns A function that builds an E2E testing environment.
    */
-  getCreateJestPuppeteerEnvironment(): () => JestPuppeteerEnvironment;
+  getCreateJestPuppeteerEnvironment(): () => JestPuppeteerEnvironmentConstructor;
 
   /**
    * Create an object used to transform files as a part of running Jest.


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?

We use `any` as a result of our work to implement Jest 29 support. This removes that `any`
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

narrow the type used for jest/puppeteer environments from `any` by introducing new types that accurately reflect the objects that are returned by all underlying `JestFacade` implementations.

a dynamic import that was previously used in  each `JestEnvironment` was hoisted/removed in favor of a build-time import of the class. this led to stronger typing within the anonymous class returned from the retrieval function itself.

by removing the dynamic import within the `jest-environment.ts` implementations for each respective version of jest, stencil's bundler would not resolve the node environment properly, causing userland tests to fail. jest's `jest-environment-node` module was already being dynamically imported, and was deemed to externalize in stencil's testing bundle.



## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
First, build the project with this branch:
```
./src/testing/jest/install-dependencies.sh && npm ci && npm run clean && npm run build && npm pack
```

Then install it in the output of creating a new stencil component library:

```bash
cd /tmp \
&& npm init stencil@latest component jest-test \
&& cd $_ \
&& npm i [PATH_TO_STENCIL]
```
Run tests for all versions of Jest:
```
npm i jest@24 jest-cli@24 @types/jest@24 && npm t -- --no-cache && \
npm i jest@25 jest-cli@25 @types/jest@25 && npm t -- --no-cache && \
npm i jest@26 jest-cli@26 @types/jest@26 && npm t -- --no-cache && \
npm i jest@27 jest-cli@27 @types/jest@27 && npm t -- --no-cache && \
npm i jest@28 jest-cli@28 @types/jest@28 && npm t -- --no-cache && \
npm i jest@29 jest-cli@29 @types/jest@29 && npm t -- --no-cache
```
## Other information
STENCIL-959 Narrow JestPuppeteerEnvironment type
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
