### PR TITLE
chore(snc): fix some snc errors in puppeteer-emulate.ts

### DIFF
--- a/src/testing/puppeteer/puppeteer-emulate.ts
+++ b/src/testing/puppeteer/puppeteer-emulate.ts
@@ -2,7 +2,7 @@ import type { E2EProcessEnv, EmulateConfig } from '@stencil/core/internal';
 import type * as puppeteer from 'puppeteer';
 
 export function setScreenshotEmulateData(userEmulateConfig: EmulateConfig, env: E2EProcessEnv) {
-  const screenshotEmulate: EmulateConfig = {
+  const screenshotEmulate = {
     userAgent: 'default',
     viewport: {
       width: 800,
@@ -11,8 +11,9 @@ export function setScreenshotEmulateData(userEmulateConfig: EmulateConfig, env: 
       isMobile: false,
       hasTouch: false,
       isLandscape: false,
-    },
-  };
+    } as puppeteer.Viewport,
+    device: undefined as string | undefined,
+  } satisfies EmulateConfig;
 
   if (typeof userEmulateConfig.device === 'string') {
     try {


### PR DESCRIPTION
This fixes 6 SNC errors by switching from explicit annotation to using the `satisfies` keyword.

This is a type-level only change, no runtime behavior should change.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

This is only changing type annotations, so I think as long as the build is passing and unit tests are green we should be good!
