### PR TITLE
fix(declarations): bundle child_process type for portability

### DIFF
--- a/scripts/utils/bundle-dts.ts
+++ b/scripts/utils/bundle-dts.ts
@@ -1,4 +1,4 @@
-import { EntryPointConfig, generateDtsBundle, OutputOptions } from 'dts-bundle-generator/dist/bundle-generator.js';
+import { EntryPointConfig, generateDtsBundle, OutputOptions } from 'dts-bundle-generator';
 import fs from 'fs-extra';
 
 import { BuildOptions } from './options';

--- a/src/declarations/child_process.ts
+++ b/src/declarations/child_process.ts
@@ -1,0 +1,5 @@
+import type { Serializable } from 'child_process';
+
+// this is just so that we can bundle this type for `stencil-private.d.ts`
+// without having to run dts-bundle-generator on that whole file
+export { Serializable as CPSerializable };

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -1,7 +1,7 @@
 import { result } from '@utils';
-import type { Serializable as CPSerializable } from 'child_process';
 
 import type { InMemoryFileSystem } from '../compiler/sys/in-memory-fs';
+import type { CPSerializable } from './child_process';
 import type {
   BuildEvents,
   BuildLog,


### PR DESCRIPTION
We need to make sure our type declarations don't depend on types we don't bundle!

fixes #5162

STENCIL-1077

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

There's a reproduction case on #5162. You could test that this fixes the issue by building and packing this locally, installing it in that reproduction case, and confirming that you don't get a type error when building.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
