### PR TITLE
fix(runtime): apply nonce to data styles before DOM insert

### DIFF
--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -213,6 +213,8 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
       dataStyles.setAttribute('nonce', nonce);
     }
 
+    // Insert the styles into the document head
+    // NOTE: this _needs_ to happen last so we can ensure the nonce (and other attributes) are applied
     head.insertBefore(dataStyles, metaCharset ? metaCharset.nextSibling : head.firstChild);
   }
 

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -206,13 +206,14 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
   // If we have styles, add them to the DOM
   if (dataStyles.innerHTML.length) {
     dataStyles.setAttribute('data-styles', '');
-    head.insertBefore(dataStyles, metaCharset ? metaCharset.nextSibling : head.firstChild);
 
     // Apply CSP nonce to the style tag if it exists
     const nonce = plt.$nonce$ ?? queryNonceMetaTagContent(doc);
     if (nonce != null) {
       dataStyles.setAttribute('nonce', nonce);
     }
+
+    head.insertBefore(dataStyles, metaCharset ? metaCharset.nextSibling : head.firstChild);
   }
 
   // Process deferred connectedCallbacks now all components have been registered


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I introduced a regression in v4.7.2 via 72c1f1a352e8b9ce3c965f6dc751e16acd9cb3ae. The issue is that the style tag is inserted into the DOM prior to the `nonce` attribute being set which results in a CSP violation error.

Fixes: #5102 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This commit makes it so that the `nonce` value gets set prior to the DOM insert operation

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

**Manual tests**
1. Spin up a new component starter.
2. Install v4.7.2 (`npm i @stencil/core@4.7.2)
3. In `src/index.html`, replace _all_ content in the document `head` with the following snippet:
```html
    <meta http-equiv="Content-Security-Policy" content="style-src 'nonce-111'; script-src 'nonce-111';" />
    <meta name="csp-nonce" content="111" />

    <meta charset="utf-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
    <title>Stencil Component Starter</title>

    <script nonce="111" type="module" src="/build/stencil-starter-project-name.esm.js"></script>
    <script nonce="111" nomodule src="/build/stencil-starter-project-name.js"></script>
```
This will enable a CSP policy for the app and apply the `nonce` value to a few static `script` tags
4. Run the app (`npm start`) and observe **3** CSP violation errors. The first 2 can be safely ignored (dev-server related out-of-scope of the regression), but the third error is related to not being able to load the "data styles" which are responsible for pre-hydration styling and styles for `slot-fb` elements.
5. Install the following dev build (built off this branch):
```bash
npm i @stencil/core@4.8.0-dev.1701099049.800cac3
```
6. Re-run the app (`npm start`). Only the first two CSP errors should remain!

**Automated tests**
No automated tests were added since this is rather hacky to minimally replicate

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
