### PR TITLE
fix(runtime): patch `textContent` whenever shadow DOM is not used

### DIFF
--- a/src/runtime/bootstrap-custom-element.ts
+++ b/src/runtime/bootstrap-custom-element.ts
@@ -44,7 +44,7 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
   }
 
   // TODO(STENCIL-914): this check and `else` block can go away and be replaced by just a
-  // check for shadow encapsulation once we default our pseudo-slot behavior
+  // check for shadow encapsulation/shim once we default our pseudo-slot behavior
   if (
     BUILD.experimentalSlotFixes &&
     (cmpMeta.$flags$ & CMP_FLAGS.needsShadowDomShim || !(cmpMeta.$flags$ & CMP_FLAGS.shadowDomEncapsulation))
@@ -60,8 +60,8 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
     if (BUILD.appendChildSlotFix) {
       patchSlotAppendChild(Cstr.prototype);
     }
-    if (BUILD.scopedSlotTextContentFix) {
-      patchTextContent(Cstr.prototype, cmpMeta);
+    if (BUILD.scopedSlotTextContentFix && BUILD.scoped && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
+      patchTextContent(Cstr.prototype);
     }
   }
 

--- a/src/runtime/bootstrap-custom-element.ts
+++ b/src/runtime/bootstrap-custom-element.ts
@@ -43,9 +43,12 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
     cmpMeta.$flags$ |= CMP_FLAGS.needsShadowDomShim;
   }
 
