### PR TITLE
chore(repo): add 2023 holiday triage

### DIFF
--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -1,5 +1,5 @@
 triage:
-  label: triage
+  label: 'holiday triage'
   dryRun: false
 
 closeAndLock:
@@ -26,6 +26,15 @@ closeAndLock:
 
 comment:
   labels:
+    - label: 'holiday triage'
+      message: >
+        Thanks for the issue! This issue has been labeled as `holiday triage`. With the winter holidays quickly approaching, much of the Stencil Team will soon be taking time off. During this time, issue triaging and PR review will be delayed until the team begins to return. After this period, we will work to ensure that all new issues & PRs are properly triaged.
+
+
+        In the meantime, please read our [2023 Winter Holiday Triage Guide](https://github.com/ionic-team/stencil/issues/5183) for information on how to ensure that your issue is triaged correctly.
+
+
+        Thank you!
     - label: 'ionitron: needs reproduction'
       message: >
         Thanks for the issue! This issue has been labeled as `needs reproduction`. This label is added to issues that


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

the team is about to go on a small break for the holidays. 

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

update ionitron to use the label "holiday triage" over the 2023 holiday break & comment appropriately.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

We can't test this until it merges :-(

This is the same message as last year, FWIW (with the GH issue number changed).

## Other information

**I'll merge this next week** and update the linked issue. I just wanted to get something in place for review while I had a minute.
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
