### PR TITLE
chore(snc): fix four snc errors relating to `sys.details` in `cli/`

### DIFF
--- a/src/cli/task-help.ts
+++ b/src/cli/task-help.ts
@@ -10,7 +10,7 @@ import { taskTelemetry } from './task-telemetry';
  * @param sys the abstraction for interfacing with the operating system
  */
 export const taskHelp = async (flags: ConfigFlags, logger: d.Logger, sys: d.CompilerSystem): Promise<void> => {
-  const prompt = logger.dim(sys.details.platform === 'windows' ? '>' : '$');
+  const prompt = logger.dim(sys.details?.platform === 'windows' ? '>' : '$');
 
   console.log(`
   ${logger.bold('Build:')} ${logger.dim('Build components for development or production.')}

--- a/src/cli/task-info.ts
+++ b/src/cli/task-info.ts
@@ -13,12 +13,14 @@ export const taskInfo = (coreCompiler: CoreCompiler, sys: CompilerSystem, logger
 
   console.log(``);
   console.log(`${logger.cyan('      System:')} ${sys.name} ${sys.version}`);
-  console.log(`${logger.cyan('    Platform:')} ${details.platform} (${details.release})`);
-  console.log(
-    `${logger.cyan('   CPU Model:')} ${details.cpuModel} (${sys.hardwareConcurrency} cpu${
-      sys.hardwareConcurrency !== 1 ? 's' : ''
-    })`,
-  );
+  if (details) {
+    console.log(`${logger.cyan('    Platform:')} ${details.platform} (${details.release})`);
+    console.log(
+      `${logger.cyan('   CPU Model:')} ${details.cpuModel} (${sys.hardwareConcurrency} cpu${
+        sys.hardwareConcurrency !== 1 ? 's' : ''
+      })`,
+    );
+  }
   console.log(`${logger.cyan('    Compiler:')} ${sys.getCompilerExecutingPath()}`);
   console.log(`${logger.cyan('       Build:')} ${coreCompiler.buildId}`);
   console.log(`${logger.cyan('     Stencil:')} ${coreCompiler.version}${logger.emoji(' ' + coreCompiler.vermoji)}`);

--- a/src/cli/task-telemetry.ts
+++ b/src/cli/task-telemetry.ts
@@ -10,7 +10,7 @@ import { checkTelemetry, disableTelemetry, enableTelemetry } from './telemetry/t
  * @param logger a logging implementation to log the results out to the user
  */
 export const taskTelemetry = async (flags: ConfigFlags, sys: d.CompilerSystem, logger: d.Logger): Promise<void> => {
-  const prompt = logger.dim(sys.details.platform === 'windows' ? '>' : '$');
+  const prompt = logger.dim(sys.details?.platform === 'windows' ? '>' : '$');
   const isEnabling = flags.args.includes('on');
   const isDisabling = flags.args.includes('off');
   const INFORMATION = `Opt in or out of telemetry. Information about the data we collect is available on our website: ${logger.bold(


### PR DESCRIPTION
This fixes a few snc errors resulting from the typing of `sys.details` as `SystemDetails | undefined` that show up in `src/cli`.

Ideally we'd fix the typing but it's a public type, so for now the best thing is just to add some optional chaining.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

This is just adding some optional chaining property accesses, so I believe there should not be any runtime changes here to worry about. If the build is passing and the tests are green I think we're good.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
