### PR TITLE
fix(compiler): reapply changes to style import transformer

### DIFF
--- a/src/compiler/transformers/component-native/native-static-style.ts
+++ b/src/compiler/transformers/component-native/native-static-style.ts
@@ -1,9 +1,10 @@
-import { dashToPascalCase, DEFAULT_STYLE_MODE } from '@utils';
+import { DEFAULT_STYLE_MODE } from '@utils';
 import ts from 'typescript';
 
 import type * as d from '../../../declarations';
 import { scopeCss } from '../../../utils/shadow-css';
 import { getScopeId } from '../../style/scope-css';
+import { createStyleIdentifier } from '../add-static-style';
 import { createStaticGetter } from '../transform-utils';
 
 export const addNativeStaticStyle = (classMembers: ts.ClassElement[], cmp: d.ComponentCompilerMeta) => {
@@ -43,7 +44,7 @@ const addMultipleModeStyleGetter = (
       // import generated from @Component() styleUrls option
       // import myTagIosStyle from './import-path.css';
       // static get style() { return { "ios": myTagIosStyle }; }
-      const styleUrlIdentifier = createStyleIdentifierFromUrl(cmp, style);
+      const styleUrlIdentifier = createStyleIdentifier(cmp, style);
       const propUrlIdentifier = ts.factory.createPropertyAssignment(style.modeName, styleUrlIdentifier);
       styleModes.push(propUrlIdentifier);
     }
@@ -74,7 +75,7 @@ const addSingleStyleGetter = (
     // import generated from @Component() styleUrls option
     // import myTagStyle from './import-path.css';
     // static get style() { return myTagStyle; }
-    const styleUrlIdentifier = createStyleIdentifierFromUrl(cmp, style);
+    const styleUrlIdentifier = createStyleIdentifier(cmp, style);
     classMembers.push(createStaticGetter('style', styleUrlIdentifier));
   }
 };
@@ -87,18 +88,4 @@ const createStyleLiteral = (cmp: d.ComponentCompilerMeta, style: d.StyleCompiler
   }
 
   return ts.factory.createStringLiteral(style.styleStr);
-};
-
-const createStyleIdentifierFromUrl = (cmp: d.ComponentCompilerMeta, style: d.StyleCompiler) => {
-  style.styleIdentifier = dashToPascalCase(cmp.tagName);
-  style.styleIdentifier = style.styleIdentifier.charAt(0).toLowerCase() + style.styleIdentifier.substring(1);
-
-  if (style.modeName !== DEFAULT_STYLE_MODE) {
-    style.styleIdentifier += dashToPascalCase(style.modeName);
-  }
-
-  style.styleIdentifier += 'Style';
-  style.externalStyles = [style.externalStyles[0]];
-
-  return ts.factory.createIdentifier(style.styleIdentifier);
 };

