### PR TITLE
fix(mock-doc): add HTMLUListElement

### DIFF
--- a/src/mock-doc/element.ts
+++ b/src/mock-doc/element.ts
@@ -49,6 +49,9 @@ export function createElement(ownerDocument: any, tagName: string): any {
 
     case 'title':
       return new MockTitleElement(ownerDocument);
+
+    case 'ul':
+      return new MockUListElement(ownerDocument);
   }
 
   if (ownerDocument != null && tagName.includes('-')) {
@@ -490,6 +493,12 @@ export class MockTitleElement extends MockHTMLElement {
   }
   set text(value: string) {
     this.textContent = value;
+  }
+}
+
+export class MockUListElement extends MockHTMLElement {
+  constructor(ownerDocument: any) {
+    super(ownerDocument, 'ul');
   }
 }
 

--- a/src/mock-doc/global.ts
+++ b/src/mock-doc/global.ts
@@ -12,6 +12,7 @@ import {
   MockStyleElement,
   MockTemplateElement,
   MockTitleElement,
+  MockUListElement,
 } from './element';
 import { MockCustomEvent, MockEvent, MockFocusEvent, MockKeyboardEvent, MockMouseEvent } from './event';
 import { MockHeaders } from './headers';
@@ -177,4 +178,5 @@ const GLOBAL_CONSTRUCTORS: [string, any][] = [
   ['HTMLStyleElement', MockStyleElement],
   ['HTMLTemplateElement', MockTemplateElement],
   ['HTMLTitleElement', MockTitleElement],
+  ['HTMLUListElement', MockUListElement],
 ];

--- a/src/mock-doc/test/element.spec.ts
+++ b/src/mock-doc/test/element.spec.ts
@@ -1,5 +1,5 @@
 import { MockDocument } from '../document';
-import { MockAnchorElement, MockMetaElement, MockSVGElement } from '../element';
+import { MockAnchorElement, MockMetaElement, MockSVGElement, MockUListElement } from '../element';
 import { MockElement, MockHTMLElement } from '../node';
 import { cloneWindow, MockWindow } from '../window';
 
@@ -477,6 +477,14 @@ describe('element', () => {
       const elm: MockAnchorElement = doc.createElement('a');
       elm.href = 'http://stenciljs.com/path/to/page';
       expect(elm.pathname).toBe('/path/to/page');
+    });
+  });
+
+  describe('ul', () => {
+    it('textContent', () => {
+      const elm: MockUListElement = doc.createElement('ul');
+      elm.textContent = 'this is an item in an unordered list';
+      expect(elm.textContent).toBe('this is an item in an unordered list');
     });
   });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When Stencil's mock-doc creates an `HTMLUListElement`, we create an element that does not descend from `HTMLUListElement`

Fixes: #3382

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
add a definition for `HTMLUListElement`. this allows `createElement` calls to return a mocked version of `HTMLUListElement` that passes `instanceof` calls.

prior to this commit, folks attempting to use an `HTMLUListElement` in a stencil test like so would receive an error:
```ts
describe('my-component', () => {
  it('using HTMLUListElement works', async () => {
    const unorderedList = document.createElement('ul');
    console.log(unorderedList instanceof HTMLUListElement);
  });
});
```
```
[46:08.8]  jest args: --spec --e2e --max-workers=8
 FAIL  src/my-component.spec.ts
  my-component
    ✕ using HTMLUListElement works (4 ms)

  ● my-component › using HTMLUListElement works

    ReferenceError: HTMLUListElement is not defined

      2 |   it('using HTMLUListElement works', async () => {
      3 |     const unorderedList = document.createElement('ul');
    > 4 |     console.log(unorderedList instanceof HTMLUListElement);
        |                                          ^
      5 |   });
      6 | });
      7 |

      at Object.<anonymous> (src/my-component.spec.ts:4:42)
```


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

I used the original reproduction case in the linked issue.
For posterity, it had a test that matched the one in the "New Behavior"/commit message:
```ts
describe('my-component', () => {
  it('using HTMLUListElement works', async () => {
    const unorderedList = document.createElement('ul');
    console.log(unorderedList instanceof HTMLUListElement);
  });
});
```
If this test were placed in a new Stencil Component Starter project (`npm init stencil@latest component ul-test && cd $_ && npm i`, then copy the test to any `*.spec.ts` file), then the tests run (`npm t`), we'd see the failure above.

After building this branch and packing it (`npm run clean && npm ci && npm run build && npm pack`) and installing the tarball into the component starter project (`npm i <TARBALL>`), the tests pass (`npm t`)
## Other information
STENCIL-466 bug: HTMLUListElement is not defined

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
