### PR TITLE
chore(snc): fix a few snc errors in `src/testing/test-transpile.ts`

### DIFF
--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -2673,7 +2673,7 @@ export interface TranspileOptions {
    * A component can be defined as a custom element by using `customelement`, or the
    * component class can be exported by using `module`. Default is `customelement`.
    */
-  componentExport?: 'customelement' | 'module' | string | undefined;
+  componentExport?: 'customelement' | 'module' | string | undefined | null;
   /**
    * Sets how and if component metadata should be assigned on the compiled
    * component output. The `compilerstatic` value will set the metadata to
@@ -2704,12 +2704,12 @@ export interface TranspileOptions {
    * component class. The `defineproperty` value sets the getters and setters
    * using Object.defineProperty. Default is `defineproperty`.
    */
-  proxy?: 'defineproperty' | string | undefined;
+  proxy?: 'defineproperty' | string | undefined | null;
   /**
    * How component styles should be associated to the component. The `static`
    * setting will assign the styles as a static getter on the component class.
    */
-  style?: 'static' | string | undefined;
+  style?: 'static' | string | undefined | null;
   /**
    * How style data should be added for imports. For example, the `queryparams` value
    * adds the component's tagname and encapsulation info as querystring parameter


### PR DESCRIPTION
This fixes a few snc errors by avoiding initializing properties as `null` on an object where they're typed e.g. `string | undefined`.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Just fixing a few SNCs by bringing some types inline with how they're used

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