--- a/src/compiler/transformers/test/lazy-component.spec.ts
+++ b/src/compiler/transformers/test/lazy-component.spec.ts
@@ -108,4 +108,102 @@ describe('lazy-component', () => {
       }`,
     );
   });
+
+  describe('styling', () => {
+    function verifyStylingUsingComponent(inputComponent: string, expectedOutput: string) {
+      return async () => {
+        const compilerCtx = mockCompilerCtx();
+        const transformOpts: d.TransformOptions = {
+          coreImportPath: '@stencil/core',
+          componentExport: 'lazy',
+          componentMetadata: null,
+          currentDirectory: '/',
+          proxy: null,
+          style: 'static',
+          styleImportData: null,
+        };
+
+        const transformer = lazyComponentTransform(compilerCtx, transformOpts);
+        const t = transpileModule(inputComponent, null, compilerCtx, [], [transformer]);
+        expect(await formatCode(t.outputText)).toBe(await formatCode(expectedOutput));
+      };
+    }
+
+    // eslint-disable-next-line jest/expect-expect
+    it(
+      'using `styleUrl` parameter',
+      verifyStylingUsingComponent(
+        `
+        @Component({
+          tag: 'cmp-a',
+          styleUrl: 'cmp-a.css'
+        })
+        export class CmpA {}
+      `,
+        `
+        import { registerInstance as __stencil_registerInstance } from "@stencil/core";
+        import CmpAStyle0 from './cmp-a.css';
+        export const CmpA = class {
+          constructor (hostRef) {
+            __stencil_registerInstance(this, hostRef);
+          }
+        };
+        CmpA.style = CmpAStyle0;
+      `,
+      ),
+    );
+
+    // eslint-disable-next-line jest/expect-expect
+    it(
+      'using `styleUrls` parameter as object',
+      verifyStylingUsingComponent(
+        `
+        @Component({
+          tag: 'cmp-a',
+          styleUrls: {
+            foo: 'cmp-a.foo.css',
+            bar: 'cmp-a.bar.css',
+          }
+        })
+        export class CmpA {}
+      `,
+        `
+        import { registerInstance as __stencil_registerInstance } from "@stencil/core";
+        import CmpABarStyle0 from './cmp-a.bar.css';
+        import CmpAFooStyle0 from './cmp-a.foo.css';
+        export const CmpA = class {
+          constructor (hostRef) {
+            __stencil_registerInstance(this, hostRef);
+          }
+        };
+        CmpA.style = { bar: CmpABarStyle0, foo: CmpAFooStyle0 };
+      `,
+      ),
+    );
+
+    // eslint-disable-next-line jest/expect-expect
+    it(
+      'using `styleUrls` parameter as array',
+      verifyStylingUsingComponent(
+        `
+        @Component({
+          tag: 'cmp-a',
+          styleUrls: ['cmp-a.foo.css', 'cmp-a.bar.css', 'cmp-a.foo.css'],
+        })
+        export class CmpA {}
+      `,
+        `
+        import { registerInstance as __stencil_registerInstance } from "@stencil/core";
+        import CmpAStyle0 from './cmp-a.bar.css';
+        import CmpAStyle1 from './cmp-a.foo.css';
+        export const CmpA = class {
+          constructor (hostRef) {
+            __stencil_registerInstance(this, hostRef);
+          }
+        };
+        CmpA.style = CmpAStyle0 + CmpAStyle1;
+      `,
+      ),
+    );
+  });
 });

--- a/src/compiler/transformers/test/parse-styles.spec.ts
+++ b/src/compiler/transformers/test/parse-styles.spec.ts
@@ -18,11 +18,12 @@ describe('parse styles', () => {
     const t = transpileModule(`
       @Component({
         tag: 'cmp-a',
-        styleUrls: ['style.css']
+        styleUrls: ['style.css', 'style2.css']
       })
       export class CmpA {}
     `);
-    expect(getStaticGetter(t.outputText, 'styleUrls')).toEqual({ $: ['style.css'] });
+
+    expect(getStaticGetter(t.outputText, 'styleUrls')).toEqual({ $: ['style.css', 'style2.css'] });
   });
 
   it('add static "styles"', () => {

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -1097,3 +1097,35 @@ export const tsPropDeclNameAsString = (node: ts.PropertyDeclaration, typeChecker
 
   return memberName;
 };
+
+/**
+ * Reverse order and reduce to remove duplicates. This will make sure that duplicate
+ * styles applied to the same component will be applied in the order they are
+ * defined in the component, e.g.
+ * ```
+ * @Component({
+ *  styleUrls: ['cmp-a.css', 'cmp-b.css', 'cmp-a.css']
+ * })
+ * ```
+ * will be applied in the order `cmp-b.css`, `cmp-a.css`.
+ *
+ * @param style style meta data
+ * @returns a list of external styles sorted in order
+ */
+export function getExternalStyles(style: d.StyleCompiler) {
+  return (
+    style.externalStyles
+      .map((s) => s.absolutePath)
+      .reverse()
+      .reduce((extStyles, styleUrl) => {
+        if (!extStyles.includes(styleUrl)) {
+          extStyles.push(styleUrl);
+        }
+        return extStyles;
+      }, [] as string[])
+      /**
+       * Reverse back to the original order
+       */
+      .reverse()
+  );
+}

--- a/test/karma/test-app/components.d.ts
+++ b/test/karma/test-app/components.d.ts
@@ -213,6 +213,8 @@ export namespace Components {
     }
     interface ListenWindow {
     }
+    interface MultipleStylesCmp {
+    }
     interface NoDelegatesFocus {
     }
     interface NodeResolution {
@@ -970,6 +972,12 @@ declare global {
         prototype: HTMLListenWindowElement;
         new (): HTMLListenWindowElement;
     };
+    interface HTMLMultipleStylesCmpElement extends Components.MultipleStylesCmp, HTMLStencilElement {
+    }
+    var HTMLMultipleStylesCmpElement: {
+        prototype: HTMLMultipleStylesCmpElement;
+        new (): HTMLMultipleStylesCmpElement;
+    };
     interface HTMLNoDelegatesFocusElement extends Components.NoDelegatesFocus, HTMLStencilElement {
     }
     var HTMLNoDelegatesFocusElement: {
@@ -1482,6 +1490,7 @@ declare global {
         "listen-jsx-root": HTMLListenJsxRootElement;
         "listen-reattach": HTMLListenReattachElement;
         "listen-window": HTMLListenWindowElement;
+        "multiple-styles-cmp": HTMLMultipleStylesCmpElement;
         "no-delegates-focus": HTMLNoDelegatesFocusElement;
         "node-resolution": HTMLNodeResolutionElement;
         "non-shadow-host": HTMLNonShadowHostElement;
@@ -1766,6 +1775,8 @@ declare namespace LocalJSX {
     }
     interface ListenWindow {
     }
+    interface MultipleStylesCmp {
+    }
     interface NoDelegatesFocus {
     }
     interface NodeResolution {
@@ -2018,6 +2029,7 @@ declare namespace LocalJSX {
         "listen-jsx-root": ListenJsxRoot;
         "listen-reattach": ListenReattach;
         "listen-window": ListenWindow;
+        "multiple-styles-cmp": MultipleStylesCmp;
         "no-delegates-focus": NoDelegatesFocus;
         "node-resolution": NodeResolution;
         "non-shadow-host": NonShadowHost;
@@ -2175,6 +2187,7 @@ declare module "@stencil/core" {
             "listen-jsx-root": LocalJSX.ListenJsxRoot & JSXBase.HTMLAttributes<HTMLListenJsxRootElement>;
             "listen-reattach": LocalJSX.ListenReattach & JSXBase.HTMLAttributes<HTMLListenReattachElement>;
             "listen-window": LocalJSX.ListenWindow & JSXBase.HTMLAttributes<HTMLListenWindowElement>;
+            "multiple-styles-cmp": LocalJSX.MultipleStylesCmp & JSXBase.HTMLAttributes<HTMLMultipleStylesCmpElement>;
             "no-delegates-focus": LocalJSX.NoDelegatesFocus & JSXBase.HTMLAttributes<HTMLNoDelegatesFocusElement>;
             "node-resolution": LocalJSX.NodeResolution & JSXBase.HTMLAttributes<HTMLNodeResolutionElement>;
             "non-shadow-host": LocalJSX.NonShadowHost & JSXBase.HTMLAttributes<HTMLNonShadowHostElement>;

--- a/test/karma/test-app/style-plugin/bar.scss
+++ b/test/karma/test-app/style-plugin/bar.scss
@@ -1,0 +1,13 @@
+:host {
+  display: block;
+  font-style: italic;
+}
+
+h1 {
+  color: blue;
+}
+
+p {
+  // change
+  color: blue;
+}

--- a/test/karma/test-app/style-plugin/foo.scss
+++ b/test/karma/test-app/style-plugin/foo.scss
@@ -1,0 +1,11 @@
+:host {
+  display: block;
+}
+
+h1 {
+  color: red;
+}
+
+p {
+  color: red;
+}

--- a/test/karma/test-app/style-plugin/index.html
+++ b/test/karma/test-app/style-plugin/index.html
@@ -11,3 +11,5 @@
 <css-cmp></css-cmp>
 
 <sass-cmp></sass-cmp>
+
+<multiple-styles-cmp></multiple-styles-cmp>

--- a/test/karma/test-app/style-plugin/karma.spec.ts
+++ b/test/karma/test-app/style-plugin/karma.spec.ts
@@ -38,4 +38,18 @@ describe('style-plugin', function () {
     expect(window.getComputedStyle(cssImportee).color).toBe('rgb(0, 0, 255)');
     expect(window.getComputedStyle(hr).height).toBe('0px');
   });
+
+  it('multiple-styles-cmp', async () => {
+    const cssHost = app.querySelector('multiple-styles-cmp');
+    const shadowRoot = cssHost.shadowRoot;
+
+    const h1 = getComputedStyle(shadowRoot.querySelector('h1'));
+    const div = getComputedStyle(shadowRoot.querySelector('p'));
+    // color is red because foo.scss is mentioned last and overwrites bar.scss
+    expect(h1.color).toEqual('rgb(255, 0, 0)');
+    expect(div.color).toEqual('rgb(255, 0, 0)');
+    // ensure styles defined in bar.scss are applied too
+    expect(h1.fontStyle).toEqual('italic');
+    expect(div.fontStyle).toEqual('italic');
+  });
 });

--- a/test/karma/test-app/style-plugin/multiple-styles.tsx
+++ b/test/karma/test-app/style-plugin/multiple-styles.tsx
@@ -1,0 +1,21 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'multiple-styles-cmp',
+  /**
+   * styles are intentionally duplicated to ensure that `foo.scss` can overwrite
+   * `bar.scss` since it is set last in the `styleUrls` array.
+   */
+  styleUrls: ['foo.scss', 'bar.scss', 'foo.scss'],
+  shadow: true,
+})
+export class SassCmp {
+  render() {
+    return (
+      <main>
+        <h1>Hello World</h1>
+        <p>What's your name?</p>
+      </main>
+    );
+  }
+}


### PR DESCRIPTION
## What is the current behavior?
Currently if multiple style urls are provided, as described in the docs:

```ts
@Component({
  tag: 'my-component',
  styleUrls: ['reset.scss', 'roboto.scss', 'css-variables.scss', 'core.scss'] 
})
export class MyComponent {
  // ...
}
```

Only the first (`reset.css`) style would get applied to the component.

fixes: #5016
STENCIL-999

## What is the new behavior?
Instead of just compiling the first external style, I make it loop through all external styles and join the style strings together. Here is an example:

```ts
const barCss = ":host{display:block}";
const fooCss = ":host{display:none}";

const MyComponent = class {
    // ...
};
MyComponent.style = barCss + fooCss;

export { MyComponent as my_component };
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I've added a bunch of unit and e2e tests to verify this change. You can verify the new behavior by bootstrapping a Stencil component like this:

```ts
import { Component, h } from '@stencil/core';

@Component({
  tag: 'my-component',
  styleUrls: ['bar.css', 'foo.css', 'foo.css'],
})
export class MyComponent {
  render() {
    return <div>Hello, World! I'm here</div>;
  }
}
```

You will see that the compiled code will only import a single css file.


## Other information

After further investigations it turns out that removing the assignment to `style.styleIdentifer` was the problem.
