### PR TITLE
test(runtime): more tests for form associated custom element lifecycle callbacks

### DIFF
--- a/test/karma/test-app/form-associated/cmp.tsx
+++ b/test/karma/test-app/form-associated/cmp.tsx
@@ -1,4 +1,5 @@
-import { Component, h, AttachInternals } from '@stencil/core';
+import { AttachInternals, Component, h } from '@stencil/core';
+
 
 @Component({
   tag: 'form-associated',
@@ -17,6 +18,14 @@ export class FormAssociatedCmp {
     // this is a regression test for #5106 which ensures that `this` is
     // resolved correctly
     this.internals.setValidity({});
+  }
+
+  formResetCallback(this: HTMLFormAssociatedElement & FormAssociatedCmp) {
+    this.internals.form.ariaLabel = 'formResetCallback called';
+  }
+
+  formDisabledCallback(disabled: boolean) {
+    this.internals.form.ariaLabel = `formDisabledCallback called with ${disabled}`;
   }
 
   render() {

--- a/test/karma/test-app/form-associated/index.html
+++ b/test/karma/test-app/form-associated/index.html
@@ -5,4 +5,5 @@
 
 <form>
   <form-associated name="test-input"></form-associated>
+  <input type="reset" value="Reset">
 </form>

--- a/test/karma/test-app/form-associated/karma.spec.ts
+++ b/test/karma/test-app/form-associated/karma.spec.ts
@@ -14,10 +14,30 @@ describe('form associated', function () {
     expect(elm).not.toBeNull();
   });
 
-  it('should trigger form associated custom element lifecycle callbacks', async () => {
-    const formEl = app.querySelector('form');
-    expect(formEl.ariaLabel).toBe('formAssociated called');
-  });
+  describe('form associated custom element lifecycle callback', () => {
+    it('should trigger "formAssociated"', async () => {
+      const formEl = app.querySelector('form');
+      expect(formEl.ariaLabel).toBe('formAssociated called');
+    });
+
+    it('should trigger "formResetCallback"', async () => {
+      const resetBtn: HTMLInputElement = app.querySelector('input');
+      resetBtn.click();
+
+      const formEl = app.querySelector('form');
+      expect(formEl.ariaLabel).toBe('formResetCallback called');
+    });
+
+    it('should trigger "formDisabledCallback"', async () => {
+      const elm = app.querySelector('form-associated');
+      const formEl = app.querySelector('form');
+
+      elm.setAttribute('disabled', 'disabled')
+      expect(formEl.ariaLabel).toBe('formDisabledCallback called with true');
+      elm.removeAttribute('disabled')
+      expect(formEl.ariaLabel).toBe('formDisabledCallback called with false');
+    })
+  })
 
   it('should link up to the surrounding form', async () => {
     const formEl = app.querySelector('form');


### PR DESCRIPTION
## What is the current behavior?
We were missing tests for form associated custom element lifecycle callbacks.

## What is the new behavior?
Adding more tests for form associated custom element lifecycle callbacks. 

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
