### PR TITLE
fix(runtime): update `textContent` patch to mimic Shadow Root

### DIFF
--- a/src/runtime/bootstrap-custom-element.ts
+++ b/src/runtime/bootstrap-custom-element.ts
@@ -44,7 +44,7 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
   }
 
   // TODO(STENCIL-914): this check and `else` block can go away and be replaced by just the `scoped` check
-  if (BUILD.experimentalSlotFixes && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
+  if (BUILD.experimentalSlotFixes && BUILD.scoped && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
     patchPseudoShadowDom(Cstr.prototype, cmpMeta);
   } else {
     if (BUILD.slotChildNodesFix) {

--- a/src/runtime/bootstrap-custom-element.ts
+++ b/src/runtime/bootstrap-custom-element.ts
@@ -43,9 +43,8 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
     cmpMeta.$flags$ |= CMP_FLAGS.needsShadowDomShim;
   }
 
-  // TODO(STENCIL-914): this check and `else` block can go away and be replaced by just `BUILD.scoped` once we
-  // default our pseudo-slot behavior
-  if (BUILD.experimentalSlotFixes && BUILD.scoped) {
+  // TODO(STENCIL-914): this check and `else` block can go away and be replaced by just the `scoped` check
+  if (BUILD.experimentalSlotFixes && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
     patchPseudoShadowDom(Cstr.prototype, cmpMeta);
   } else {
     if (BUILD.slotChildNodesFix) {
@@ -57,8 +56,8 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
     if (BUILD.appendChildSlotFix) {
       patchSlotAppendChild(Cstr.prototype);
     }
-    if (BUILD.scopedSlotTextContentFix) {
-      patchTextContent(Cstr.prototype, cmpMeta);
+    if (BUILD.scopedSlotTextContentFix && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
+      patchTextContent(Cstr.prototype);
     }
   }
 

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -146,9 +146,8 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
         }
       };
 
-      // TODO(STENCIL-914): this check and `else` block can go away and be replaced by just `BUILD.scoped` once we
-      // default our pseudo-slot behavior
-      if (BUILD.experimentalSlotFixes && BUILD.scoped) {
+      // TODO(STENCIL-914): this check and `else` block can go away and be replaced by just the `scoped` check
+      if (BUILD.experimentalSlotFixes && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
         patchPseudoShadowDom(HostElement.prototype, cmpMeta);
       } else {
         if (BUILD.slotChildNodesFix) {
@@ -160,8 +159,8 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
         if (BUILD.appendChildSlotFix) {
           patchSlotAppendChild(HostElement.prototype);
         }
-        if (BUILD.scopedSlotTextContentFix) {
-          patchTextContent(HostElement.prototype, cmpMeta);
+        if (BUILD.scopedSlotTextContentFix && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
+          patchTextContent(HostElement.prototype);
         }
       }
 

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -147,7 +147,7 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
       };
 
       // TODO(STENCIL-914): this check and `else` block can go away and be replaced by just the `scoped` check
-      if (BUILD.experimentalSlotFixes && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
+      if (BUILD.experimentalSlotFixes && BUILD.scoped && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
         patchPseudoShadowDom(HostElement.prototype, cmpMeta);
       } else {
         if (BUILD.slotChildNodesFix) {

--- a/src/runtime/dom-extras.ts
+++ b/src/runtime/dom-extras.ts
@@ -253,8 +253,9 @@ export const patchTextContent = (hostElementPrototype: HTMLElement): void => {
           // Remove the existing content of the slot
           let slotContent = node.nextSibling as d.RenderNode | null;
           while (slotContent && slotContent['s-sn'] === node['s-sn']) {
-            slotContent.remove();
+            const tmp = slotContent;
             slotContent = slotContent.nextSibling as d.RenderNode | null;
+            tmp.remove();
           }
 
           // If this is a default slot, add the text node in the slot location.

--- a/src/runtime/dom-extras.ts
+++ b/src/runtime/dom-extras.ts
@@ -228,7 +228,9 @@ export const patchTextContent = (hostElementPrototype: HTMLElement): void => {
             // Need to get the text content of all nodes in the slot reference node
             let slotContent = node.nextSibling as d.RenderNode | null;
             while (slotContent && slotContent['s-sn'] === node['s-sn']) {
-              text.push(slotContent.textContent?.trim() ?? '');
+              if (slotContent.nodeType === NODE_TYPES.TEXT_NODE || slotContent.nodeType === NODE_TYPES.ELEMENT_NODE) {
+                text.push(slotContent.textContent?.trim() ?? '');
+              }
               slotContent = slotContent.nextSibling as d.RenderNode | null;
             }
 

--- a/test/karma/test-app/components.d.ts
+++ b/test/karma/test-app/components.d.ts
@@ -389,6 +389,10 @@ export namespace Components {
     }
     interface Tag88 {
     }
+    interface TextContentPatchScoped {
+    }
+    interface TextContentPatchScopedWithSlot {
+    }
     interface WatchNativeAttributes {
     }
 }
@@ -1414,6 +1418,18 @@ declare global {
         prototype: HTMLTag88Element;
         new (): HTMLTag88Element;
     };
+    interface HTMLTextContentPatchScopedElement extends Components.TextContentPatchScoped, HTMLStencilElement {
+    }
+    var HTMLTextContentPatchScopedElement: {
+        prototype: HTMLTextContentPatchScopedElement;
+        new (): HTMLTextContentPatchScopedElement;
+    };
+    interface HTMLTextContentPatchScopedWithSlotElement extends Components.TextContentPatchScopedWithSlot, HTMLStencilElement {
+    }
+    var HTMLTextContentPatchScopedWithSlotElement: {
+        prototype: HTMLTextContentPatchScopedWithSlotElement;
+        new (): HTMLTextContentPatchScopedWithSlotElement;
+    };
     interface HTMLWatchNativeAttributesElement extends Components.WatchNativeAttributes, HTMLStencilElement {
     }
     var HTMLWatchNativeAttributesElement: {
@@ -1573,6 +1589,8 @@ declare global {
         "svg-class": HTMLSvgClassElement;
         "tag-3d-component": HTMLTag3dComponentElement;
         "tag-88": HTMLTag88Element;
+        "text-content-patch-scoped": HTMLTextContentPatchScopedElement;
+        "text-content-patch-scoped-with-slot": HTMLTextContentPatchScopedWithSlotElement;
         "watch-native-attributes": HTMLWatchNativeAttributesElement;
     }
 }
@@ -1962,6 +1980,10 @@ declare namespace LocalJSX {
     }
     interface Tag88 {
     }
+    interface TextContentPatchScoped {
+    }
+    interface TextContentPatchScopedWithSlot {
+    }
     interface WatchNativeAttributes {
     }
     interface IntrinsicElements {
@@ -2117,6 +2139,8 @@ declare namespace LocalJSX {
         "svg-class": SvgClass;
         "tag-3d-component": Tag3dComponent;
         "tag-88": Tag88;
+        "text-content-patch-scoped": TextContentPatchScoped;
+        "text-content-patch-scoped-with-slot": TextContentPatchScopedWithSlot;
         "watch-native-attributes": WatchNativeAttributes;
     }
 }
@@ -2276,6 +2300,8 @@ declare module "@stencil/core" {
             "svg-class": LocalJSX.SvgClass & JSXBase.HTMLAttributes<HTMLSvgClassElement>;
             "tag-3d-component": LocalJSX.Tag3dComponent & JSXBase.HTMLAttributes<HTMLTag3dComponentElement>;
             "tag-88": LocalJSX.Tag88 & JSXBase.HTMLAttributes<HTMLTag88Element>;
+            "text-content-patch-scoped": LocalJSX.TextContentPatchScoped & JSXBase.HTMLAttributes<HTMLTextContentPatchScopedElement>;
+            "text-content-patch-scoped-with-slot": LocalJSX.TextContentPatchScopedWithSlot & JSXBase.HTMLAttributes<HTMLTextContentPatchScopedWithSlotElement>;
             "watch-native-attributes": LocalJSX.WatchNativeAttributes & JSXBase.HTMLAttributes<HTMLWatchNativeAttributesElement>;
         }
     }

--- a/test/karma/test-app/scoped-slot-text-with-sibling/karma.spec.ts
+++ b/test/karma/test-app/scoped-slot-text-with-sibling/karma.spec.ts
@@ -30,7 +30,7 @@ describe('scoped-slot-text-with-sibling', () => {
 
     cmpLabel.textContent = 'New text to go in the slot';
 
-    expect(cmpLabel.textContent).toBe('New text to go in the slot');
+    expect(cmpLabel.textContent.trim()).toBe('New text to go in the slot');
   });
 
   it("doesn't override all children when assigning textContent", () => {

--- a/test/karma/test-app/scoped-slot-text/karma.spec.ts
+++ b/test/karma/test-app/scoped-slot-text/karma.spec.ts
@@ -30,7 +30,7 @@ describe('scoped-slot-text', () => {
 
     cmpLabel.textContent = 'New text to go in the slot';
 
-    expect(cmpLabel.textContent).toBe('New text to go in the slot');
+    expect(cmpLabel.textContent.trim()).toBe('New text to go in the slot');
   });
 
   it('leaves the structure of the label intact', () => {

--- a/test/karma/test-app/text-content-patch/cmp-scoped-slot.tsx
+++ b/test/karma/test-app/text-content-patch/cmp-scoped-slot.tsx
@@ -1,0 +1,11 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'text-content-patch-scoped-with-slot',
+  scoped: true,
+})
+export class TextContentPatchScopedWithSlot {
+  render() {
+    return [<p>Top content</p>, <slot></slot>, <p>Bottom content</p>, <slot name="suffix"></slot>];
+  }
+}

--- a/test/karma/test-app/text-content-patch/cmp-scoped.tsx
+++ b/test/karma/test-app/text-content-patch/cmp-scoped.tsx
@@ -1,0 +1,11 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'text-content-patch-scoped',
+  scoped: true,
+})
+export class TextContentPatchScoped {
+  render() {
+    return [<p>Top content</p>, <p>Bottom content</p>];
+  }
+}

--- a/test/karma/test-app/text-content-patch/index.html
+++ b/test/karma/test-app/text-content-patch/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<meta charset="utf8" />
+<script src="./build/testapp.esm.js" type="module"></script>
+<script src="./build/testapp.js" nomodule></script>
+
+<text-content-patch-scoped></text-content-patch-scoped>
+<text-content-patch-scoped-with-slot>
+  <!-- This should be ignored -->
+  Slot content
+  <p slot="suffix">Suffix content</p>
+</text-content-patch-scoped-with-slot>

--- a/test/karma/test-app/text-content-patch/karma.spec.ts
+++ b/test/karma/test-app/text-content-patch/karma.spec.ts
@@ -1,0 +1,37 @@
+import { setupDomTests } from '../util';
+
+describe('textContent patch', () => {
+  const { setupDom, tearDownDom } = setupDomTests(document);
+  let app: HTMLElement;
+
+  beforeEach(async () => {
+    app = await setupDom('/text-content-patch/index.html');
+  });
+  afterEach(tearDownDom);
+
+  describe('scoped encapsulation', () => {
+    it('should return the content of all slots', () => {
+      const elm = app.querySelector('text-content-patch-scoped-with-slot');
+      expect(elm.textContent.trim()).toBe('Slot content Suffix content');
+    });
+
+    it('should return an empty string if there is no slotted content', () => {
+      const elm = app.querySelector('text-content-patch-scoped');
+      expect(elm.textContent.trim()).toBe('');
+    });
+
+    it('should overwrite the default slot content', () => {
+      const elm = app.querySelector('text-content-patch-scoped-with-slot');
+      elm.textContent = 'New slot content';
+
+      expect(elm.textContent.trim()).toBe('New slot content');
+    });
+
+    it('should not insert the text node if there is no default slot', () => {
+      const elm = app.querySelector('text-content-patch-scoped');
+      elm.textContent = 'New slot content';
+
+      expect(elm.textContent.trim()).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Stencil's current `textContent` patch for `scoped` elements only deals with a component's default slot. However, the team has recently agreed that our `scoped` component behavior should mimic a `shadow` component as closely as possible.

Fixes: #3977 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The `textContent` patch now behaves like the native implementation for an element with a Shadow Root. The getter will return the combined `textContent` of all child nodes that are located in slot references. And the setter will replace all content within slot reference nodes with a single text node in the default slot reference (if one exists).

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

**Manual testing**
1. Create new component starter
2. Enable `extras.experimentalSlotFixes` in Stencil config
3. Update `my-component` to the following:
```tsx
@Component({
  tag: 'my-component',
  styleUrl: 'my-component.css',
  scoped: true,
})
export class MyComponent {
  render(): HTMLElement {
    return (
      <Host>
        <button>
          <div class="content-wrapper">
            <span class="prefix">
              <slot name="prefix" />
            </span>
            <slot />
            <slot name="suffix" />
          </div>
        </button>
      </Host>
    );
  }
}
```
4. Update `index.html` to have the following `body`:
```html
          <my-component>
            <span slot="prefix">Prefix</span>
            <p>Button</p>
            <span slot="suffix">Suffix</span>
          </my-component>
```
5. Run `npm start`
6. Execute the `textContent` getter/setter on the element from browser dev tools. Notice that it will only ever change the "Button" node in the default slot
7. Install a build of this branch
8. Execute the `textContent` getter/setter on the element from browser dev tools. Notice that it will now return the value of all slotted content and will replace all nodes when using the setter

**Automated testing**
Update a few existing tests to account for whitespace differences in return value. Added new e2e tests to verify behavior for `scoped` components.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

Only available with the `experimentalSlotFixes` extra flag enabled in a project's Stencil config.

This **does not** include a patch for `innerText`. That method is trickier to patch to correctly get whitespace and line break formatting.
