### PR TITLE
fix(compiler): fix transforming method parameters into docs

### DIFF
--- a/src/compiler/docs/generate-doc-data.ts
+++ b/src/compiler/docs/generate-doc-data.ts
@@ -268,22 +268,25 @@ const parseTypeIntoValues = (type: string): d.JsonDocsValue[] => {
 const getDocsMethods = (methods: d.ComponentCompilerMethod[]): d.JsonDocsMethod[] => {
   return sortBy(methods, (member) => member.name)
     .filter((member) => !member.internal)
-    .map((member) => ({
-      name: member.name,
-      returns: {
-        type: member.complexType.return,
-        docs: member.docs.tags
-          .filter((t) => t.name === 'return' || t.name === 'returns')
-          .map((t) => t.text)
-          .join('\n'),
-      },
-      complexType: member.complexType,
-      signature: `${member.name}${member.complexType.signature}`,
-      parameters: [], // TODO
-      docs: member.docs.text,
-      docsTags: member.docs.tags,
-      deprecation: getDocsDeprecationText(member.docs.tags),
-    }));
+    .map(
+      (member) =>
+        <d.JsonDocsMethod>{
+          name: member.name,
+          returns: {
+            type: member.complexType.return,
+            docs: member.docs.tags
+              .filter((t) => t.name === 'return' || t.name === 'returns')
+              .map((t) => t.text)
+              .join('\n'),
+          },
+          complexType: member.complexType,
+          signature: `${member.name}${member.complexType.signature}`,
+          parameters: member.complexType.parameters,
+          docs: member.docs.text,
+          docsTags: member.docs.tags,
+          deprecation: getDocsDeprecationText(member.docs.tags),
+        },
+    );
 };
 
 const getDocsEvents = (events: d.ComponentCompilerEvent[]): d.JsonDocsEvent[] => {

--- a/src/compiler/transformers/decorators-to-static/method-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/method-decorator.ts
@@ -11,7 +11,6 @@ import {
   mapJSDocTagInfo,
   retrieveTsDecorators,
   retrieveTsModifiers,
-  serializeSymbol,
   typeToString,
   validateReferences,
 } from '../transform-utils';
@@ -92,7 +91,11 @@ const parseMethodDecorator = (
   const methodMeta: d.ComponentCompilerStaticMethod = {
     complexType: {
       signature: signatureString,
-      parameters: signature.parameters.map((symbol) => serializeSymbol(typeChecker, symbol)),
+      parameters: signature.parameters.map((symbol) => ({
+        name: symbol.getName(),
+        type: typeToString(typeChecker, typeChecker.getTypeOfSymbolAtLocation(symbol, method)),
+        docs: ts.displayPartsToString(symbol.getDocumentationComment(typeChecker)),
+      })),
       references: {
         ...getAttributeTypeInfo(returnTypeNode, tsSourceFile, typeChecker, program),
         ...getAttributeTypeInfo(method, tsSourceFile, typeChecker, program),

--- a/src/compiler/transformers/test/parse-comments.spec.ts
+++ b/src/compiler/transformers/test/parse-comments.spec.ts
@@ -61,8 +61,9 @@ describe('parse comments', () => {
       complexType: {
         parameters: [
           {
-            tags: [],
-            text: '',
+            name: 'prop',
+            type: 'string',
+            docs: '',
           },
         ],
         return: 'unknown',

--- a/src/compiler/transformers/test/parse-methods.spec.ts
+++ b/src/compiler/transformers/test/parse-methods.spec.ts
@@ -5,39 +5,52 @@ describe('parse methods', () => {
     const t = transpileModule(`
       @Component({tag: 'cmp-a'})
       export class CmpA {
+        /**
+         * @param foo bar
+         * @param bar foo
+         */
         @Method()
-        someMethod() {
+        someMethod(foo: string, bar: number) {
 
         }
       }
     `);
 
-    expect(getStaticGetter(t.outputText, 'methods')).toEqual({
-      someMethod: {
-        complexType: {
-          parameters: [],
-          return: 'void',
-          references: {},
-          signature: '() => void',
-        },
-        docs: {
-          text: '',
-          tags: [],
-        },
-      },
-    });
-
-    expect(t.method).toEqual({
+    const someMethod = {
       complexType: {
-        parameters: [],
+        parameters: [
+          {
+            name: 'foo',
+            type: 'string',
+            docs: 'bar',
+          },
+          {
+            name: 'bar',
+            type: 'number',
+            docs: 'foo',
+          },
+        ],
         return: 'void',
         references: {},
-        signature: '() => void',
+        signature: '(foo: string, bar: number) => void',
       },
       docs: {
-        tags: [],
         text: '',
+        tags: [
+          {
+            name: 'param',
+            text: 'foo bar',
+          },
+          {
+            name: 'param',
+            text: 'bar foo',
+          },
+        ],
       },
+    };
+    expect(getStaticGetter(t.outputText, 'methods')).toEqual({ someMethod });
+    expect(t.method).toEqual({
+      ...someMethod,
       internal: false,
       name: 'someMethod',
     });

--- a/src/compiler/types/tests/ComponentCompilerMethod.stub.ts
+++ b/src/compiler/types/tests/ComponentCompilerMethod.stub.ts
@@ -14,7 +14,7 @@ export const stubComponentCompilerMethod = (
     name: 'myMethod',
     internal: false,
     complexType: {
-      parameters: [{ tags: [], text: '' }],
+      parameters: [{ name: 'name', type: 'Foo', docs: '' }],
       references: { Foo: { location: 'import', path: './resources', id: 'placeholder' } },
       return: 'Promise<void>',
       signature: '(name: Foo) => Promise<void>',

--- a/src/compiler/types/tests/generate-method-types.spec.ts
+++ b/src/compiler/types/tests/generate-method-types.spec.ts
@@ -97,7 +97,7 @@ describe('generate-method-types', () => {
         name: 'myOtherMethod',
         internal: true,
         complexType: {
-          parameters: [{ tags: [], text: '' }],
+          parameters: [{ name: 'age', type: 'Bar', docs: '' }],
           references: { Bar: { location: 'local', id: 'placeholder_id', path: './other-resources' } },
           return: 'Promise<boolean>',
           signature: '(age: Bar) => Promise<boolean>',

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -28,6 +28,7 @@ import type {
   TaskCommand,
   ValidatedConfig,
 } from './stencil-public-compiler';
+import type { JsonDocMethodParameter } from './stencil-public-docs';
 import type { ComponentInterface, ListenTargetOptions, VNode } from './stencil-public-runtime';
 
 export interface SourceMap {
@@ -799,7 +800,7 @@ export interface ComponentCompilerStaticMethod {
 
 export interface ComponentCompilerMethodComplexType {
   signature: string;
-  parameters: CompilerJsDoc[];
+  parameters: JsonDocMethodParameter[];
   references: ComponentCompilerTypeReferences;
   return: string;
 }

--- a/test/docs-json/docs.d.ts
+++ b/test/docs-json/docs.d.ts
@@ -60,29 +60,9 @@ interface ComponentCompilerEventComplexType {
 }
 interface ComponentCompilerMethodComplexType {
   signature: string;
-  parameters: CompilerJsDoc[];
+  parameters: JsonDocMethodParameter[];
   references: ComponentCompilerTypeReferences;
   return: string;
-}
-interface CompilerJsDoc {
-  /**
-   * The text associated with the JSDoc
-   */
-  text: string;
-  /**
-   * Tags included in the JSDoc
-   */
-  tags: CompilerJsDocTagInfo[];
-}
-interface CompilerJsDocTagInfo {
-  /**
-   * The name of the tag - e.g. `@deprecated`
-   */
-  name: string;
-  /**
-   * Additional text that is associated with the tag - e.g. `@deprecated use v2 of this API`
-   */
-  text?: string;
 }
 /**
  * The Type Library holds information about the types which are used in a

--- a/test/docs-json/docs.json
+++ b/test/docs-json/docs.json
@@ -19,8 +19,9 @@
             "signature": "<T>(arg: T) => Promise<ImportedInterface<T>>",
             "parameters": [
               {
-                "tags": [],
-                "text": ""
+                "name": "arg",
+                "type": "T",
+                "docs": ""
               }
             ],
             "references": {
@@ -41,7 +42,13 @@
             "return": "Promise<ImportedInterface<T>>"
           },
           "signature": "onDidDismiss<T>(arg: T) => Promise<ImportedInterface<T>>",
-          "parameters": [],
+          "parameters": [
+            {
+              "name": "arg",
+              "type": "T",
+              "docs": ""
+            }
+          ],
           "docs": "A comment, which should be included, I should think!",
           "docsTags": []
         }

--- a/test/end-to-end/src/components.d.ts
+++ b/test/end-to-end/src/components.d.ts
@@ -33,8 +33,21 @@ export namespace Components {
     interface EnvData {
     }
     interface EventCmp {
+        /**
+          * this is some method that fires an event with options
+          * @returns
+         */
         "methodThatFiresEventWithOptions": () => Promise<void>;
+        /**
+          * this is some method that fires a document event
+          * @returns
+         */
         "methodThatFiresMyDocumentEvent": () => Promise<void>;
+        /**
+          * this is some method that fires a window event
+          * @param value some value
+          * @returns
+         */
         "methodThatFiresMyWindowEvent": (value: number) => Promise<void>;
     }
     interface ImportAssets {
@@ -43,7 +56,17 @@ export namespace Components {
         "opened": boolean;
     }
     interface MethodCmp {
+        /**
+          * this is some method
+          * @returns some number
+         */
         "someMethod": () => Promise<number>;
+        /**
+          * this is some method with args
+          * @param unit some unit
+          * @param value some value
+          * @returns some string
+         */
         "someMethodWithArgs": (unit: string, value: number) => Promise<string>;
         "someProp": number;
     }

--- a/test/end-to-end/src/event-cmp/event-cmp.tsx
+++ b/test/end-to-end/src/event-cmp/event-cmp.tsx
@@ -15,16 +15,29 @@ export class EventCmp {
 
   @Event() myWindowEvent: EventEmitter<number>;
 
+  /**
+   * this is some method that fires a window event
+   * @param value some value
+   * @returns {void}
+   */
   @Method()
   async methodThatFiresMyWindowEvent(value: number) {
     this.myWindowEvent.emit(value);
   }
 
+  /**
+   * this is some method that fires a document event
+   * @returns {void}
+   */
   @Method()
   async methodThatFiresMyDocumentEvent() {
     this.myDocumentEvent.emit();
   }
 
+  /**
+   * this is some method that fires an event with options
+   * @returns {void}
+   */
   @Method()
   async methodThatFiresEventWithOptions() {
     this.myEventWithOptions.emit({ mph: 88 });

--- a/test/end-to-end/src/event-cmp/readme.md
+++ b/test/end-to-end/src/event-cmp/readme.md
@@ -18,7 +18,7 @@
 
 ### `methodThatFiresEventWithOptions() => Promise<void>`
 
-
+this is some method that fires an event with options
 
 #### Returns
 
@@ -28,7 +28,7 @@ Type: `Promise<void>`
 
 ### `methodThatFiresMyDocumentEvent() => Promise<void>`
 
-
+this is some method that fires a document event
 
 #### Returns
 
@@ -38,7 +38,13 @@ Type: `Promise<void>`
 
 ### `methodThatFiresMyWindowEvent(value: number) => Promise<void>`
 
+this is some method that fires a window event
 
+#### Parameters
+
+| Name    | Type     | Description |
+| ------- | -------- | ----------- |
+| `value` | `number` | some value  |
 
 #### Returns
 

--- a/test/end-to-end/src/method-cmp/method-cmp.tsx
+++ b/test/end-to-end/src/method-cmp/method-cmp.tsx
@@ -6,11 +6,21 @@ import { Component, Method, Prop } from '@stencil/core';
 export class MethodCmp {
   @Prop() someProp = 0;
 
+  /**
+   * this is some method
+   * @returns {number} some number
+   */
   @Method()
   async someMethod() {
     return this.someProp;
   }
 
+  /**
+   * this is some method with args
+   * @param unit some unit
+   * @param value some value
+   * @returns {string} some string
+   */
   @Method()
   async someMethodWithArgs(unit: string, value: number) {
     return `${value} ${unit}`;

--- a/test/end-to-end/src/method-cmp/readme.md
+++ b/test/end-to-end/src/method-cmp/readme.md
@@ -16,23 +16,30 @@
 
 ### `someMethod() => Promise<number>`
 
-
+this is some method
 
 #### Returns
 
 Type: `Promise<number>`
 
-
+some number
 
 ### `someMethodWithArgs(unit: string, value: number) => Promise<string>`
 
+this is some method with args
 
+#### Parameters
+
+| Name    | Type     | Description |
+| ------- | -------- | ----------- |
+| `unit`  | `string` | some unit   |
+| `value` | `number` | some value  |
 
 #### Returns
 
 Type: `Promise<string>`
 
-
+some string
 
 
 ----------------------------------------------


### PR DESCRIPTION
## What is the current behavior?
Parsing parameters from a Stencil component currently relies on a JSDoc string and not actually on the types defined by the user in TypeScript. With that most method types were not documented at all.

fixes #4394
STENCIL-846

## What is the new behavior?
I updated the part where we propagate parameter informations and now propagate a parameter name and type to the resulting JSON as well as made updates so that these types are correctly set in the markdown docs.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

No changes to any public TS interfaces.

## Testing

To test this behavior:

- create a new Stencil project
- add a method to the component, e.g.:
   ```ts
    /**
     * @param active foobar some description
     */
    @Method()
    async setActive(active: string) {
      this.active = active;
    }
   ```
- add `docs-json` output target, e.g.
   ```ts
       {
         type: 'docs-json',
         file: 'components.json',
       },
    ```
- run `npx stencil build --docs`

You will see an updated `src/components/my-component/readme.md` that has missing details about the method parameters:

```md
## Methods

### `setActive(active: string) => Promise<void>`


#### Returns

Type: `Promise<void>`
```

and a `components.json` that has missing information about parameters too:

```json
      "methods": [
        {
          "name": "setActive",
          "returns": {
            "type": "Promise<void>",
            "docs": ""
          },
          "complexType": {
            "signature": "(active: string) => Promise<void>",
            "parameters": [
              {
                "tags": [
                  {
                    "name": "param",
                    "text": "active foobar some descriptuon"
                  }
                ],
                "text": "foobar some descriptuon"
              }
            ],
            "references": {
              "Promise": {
                "location": "global",
                "id": "global::Promise"
              }
            },
            "return": "Promise<void>"
          },
          "signature": "setActive(active: string) => Promise<void>",
          "parameters": [],
          "docs": "",
          "docsTags": [
            {
              "name": "param",
              "text": "active foobar some descriptuon"
            }
          ]
        }
      ],
```

After checking out this branch and install the Stencil version to the project, the readme file now has the correct parameters table:

```md
## Methods

### `setActive(active: string) => Promise<void>`



#### Parameters

| Name     | Type     | Description             |
| -------- | -------- | ----------------------- |
| `active` | `string` | foobar some description |


#### Returns

Type: `Promise<void>`
```

and the parameters are set correctly in the json file:

```json
      "methods": [
        {
          "name": "setActive",
          "returns": {
            "type": "Promise<void>",
            "docs": ""
          },
          "complexType": {
            "signature": "(active: string) => Promise<void>",
            "parameters": [
              {
                "name": "active",
                "type": "string",
                "docs": "foobar some descriptuon"
              }
            ],
            "references": {
              "Promise": {
                "location": "global",
                "id": "global::Promise"
              }
            },
            "return": "Promise<void>"
          },
          "signature": "setActive(active: string) => Promise<void>",
          "parameters": [
            {
              "name": "active",
              "type": "string",
              "docs": "foobar some description"
            }
          ],
          "docs": "",
          "docsTags": [
            {
              "name": "param",
              "text": "active foobar some description"
            }
          ]
        }
      ],
```


## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