-  // TODO(STENCIL-914): this check and `else` block can go away and be replaced by just `BUILD.scoped` once we
-  // default our pseudo-slot behavior
-  if (BUILD.experimentalSlotFixes && BUILD.scoped) {
+  // TODO(STENCIL-914): this check and `else` block can go away and be replaced by just a
+  // check for shadow encapsulation once we default our pseudo-slot behavior
+  if (
+    BUILD.experimentalSlotFixes &&
+    (cmpMeta.$flags$ & CMP_FLAGS.needsShadowDomShim || !(cmpMeta.$flags$ & CMP_FLAGS.shadowDomEncapsulation))
+  ) {
     patchPseudoShadowDom(Cstr.prototype, cmpMeta);
   } else {
     if (BUILD.slotChildNodesFix) {

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -138,9 +138,12 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
         }
       };
 
-      // TODO(STENCIL-914): this check and `else` block can go away and be replaced by just `BUILD.scoped` once we
-      // default our pseudo-slot behavior
-      if (BUILD.experimentalSlotFixes && BUILD.scoped) {
+      // TODO(STENCIL-914): this check and `else` block can go away and be replaced by just a
+      // check for shadow encapsulation once we default our pseudo-slot behavior
+      if (
+        BUILD.experimentalSlotFixes &&
+        (cmpMeta.$flags$ & CMP_FLAGS.needsShadowDomShim || !(cmpMeta.$flags$ & CMP_FLAGS.shadowDomEncapsulation))
+      ) {
         patchPseudoShadowDom(HostElement.prototype, cmpMeta);
       } else {
         if (BUILD.slotChildNodesFix) {

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -139,7 +139,7 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
       };
 
       // TODO(STENCIL-914): this check and `else` block can go away and be replaced by just a
-      // check for shadow encapsulation once we default our pseudo-slot behavior
+      // check for shadow encapsulation/shim once we default our pseudo-slot behavior
       if (
         BUILD.experimentalSlotFixes &&
         (cmpMeta.$flags$ & CMP_FLAGS.needsShadowDomShim || !(cmpMeta.$flags$ & CMP_FLAGS.shadowDomEncapsulation))
@@ -155,8 +155,8 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
         if (BUILD.appendChildSlotFix) {
           patchSlotAppendChild(HostElement.prototype);
         }
-        if (BUILD.scopedSlotTextContentFix) {
-          patchTextContent(HostElement.prototype, cmpMeta);
+        if (BUILD.scopedSlotTextContentFix && BUILD.scoped && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
+          patchTextContent(HostElement.prototype);
         }
       }
 

--- a/src/runtime/dom-extras.ts
+++ b/src/runtime/dom-extras.ts
@@ -204,6 +204,7 @@ export const patchSlotInsertAdjacentElement = (HostElementPrototype: HTMLElement
   };
 };
 
+// TODO(STENCIL-1019): Evaluate if this patch should be modified
 /**
  * Patches the text content of an unnamed slotted node inside a scoped component
  * @param hostElementPrototype the `Element` to be patched

--- a/src/runtime/dom-extras.ts
+++ b/src/runtime/dom-extras.ts
@@ -17,7 +17,7 @@ export const patchPseudoShadowDom = (
   patchSlotInsertAdjacentElement(hostElementPrototype);
   patchSlotInsertAdjacentHTML(hostElementPrototype);
   patchSlotInsertAdjacentText(hostElementPrototype);
-  patchTextContent(hostElementPrototype, descriptorPrototype);
+  patchTextContent(hostElementPrototype);
   patchChildSlotNodes(hostElementPrototype, descriptorPrototype);
 };
 
@@ -207,55 +207,52 @@ export const patchSlotInsertAdjacentElement = (HostElementPrototype: HTMLElement
 /**
  * Patches the text content of an unnamed slotted node inside a scoped component
  * @param hostElementPrototype the `Element` to be patched
- * @param cmpMeta component runtime metadata used to determine if the component should be patched or not
  */
-export const patchTextContent = (hostElementPrototype: HTMLElement, cmpMeta: d.ComponentRuntimeMeta): void => {
-  if (BUILD.scoped && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
-    const descriptor = Object.getOwnPropertyDescriptor(Node.prototype, 'textContent');
+export const patchTextContent = (hostElementPrototype: HTMLElement): void => {
+  const descriptor = Object.getOwnPropertyDescriptor(Node.prototype, 'textContent');
 
-    Object.defineProperty(hostElementPrototype, '__textContent', descriptor);
+  Object.defineProperty(hostElementPrototype, '__textContent', descriptor);
 
-    Object.defineProperty(hostElementPrototype, 'textContent', {
-      get(): string | null {
-        // get the 'default slot', which would be the first slot in a shadow tree (if we were using one), whose name is
-        // the empty string
-        const slotNode = getHostSlotNode(this.childNodes, '');
-        // when a slot node is found, the textContent _may_ be found in the next sibling (text) node, depending on how
-        // nodes were reordered during the vdom render. first try to get the text content from the sibling.
-        if (slotNode?.nextSibling?.nodeType === NODE_TYPES.TEXT_NODE) {
-          return slotNode.nextSibling.textContent;
-        } else if (slotNode) {
-          return slotNode.textContent;
-        } else {
-          // fallback to the original implementation
-          return this.__textContent;
+  Object.defineProperty(hostElementPrototype, 'textContent', {
+    /**
+     * Text content is just an aggregate of all child nodes of a node (whether they are
+     * style elements, slotted, or hidden). So, we just iterate over all child nodes
+     * and keep appending the text content of each node to a string.
+     *
+     * @returns The text content of all child nodes of the element
+     */
+    get(): string | null {
+      let text = '';
+      this.childNodes.forEach((node: d.RenderNode) => {
+        text += node.textContent || '';
+      });
+
+      return text;
+    },
+
+    set(value: string | null) {
+      // get the 'default slot', which would be the first slot in a shadow tree (if we were using one), whose name is
+      // the empty string
+      const slotNode = getHostSlotNode(this.childNodes, '');
+      // when a slot node is found, the textContent _may_ need to be placed in the next sibling (text) node,
+      // depending on how nodes were reordered during the vdom render. first try to set the text content on the
+      // sibling.
+      if (slotNode?.nextSibling?.nodeType === NODE_TYPES.TEXT_NODE) {
+        slotNode.nextSibling.textContent = value;
+      } else if (slotNode) {
+        slotNode.textContent = value;
+      } else {
+        // we couldn't find a slot, but that doesn't mean that there isn't one. if this check ran before the DOM
+        // loaded, we could have missed it. check for a content reference element on the scoped component and insert
+        // it there
+        this.__textContent = value;
+        const contentRefElm = this['s-cr'];
+        if (contentRefElm) {
+          this.insertBefore(contentRefElm, this.firstChild);
         }
-      },
-
-      set(value: string | null) {
-        // get the 'default slot', which would be the first slot in a shadow tree (if we were using one), whose name is
-        // the empty string
-        const slotNode = getHostSlotNode(this.childNodes, '');
-        // when a slot node is found, the textContent _may_ need to be placed in the next sibling (text) node,
-        // depending on how nodes were reordered during the vdom render. first try to set the text content on the
-        // sibling.
-        if (slotNode?.nextSibling?.nodeType === NODE_TYPES.TEXT_NODE) {
-          slotNode.nextSibling.textContent = value;
-        } else if (slotNode) {
-          slotNode.textContent = value;
-        } else {
-          // we couldn't find a slot, but that doesn't mean that there isn't one. if this check ran before the DOM
-          // loaded, we could have missed it. check for a content reference element on the scoped component and insert
-          // it there
-          this.__textContent = value;
-          const contentRefElm = this['s-cr'];
-          if (contentRefElm) {
-            this.insertBefore(contentRefElm, this.firstChild);
-          }
-        }
-      },
-    });
-  }
+      }
+    },
+  });
 };
 
 export const patchChildSlotNodes = (elm: HTMLElement, cmpMeta: d.ComponentRuntimeMeta) => {

--- a/test/karma/test-app/components.d.ts
+++ b/test/karma/test-app/components.d.ts
@@ -383,6 +383,14 @@ export namespace Components {
     }
     interface Tag88 {
     }
+    interface TextContentPatch {
+    }
+    interface TextContentPatchScoped {
+    }
+    interface TextContentPatchScopedWithSlot {
+    }
+    interface TextContentPatchWithSlot {
+    }
     interface WatchNativeAttributes {
     }
 }
@@ -1396,6 +1404,30 @@ declare global {
         prototype: HTMLTag88Element;
         new (): HTMLTag88Element;
     };
+    interface HTMLTextContentPatchElement extends Components.TextContentPatch, HTMLStencilElement {
+    }
+    var HTMLTextContentPatchElement: {
+        prototype: HTMLTextContentPatchElement;
+        new (): HTMLTextContentPatchElement;
+    };
+    interface HTMLTextContentPatchScopedElement extends Components.TextContentPatchScoped, HTMLStencilElement {
+    }
+    var HTMLTextContentPatchScopedElement: {
+        prototype: HTMLTextContentPatchScopedElement;
+        new (): HTMLTextContentPatchScopedElement;
+    };
+    interface HTMLTextContentPatchScopedWithSlotElement extends Components.TextContentPatchScopedWithSlot, HTMLStencilElement {
+    }
+    var HTMLTextContentPatchScopedWithSlotElement: {
+        prototype: HTMLTextContentPatchScopedWithSlotElement;
+        new (): HTMLTextContentPatchScopedWithSlotElement;
+    };
+    interface HTMLTextContentPatchWithSlotElement extends Components.TextContentPatchWithSlot, HTMLStencilElement {
+    }
+    var HTMLTextContentPatchWithSlotElement: {
+        prototype: HTMLTextContentPatchWithSlotElement;
+        new (): HTMLTextContentPatchWithSlotElement;
+    };
     interface HTMLWatchNativeAttributesElement extends Components.WatchNativeAttributes, HTMLStencilElement {
     }
     var HTMLWatchNativeAttributesElement: {
@@ -1553,6 +1585,10 @@ declare global {
         "svg-class": HTMLSvgClassElement;
         "tag-3d-component": HTMLTag3dComponentElement;
         "tag-88": HTMLTag88Element;
+        "text-content-patch": HTMLTextContentPatchElement;
+        "text-content-patch-scoped": HTMLTextContentPatchScopedElement;
+        "text-content-patch-scoped-with-slot": HTMLTextContentPatchScopedWithSlotElement;
+        "text-content-patch-with-slot": HTMLTextContentPatchWithSlotElement;
         "watch-native-attributes": HTMLWatchNativeAttributesElement;
     }
 }
@@ -1936,6 +1972,14 @@ declare namespace LocalJSX {
     }
     interface Tag88 {
     }
+    interface TextContentPatch {
+    }
+    interface TextContentPatchScoped {
+    }
+    interface TextContentPatchScopedWithSlot {
+    }
+    interface TextContentPatchWithSlot {
+    }
     interface WatchNativeAttributes {
     }
     interface IntrinsicElements {
@@ -2089,6 +2133,10 @@ declare namespace LocalJSX {
         "svg-class": SvgClass;
         "tag-3d-component": Tag3dComponent;
         "tag-88": Tag88;
+        "text-content-patch": TextContentPatch;
+        "text-content-patch-scoped": TextContentPatchScoped;
+        "text-content-patch-scoped-with-slot": TextContentPatchScopedWithSlot;
+        "text-content-patch-with-slot": TextContentPatchWithSlot;
         "watch-native-attributes": WatchNativeAttributes;
     }
 }
@@ -2246,6 +2294,10 @@ declare module "@stencil/core" {
             "svg-class": LocalJSX.SvgClass & JSXBase.HTMLAttributes<HTMLSvgClassElement>;
             "tag-3d-component": LocalJSX.Tag3dComponent & JSXBase.HTMLAttributes<HTMLTag3dComponentElement>;
             "tag-88": LocalJSX.Tag88 & JSXBase.HTMLAttributes<HTMLTag88Element>;
+            "text-content-patch": LocalJSX.TextContentPatch & JSXBase.HTMLAttributes<HTMLTextContentPatchElement>;
+            "text-content-patch-scoped": LocalJSX.TextContentPatchScoped & JSXBase.HTMLAttributes<HTMLTextContentPatchScopedElement>;
+            "text-content-patch-scoped-with-slot": LocalJSX.TextContentPatchScopedWithSlot & JSXBase.HTMLAttributes<HTMLTextContentPatchScopedWithSlotElement>;
+            "text-content-patch-with-slot": LocalJSX.TextContentPatchWithSlot & JSXBase.HTMLAttributes<HTMLTextContentPatchWithSlotElement>;
             "watch-native-attributes": LocalJSX.WatchNativeAttributes & JSXBase.HTMLAttributes<HTMLWatchNativeAttributesElement>;
         }
     }

--- a/test/karma/test-app/text-content-patch/cmp-scoped-slot.tsx
+++ b/test/karma/test-app/text-content-patch/cmp-scoped-slot.tsx
@@ -1,0 +1,11 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'text-content-patch-scoped-with-slot',
+  scoped: true,
+})
+export class TextContentPatchScopedWithSlot {
+  render() {
+    return [<p>Top content</p>, <slot></slot>, <p>Bottom content</p>];
+  }
+}

--- a/test/karma/test-app/text-content-patch/cmp-scoped.tsx
+++ b/test/karma/test-app/text-content-patch/cmp-scoped.tsx
@@ -1,0 +1,11 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'text-content-patch-scoped',
+  scoped: true,
+})
+export class TextContentPatchScoped {
+  render() {
+    return [<p>Top content</p>, <p>Bottom content</p>];
+  }
+}

