### PR TITLE
test(ci): smoke test that Stencil doesn't error when installed alone

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,13 @@ jobs:
     with:
       build_name: stencil-core
 
+  no_starter_smoke_tests:
+    name: Stencil Smoke Test (no starter)
+    needs: [build_core]
+    uses: ./.github/workflows/test-smoke-no-starter.yml
+    with:
+      build_name: stencil-core
+
   e2e_tests:
     name: E2E Tests
     needs: [build_core]

--- a/.github/workflows/test-smoke-no-starter.yml
+++ b/.github/workflows/test-smoke-no-starter.yml
@@ -1,0 +1,97 @@
+name: Component Starter Smoke Test
+
+on:
+  workflow_call:
+    # Make this a reusable workflow, no value needed
+    # https://docs.github.com/en/actions/using-workflows/reusing-workflows
+    inputs:
+      build_name:
+        description: Name for the build, used to resolve the correct build artifact
+        required: true
+        type: string
+
+jobs:
+  analysis_test:
+    name: (${{ matrix.os }}.node-${{ matrix.node }})
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['16', '18', '20']
+        os: ['ubuntu-latest', 'windows-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Get Core Dependencies
+        uses: ./.github/workflows/actions/get-core-dependencies
+
+      - name: Use Node ${{ matrix.node }}
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+
+      - name: Create Pack Directory
+        # `mkdir` will fail if this directory already exists.
+        # in the next steps, we'll immediately put the packed build archive in this directory.
+        # between that and excluding `*.tgz` files in `.gitignore`, that _should_ make it safe enough for us to later
+        # use `mv` to rename the `npm pack`ed tarball
+        run: mkdir stencil-pack-destination
+        shell: bash
+
+      - name: Download Build Archive
+        uses: ./.github/workflows/actions/download-archive
+        with:
+          name: ${{ inputs.build_name }}
+          path: ./stencil-pack-destination
+          filename: stencil-core-build.zip
+
+      - name: Copy package.json
+        # need `package.json` in order to run `npm pack`
+        run: cp package.json ./stencil-pack-destination
+        shell: bash
+
+      - name: Copy bin
+        # `bin/` isn't a part of the compiled output (therefore not in the build archive).
+        # we need this entrypoint for stencil to run.
+        run: cp -R bin ./stencil-pack-destination
+        shell: bash
+
+      - name: Remove node_modules
+        # clear out our local `node_modules/` so that they're not linked to in any way when `npm pack` is run
+        run: rm -rf node_modules/
+        shell: bash
+
+      - name: Pack the Build Archive
+        run: npm pack
+        working-directory: ./stencil-pack-destination
+        shell: bash
+
+      - name: Move the Stencil Build Artifact
+        # there isn't a great way to get the output of `npm pack`, just grab the most recent from our destination
+        # directory and hope for the best.
+        #
+        # we don't set the working-directory here to avoid having to deal with relative paths in the destination arg
+        run: mv $(ls -t stencil-pack-destination/*.tgz | head -1) stencil-eval.tgz
+        shell: bash
+
+      - name: Initialize Component Starter
+        run: npm init stencil component tmp-component-starter
+        shell: bash
+
+      - name: Remove starter package.json
+        run: rm package.json
+
+      - name: Intialize new package.json
+        run: npm init -y
+
+      - name: Install Stencil Eval
+        run: npm i ../stencil-eval.tgz
+        working-directory: ./tmp-component-starter
+        shell: bash
+
+      - name: Build Starter Project
+        run: npm run build
+        working-directory: ./tmp-component-starter
+        shell: bash

--- a/.github/workflows/test-smoke-no-starter.yml
+++ b/.github/workflows/test-smoke-no-starter.yml
@@ -91,6 +91,12 @@ jobs:
         working-directory: ./tmp-component-starter
         shell: bash
 
+      - name: npm ls
+        run: npm ls
+
+      - name: npm prune
+        run: npm prune
+
       - name: Build Starter Project
         run: npm run build
         working-directory: ./tmp-component-starter


### PR DESCRIPTION
This adds a smoke test that checks that a project with only `@stencil/core` installed will build a simple component without errors.

When working on #5165 it became clear we should have a regression test in place to ensure we know right away if a change makes a 'bare' stencil project (i.e. with only `@stencil/core` installed) is going to error out.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
