### PR TITLE
chore(test): use mock module function in proxy-custom-element-function

### DIFF
--- a/src/compiler/transformers/test/proxy-custom-element-function.spec.ts
+++ b/src/compiler/transformers/test/proxy-custom-element-function.spec.ts
@@ -1,7 +1,8 @@
 import * as d from '@stencil/core/declarations';
-import { mockCompilerCtx } from '@stencil/core/testing';
+import { mockCompilerCtx, mockModule } from '@stencil/core/testing';
 import * as ts from 'typescript';
 
+import { stubComponentCompilerMeta } from '../../types/tests/ComponentCompilerMeta.stub';
 import * as AddComponentMetaProxy from '../add-component-meta-proxy';
 import { proxyCustomElement } from '../component-native/proxy-custom-element-function';
 import { PROXY_CUSTOM_ELEMENT } from '../core-runtime-apis';
@@ -38,14 +39,13 @@ describe('proxy-custom-element-function', () => {
 
     getModuleFromSourceFileSpy = jest.spyOn(TransformUtils, 'getModuleFromSourceFile');
     getModuleFromSourceFileSpy.mockImplementation((_compilerCtx: d.CompilerCtx, _tsSourceFile: ts.SourceFile) => {
-      // TODO(STENCIL-379): Replace with a getMockModule() call
-      return {
+      return mockModule({
         cmps: [
-          {
+          stubComponentCompilerMeta({
             componentClassName,
-          },
+          }),
         ],
-      } as d.Module;
+      });
     });
 
     createClassMetadataProxySpy = jest.spyOn(AddComponentMetaProxy, 'createClassMetadataProxy');
@@ -146,10 +146,7 @@ describe('proxy-custom-element-function', () => {
   describe('source file unchanged', () => {
     it('returns the source file when no Stencil module is found', async () => {
       getModuleFromSourceFileSpy.mockImplementation((_compilerCtx: d.CompilerCtx, _tsSourceFile: ts.SourceFile) => {
-        // TODO(STENCIL-379): Replace with a getMockModule() call
-        return {
-          cmps: [],
-        } as d.Module;
+        return mockModule();
       });
 
       const code = `const ${componentClassName} = class extends HTMLElement {};`;
@@ -162,14 +159,9 @@ describe('proxy-custom-element-function', () => {
 
     it('returns the source file when no variable statements are found', () => {
       getModuleFromSourceFileSpy.mockImplementation((_compilerCtx: d.CompilerCtx, _tsSourceFile: ts.SourceFile) => {
-        // TODO(STENCIL-379): Replace with a getMockModule() call
-        return {
-          cmps: [
-            {
-              componentClassName,
-            },
-          ],
-        } as d.Module;
+        return mockModule({
+          cmps: [stubComponentCompilerMeta({ componentClassName })],
+        });
       });
 
       const code = `helloWorld();`;
@@ -182,14 +174,13 @@ describe('proxy-custom-element-function', () => {
 
     it("returns the source file when variable statements don't match the component name", () => {
       getModuleFromSourceFileSpy.mockImplementation((_compilerCtx: d.CompilerCtx, _tsSourceFile: ts.SourceFile) => {
-        // TODO(STENCIL-379): Replace with a getMockModule() call
-        return {
+        return mockModule({
           cmps: [
-            {
+            stubComponentCompilerMeta({
               componentClassName: 'ComponentNameDoesNotExist',
-            },
+            }),
           ],
-        } as d.Module;
+        });
       });
 
       const code = `const ${componentClassName} = class extends HTMLElement { };`;


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See "New Behavior" section

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

use the (now) existing stub creation function for building a `Module` entity, rather than using an object literal asserted to be a `Module`.



## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
I traced the code in a debugger for the tests - I kicked off each test with a breakpoint in the function under test, and ensured that the code was interacted with:
<img width="1340" alt="Screenshot 2023-12-08 at 3 10 43 PM" src="https://github.com/ionic-team/stencil/assets/1930213/96ac5f41-6ebd-490a-b260-b408e3b58912">

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
STENCIL-379 Use `mockModule` in tests