### PR TITLE
chore(snc): make optional property required on `PrintLine`

### DIFF
--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -44,7 +44,7 @@ export interface SourceMap {
 export interface PrintLine {
   lineIndex: number;
   lineNumber: number;
-  text?: string;
+  text: string;
   errorCharStart: number;
   errorLength?: number;
 }


### PR DESCRIPTION
the `.text` property on the `PrintLine` interface was previously marked optional, but there are no locations in the Stencil codebase where we do not supply a value for it, so we can safely remove a few snc violations by typing it as just `string` instead of `string | undefined`.

I believe this is safe to do because this is not a public type, but instead is an internal type used for logging and so on.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

This is just a type-level change so we should be good as long as the build is green!