--- a/test/karma/test-app/text-content-patch/cmp-slot.tsx
+++ b/test/karma/test-app/text-content-patch/cmp-slot.tsx
@@ -1,0 +1,10 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'text-content-patch-with-slot',
+})
+export class TextContentPatchWithSlot {
+  render() {
+    return [<p>Top content</p>, <slot></slot>, <p>Bottom content</p>];
+  }
+}

--- a/test/karma/test-app/text-content-patch/cmp.tsx
+++ b/test/karma/test-app/text-content-patch/cmp.tsx
@@ -1,0 +1,10 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'text-content-patch',
+})
+export class TextContentPatch {
+  render() {
+    return [<p>Top content</p>, <p>Bottom content</p>];
+  }
+}

--- a/test/karma/test-app/text-content-patch/index.html
+++ b/test/karma/test-app/text-content-patch/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<meta charset="utf8" />
+<script src="./build/testapp.esm.js" type="module"></script>
+<script src="./build/testapp.js" nomodule></script>
+
+<text-content-patch></text-content-patch>
+<text-content-patch-with-slot>Slot content</text-content-patch-with-slot>
+<text-content-patch-scoped></text-content-patch-scoped>
+<text-content-patch-scoped-with-slot>Slot content</text-content-patch-scoped-with-slot>

