### PR TITLE
chore(esbuild): ensure base esbuild options are set for compiler

### DIFF
--- a/scripts/esbuild/compiler.ts
+++ b/scripts/esbuild/compiler.ts
@@ -10,7 +10,7 @@ import { bundleTypeScriptSource, tsCacheFilePath } from '../bundles/plugins/type
 import { getBanner } from '../utils/banner';
 import { BuildOptions, createReplaceData } from '../utils/options';
 import { writePkgJson } from '../utils/write-pkg-json';
-import { getEsbuildAliases, getEsbuildExternalModules, runBuilds } from './util';
+import { getBaseEsbuildOptions, getEsbuildAliases, getEsbuildExternalModules, runBuilds } from './util';
 
 export async function buildCompiler(opts: BuildOptions) {
   const inputDir = join(opts.buildDir, 'compiler');
@@ -80,11 +80,10 @@ export async function buildCompiler(opts: BuildOptions) {
   alias['parse5'] = parse5path;
 
   const compilerEsbuildOptions: ESBuildOptions = {
+    ...getBaseEsbuildOptions(),
     banner: { js: getBanner(opts, 'Stencil Compiler', true) },
     entryPoints: [join(srcDir, 'index.ts')],
-    bundle: true,
     platform: 'node',
-    logLevel: 'info',
     sourcemap: 'linked',
     external,
     format: 'cjs',


### PR DESCRIPTION
This adds the `getBaseEsbuildOptions` function to the Esbuild configuration for the `compiler/` bundle. This ensures that the following options are set consistently:

- [`logLevel`](https://esbuild.github.io/api/#log-level)
- [`legalComments`](https://esbuild.github.io/api/#legal-comments)
- [`bundle`](https://esbuild.github.io/api/#bundle)

This was accidentally omitted from #5027.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
