### PR TITLE
fix(testing): re-add Puppeteer `asElement()` calls

### DIFF
--- a/src/testing/puppeteer/puppeteer-element.ts
+++ b/src/testing/puppeteer/puppeteer-element.ts
@@ -593,7 +593,7 @@ async function findWithCssSelector(
       return null;
     }
 
-    elmHandle = shadowHandle;
+    elmHandle = shadowHandle.asElement() as puppeteer.ElementHandle<Element>;
   }
 
   return elmHandle;
@@ -646,7 +646,7 @@ async function findWithText(
   );
 
   if (jsHandle) {
-    return jsHandle;
+    return jsHandle.asElement() as puppeteer.ElementHandle<Element>;
   }
 
   return null;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes a regression caused by the removal of a few `asElement()` calls in 91cfa2c9adb50f27c823653511a4913d320398b1. Turns out these are necessary for the case where the handle is `null`. To avoid type errors, we cast the returned value to be of type `ElementHandle<Element>` rather than `ElementHandle<Node`.

Fixes: #5113

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

No more errors 🙂

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

1. Open the repro case in the linked issue
2. Run `npm run test` and observe a failure on the second call to `page.find` in the e2e test
3. Install a build of this branch
4. Run `npm run test` and observe no more errors and tests pass!

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
