### PR TITLE
chore(snc): make properties on `CompilerWorkerTask` required

### DIFF
--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -2428,11 +2428,11 @@ export type MsgFromWorker<T extends WorkerContextMethod> = IPCSerializable<{
  * completes.
  */
 export interface CompilerWorkerTask {
-  stencilId?: number;
-  inputArgs?: any[];
+  stencilId: number;
+  inputArgs: any[];
   resolve: (val: any) => any;
   reject: (msg: string) => any;
-  retries?: number;
+  retries: number;
 }
 
 /**

--- a/src/sys/node/test/worker-manager.spec.ts
+++ b/src/sys/node/test/worker-manager.spec.ts
@@ -2,14 +2,24 @@ import type * as d from '../../../declarations';
 import { getNextWorker } from '../node-worker-controller';
 import { TestWorkerMain } from './test-worker-main';
 
+const incr = (function* () {
+  let i = 1;
+  while (true) {
+    yield i++;
+  }
+})();
+
 describe('getNextWorker', () => {
   let workers: TestWorkerMain[];
   const maxConcurrentWorkers = 4;
 
   const stubCompilerWorkerTask = (): d.CompilerWorkerTask => {
     return {
+      stencilId: incr.next().value,
       resolve: () => {},
       reject: () => {},
+      inputArgs: [],
+      retries: 1,
     };
   };
 


### PR DESCRIPTION
We had some optional properties on this interface which are always supplied in practice, so we can drop a few snc errors by making them required.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

This PR is _mainly_ a type-level change, but does also require a small change to a mock. As long as the build is green I believe we're safe!
