### PR TITLE
chore(snc): resolve validate-dev-server.spec errors

### DIFF
--- a/src/compiler/config/test/validate-dev-server.spec.ts
+++ b/src/compiler/config/test/validate-dev-server.spec.ts
@@ -123,9 +123,16 @@ describe('validateDevServer', () => {
   );
 
   it('should not set default port if null', () => {
-    inputConfig.devServer = { ...inputDevServerConfig, port: null };
+    // we intentionally set the value to `null` for the purposes of this test, hence the type assertion
+    inputConfig.devServer = { ...inputDevServerConfig, port: null as unknown as number };
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.port).toBe(null);
+  });
+
+  it('sets the port to 3333 if the port is undefined', () => {
+    inputConfig.devServer = { ...inputDevServerConfig, port: undefined };
+    const { config } = validateConfig(inputConfig, mockLoadConfigInit());
+    expect(config.devServer.port).toBe(3333);
   });
 
   it.each(['localhost:20/', 'localhost:20'])('should set port from address %p if no port prop', (address) => {

--- a/src/compiler/config/test/validate-dev-server.spec.ts
+++ b/src/compiler/config/test/validate-dev-server.spec.ts
@@ -183,8 +183,17 @@ describe('validateDevServer', () => {
     expect(config.devServer.historyApiFallback.index).toBe('index.html');
   });
 
+  it('should sets the historyApiFallback when undefined is provided', () => {
+    inputConfig.devServer = { ...inputDevServerConfig, historyApiFallback: undefined };
+    const { config } = validateConfig(inputConfig, mockLoadConfigInit());
+    expect(config.devServer.historyApiFallback).toBeDefined();
+    expect(config.devServer.historyApiFallback!.disableDotRule).toBe(false);
+    expect(config.devServer.historyApiFallback!.index).toBe('index.html');
+  });
+
   it('should disable historyApiFallback', () => {
-    inputConfig.devServer = { ...inputDevServerConfig, historyApiFallback: null };
+    // we intentionally set the value to `null` for the purposes of this test, hence the type assertion
+    inputConfig.devServer = { ...inputDevServerConfig, historyApiFallback: null as unknown as d.HistoryApiFallback };
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.historyApiFallback).toBe(null);
   });

--- a/src/compiler/config/test/validate-dev-server.spec.ts
+++ b/src/compiler/config/test/validate-dev-server.spec.ts
@@ -165,7 +165,7 @@ describe('validateDevServer', () => {
   it('should default historyApiFallback', () => {
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.historyApiFallback).toBeDefined();
-    expect(config.devServer.historyApiFallback.index).toBe('index.html');
+    expect(config.devServer.historyApiFallback!.index).toBe('index.html');
   });
 
   it.each([1, []])('should default historyApiFallback when an invalid value (%s) is provided', (badValue) => {
@@ -173,14 +173,14 @@ describe('validateDevServer', () => {
     inputConfig.devServer = { ...inputDevServerConfig, historyApiFallback: badValue as any };
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.historyApiFallback).toBeDefined();
-    expect(config.devServer.historyApiFallback.index).toBe('index.html');
+    expect(config.devServer.historyApiFallback!.index).toBe('index.html');
   });
 
   it('should set historyApiFallback', () => {
     inputConfig.devServer = { ...inputDevServerConfig, historyApiFallback: {} };
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.historyApiFallback).toBeDefined();
-    expect(config.devServer.historyApiFallback.index).toBe('index.html');
+    expect(config.devServer.historyApiFallback!.index).toBe('index.html');
   });
 
   it('should sets the historyApiFallback when undefined is provided', () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We have quite a few SNC violations in the code base!

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

update testing for `devServer#port` values:
1. add a test for `undefined` to verify the desired behavior (setting a
default port if one is not specified)
2. add a type assertion to suppress SNC violation when the port is set
to null

update testing for `devServer#historyApiFallback` values:
1. add a test for `undefined` to verify the desired behavior (setting a
default port if one is not specified)
2. add a type assertion to suppress SNC violation when the port is set
to null

add the bang operator to assertions where we have previously verified
the existence of a property (using `toBeDefined`)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I've run the new tests locally to verify they pass and are hitting the code paths they intend to (with a local debugger)

Otherwise, all other changes are affecting the type system. Locally running `npx tsc --strictNullChecks --noEmit` and `npm run build` verifies the drop in SNCs and the build still passes.

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

I'll squash this before merging to pretty up the commit msg
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
