### PR TITLE
fix(compiler): make style getter behavior consistent between default and native components

### DIFF
--- a/src/compiler/transformers/add-static-style.ts
+++ b/src/compiler/transformers/add-static-style.ts
@@ -74,6 +74,12 @@ const getMultipleModeStyle = (
   const styleModes: ts.ObjectLiteralElementLike[] = [];
 
   styles.forEach((style) => {
+    /**
+     * the order of these if statements must match with
+     * - {@link src/compiler/transformers/component-native/native-static-style.ts#addSingleStyleGetter}
+     * - {@link src/compiler/transformers/component-native/native-static-style.ts#addMultipleModeStyleGetter}
+     * - {@link src/compiler/transformers/add-static-style.ts#getMultipleModeStyle}
+     */
     if (typeof style.styleStr === 'string') {
       // inline the style string
       // static get style() { return { ios: "string" }; }
@@ -101,6 +107,12 @@ const getMultipleModeStyle = (
 };
 
 const getSingleStyle = (cmp: d.ComponentCompilerMeta, style: d.StyleCompiler, commentOriginalSelector: boolean) => {
+  /**
+   * the order of these if statements must match with
+   * - {@link src/compiler/transformers/component-native/native-static-style.ts#addSingleStyleGetter}
+   * - {@link src/compiler/transformers/component-native/native-static-style.ts#addMultipleModeStyleGetter}
+   * - {@link src/compiler/transformers/add-static-style.ts#getSingleStyle}
+   */
   if (typeof style.styleStr === 'string') {
     // inline the style string
     // static get style() { return "string"; }

--- a/src/compiler/transformers/add-static-style.ts
+++ b/src/compiler/transformers/add-static-style.ts
@@ -80,13 +80,6 @@ const getMultipleModeStyle = (
       const styleLiteral = createStyleLiteral(cmp, style, commentOriginalSelector);
       const propStr = ts.factory.createPropertyAssignment(style.modeName, styleLiteral);
       styleModes.push(propStr);
-    } else if (typeof style.styleIdentifier === 'string') {
-      // direct import already written in the source code
-      // import myTagIosStyle from './import-path.css';
-      // static get style() { return { ios: myTagIosStyle }; }
-      const styleIdentifier = ts.factory.createIdentifier(style.styleIdentifier);
-      const propIdentifier = ts.factory.createPropertyAssignment(style.modeName, styleIdentifier);
-      styleModes.push(propIdentifier);
     } else if (Array.isArray(style.externalStyles) && style.externalStyles.length > 0) {
       // import generated from @Component() styleUrls option
       // import myTagIosStyle from './import-path.css';
@@ -94,6 +87,13 @@ const getMultipleModeStyle = (
       const styleUrlIdentifier = createStyleIdentifier(cmp, style);
       const propUrlIdentifier = ts.factory.createPropertyAssignment(style.modeName, styleUrlIdentifier);
       styleModes.push(propUrlIdentifier);
+    } else if (typeof style.styleIdentifier === 'string') {
+      // direct import already written in the source code
+      // import myTagIosStyle from './import-path.css';
+      // static get style() { return { ios: myTagIosStyle }; }
+      const styleIdentifier = ts.factory.createIdentifier(style.styleIdentifier);
+      const propIdentifier = ts.factory.createPropertyAssignment(style.modeName, styleIdentifier);
+      styleModes.push(propIdentifier);
     }
   });
 

--- a/src/compiler/transformers/component-native/native-static-style.ts
+++ b/src/compiler/transformers/component-native/native-static-style.ts
@@ -33,13 +33,6 @@ const addMultipleModeStyleGetter = (
       const styleLiteral = createStyleLiteral(cmp, style);
       const propStr = ts.factory.createPropertyAssignment(style.modeName, styleLiteral);
       styleModes.push(propStr);
-    } else if (typeof style.styleIdentifier === 'string') {
-      // direct import already written in the source code
-      // import myTagIosStyle from './import-path.css';
-      // static get style() { return { "ios": myTagIosStyle }; }
-      const styleIdentifier = ts.factory.createIdentifier(style.styleIdentifier);
-      const propIdentifier = ts.factory.createPropertyAssignment(style.modeName, styleIdentifier);
-      styleModes.push(propIdentifier);
     } else if (Array.isArray(style.externalStyles) && style.externalStyles.length > 0) {
       // import generated from @Component() styleUrls option
       // import myTagIosStyle from './import-path.css';
@@ -47,6 +40,13 @@ const addMultipleModeStyleGetter = (
       const styleUrlIdentifier = createStyleIdentifier(cmp, style);
       const propUrlIdentifier = ts.factory.createPropertyAssignment(style.modeName, styleUrlIdentifier);
       styleModes.push(propUrlIdentifier);
+    } else if (typeof style.styleIdentifier === 'string') {
+      // direct import already written in the source code
+      // import myTagIosStyle from './import-path.css';
+      // static get style() { return { "ios": myTagIosStyle }; }
+      const styleIdentifier = ts.factory.createIdentifier(style.styleIdentifier);
+      const propIdentifier = ts.factory.createPropertyAssignment(style.modeName, styleIdentifier);
+      styleModes.push(propIdentifier);
     }
   });
 

--- a/src/compiler/transformers/component-native/native-static-style.ts
+++ b/src/compiler/transformers/component-native/native-static-style.ts
@@ -65,18 +65,18 @@ const addSingleStyleGetter = (
     // static get style() { return "string"; }
     const styleLiteral = createStyleLiteral(cmp, style);
     classMembers.push(createStaticGetter('style', styleLiteral));
-  } else if (typeof style.styleIdentifier === 'string') {
-    // direct import already written in the source code
-    // import myTagStyle from './import-path.css';
-    // static get style() { return myTagStyle; }
-    const styleIdentifier = ts.factory.createIdentifier(style.styleIdentifier);
-    classMembers.push(createStaticGetter('style', styleIdentifier));
   } else if (Array.isArray(style.externalStyles) && style.externalStyles.length > 0) {
     // import generated from @Component() styleUrls option
     // import myTagStyle from './import-path.css';
     // static get style() { return myTagStyle; }
     const styleUrlIdentifier = createStyleIdentifier(cmp, style);
     classMembers.push(createStaticGetter('style', styleUrlIdentifier));
+  } else if (typeof style.styleIdentifier === 'string') {
+    // direct import already written in the source code
+    // import myTagStyle from './import-path.css';
+    // static get style() { return myTagStyle; }
+    const styleIdentifier = ts.factory.createIdentifier(style.styleIdentifier);
+    classMembers.push(createStaticGetter('style', styleIdentifier));
   }
 };
 

--- a/src/compiler/transformers/component-native/native-static-style.ts
+++ b/src/compiler/transformers/component-native/native-static-style.ts
@@ -27,6 +27,12 @@ const addMultipleModeStyleGetter = (
   const styleModes: ts.ObjectLiteralElementLike[] = [];
 
   styles.forEach((style) => {
+    /**
+     * the order of these if statements must match with
+     * - {@link src/compiler/transformers/component-native/native-static-style.ts#addSingleStyleGetter}
+     * - {@link src/compiler/transformers/add-static-style.ts#getSingleStyle}
+     * - {@link src/compiler/transformers/add-static-style.ts#getMultipleModeStyle}
+     */
     if (typeof style.styleStr === 'string') {
       // inline the style string
       // static get style() { return { "ios": "string" }; }
@@ -60,6 +66,12 @@ const addSingleStyleGetter = (
   cmp: d.ComponentCompilerMeta,
   style: d.StyleCompiler,
 ) => {
+  /**
+   * the order of these if statements must match with
+   * - {@link src/compiler/transformers/component-native/native-static-style.ts#addMultipleModeStyleGetter}
+   * - {@link src/compiler/transformers/add-static-style.ts#getSingleStyle}
+   * - {@link src/compiler/transformers/add-static-style.ts#getMultipleModeStyle}
+   */
   if (typeof style.styleStr === 'string') {
     // inline the style string
     // static get style() { return "string"; }


### PR DESCRIPTION
## What is the current behavior?
Currently our nightly build is broken due changes introduced in #5131 (see https://github.com/ionic-team/ionic-framework/actions/runs/7124408050). Investigating this issue was difficult as it happens to be random behavior. However I found that the static style property wasn't applied correctly in the failing cases which gave me a hint to the location of this fix.

## What is the new behavior?
I made changes in the order of if statements in [`getSingleStyle`](https://github.com/ionic-team/stencil/blob/735d45afdda420420f6d3992662cb63ded2c937e/src/compiler/transformers/add-static-style.ts#L103)  and [`getMultipleModeStyle`](https://github.com/ionic-team/stencil/blob/735d45afdda420420f6d3992662cb63ded2c937e/src/compiler/transformers/add-static-style.ts#L69) 
 and have recognised a file with similar implementation features: `/src/compiler/transformers/component-native/native-static-style.ts`. Afaik this is done if `transformOpts.componentExport` is set to `customelement`.

It turns out that after aligning the order of if statements in `addSingleStyleGetter` with how it is in `getSingleStyle` the component was rendered correctly in a consistent fashion.

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Added some tests but you can reproduce the issue by:

- create a stencil project `npm init stencil`
- change the stencil dependency to be nightly in `package.json`: `"@stencil/core": "nightly"`
- `npm install`
- add another output target:
   ```
    {
      type: 'dist-custom-elements',
      dir: 'components',
    },
   ```
- go in `components/my-component.js` and verify that `MyComponentStyle` is not defined

No to verify the fix pack the build of this branch and link it to that project. After rebuilding the component you should see a `myComponentCss` defined.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
