### PR TITLE
chore(snc): resolve errors for optimize-css tests

### DIFF
--- a/src/compiler/style/optimize-css.ts
+++ b/src/compiler/style/optimize-css.ts
@@ -8,6 +8,8 @@ export const optimizeCss = async (
   compilerCtx: d.CompilerCtx,
   diagnostics: d.Diagnostic[],
   styleText: string,
+  // TODO(STENCIL-1076): Investigate removing this parameter, which appears to be unused. This function is exported by
+  // the compiler, making this a breaking change should we remove it.
   filePath: string,
 ) => {
   if (typeof styleText !== 'string' || !styleText.length) {

--- a/src/compiler/style/test/optimize-css.spec.ts
+++ b/src/compiler/style/test/optimize-css.spec.ts
@@ -6,6 +6,8 @@ import path from 'path';
 import { optimizeCss } from '../optimize-css';
 
 describe('optimizeCss', () => {
+  const MOCK_FILE_PATH = './mock/path/to/file.css';
+
   let config: d.ValidatedConfig;
   let compilerCtx: d.CompilerCtx;
   let diagnostics: d.Diagnostic[];
@@ -30,7 +32,7 @@ describe('optimizeCss', () => {
 
   it('discard-comments', async () => {
     const styleText = `/* css */ body { color: #ff0000; }`;
-    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
+    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, MOCK_FILE_PATH);
 
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(`body{color:#ff0000}`);
@@ -43,7 +45,7 @@ describe('optimizeCss', () => {
         background: linear-gradient(to bottom, #ffe500 0%, #ffe500 50%, #121 50%, #121 100%);
       }
     `;
-    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
+    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, MOCK_FILE_PATH);
 
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(`h1{background:linear-gradient(to bottom, #ffe500 0%, #ffe500 50%, #121 50%, #121 100%)}`);
@@ -55,7 +57,7 @@ describe('optimizeCss', () => {
         min-width: initial;
       }
     `;
-    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
+    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, MOCK_FILE_PATH);
 
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(`h1{min-width:initial}`);
@@ -67,7 +69,7 @@ describe('optimizeCss', () => {
         display: inline flow-root;
       }
     `;
-    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
+    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, MOCK_FILE_PATH);
 
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(`h1{display:inline flow-root}`);
@@ -80,7 +82,7 @@ describe('optimizeCss', () => {
         transform: rotate3d(0, 0, 1, 20deg);
       }
     `;
-    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
+    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, MOCK_FILE_PATH);
 
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(`h1{transform:rotate3d(0, 0, 1, 20deg)}`);
@@ -88,7 +90,7 @@ describe('optimizeCss', () => {
 
   it('colormin', async () => {
     const styleText = `body { color: #ff0000; }`;
-    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
+    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, MOCK_FILE_PATH);
 
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(`body{color:#ff0000}`);
@@ -100,7 +102,7 @@ describe('optimizeCss', () => {
         width: 0em;
       }
     `;
-    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
+    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, MOCK_FILE_PATH);
 
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(`h1{width:0em}`);
@@ -112,7 +114,7 @@ describe('optimizeCss', () => {
         border: red solid .5em;
       }
     `;
-    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
+    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, MOCK_FILE_PATH);
 
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(`h1{border:red solid .5em}`);
@@ -122,7 +124,7 @@ describe('optimizeCss', () => {
     const styleText = `
       h1 + p, h2, h3, h2{color:red}
     `;
-    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
+    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, MOCK_FILE_PATH);
 
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(`h1+p,h2,h3{color:red}`);
@@ -136,7 +138,7 @@ describe('optimizeCss', () => {
         }
       }
     `;
-    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
+    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, MOCK_FILE_PATH);
 
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(`@media only screen and ( min-width: 400px, min-height: 500px ){h2{color:red}}`);
@@ -148,7 +150,7 @@ describe('optimizeCss', () => {
         content: '\\'string\\' is intact';
       }
     `;
-    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
+    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, MOCK_FILE_PATH);
 
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(`p:after{content:'\\'string\\' is intact'}`);
@@ -161,7 +163,7 @@ describe('optimizeCss', () => {
         font-weight: normal;
       }
     `;
-    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
+    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, MOCK_FILE_PATH);
 
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(`p{font-family:\"Helvetica Neue\", Arial, sans-serif, Helvetica;font-weight:normal}`);
@@ -173,7 +175,7 @@ describe('optimizeCss', () => {
         background: url(image.jpg) repeat no-repeat;
       }
     `;
-    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
+    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, MOCK_FILE_PATH);
 
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(`h1{background:url(image.jpg) repeat no-repeat}`);
@@ -185,7 +187,7 @@ describe('optimizeCss', () => {
         background-position: bottom left;
       }
     `;
-    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
+    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, MOCK_FILE_PATH);
 
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(`h1{background-position:bottom left}`);
@@ -197,7 +199,7 @@ describe('optimizeCss', () => {
         width: calc(10px -  ( 100px / var(--test)  )) ;
       }
     `;
-    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
+    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, MOCK_FILE_PATH);
 
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(`h1{width:calc(10px -  ( 100px / var(--test)  ))}`);
@@ -209,7 +211,7 @@ describe('optimizeCss', () => {
         color: red;
       }
     `;
-    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
+    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, MOCK_FILE_PATH);
 
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(`h1,h3,h2{color:red}`);
@@ -222,7 +224,7 @@ describe('optimizeCss', () => {
         box-shadow: 1px;
       }
     `;
-    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
+    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, MOCK_FILE_PATH);
 
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(`h1{box-shadow:1px}`);
@@ -235,7 +237,7 @@ describe('optimizeCss', () => {
         box-shadow: 1px;
       }
     `;
-    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
+    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, MOCK_FILE_PATH);
 
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(`h1{box-shadow:1px}`);
@@ -247,7 +249,7 @@ describe('optimizeCss', () => {
         box-shadow: 1px;
       }
     `;
-    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
+    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, MOCK_FILE_PATH);
 
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(`h1{-webkit-box-shadow:1px;box-shadow:1px}`);
@@ -260,22 +262,24 @@ describe('optimizeCss', () => {
         box-shadow: 1px;
       }
     `;
-    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, null);
+    const output = await optimizeCss(config, compilerCtx, diagnostics, styleText, MOCK_FILE_PATH);
 
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(`h1{-webkit-box-shadow:1px;box-shadow:1px}`);
   });
 
   it('do nothing for invalid data', async () => {
-    let output = await optimizeCss(config, compilerCtx, diagnostics, null, null);
+    // we intentionally pass `null` as an argument for the provided styles, hence the type assertion
+    let output = await optimizeCss(config, compilerCtx, diagnostics, null as unknown as string, MOCK_FILE_PATH);
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(null);
 
-    output = await optimizeCss(config, compilerCtx, diagnostics, undefined, null);
+    // we intentionally pass `null` as an argument for the provided styles, hence the type assertion
+    output = await optimizeCss(config, compilerCtx, diagnostics, undefined as unknown as string, MOCK_FILE_PATH);
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe(undefined);
 
-    output = await optimizeCss(config, compilerCtx, diagnostics, '', null);
+    output = await optimizeCss(config, compilerCtx, diagnostics, '', MOCK_FILE_PATH);
     expect(diagnostics).toHaveLength(0);
     expect(output).toBe('');
   });


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We have quite a few SNC violations in our code!

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

resolve `strictNullCheck` violations for `optimize-css#optimizeCss` unit tests. the `fileName` argument doesn't appear to be used by `optimizeCss` in any meaningful way that (other than an additional path normalization call).

`optimizeCss` is a part of stencil's public api. as a result, we cannot remove this otherwise unused function parameter without it constituting a breaking change. add a TODO for now, to be completed in the next major version of stencil.

add a type assertion to invalid styling input. this allows us to test invalid css being passed to the optimizatiton function, without widening the type signature of `optimizeCss`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
`filePath` only seems to be used here (highlighted in green):
![Screenshot 2023-12-12 at 8 19 11 AM](https://github.com/ionic-team/stencil/assets/1930213/3946d959-bf33-4712-8d4e-ebd0af2ea380)
where the only semi-meaningful use I can see is in the worker's `optimizeCss` fn, which never seems to use it: 
![Screenshot 2023-12-12 at 8 19 45 AM](https://github.com/ionic-team/stencil/assets/1930213/ed050f6a-bb0e-445a-91b7-c29d6d815747)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
