### PR TITLE
chore(snc): resolve compiler event.ts violation

### DIFF
--- a/src/compiler/events.ts
+++ b/src/compiler/events.ts
@@ -14,7 +14,7 @@ export const buildEvents = (): d.BuildEvents => {
 
   const on = (arg0: any, arg1?: any): d.BuildOnEventRemove => {
     if (typeof arg0 === 'function') {
-      const eventName: string = null;
+      const eventName: null = null;
       const callback = arg0;
       evCallbacks.push({
         eventName,
@@ -68,6 +68,6 @@ export const buildEvents = (): d.BuildEvents => {
 };
 
 interface EventCallback {
-  eventName: string;
+  eventName: string | null;
   callback: Function;
 }


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

we have several SNC violations in the codebase
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

remove a single strictNullCheck violation for `events.ts`. this change only affects the type system, no functional changes have been made to the codebase.

specifically:
- the type of the internal (non-exported) `EventCallback#eventName` property has been widened to accept `null` in addition to `string`s.
- the type of the `eventName` local variable when parsing `arg0` in `on()` has been changed from `string`->`null`. this aligns us closer with the value we're assigning, and prevents 'implicit `any`' errors from the type checker


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

The change here only affects the type system. Since the interface that I'm changing is local only to the file it's contained in, and we have the value `null` assigned to the property I'm widening, I think that running the type checker here is sufficient. However, please let me know if there's anything else you'd like to see me try to verify this change.
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
