### PR TITLE
chore(compiler): make dependency fields non-optional

### DIFF
--- a/src/compiler/transformers/static-to-meta/component.ts
+++ b/src/compiler/transformers/static-to-meta/component.ts
@@ -133,6 +133,11 @@ export const parseStaticComponentMeta = (
     htmlParts: [],
     isUpdateable: false,
     potentialCmpRefs: [],
+
+    dependents: [],
+    dependencies: [],
+    directDependents: [],
+    directDependencies: [],
   };
 
   const visitComponentChildNode = (node: ts.Node) => {

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -611,21 +611,21 @@ export interface ComponentCompilerMeta extends ComponentCompilerFeatures {
    * - directly referenced in a Stencil component's JSX/h() function
    * - are referenced by a web component that is directly referenced in a Stencil component's JSX/h() function
    */
-  dependencies?: string[];
+  dependencies: string[];
   /**
    * A list of web component tag names that either:
    * - directly reference the current component directly in their JSX/h() function
    * - indirectly/transitively reference the current component directly in their JSX/h() function
    */
-  dependents?: string[];
+  dependents: string[];
   /**
    * A list of web component tag names that are directly referenced in a Stencil component's JSX/h() function
    */
-  directDependencies?: string[];
+  directDependencies: string[];
   /**
    * A list of web component tag names that the current component directly in their JSX/h() function
    */
-  directDependents?: string[];
+  directDependents: string[];
   docs: CompilerJsDoc;
   elementRef: string;
   encapsulation: Encapsulation;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?

we have several SNCs related to the fields listed below.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

make the following fields non-optional on `ComponentCompilerMeta`:
- dependents
- dependencies
- directDependents
- directDependencies

these fields were previously marked as optional as they are not set when the metadata for a component is created, as we need to generate the metadata for all components in order to set these fields.

with this constraint in mind, we stub the initial fields with an empty array.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Removing the optional aspect of the backing type only affects our type system - insofar as I can tell, we do not expose that type publicly in such a way that it would break our existing API's typings.

However, as a result of changing those types, I had to make an internal change such that each of the fields is initialized with an empty array. I was unable to find an instance in the codebase where we perform falsy checks on any of the fields (which is why we had so many SNC's in the first place). As a result, if this field _were_ falsy, we'd be hitting runtime errors (assuming there isn't a try/catch block I've missed)

Otherwise, other tests passed locally. Happy to create a test suite of some kind, but I failed to think of something beyond "do we initialize component compiler metadata with empty arrays for these fields" (which didn't seem super useful).

## Other information

I intended to do something _very_ different here. In https://github.com/ionic-team/stencil/pull/5163, I put a function that had ~20 SNCs for these fields under test. I originally was going to add some type of checking on the field accesses, which today look something like:
```ts
  // this is just a snippet, but here, there would be 2 SNC's from `directDependents` accesses
  if (a.directDependents.includes(b.tagName)) return 1;
  if (b.directDependents.includes(a.tagName)) return -1;
```
As I started to think about how to best check these if they were falsy, I came up with two possibilities:
```ts
  // option 1: add an if-statement per existing if-statement
  // in this design, if `directDependents` is falsy, the check doesn't occur
  if (a.directDependents) {
    if (a.directDependents.includes(b.tagName)) return 1;
  }
  if (b.directDependents) {
    if (b.directDependents.includes(a.tagName)) return -1;
  }
```
```ts
  // options 2: use optional chaining. this is subtly different, as the check will always occur (and could affect the control flow)
  if (a.directDependents?.includes(b.tagName)) return 1;
  if (b.directDependents?.includes(a.tagName)) return -1;
  // I.E. does `a.directDependents` being falsy mean the same as an empty array/one thatdoesn't include `b.tagName`?
```
As I started writing the tests, that got equally cumbersome given the number of conditions and combinations of falsy values/arrays we could have. This led me to think, "Why am I solving this problem? Why do these need to be optional?", and here we are 🎉 
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
