### PR TITLE
fix(runtime): allow setting `key` attr on nested Stencil components

### DIFF
--- a/src/runtime/test/hydrate-no-encapsulation.spec.tsx
+++ b/src/runtime/test/hydrate-no-encapsulation.spec.tsx
@@ -13,7 +13,6 @@ describe('hydrate no encapsulation', () => {
         );
       }
     }
-    // @ts-ignore
     const serverHydrated = await newSpecPage({
       components: [CmpA],
       html: `<cmp-a></cmp-a>`,
@@ -38,7 +37,6 @@ describe('hydrate no encapsulation', () => {
         );
       }
     }
-    // @ts-ignore
     const serverHydrated = await newSpecPage({
       components: [CmpA],
       html: `<cmp-a></cmp-a>`,
@@ -54,7 +52,6 @@ describe('hydrate no encapsulation', () => {
       </cmp-a>
     `);
 
-    // @ts-ignore
     const clientHydrated = await newSpecPage({
       components: [CmpA],
       html: serverHydrated.root.outerHTML,
@@ -81,7 +78,6 @@ describe('hydrate no encapsulation', () => {
         return <Host>Hello</Host>;
       }
     }
-    // @ts-ignore
     const serverHydrated = await newSpecPage({
       components: [CmpA],
       html: `<cmp-a></cmp-a>`,
@@ -95,7 +91,6 @@ describe('hydrate no encapsulation', () => {
       </cmp-a>
     `);
 
-    // @ts-ignore
     const clientHydrated = await newSpecPage({
       components: [CmpA],
       html: serverHydrated.root.outerHTML,
@@ -126,7 +121,6 @@ describe('hydrate no encapsulation', () => {
         );
       }
     }
-    // @ts-ignore
     const serverHydrated = await newSpecPage({
       components: [CmpA],
       html: `<cmp-a></cmp-a>`,
@@ -146,7 +140,6 @@ describe('hydrate no encapsulation', () => {
       </cmp-a>
     `);
 
-    // @ts-ignore
     const clientHydrated = await newSpecPage({
       components: [CmpA],
       html: serverHydrated.root.outerHTML,
@@ -162,6 +155,67 @@ describe('hydrate no encapsulation', () => {
           middle
         </p>
         bottom
+      </cmp-a>
+    `);
+  });
+
+  it('nested text slot with key', async () => {
+    @Component({ tag: 'cmp-a' })
+    class CmpA {
+      render() {
+        return (
+          <Host key="test">
+            <cmp-b key="my-test-key">light-dom</cmp-b>
+          </Host>
+        );
+      }
+    }
+    @Component({ tag: 'cmp-b' })
+    class CmpB {
+      render() {
+        return (
+          <Host>
+            <slot key="key1"></slot>
+            <footer key="key2"></footer>
+          </Host>
+        );
+      }
+    }
+    const serverHydrated = await newSpecPage({
+      components: [CmpA, CmpB],
+      html: `<cmp-a></cmp-a>`,
+      hydrateServerSide: true,
+    });
+    expect(serverHydrated.root).toEqualHtml(`
+      <cmp-a class="hydrated" s-id="1">
+        <!--r.1-->
+        <cmp-b class="hydrated" c-id="1.0.0.0" s-id="2">
+          <!--r.2-->
+          <!--o.1.1-->
+          <!--s.2.0.0.0.-->
+          <!--t.1.1.1.0-->
+          light-dom
+          <footer c-id="2.1.0.1"></footer>
+        </cmp-b>
+      </cmp-a>
+    `);
+
+    const clientHydrated = await newSpecPage({
+      components: [CmpA, CmpB],
+      html: serverHydrated.root.outerHTML,
+      hydrateClientSide: true,
+    });
+
+    expect(clientHydrated.root).toEqualHtml(`
+      <cmp-a class="hydrated">
+        <!--r.1-->
+        <cmp-b class="hydrated">
+          <!--r.2-->
+          <!---->
+          <!--s.2.0.0.0.-->
+          light-dom
+          <footer></footer>
+        </cmp-b>
       </cmp-a>
     `);
   });
@@ -188,7 +242,6 @@ describe('hydrate no encapsulation', () => {
         );
       }
     }
-    // @ts-ignore
     const serverHydrated = await newSpecPage({
       components: [CmpA, CmpB],
       html: `<cmp-a></cmp-a>`,
@@ -208,7 +261,6 @@ describe('hydrate no encapsulation', () => {
       </cmp-a>
     `);
 
-    // @ts-ignore
     const clientHydrated = await newSpecPage({
       components: [CmpA, CmpB],
       html: serverHydrated.root.outerHTML,
@@ -252,7 +304,6 @@ describe('hydrate no encapsulation', () => {
       }
     }
 
-    // @ts-ignore
     const serverHydrated = await newSpecPage({
       components: [CmpA, CmpB],
       html: `<cmp-a></cmp-a>`,
@@ -272,7 +323,6 @@ describe('hydrate no encapsulation', () => {
       </cmp-a>
     `);
 
-    // @ts-ignore
     const clientHydrated = await newSpecPage({
       components: [CmpA, CmpB],
       html: serverHydrated.root.outerHTML,
@@ -316,7 +366,6 @@ describe('hydrate no encapsulation', () => {
         );
       }
     }
-    // @ts-ignore
     const serverHydrated = await newSpecPage({
       components: [CmpA, CmpB],
       html: `<cmp-a></cmp-a>`,
@@ -337,7 +386,6 @@ describe('hydrate no encapsulation', () => {
       </cmp-a>
     `);
 
-    // @ts-ignore
     const clientHydrated = await newSpecPage({
       components: [CmpA, CmpB],
       html: serverHydrated.root.outerHTML,
@@ -388,7 +436,6 @@ describe('hydrate no encapsulation', () => {
         );
       }
     }
-    // @ts-ignore
     const serverHydrated = await newSpecPage({
       components: [CmpA, CmpB],
       html: `<cmp-a></cmp-a>`,
@@ -421,7 +468,6 @@ describe('hydrate no encapsulation', () => {
       </cmp-a>
     `);
 
-    // @ts-ignore
     const clientHydrated = await newSpecPage({
       components: [CmpA, CmpB],
       html: serverHydrated.root.outerHTML,


### PR DESCRIPTION
This makes it possible to set a `key` attribute on a nested Stencil component without messing up how hydration works. I noticed that this was not working correctly when working on #5143.


## What is the current behavior?

There's a regression test which will reproduce the issue if run in the context of `main`. In short, if you have two components like so:

```tsx
    @Component({ tag: 'cmp-a' })
    class CmpA {
      render() {
        return (
          <Host key="test">
            <cmp-b key="my-test-key">light-dom</cmp-b>
          </Host>
        );
      }
    }
    @Component({ tag: 'cmp-b' })
    class CmpB {
      render() {
        return (
          <Host>
            <slot key="key1"></slot>
            <footer key="key2"></footer>
          </Host>
        );
      }
    }
```

You'll get rendering issues where comments that need to be present for slot relocation and whatnot to work aren't appearing. Not good!


## What is the new behavior?

This ensures that we only start to check whether `vnode.$key$` matches between vnodes _after_ the first render. This fixes a situation where on the first render the `.$key$` property of the _old_ root vnode would _always_ be `null`, leading the comparison to result in always re-rendering the component.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I've run this in Framework (the unit tests) and haven't seen any issues, and I've also checked in out in an [example hydrate app](https://github.com/alicewriteswrongs/stencil-hydrate-example) I created the other day.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
