### PR TITLE
fix(compiler): revert un-intentional changes that causes regression in upstream projects

### DIFF
--- a/src/compiler/transformers/style-imports.ts
+++ b/src/compiler/transformers/style-imports.ts
@@ -65,12 +65,15 @@ const updateEsmStyleImports = (
 
   moduleFile.cmps.forEach((cmp) => {
     cmp.styles.forEach((style) => {
-      updateSourceFile = true;
       if (typeof style.styleIdentifier === 'string') {
-        statements = updateEsmStyleImportPath(transformOpts, tsSourceFile, statements, cmp, style);
-      } else if (style.externalStyles.length > 0) {
-        // add style imports built from @Component() styleUrl option
-        styleImports.push(...createStyleImport(transformOpts, tsSourceFile, cmp, style, transformOpts.module as 'esm'));
+        updateSourceFile = true;
+        if (style.externalStyles.length > 0) {
+          // add style imports built from @Component() styleUrl option
+          styleImports.push(...createStyleImport(transformOpts, tsSourceFile, cmp, style));
+        } else if (style.externalStyles.length > 0) {
+          // update existing esm import of a style identifier
+          statements = updateEsmStyleImportPath(transformOpts, tsSourceFile, statements, cmp, style);
+        }
       }
     });
   });
@@ -244,7 +247,7 @@ const updateCjsStyleRequires = (
 
   moduleFile.cmps.forEach((cmp) => {
     cmp.styles.forEach((style) => {
-      if (style.externalStyles.length > 0) {
+      if (typeof style.styleIdentifier === 'string' && style.externalStyles.length > 0) {
         // add style imports built from @Component() styleUrl option
         styleRequires.push(...createStyleImport(transformOpts, tsSourceFile, cmp, style, transformOpts.module));
       }

--- a/src/compiler/transformers/test/lazy-component.spec.ts
+++ b/src/compiler/transformers/test/lazy-component.spec.ts
@@ -132,8 +132,6 @@ describe('lazy-component', () => {
     const t = transpileModule(code, null, compilerCtx, [], [transformer]);
     expect(await formatCode(t.outputText)).toBe(
       await c`import { registerInstance as __stencil_registerInstance } from "@stencil/core";
-      import CMP_A__foo_bar_css from './foo/bar.css';
-      import CMP_A__bar_foo_css  from './bar/foo.css';
       export const CmpA = class {
         constructor(hostRef) {
           __stencil_registerInstance(this, hostRef);
@@ -165,14 +163,12 @@ describe('lazy-component', () => {
     const transformer = lazyComponentTransform(compilerCtx, transformOpts);
     const t = transpileModule(code, null, compilerCtx, [], [transformer]);
     expect(await formatCode(t.outputText)).toBe(
-      await c`const CMP_A__foo_bar_css = require('./foo/bar.css');
-      const CMP_A__bar_foo_css  = require('./bar/foo.css');
-      const { registerInstance: __stencil_registerInstance } = require('@stencil/core');
-      export class CmpA {
+      await c`export class CmpA {
         constructor(hostRef) {
           __stencil_registerInstance(this, hostRef);
         }
       };
+      const { registerInstance: __stencil_registerInstance } = require('@stencil/core');
       CmpA.style = CMP_A__foo_bar_css + CMP_A__bar_foo_css ;`,
     );
   });
@@ -199,8 +195,7 @@ describe('lazy-component', () => {
     const transformer = lazyComponentTransform(compilerCtx, transformOpts);
     const t = transpileModule(code, null, compilerCtx, [], [transformer]);
     expect(await formatCode(t.outputText)).toBe(
-      await c`const CMP_A__foo_bar_css = require('./foo/bar.css');
-      export class CmpA {
+      await c`export class CmpA {
         constructor(hostRef) {
           __stencil_registerInstance(this, hostRef);
         }
@@ -236,9 +231,6 @@ describe('lazy-component', () => {
     const t = transpileModule(code, null, compilerCtx, [], [transformer]);
     expect(await formatCode(t.outputText)).toBe(
       await c`import { registerInstance as __stencil_registerInstance } from "@stencil/core";
-      import CMP_A_bar__bar_foo_css  from './bar/foo.css';
-      import CMP_A_foo__foo_bar_css from './foo/bar.css';
-      import CMP_A_loo__bar_foo_css  from './bar/foo.css';
       export const CmpA = class {
         constructor(hostRef) {
           __stencil_registerInstance(this, hostRef);


### PR DESCRIPTION
## What is the current behavior?

We recently landed changes in `main` (not released) related to support multiple style urls:

- https://github.com/ionic-team/stencil/commit/54e52da952faa59026c00cf603a027dae5fe82ee
- https://github.com/ionic-team/stencil/commit/7591dce85e3b19ab623752341344d009881032be

These changes however have caused failures when building upstream project, e.g. in Ionic framework (see https://github.com/ionic-team/ionic-framework/actions/runs/7064837482/job/19233697164)

GitHub Issue Number: N/A

## What is the new behavior?

I bisected the changes and found some that looked like a code improvement but turned out to cause side effects. The reason why this seemed harmless in the first place was because the unit test now show _no_ imports and make the assertion look invalid. My hunch is that these import statements get resolved later and its CSS gets injected into the component directly. Further investigations is needed to verify this though.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

To test this change:

- checkout current `main` branch in Stencil, build it `npm run build` and pack `npm pack`
- now checkout the Ionic project `ionic-team/ionic-framework` and install the packaged Stencil project, e.g. `npm i ../../stencil/stencil-core-4.8.0.tgz`
- run a failing test, e.g. `npm run test.spec -- --clearCache && npm run test.spec -- -- core/src/utils/test/aria.spec.ts`

Expected behavior: test fails, similar to [mentioned pipeline](https://github.com/ionic-team/ionic-framework/actions/runs/7064837482/job/19233697164).

Verify via:

- check out this branch, build and pack
- re-run above steps and test on the Ionic project

Expected behavior: test pass now

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
