### PR TITLE
fix(runtime): relocate slotted content when slot parent element tag changes

### DIFF
--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -172,8 +172,8 @@ const createElm = (oldParentVNode: d.VNode, newParentVNode: d.VNode, childIndex:
 
 /**
  * Relocates all child nodes of an element that were a part of a previous slot relocation
- * to the root of the Stencil component currently being rendered. This happens when a the parent
- * element of a slot reference node is dynamically changes and triggers a re-render. We cannot use
+ * to the root of the Stencil component currently being rendered. This happens when a parent
+ * element of a slot reference node dynamically changes and triggers a re-render. We cannot use
  * `putBackInOriginalLocation()` because that may relocate nodes to elements that will not be re-rendered
  * and so they will not be relocated again.
  *

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -164,6 +164,15 @@ const createElm = (oldParentVNode: d.VNode, newParentVNode: d.VNode, childIndex:
   return elm;
 };
 
+/**
+ * Relocates all child nodes of an element that were a part of a previous slot relocation
+ * to the root of the Stencil component currently being rendered. This happens when a the parent
+ * element of a slot reference node is dynamically changes and triggers a re-render. We cannot use
+ * `putBackInOriginalLocation()` because that may relocate nodes to elements that will not be re-rendered
+ * and so they will not be relocated again.
+ *
+ * @param parentElm The element potentially containing relocated nodes.
+ */
 const relocateToHostRoot = (parentElm: Element) => {
   plt.$flags$ |= PLATFORM_FLAGS.isTmpDisconnected;
 
@@ -182,6 +191,7 @@ const relocateToHostRoot = (parentElm: Element) => {
         childNode.setAttribute('slot', childNode['s-sn']);
       }
 
+      // Need to tell the render pipeline to check to relocate slot content again
       checkSlotRelocate = true;
     }
   }

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -183,22 +183,24 @@ const relocateToHostRoot = (parentElm: Element) => {
   plt.$flags$ |= PLATFORM_FLAGS.isTmpDisconnected;
 
   const host = parentElm.closest(hostTagName.toLowerCase());
-  for (const childNode of Array.from(parentElm.childNodes) as d.RenderNode[]) {
-    // Only relocate nodes that were slotted in
-    if (childNode['s-sh'] != null) {
-      host.insertBefore(childNode, null);
-      // Reset so we can correctly move the node around again.
-      childNode['s-sh'] = undefined;
+  if (host != null) {
+    for (const childNode of Array.from(parentElm.childNodes) as d.RenderNode[]) {
+      // Only relocate nodes that were slotted in
+      if (childNode['s-sh'] != null) {
+        host.insertBefore(childNode, null);
+        // Reset so we can correctly move the node around again.
+        childNode['s-sh'] = undefined;
 
-      // When putting an element node back in its original location,
-      // we need to reset the `slot` attribute back to the value it originally had
-      // so we can correctly relocate it again in the future
-      if (childNode.nodeType === NODE_TYPE.ElementNode && !!childNode['s-sn']) {
-        childNode.setAttribute('slot', childNode['s-sn']);
+        // When putting an element node back in its original location,
+        // we need to reset the `slot` attribute back to the value it originally had
+        // so we can correctly relocate it again in the future
+        if (childNode.nodeType === NODE_TYPE.ElementNode && !!childNode['s-sn']) {
+          childNode.setAttribute('slot', childNode['s-sn']);
+        }
+
+        // Need to tell the render pipeline to check to relocate slot content again
+        checkSlotRelocate = true;
       }
-
-      // Need to tell the render pipeline to check to relocate slot content again
-      checkSlotRelocate = true;
     }
   }
 

--- a/test/karma/test-app/components.d.ts
+++ b/test/karma/test-app/components.d.ts
@@ -351,6 +351,12 @@ export namespace Components {
     }
     interface SlotNoDefault {
     }
+    interface SlotParentTagChange {
+        "element": string;
+    }
+    interface SlotParentTagChangeRoot {
+        "element": string;
+    }
     interface SlotReorder {
         "reordered": boolean;
     }
@@ -1306,6 +1312,18 @@ declare global {
         prototype: HTMLSlotNoDefaultElement;
         new (): HTMLSlotNoDefaultElement;
     };
+    interface HTMLSlotParentTagChangeElement extends Components.SlotParentTagChange, HTMLStencilElement {
+    }
+    var HTMLSlotParentTagChangeElement: {
+        prototype: HTMLSlotParentTagChangeElement;
+        new (): HTMLSlotParentTagChangeElement;
+    };
+    interface HTMLSlotParentTagChangeRootElement extends Components.SlotParentTagChangeRoot, HTMLStencilElement {
+    }
+    var HTMLSlotParentTagChangeRootElement: {
+        prototype: HTMLSlotParentTagChangeRootElement;
+        new (): HTMLSlotParentTagChangeRootElement;
+    };
     interface HTMLSlotReorderElement extends Components.SlotReorder, HTMLStencilElement {
     }
     var HTMLSlotReorderElement: {
@@ -1538,6 +1556,8 @@ declare global {
         "slot-nested-order-parent": HTMLSlotNestedOrderParentElement;
         "slot-ng-if": HTMLSlotNgIfElement;
         "slot-no-default": HTMLSlotNoDefaultElement;
+        "slot-parent-tag-change": HTMLSlotParentTagChangeElement;
+        "slot-parent-tag-change-root": HTMLSlotParentTagChangeRootElement;
         "slot-reorder": HTMLSlotReorderElement;
         "slot-reorder-root": HTMLSlotReorderRootElement;
         "slot-replace-wrapper": HTMLSlotReplaceWrapperElement;
@@ -1904,6 +1924,12 @@ declare namespace LocalJSX {
     }
     interface SlotNoDefault {
     }
+    interface SlotParentTagChange {
+        "element"?: string;
+    }
+    interface SlotParentTagChangeRoot {
+        "element"?: string;
+    }
     interface SlotReorder {
         "reordered"?: boolean;
     }
@@ -2074,6 +2100,8 @@ declare namespace LocalJSX {
         "slot-nested-order-parent": SlotNestedOrderParent;
         "slot-ng-if": SlotNgIf;
         "slot-no-default": SlotNoDefault;
+        "slot-parent-tag-change": SlotParentTagChange;
+        "slot-parent-tag-change-root": SlotParentTagChangeRoot;
         "slot-reorder": SlotReorder;
         "slot-reorder-root": SlotReorderRoot;
         "slot-replace-wrapper": SlotReplaceWrapper;
@@ -2231,6 +2259,8 @@ declare module "@stencil/core" {
             "slot-nested-order-parent": LocalJSX.SlotNestedOrderParent & JSXBase.HTMLAttributes<HTMLSlotNestedOrderParentElement>;
             "slot-ng-if": LocalJSX.SlotNgIf & JSXBase.HTMLAttributes<HTMLSlotNgIfElement>;
             "slot-no-default": LocalJSX.SlotNoDefault & JSXBase.HTMLAttributes<HTMLSlotNoDefaultElement>;
+            "slot-parent-tag-change": LocalJSX.SlotParentTagChange & JSXBase.HTMLAttributes<HTMLSlotParentTagChangeElement>;
+            "slot-parent-tag-change-root": LocalJSX.SlotParentTagChangeRoot & JSXBase.HTMLAttributes<HTMLSlotParentTagChangeRootElement>;
             "slot-reorder": LocalJSX.SlotReorder & JSXBase.HTMLAttributes<HTMLSlotReorderElement>;
             "slot-reorder-root": LocalJSX.SlotReorderRoot & JSXBase.HTMLAttributes<HTMLSlotReorderRootElement>;
             "slot-replace-wrapper": LocalJSX.SlotReplaceWrapper & JSXBase.HTMLAttributes<HTMLSlotReplaceWrapperElement>;

--- a/test/karma/test-app/slot-parent-tag-change/cmp-root.tsx
+++ b/test/karma/test-app/slot-parent-tag-change/cmp-root.tsx
@@ -1,0 +1,16 @@
+import { Component, h, Prop } from '@stencil/core';
+
+@Component({
+  tag: 'slot-parent-tag-change-root',
+})
+export class SlotParentTagChangeRoot {
+  @Prop() element = 'p';
+
+  render() {
+    return (
+      <slot-parent-tag-change element={this.element}>
+        <slot></slot>
+      </slot-parent-tag-change>
+    );
+  }
+}

--- a/test/karma/test-app/slot-parent-tag-change/cmp.tsx
+++ b/test/karma/test-app/slot-parent-tag-change/cmp.tsx
@@ -1,0 +1,16 @@
+import { Component, h, Prop } from '@stencil/core';
+
+@Component({
+  tag: 'slot-parent-tag-change',
+})
+export class SlotParentTagChange {
+  @Prop() element = 'p';
+
+  render() {
+    return (
+      <this.element>
+        <slot></slot>
+      </this.element>
+    );
+  }
+}

--- a/test/karma/test-app/slot-parent-tag-change/index.html
+++ b/test/karma/test-app/slot-parent-tag-change/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf8" />
+<script src="./build/testapp.esm.js" type="module"></script>
+<script src="./build/testapp.js" nomodule></script>
+
+<!-- Test "top-level" slot -->
+<slot-parent-tag-change id="top-level"> Hello </slot-parent-tag-change>
+<!-- Test nested slot -->
+<slot-parent-tag-change-root> World </slot-parent-tag-change-root>
+
+<button type="button" id="top-level-button">Change Top-Level Slot</button>
+<button type="button" id="nested-button">Change Nested Slot</button>
+
+<script>
+  document.querySelector('#top-level-button').addEventListener('click', () => {
+    document.querySelector('#top-level').setAttribute('element', 'span');
+  });
+  document.querySelector('#nested-button').addEventListener('click', () => {
+    document.querySelector('slot-parent-tag-change-root').setAttribute('element', 'span');
+  });
+</script>

--- a/test/karma/test-app/slot-parent-tag-change/karma.spec.ts
+++ b/test/karma/test-app/slot-parent-tag-change/karma.spec.ts
@@ -1,0 +1,52 @@
+import { setupDomTests, waitForChanges } from '../util';
+
+/**
+ * Tests the cases where a node is slotted in from the root `index.html` file
+ * and the slot's parent element dynamically changes (e.g. from `p` to `span`).
+ */
+describe('slot-parent-tag-change', () => {
+  const { setupDom, tearDownDom } = setupDomTests(document);
+  let app: HTMLElement;
+
+  beforeEach(async () => {
+    app = await setupDom('/slot-parent-tag-change/index.html');
+  });
+
+  afterEach(tearDownDom);
+
+  describe('direct slot', () => {
+    it('should relocate the text node to the slot after the parent tag changes', async () => {
+      const root = app.querySelector('#top-level');
+
+      expect(root).not.toBeNull();
+      expect(root.children.length).toBe(1);
+      expect(root.children[0].tagName).toBe('P');
+      expect(root.children[0].textContent.trim()).toBe('Hello');
+
+      app.querySelector<HTMLButtonElement>('#top-level-button').click();
+      await waitForChanges();
+
+      expect(root.children.length).toBe(1);
+      expect(root.children[0].tagName).toBe('SPAN');
+      expect(root.children[0].textContent.trim()).toBe('Hello');
+    });
+  });
+
+  describe('nested slot', () => {
+    it('should relocate the text node to the slot after the parent tag changes', async () => {
+      const root = app.querySelector('slot-parent-tag-change-root slot-parent-tag-change');
+
+      expect(root).not.toBeNull();
+      expect(root.children.length).toBe(1);
+      expect(root.children[0].tagName).toBe('P');
+      expect(root.children[0].textContent.trim()).toBe('World');
+
+      app.querySelector<HTMLButtonElement>('#nested-button').click();
+      await waitForChanges();
+
+      expect(root.children.length).toBe(1);
+      expect(root.children[0].tagName).toBe('SPAN');
+      expect(root.children[0].textContent.trim()).toBe('World');
+    });
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Stencil can re-render incorrectly when content is slotted in from the "implementation layer" (i.e. from `index.html`) and a `slot`s parent element tag changes (e.g. from `p` to `span`). This is only an issue when using slots outside the Shadow DOM. 

The issue is caused by our vDOM algorithm relocating slotted content back to its _original_ location when it determines that a child node has changed. When this happens, we call `putBackInOriginalLocation()` which will relocate a node back to where it was original defined. But, this can result in the node no being re-relocated if it was put back into a location inside another Stencil element that has already gone through its render cycle. In this case, the node will stay in its original location rather than being relocated through the DOM elements again.

Fixes: #4284 #3913 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Instead of using `putBackInOriginalLocation()` when we identify changed nodes, this PR introduces a new method, `relocateToHostRoot()`. This method will move all nodes that were slotted into the changed node to the root of the element currently being rendered. So, when we enter the `renderVdom()` method for the component, it will be able to relocate any slotted content back to its new location.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

**Manual testing**
Two test cases can be reproduced using the repros from the linked issues and a build of this branch. These cases are also covered by e2e test.

A third test case can be created similar to the following (testing same behavior as first two, just more complex):
1. Create a new Stencil component starter
2. Enable `extras.experimentalSlotFixes` in the Stencil config
3. Create the following three components:
```tsx
@Component({
  tag: 'super-cmp',
  shadow: false,
  scoped: false,
})
export class SuperCmp implements ComponentInterface {
  @Prop() tag: any = 'p';

  render(): HTMLElement {
    return (
      <Host>
        <slot name="tmp"></slot>
        <my-cmp tag={this.tag}>
          <p>YOOO</p>
          <slot></slot>
        </my-cmp>
      </Host>
    );
  }
}
```

```tsx
@Component({
  tag: 'my-cmp',
  shadow: false,
  scoped: false,
})
export class MyCmp implements ComponentInterface {
  @Prop() tag: any = 'p';

  render(): HTMLElement {
    return (
      <Host>
        <base-cmp tag={this.tag}>
          <span>HOWDY</span>
          <slot></slot>
        </base-cmp>
      </Host>
    );
  }
}
```

```tsx
@Component({
  tag: 'base-cmp',
})
export class BaseCmp implements ComponentInterface {
  @Prop() tag: any = 'p';

  render() {
    return (
      <Host>
        <this.tag>
          <slot />
        </this.tag>
      </Host>
    );
  }
}
```
4. Update the `src/index.html` to have the following `body`
```html
<super-cmp>
  <p slot="tmp">Test</p>
  Hello
</super-cmp>
<button type="button">Click</button>

<script>
  document.querySelector('button').addEventListener('click', () => {
    document.querySelector('super-cmp').setAttribute('tag', 'span');
  });
</script>
```
5. The components will render correctly initially, but "Hello" will be in the incorrect location after clicking the button (should be in the `span` tag in the `base-cmp` component.
6. Install a build of this branch into the starter.
7. Run the project. The "hello" test will no relocate to the `span` tag after clicking the button. All "statically slotted" content will also render in the expected order ("yooo", "howdy", "hello")

**Automated testing**
All existing unit & e2e tests continue to pass. Also added new e2e tests for the reproduction cases in the linked issues.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

Only available with the `experimentalSlotFixes` extra flag enabled.
