### PR TITLE
fix(runtime): call form-associated lifecycle callbacks w/ `this`

### DIFF
--- a/src/runtime/proxy-component.ts
+++ b/src/runtime/proxy-component.ts
@@ -36,10 +36,13 @@ export const proxyComponent = (
           const elm = BUILD.lazyLoad ? hostRef.$hostElement$ : this;
           const instance: d.ComponentInterface = BUILD.lazyLoad ? hostRef.$lazyInstance$ : elm;
           if (!instance) {
-            hostRef.$onReadyPromise$.then((instance: d.ComponentInterface) => instance[cbName]?.(...args));
+            hostRef.$onReadyPromise$.then((instance: d.ComponentInterface) => {
+              const cb = instance[cbName];
+              typeof cb === 'function' && cb.call(instance, ...args);
+            });
           } else {
             const cb = instance[cbName];
-            typeof cb === 'function' && cb(...args);
+            typeof cb === 'function' && cb.call(instance, ...args);
           }
         },
       }),

--- a/test/karma/test-app/form-associated/cmp.tsx
+++ b/test/karma/test-app/form-associated/cmp.tsx
@@ -14,6 +14,9 @@ export class FormAssociatedCmp {
 
   formAssociatedCallback(form: HTMLFormAssociatedElement) {
     form.ariaLabel = 'formAssociated called';
+    // this is a regression test for #5106 which ensures that `this` is
+    // resolved correctly
+    this.internals.setValidity({});
   }
 
   render() {


### PR DESCRIPTION
This fixes an issue where form-associated lifecycle callbacks were not being called with the correct `this` value, making it impossible to set something like a `@State` value from within a callback.



## What is the current behavior?

The right `this` value isn't resolved for the form-associated callbacks.

GitHub Issue Number: fixes #5106


## What is the new behavior?

It's resolved the same way it is for other similar lifecycle callbacks.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I added some code to our current karma test for this functionality which functions as a regression test, i.e. it will cause a test to fail without this fix.