--- a/test/karma/test-app/text-content-patch/karma.spec.ts
+++ b/test/karma/test-app/text-content-patch/karma.spec.ts
@@ -1,0 +1,63 @@
+import { setupDomTests } from '../util';
+
+describe('textContent patch', () => {
+  const { setupDom, tearDownDom } = setupDomTests(document);
+  let app: HTMLElement;
+
+  beforeEach(async () => {
+    app = await setupDom('/text-content-patch/index.html');
+  });
+  afterEach(tearDownDom);
+
+  describe('scoped encapsulation', () => {
+    it('should return the content of the default slot', () => {
+      const elm = app.querySelector('text-content-patch-scoped-with-slot');
+      expect(elm.textContent.trim()).toBe('Slot content');
+    });
+
+    it('should set the content of the default slot', () => {
+      const elm = app.querySelector('text-content-patch-scoped-with-slot');
+      elm.textContent = 'New slot content';
+
+      expect(elm.textContent.trim()).toBe('New slot content');
+    });
+
+    it('should return the content of all child nodes', () => {
+      const elm = app.querySelector('text-content-patch-scoped');
+      expect(elm.textContent.trim()).toBe('Top contentBottom content');
+    });
+
+    it('should replace all child nodes with a single text node', () => {
+      const elm = app.querySelector('text-content-patch-scoped');
+      elm.textContent = 'New content';
+
+      expect(elm.textContent.trim()).toBe('New content');
+    });
+  });
+
+  describe('no encapsulation', () => {
+    it('should return the content of the default slot', () => {
+      const elm = app.querySelector('text-content-patch-with-slot');
+      expect(elm.textContent.trim()).toBe('Slot content');
+    });
+
+    it('should set the content of the default slot', () => {
+      const elm = app.querySelector('text-content-patch-with-slot');
+      elm.textContent = 'New slot content';
+
+      expect(elm.textContent.trim()).toBe('New slot content');
+    });
+
+    it('should return the content of all child nodes', () => {
+      const elm = app.querySelector('text-content-patch');
+      expect(elm.textContent.trim()).toBe('Top contentBottom content');
+    });
+
+    it('should replace all child nodes with a single text node', () => {
+      const elm = app.querySelector('text-content-patch');
+      elm.textContent = 'New content';
+
+      expect(elm.textContent.trim()).toBe('New content');
+    });
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Stencil does not patch a component's `textContent` method for our pseudo-slot behavior in all cases. Patching this method should occur whenever a component does not use the Shadow DOM.

Fixes: #3977 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

`textContent` gets patched for both scoped encapsulation and when not using any encapsulation strategy.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

**Manual testing**
Tested in the linked issue's reproduction case

**Automated testing**
Added e2e tests to verify the patch behavior and that it happens for the appropriate encapsulation strategies.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

The patch implementation may change in the future. STENCIL-1019 was added as a potential task for a future major version to evaluate our implementation compared to the spec.
