### PR TITLE
fix(compiler): support multiple styleUrls in components

### DIFF
--- a/src/compiler/transformers/add-static-style.ts
+++ b/src/compiler/transformers/add-static-style.ts
@@ -163,7 +163,7 @@ const createStyleLiteral = (cmp: d.ComponentCompilerMeta, style: d.StyleCompiler
  * @param externalStyles a list of external styles to be applied the component
  * @returns an assignment expression to be applied to the `style` property of a component class (e.g. `_myComponentCssStyle + _myComponentIosCssStyle` based on the example)
  */
-const createStyleIdentifierFromUrl = (externalStyles: d.ExternalStyleCompiler[]): ts.Identifier | ts.BinaryExpression => {
+export const createStyleIdentifierFromUrl = (externalStyles: d.ExternalStyleCompiler[]): ts.Identifier | ts.BinaryExpression => {
   if (externalStyles.length === 1) {
     return ts.factory.createIdentifier(getIdentifierFromResourceUrl(externalStyles[0].absolutePath))
   }

--- a/src/compiler/transformers/add-static-style.ts
+++ b/src/compiler/transformers/add-static-style.ts
@@ -1,10 +1,10 @@
-import { dashToPascalCase, DEFAULT_STYLE_MODE } from '@utils';
+import { DEFAULT_STYLE_MODE } from '@utils';
 import ts from 'typescript';
 
 import type * as d from '../../declarations';
 import { scopeCss } from '../../utils/shadow-css';
 import { getScopeId } from '../style/scope-css';
-import { createStaticGetter } from './transform-utils';
+import { createStaticGetter, getIdentifierFromResourceUrl } from './transform-utils';
 
 /**
  * Adds static "style" getter within the class
@@ -91,7 +91,7 @@ const getMultipleModeStyle = (
       // import generated from @Component() styleUrls option
       // import myTagIosStyle from './import-path.css';
       // static get style() { return { ios: myTagIosStyle }; }
-      const styleUrlIdentifier = createStyleIdentifierFromUrl(cmp, style);
+      const styleUrlIdentifier = createStyleIdentifierFromUrl(style.externalStyles);
       const propUrlIdentifier = ts.factory.createPropertyAssignment(style.modeName, styleUrlIdentifier);
       styleModes.push(propUrlIdentifier);
     }
@@ -118,7 +118,7 @@ const getSingleStyle = (cmp: d.ComponentCompilerMeta, style: d.StyleCompiler, co
     // import generated from @Component() styleUrls option
     // import myTagStyle from './import-path.css';
     // static get style() { return myTagStyle; }
-    return createStyleIdentifierFromUrl(cmp, style);
+    return createStyleIdentifierFromUrl(style.externalStyles);
   }
 
   return null;
@@ -134,16 +134,44 @@ const createStyleLiteral = (cmp: d.ComponentCompilerMeta, style: d.StyleCompiler
   return ts.factory.createStringLiteral(style.styleStr);
 };
 
-const createStyleIdentifierFromUrl = (cmp: d.ComponentCompilerMeta, style: d.StyleCompiler) => {
-  style.styleIdentifier = dashToPascalCase(cmp.tagName);
-  style.styleIdentifier = style.styleIdentifier.charAt(0).toLowerCase() + style.styleIdentifier.substring(1);
-
-  if (style.modeName !== DEFAULT_STYLE_MODE) {
-    style.styleIdentifier += dashToPascalCase(style.modeName);
+/**
+ * Creates an expression to be assigned to the `style` property of a component class. For example
+ * given the following component:
+ *
+ * ```ts
+ * @Component({
+ *  styleUrls: ['my-component.css', 'my-component.ios.css']
+ * })
+ * export class MyComponent {
+ *   // ...
+ * }
+ * ```
+ *
+ * it would generate the following expression:
+ *
+ * ```ts
+ * import _myComponentCssStyle from './my-component.css';
+ * import _myComponentIosCssStyle from './my-component.ios.css';
+ * export class MyComponent {
+ *   // ...
+ * }
+ * MyComponent.style = _myComponentCssStyle + _myComponentIosCssStyle;
+ * ```
+ *
+ * Note: style imports are made in [`createEsmStyleImport`](src/compiler/transformers/style-imports.ts).
+ *
+ * @param externalStyles a list of external styles to be applied the component
+ * @returns an assignment expression to be applied to the `style` property of a component class (e.g. `_myComponentCssStyle + _myComponentIosCssStyle` based on the example)
+ */
+const createStyleIdentifierFromUrl = (externalStyles: d.ExternalStyleCompiler[]): ts.Identifier | ts.BinaryExpression => {
+  if (externalStyles.length === 1) {
+    return ts.factory.createIdentifier(getIdentifierFromResourceUrl(externalStyles[0].absolutePath))
   }
 
-  style.styleIdentifier += 'Style';
-  style.externalStyles = [style.externalStyles[0]];
-
-  return ts.factory.createIdentifier(style.styleIdentifier);
+  const firstExternalStyle = externalStyles[0];
+  return ts.factory.createBinaryExpression(
+    createStyleIdentifierFromUrl([firstExternalStyle]),
+    ts.SyntaxKind.PlusToken,
+    createStyleIdentifierFromUrl(externalStyles.slice(1)),
+  )
 };

--- a/src/compiler/transformers/add-static-style.ts
+++ b/src/compiler/transformers/add-static-style.ts
@@ -163,9 +163,11 @@ const createStyleLiteral = (cmp: d.ComponentCompilerMeta, style: d.StyleCompiler
  * @param externalStyles a list of external styles to be applied the component
  * @returns an assignment expression to be applied to the `style` property of a component class (e.g. `_myComponentCssStyle + _myComponentIosCssStyle` based on the example)
  */
-export const createStyleIdentifierFromUrl = (externalStyles: d.ExternalStyleCompiler[]): ts.Identifier | ts.BinaryExpression => {
+export const createStyleIdentifierFromUrl = (
+  externalStyles: d.ExternalStyleCompiler[],
+): ts.Identifier | ts.BinaryExpression => {
   if (externalStyles.length === 1) {
-    return ts.factory.createIdentifier(getIdentifierFromResourceUrl(externalStyles[0].absolutePath))
+    return ts.factory.createIdentifier(getIdentifierFromResourceUrl(externalStyles[0].absolutePath));
   }
 
   const firstExternalStyle = externalStyles[0];
@@ -173,5 +175,5 @@ export const createStyleIdentifierFromUrl = (externalStyles: d.ExternalStyleComp
     createStyleIdentifierFromUrl([firstExternalStyle]),
     ts.SyntaxKind.PlusToken,
     createStyleIdentifierFromUrl(externalStyles.slice(1)),
-  )
+  );
 };

--- a/src/compiler/transformers/component-native/native-static-style.ts
+++ b/src/compiler/transformers/component-native/native-static-style.ts
@@ -1,9 +1,10 @@
-import { dashToPascalCase, DEFAULT_STYLE_MODE } from '@utils';
+import { DEFAULT_STYLE_MODE } from '@utils';
 import ts from 'typescript';
 
 import type * as d from '../../../declarations';
 import { scopeCss } from '../../../utils/shadow-css';
 import { getScopeId } from '../../style/scope-css';
+import { createStyleIdentifierFromUrl } from '../add-static-style';
 import { createStaticGetter } from '../transform-utils';
 
 export const addNativeStaticStyle = (classMembers: ts.ClassElement[], cmp: d.ComponentCompilerMeta) => {
@@ -43,7 +44,7 @@ const addMultipleModeStyleGetter = (
       // import generated from @Component() styleUrls option
       // import myTagIosStyle from './import-path.css';
       // static get style() { return { "ios": myTagIosStyle }; }
-      const styleUrlIdentifier = createStyleIdentifierFromUrl(cmp, style);
+      const styleUrlIdentifier = createStyleIdentifierFromUrl(style.externalStyles);
       const propUrlIdentifier = ts.factory.createPropertyAssignment(style.modeName, styleUrlIdentifier);
       styleModes.push(propUrlIdentifier);
     }
@@ -74,7 +75,7 @@ const addSingleStyleGetter = (
     // import generated from @Component() styleUrls option
     // import myTagStyle from './import-path.css';
     // static get style() { return myTagStyle; }
-    const styleUrlIdentifier = createStyleIdentifierFromUrl(cmp, style);
+    const styleUrlIdentifier = createStyleIdentifierFromUrl(style.externalStyles);
     classMembers.push(createStaticGetter('style', styleUrlIdentifier));
   }
 };
@@ -87,18 +88,4 @@ const createStyleLiteral = (cmp: d.ComponentCompilerMeta, style: d.StyleCompiler
   }
 
   return ts.factory.createStringLiteral(style.styleStr);
-};
-
-const createStyleIdentifierFromUrl = (cmp: d.ComponentCompilerMeta, style: d.StyleCompiler) => {
-  style.styleIdentifier = dashToPascalCase(cmp.tagName);
-  style.styleIdentifier = style.styleIdentifier.charAt(0).toLowerCase() + style.styleIdentifier.substring(1);
-
-  if (style.modeName !== DEFAULT_STYLE_MODE) {
-    style.styleIdentifier += dashToPascalCase(style.modeName);
-  }
-
-  style.styleIdentifier += 'Style';
-  style.externalStyles = [style.externalStyles[0]];
-
-  return ts.factory.createIdentifier(style.styleIdentifier);
 };

--- a/src/compiler/transformers/stencil-import-path.ts
+++ b/src/compiler/transformers/stencil-import-path.ts
@@ -18,7 +18,11 @@ import type { ImportData, ParsedImport, SerializeImportData } from '../../declar
  * @param moduleSystem the module system we compile to
  * @returns a formatted string
  */
-export const serializeImportPath = (data: SerializeImportData, styleImportData: string | undefined | null, moduleSystem?: 'esm' | 'cjs'): string => {
+export const serializeImportPath = (
+  data: SerializeImportData,
+  styleImportData: string | undefined | null,
+  moduleSystem?: 'esm' | 'cjs',
+): string => {
   let p = data.importeePath;
 
   if (isString(p)) {

--- a/src/compiler/transformers/stencil-import-path.ts
+++ b/src/compiler/transformers/stencil-import-path.ts
@@ -15,9 +15,10 @@ import type { ImportData, ParsedImport, SerializeImportData } from '../../declar
  * @param data import data to be serialized
  * @param styleImportData an argument which controls whether the import data
  * will be added to the path (formatted as query params)
+ * @param moduleSystem the module system we compile to
  * @returns a formatted string
  */
-export const serializeImportPath = (data: SerializeImportData, styleImportData: string | undefined | null): string => {
+export const serializeImportPath = (data: SerializeImportData, styleImportData: string | undefined | null, moduleSystem?: 'esm' | 'cjs'): string => {
   let p = data.importeePath;
 
   if (isString(p)) {
@@ -28,7 +29,7 @@ export const serializeImportPath = (data: SerializeImportData, styleImportData: 
       p = './' + p;
     }
 
-    if (styleImportData === 'queryparams' || styleImportData === undefined) {
+    if (moduleSystem !== 'cjs' && (styleImportData === 'queryparams' || styleImportData === undefined)) {
       const paramData: ImportData = {};
       if (isString(data.tag)) {
         paramData.tag = data.tag;

--- a/src/compiler/transformers/style-imports.ts
+++ b/src/compiler/transformers/style-imports.ts
@@ -118,7 +118,7 @@ const updateCjsStyleRequires = (
 
   moduleFile.cmps.forEach((cmp) => {
     cmp.styles.forEach((style) => {
-      if (typeof style.styleIdentifier === 'string' && style.externalStyles.length > 0) {
+      if (style.externalStyles.length > 0) {
         // add style imports built from @Component() styleUrl option
         styleRequires.push(...createCjsStyleRequire(transformOpts, tsSourceFile, cmp, style));
       }

--- a/src/compiler/transformers/style-imports.ts
+++ b/src/compiler/transformers/style-imports.ts
@@ -9,7 +9,7 @@ import { getIdentifierFromResourceUrl, retrieveTsModifiers } from './transform-u
  * imported from the component's styleUrls option. For example, if a component
  * has the following:
  *
-  * ```ts
+ * ```ts
  * @Component({
  *  styleUrls: ['my-component.css', 'my-component.ios.css']
  * })
@@ -149,7 +149,6 @@ const createEsmStyleImport = (
 
   return imports;
 };
-
 
 /**
  * Iterate over all components defined in given module, collect require

--- a/src/compiler/transformers/style-imports.ts
+++ b/src/compiler/transformers/style-imports.ts
@@ -118,7 +118,7 @@ const updateCjsStyleRequires = (
 
   moduleFile.cmps.forEach((cmp) => {
     cmp.styles.forEach((style) => {
-      if (style.externalStyles.length > 0) {
+      if (typeof style.styleIdentifier === 'string' && style.externalStyles.length > 0) {
         // add style imports built from @Component() styleUrl option
         styleRequires.push(...createCjsStyleRequire(transformOpts, tsSourceFile, cmp, style));
       }

--- a/src/compiler/transformers/style-imports.ts
+++ b/src/compiler/transformers/style-imports.ts
@@ -89,11 +89,11 @@ const createEsmStyleImport = (
   cmp: d.ComponentCompilerMeta,
   style: d.StyleCompiler,
 ) => {
-  const imports: ts.ImportDeclaration[] = []
+  const imports: ts.ImportDeclaration[] = [];
   for (const externalStyle of style.externalStyles) {
     // add import statement for each style
     // e.g. `import _ImportPathStyle from './import-path.css';`
-    const importName = getIdentifierFromResourceUrl(externalStyle.absolutePath)
+    const importName = getIdentifierFromResourceUrl(externalStyle.absolutePath);
     const importIdentifier = ts.factory.createIdentifier(importName);
     const importPath = getStyleImportPath(transformOpts, tsSourceFile, cmp, style, externalStyle.absolutePath);
 
@@ -102,7 +102,7 @@ const createEsmStyleImport = (
         undefined,
         ts.factory.createImportClause(false, importIdentifier, undefined),
         ts.factory.createStringLiteral(importPath),
-      )
+      ),
     );
   }
 
@@ -138,11 +138,11 @@ const createCjsStyleRequire = (
   cmp: d.ComponentCompilerMeta,
   style: d.StyleCompiler,
 ) => {
-  const imports: ts.VariableStatement[] = []
+  const imports: ts.VariableStatement[] = [];
   for (const externalStyle of style.externalStyles) {
     // add import statement for each style
     // e.g. `import _ImportPathStyle from './import-path.css';`
-    const importName = getIdentifierFromResourceUrl(externalStyle.absolutePath)
+    const importName = getIdentifierFromResourceUrl(externalStyle.absolutePath);
     const importIdentifier = ts.factory.createIdentifier(importName);
     const importPath = getStyleImportPath(transformOpts, tsSourceFile, cmp, style, externalStyle.absolutePath);
 
@@ -164,7 +164,7 @@ const createCjsStyleRequire = (
           ],
           ts.NodeFlags.Const,
         ),
-      )
+      ),
     );
   }
 

--- a/src/compiler/transformers/style-imports.ts
+++ b/src/compiler/transformers/style-imports.ts
@@ -118,7 +118,7 @@ const updateCjsStyleRequires = (
 
   moduleFile.cmps.forEach((cmp) => {
     cmp.styles.forEach((style) => {
-      if (typeof style.styleIdentifier === 'string' && style.externalStyles.length > 0) {
+      if (style.externalStyles.length > 0) {
         // add style imports built from @Component() styleUrl option
         styleRequires.push(...createCjsStyleRequire(transformOpts, tsSourceFile, cmp, style));
       }
@@ -185,5 +185,5 @@ const getStyleImportPath = (
     encapsulation: cmp.encapsulation,
     mode: style.modeName,
   };
-  return serializeImportPath(importData, transformOpts.styleImportData);
+  return serializeImportPath(importData, transformOpts.styleImportData, transformOpts.module);
 };

--- a/src/compiler/transformers/test/lazy-component.spec.ts
+++ b/src/compiler/transformers/test/lazy-component.spec.ts
@@ -142,6 +142,40 @@ describe('lazy-component', () => {
     );
   });
 
+  it('allows to define multiple styleUrls in CJS', async () => {
+    const compilerCtx = mockCompilerCtx();
+    const transformOpts: d.TransformOptions = {
+      coreImportPath: '@stencil/core',
+      componentExport: 'lazy',
+      componentMetadata: null,
+      currentDirectory: '/',
+      proxy: null,
+      module: 'cjs',
+      style: 'static',
+      styleImportData: null,
+    };
+    const code = `
+      @Component({
+        styleUrls: ['./foo/bar.css', './bar/foo.css'],
+        tag: 'cmp-a'
+      })
+      export class CmpA {}
+    `;
+    const transformer = lazyComponentTransform(compilerCtx, transformOpts);
+    const t = transpileModule(code, null, compilerCtx, [], [transformer]);
+    expect(await formatCode(t.outputText)).toBe(
+      await c`const _FooBarCssStyle = require('./foo/bar.css');
+      const _BarFooCssStyle = require('./bar/foo.css');
+      const { registerInstance: __stencil_registerInstance } = require('@stencil/core');
+      export class CmpA {
+        constructor(hostRef) {
+          __stencil_registerInstance(this, hostRef);
+        }
+      };
+      CmpA.style = _FooBarCssStyle + _BarFooCssStyle;`,
+    );
+  });
+
   it('allows to define multiple platform styles', async () => {
     const compilerCtx = mockCompilerCtx();
     const transformOpts: d.TransformOptions = {
@@ -176,5 +210,5 @@ describe('lazy-component', () => {
       }
       CmpA.style = { bar: _BarFooCssStyle, foo: _FooBarCssStyle }`,
     );
-  })
+  });
 });

--- a/src/compiler/transformers/test/lazy-component.spec.ts
+++ b/src/compiler/transformers/test/lazy-component.spec.ts
@@ -141,4 +141,40 @@ describe('lazy-component', () => {
       CmpA.style = _FooBarCssStyle + _BarFooCssStyle;`,
     );
   });
+
+  it('allows to define multiple platform styles', async () => {
+    const compilerCtx = mockCompilerCtx();
+    const transformOpts: d.TransformOptions = {
+      coreImportPath: '@stencil/core',
+      componentExport: 'lazy',
+      componentMetadata: null,
+      currentDirectory: '/',
+      proxy: null,
+      style: 'static',
+      styleImportData: null,
+    };
+    const code = `
+      @Component({
+        styleUrls: {
+          foo: './foo/bar.css',
+          bar: './bar/foo.css'
+        },
+        tag: 'cmp-a'
+      })
+      export class CmpA {}
+    `;
+    const transformer = lazyComponentTransform(compilerCtx, transformOpts);
+    const t = transpileModule(code, null, compilerCtx, [], [transformer]);
+    expect(await formatCode(t.outputText)).toBe(
+      await c`import { registerInstance as __stencil_registerInstance } from "@stencil/core";
+      import _BarFooCssStyle from './bar/foo.css';
+      import _FooBarCssStyle from './foo/bar.css';
+      export const CmpA = class {
+        constructor(hostRef) {
+          __stencil_registerInstance(this, hostRef);
+        }
+      }
+      CmpA.style = { bar: _BarFooCssStyle, foo: _FooBarCssStyle }`,
+    );
+  })
 });

--- a/src/compiler/transformers/test/lazy-component.spec.ts
+++ b/src/compiler/transformers/test/lazy-component.spec.ts
@@ -108,4 +108,37 @@ describe('lazy-component', () => {
       }`,
     );
   });
+
+  it('allows to define multiple styleUrls', async () => {
+    const compilerCtx = mockCompilerCtx();
+    const transformOpts: d.TransformOptions = {
+      coreImportPath: '@stencil/core',
+      componentExport: 'lazy',
+      componentMetadata: null,
+      currentDirectory: '/',
+      proxy: null,
+      style: 'static',
+      styleImportData: null,
+    };
+    const code = `
+      @Component({
+        styleUrls: ['./foo/bar.css', './bar/foo.css'],
+        tag: 'cmp-a'
+      })
+      export class CmpA {}
+    `;
+    const transformer = lazyComponentTransform(compilerCtx, transformOpts);
+    const t = transpileModule(code, null, compilerCtx, [], [transformer]);
+    expect(await formatCode(t.outputText)).toBe(
+      await c`import { registerInstance as __stencil_registerInstance } from "@stencil/core";
+      import _FooBarCssStyle from './foo/bar.css';
+      import _BarFooCssStyle from './bar/foo.css';
+      export const CmpA = class {
+        constructor(hostRef) {
+          __stencil_registerInstance(this, hostRef);
+        }
+      }
+      CmpA.style = _FooBarCssStyle + _BarFooCssStyle;`,
+    );
+  })
 });

--- a/src/compiler/transformers/test/lazy-component.spec.ts
+++ b/src/compiler/transformers/test/lazy-component.spec.ts
@@ -131,14 +131,14 @@ describe('lazy-component', () => {
     const t = transpileModule(code, null, compilerCtx, [], [transformer]);
     expect(await formatCode(t.outputText)).toBe(
       await c`import { registerInstance as __stencil_registerInstance } from "@stencil/core";
-      import _FooBarCssStyle from './foo/bar.css';
-      import _BarFooCssStyle from './bar/foo.css';
+      import __foo_bar_css from './foo/bar.css';
+      import __bar_foo_css  from './bar/foo.css';
       export const CmpA = class {
         constructor(hostRef) {
           __stencil_registerInstance(this, hostRef);
         }
       }
-      CmpA.style = _FooBarCssStyle + _BarFooCssStyle;`,
+      CmpA.style = __foo_bar_css + __bar_foo_css ;`,
     );
   });
 
@@ -164,15 +164,15 @@ describe('lazy-component', () => {
     const transformer = lazyComponentTransform(compilerCtx, transformOpts);
     const t = transpileModule(code, null, compilerCtx, [], [transformer]);
     expect(await formatCode(t.outputText)).toBe(
-      await c`const _FooBarCssStyle = require('./foo/bar.css');
-      const _BarFooCssStyle = require('./bar/foo.css');
+      await c`const __foo_bar_css = require('./foo/bar.css');
+      const __bar_foo_css  = require('./bar/foo.css');
       const { registerInstance: __stencil_registerInstance } = require('@stencil/core');
       export class CmpA {
         constructor(hostRef) {
           __stencil_registerInstance(this, hostRef);
         }
       };
-      CmpA.style = _FooBarCssStyle + _BarFooCssStyle;`,
+      CmpA.style = __foo_bar_css + __bar_foo_css ;`,
     );
   });
 
@@ -201,14 +201,14 @@ describe('lazy-component', () => {
     const t = transpileModule(code, null, compilerCtx, [], [transformer]);
     expect(await formatCode(t.outputText)).toBe(
       await c`import { registerInstance as __stencil_registerInstance } from "@stencil/core";
-      import _BarFooCssStyle from './bar/foo.css';
-      import _FooBarCssStyle from './foo/bar.css';
+      import __bar_foo_css  from './bar/foo.css';
+      import __foo_bar_css from './foo/bar.css';
       export const CmpA = class {
         constructor(hostRef) {
           __stencil_registerInstance(this, hostRef);
         }
       }
-      CmpA.style = { bar: _BarFooCssStyle, foo: _FooBarCssStyle }`,
+      CmpA.style = { bar: __bar_foo_css , foo: __foo_bar_css }`,
     );
   });
 });

--- a/src/compiler/transformers/test/lazy-component.spec.ts
+++ b/src/compiler/transformers/test/lazy-component.spec.ts
@@ -140,5 +140,5 @@ describe('lazy-component', () => {
       }
       CmpA.style = _FooBarCssStyle + _BarFooCssStyle;`,
     );
-  })
+  });
 });

--- a/src/compiler/transformers/test/parse-styles.spec.ts
+++ b/src/compiler/transformers/test/parse-styles.spec.ts
@@ -18,11 +18,12 @@ describe('parse styles', () => {
     const t = transpileModule(`
       @Component({
         tag: 'cmp-a',
-        styleUrls: ['style.css']
+        styleUrls: ['style.css', 'style2.css']
       })
       export class CmpA {}
     `);
-    expect(getStaticGetter(t.outputText, 'styleUrls')).toEqual({ $: ['style.css'] });
+
+    expect(getStaticGetter(t.outputText, 'styleUrls')).toEqual({ $: ['style.css', 'style2.css'] });
   });
 
   it('add static "styles"', () => {

--- a/src/compiler/transformers/test/transform-utils.spec.ts
+++ b/src/compiler/transformers/test/transform-utils.spec.ts
@@ -1,6 +1,7 @@
 import * as ts from 'typescript';
 
 import {
+  getIdentifierFromResourceUrl,
   isMemberPrivate,
   mapJSDocTagInfo,
   retrieveModifierLike,
@@ -9,6 +10,16 @@ import {
 } from '../transform-utils';
 
 describe('transform-utils', () => {
+  it('getIdentifierFromResourceUrl', () => {
+    const testData = [
+      ['/foo/bar.css', '_FooBarCssStyle'],
+      ['C:\\foo\\bar.css', '_CFooBarCssStyle'],
+    ]
+    for (const [input, output] of testData) {
+      expect(getIdentifierFromResourceUrl(input)).toBe(output)
+    }
+  })
+
   it('flattens TypeScript JSDocTagInfo to Stencil JSDocTagInfo', () => {
     // tags corresponds to the following JSDoc
     /*

--- a/src/compiler/transformers/test/transform-utils.spec.ts
+++ b/src/compiler/transformers/test/transform-utils.spec.ts
@@ -12,9 +12,15 @@ import {
 describe('transform-utils', () => {
   it('getIdentifierFromResourceUrl', () => {
     const testData = [
-      ['/foo/bar.css', '_FooBarCssStyle'],
-      ['C:\\foo\\bar.css?tag=my-component&encapsulation=shadow', '_CFooBarCssStyle'],
-      ['/project/node_modules/@scope/foo/b_$%^&*(*())!@#a_r.css', '_ProjectNodeModulesScopeFooBARCssStyle'],
+      ['/foo/bar.css', '_foo_bar_css'],
+      ['/foo/Bar.css', '_foo_Bar_css'],
+      ['/my-other-styles.css', '_my_other_styles_css'],
+      ['/my--other-styles.css', '_my__other_styles_css'],
+      ['C:\\foo\\bar.css?tag=my-component&encapsulation=shadow', 'C__foo_bar_css'],
+      [
+        '/project/node_modules/@scope/foo/b_$%^&*(*())!@#a_r.css',
+        '_project_node_modules__scope_foo_b______________a_r_css',
+      ],
     ];
     for (const [input, output] of testData) {
       expect(getIdentifierFromResourceUrl(input)).toBe(output);

--- a/src/compiler/transformers/test/transform-utils.spec.ts
+++ b/src/compiler/transformers/test/transform-utils.spec.ts
@@ -13,7 +13,7 @@ describe('transform-utils', () => {
   it('getIdentifierFromResourceUrl', () => {
     const testData = [
       ['/foo/bar.css', '_FooBarCssStyle'],
-      ['C:\\foo\\bar.css', '_CFooBarCssStyle'],
+      ['C:\\foo\\bar.css?tag=my-component&encapsulation=shadow', '_CFooBarCssStyle'],
       ['/project/node_modules/@scope/foo/b_$%^&*(*())!@#a_r.css', '_ProjectNodeModulesScopeFooBARCssStyle'],
     ];
     for (const [input, output] of testData) {

--- a/src/compiler/transformers/test/transform-utils.spec.ts
+++ b/src/compiler/transformers/test/transform-utils.spec.ts
@@ -14,6 +14,7 @@ describe('transform-utils', () => {
     const testData = [
       ['/foo/bar.css', '_FooBarCssStyle'],
       ['C:\\foo\\bar.css', '_CFooBarCssStyle'],
+      ['/project/node_modules/@scope/foo/b_$%^&*(*())!@#a_r.css', '_ProjectNodeModulesScopeFooBARCssStyle'],
     ];
     for (const [input, output] of testData) {
       expect(getIdentifierFromResourceUrl(input)).toBe(output);

--- a/src/compiler/transformers/test/transform-utils.spec.ts
+++ b/src/compiler/transformers/test/transform-utils.spec.ts
@@ -14,11 +14,11 @@ describe('transform-utils', () => {
     const testData = [
       ['/foo/bar.css', '_FooBarCssStyle'],
       ['C:\\foo\\bar.css', '_CFooBarCssStyle'],
-    ]
+    ];
     for (const [input, output] of testData) {
-      expect(getIdentifierFromResourceUrl(input)).toBe(output)
+      expect(getIdentifierFromResourceUrl(input)).toBe(output);
     }
-  })
+  });
 
   it('flattens TypeScript JSDocTagInfo to Stencil JSDocTagInfo', () => {
     // tags corresponds to the following JSDoc

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -1107,5 +1107,5 @@ export const tsPropDeclNameAsString = (node: ts.PropertyDeclaration, typeChecker
  * @returns a valid identifier to be used as variable name
  */
 export const getIdentifierFromResourceUrl = (absolutePath: string): string => {
-  return `_${dashToPascalCase(absolutePath.toLocaleLowerCase().replace(/(\.|\/|\\)/g, '-').replace(/--/, '-'))}Style`
+  return `_${dashToPascalCase(absolutePath.toLocaleLowerCase().replace(/(\.|\/|\\|:)/g, '-').replace(/--/, '-'))}Style`
 }

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -1,7 +1,6 @@
 import {
   augmentDiagnosticWithNode,
   buildError,
-  dashToPascalCase,
   normalizePath,
   readOnlyArrayHasStringMember,
 } from '@utils';

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -1104,6 +1104,7 @@ export const tsPropDeclNameAsString = (node: ts.PropertyDeclaration, typeChecker
   return memberName;
 };
 
+const SPECIAL_CHARS = /[\s~`!@#$%\^&*+=\-\[\]\\';,/{}|\\":<>\?()\._]/g
 /**
  * transform any path to a valid identifier, e.g.
  *   - `/foo/bar/loo.css` -> `_fooBarLooCssStyle`
@@ -1116,7 +1117,7 @@ export const getIdentifierFromResourceUrl = (absolutePath: string): string => {
   return `_${dashToPascalCase(
     absolutePath
       .toLocaleLowerCase()
-      .replace(/(\.|\/|\\|:)/g, '-')
+      .replace(SPECIAL_CHARS, '-')
       .replace(/--/, '-'),
   )}Style`;
 };

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -1,4 +1,10 @@
-import { augmentDiagnosticWithNode, buildError, dashToPascalCase, normalizePath, readOnlyArrayHasStringMember } from '@utils';
+import {
+  augmentDiagnosticWithNode,
+  buildError,
+  dashToPascalCase,
+  normalizePath,
+  readOnlyArrayHasStringMember,
+} from '@utils';
 import ts from 'typescript';
 
 import type * as d from '../../declarations';
@@ -1107,5 +1113,10 @@ export const tsPropDeclNameAsString = (node: ts.PropertyDeclaration, typeChecker
  * @returns a valid identifier to be used as variable name
  */
 export const getIdentifierFromResourceUrl = (absolutePath: string): string => {
-  return `_${dashToPascalCase(absolutePath.toLocaleLowerCase().replace(/(\.|\/|\\|:)/g, '-').replace(/--/, '-'))}Style`
-}
+  return `_${dashToPascalCase(
+    absolutePath
+      .toLocaleLowerCase()
+      .replace(/(\.|\/|\\|:)/g, '-')
+      .replace(/--/, '-'),
+  )}Style`;
+};

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -1114,5 +1114,7 @@ const SPECIAL_CHARS = /[\s~`!@#$%\^&*+=\-\[\]\\';,/{}|\\":<>\?()\._]/g;
  * @returns a valid identifier to be used as variable name
  */
 export const getIdentifierFromResourceUrl = (absolutePath: string): string => {
-  return `_${dashToPascalCase(absolutePath.toLocaleLowerCase().replace(SPECIAL_CHARS, '-').replace(/--/, '-'))}Style`;
+  return `_${dashToPascalCase(
+    absolutePath.split('?').shift().toLocaleLowerCase().replace(SPECIAL_CHARS, '-').replace(/--/, '-'),
+  )}Style`;
 };

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -1104,7 +1104,7 @@ export const tsPropDeclNameAsString = (node: ts.PropertyDeclaration, typeChecker
   return memberName;
 };
 
-const SPECIAL_CHARS = /[\s~`!@#$%\^&*+=\-\[\]\\';,/{}|\\":<>\?()\._]/g
+const SPECIAL_CHARS = /[\s~`!@#$%\^&*+=\-\[\]\\';,/{}|\\":<>\?()\._]/g;
 /**
  * transform any path to a valid identifier, e.g.
  *   - `/foo/bar/loo.css` -> `_fooBarLooCssStyle`
@@ -1114,10 +1114,5 @@ const SPECIAL_CHARS = /[\s~`!@#$%\^&*+=\-\[\]\\';,/{}|\\":<>\?()\._]/g
  * @returns a valid identifier to be used as variable name
  */
 export const getIdentifierFromResourceUrl = (absolutePath: string): string => {
-  return `_${dashToPascalCase(
-    absolutePath
-      .toLocaleLowerCase()
-      .replace(SPECIAL_CHARS, '-')
-      .replace(/--/, '-'),
-  )}Style`;
+  return `_${dashToPascalCase(absolutePath.toLocaleLowerCase().replace(SPECIAL_CHARS, '-').replace(/--/, '-'))}Style`;
 };

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -1,4 +1,4 @@
-import { augmentDiagnosticWithNode, buildError, normalizePath, readOnlyArrayHasStringMember } from '@utils';
+import { augmentDiagnosticWithNode, buildError, dashToPascalCase, normalizePath, readOnlyArrayHasStringMember } from '@utils';
 import ts from 'typescript';
 
 import type * as d from '../../declarations';
@@ -1097,3 +1097,15 @@ export const tsPropDeclNameAsString = (node: ts.PropertyDeclaration, typeChecker
 
   return memberName;
 };
+
+/**
+ * transform any path to a valid identifier, e.g.
+ *   - `/foo/bar/loo.css` -> `_fooBarLooCssStyle`
+ *   - `C:\\foo\bar\loo.css` -> `_cFooBarLooCssStyle`
+ *
+ * @param absolutePath  windows or linux based path
+ * @returns a valid identifier to be used as variable name
+ */
+export const getIdentifierFromResourceUrl = (absolutePath: string): string => {
+  return `_${dashToPascalCase(absolutePath.toLocaleLowerCase().replace(/(\.|\/|\\)/g, '-').replace(/--/, '-'))}Style`
+}

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -1107,14 +1107,27 @@ export const tsPropDeclNameAsString = (node: ts.PropertyDeclaration, typeChecker
 const SPECIAL_CHARS = /[\s~`!@#$%\^&*+=\-\[\]\\';,/{}|\\":<>\?()\._]/g;
 /**
  * transform any path to a valid identifier, e.g.
- *   - `/foo/bar/loo.css` -> `_fooBarLooCssStyle`
- *   - `C:\\foo\bar\loo.css` -> `_cFooBarLooCssStyle`
+ *   - `/foo/bar/loo.css` -> `_foo_bar_loo_css`
+ *   - `C:\\foo\bar\loo.css` -> `_C__foo_bar_loo_css`
  *
  * @param absolutePath  windows or linux based path
  * @returns a valid identifier to be used as variable name
  */
 export const getIdentifierFromResourceUrl = (absolutePath: string): string => {
-  return `_${dashToPascalCase(
-    absolutePath.split('?').shift().toLocaleLowerCase().replace(SPECIAL_CHARS, '-').replace(/--/, '-'),
-  )}Style`;
+  return (
+    absolutePath
+      /**
+       * remove query params
+       */
+      .split('?')
+      .shift()
+      /**
+       * replace special characters with `-`
+       */
+      .replace(SPECIAL_CHARS, '-')
+      /**
+       * replace all `-` with `_`
+       */
+      .replace(/-/g, '_')
+  );
 };

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -1,9 +1,4 @@
-import {
-  augmentDiagnosticWithNode,
-  buildError,
-  normalizePath,
-  readOnlyArrayHasStringMember,
-} from '@utils';
+import { augmentDiagnosticWithNode, buildError, normalizePath, readOnlyArrayHasStringMember } from '@utils';
 import ts from 'typescript';
 
 import type * as d from '../../declarations';

--- a/src/runtime/test/fixtures/cmp-a.tsx
+++ b/src/runtime/test/fixtures/cmp-a.tsx
@@ -4,6 +4,7 @@ import { format } from './utils';
 
 @Component({
   tag: 'cmp-a',
+  styleUrl: 'cmp-a.css',
   shadow: true,
 })
 export class CmpA {

--- a/src/runtime/test/fixtures/cmp-a.tsx
+++ b/src/runtime/test/fixtures/cmp-a.tsx
@@ -4,7 +4,6 @@ import { format } from './utils';
 
 @Component({
   tag: 'cmp-a',
-  styleUrl: 'cmp-a.css',
   shadow: true,
 })
 export class CmpA {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?

Currently if multiple style urls are provided, as described in the docs:

```ts
@Component({
  tag: 'my-component',
  styleUrls: ['reset.scss', 'roboto.scss', 'css-variables.scss', 'core.scss'] 
})
export class MyComponent {
  // ...
}
```

Only the first (`reset.css`) style would get applied to the component.

GitHub Issue Number: #5016

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Instead of just compiling the first external style, I make it loop through all external styles and join the style strings together. Here is an example:

```ts
const barCss = ":host{display:block}";
const fooCss = ":host{display:none}";

const MyComponent = class {
    // ...
};
MyComponent.style = barCss + fooCss;
```

export { MyComponent as my_component };

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Working on adding unit tests and integration tests for it.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
