### PR TITLE
chore(snc): resolve hmr logging-related errors

### DIFF
--- a/src/compiler/build/build-finish.ts
+++ b/src/compiler/build/build-finish.ts
@@ -76,7 +76,7 @@ const buildDone = async (
     if (buildCtx.isRebuild && hasChanges && buildCtx.buildResults.hmr && !aborted) {
       // this is a rebuild, and we've got hmr data
       // and this build hasn't been aborted
-      logHmr(config.logger, buildCtx);
+      logHmr(config.logger, buildCtx.buildResults.hmr);
     }
 
     // create a nice pretty message stating what happened
@@ -130,10 +130,12 @@ const buildDone = async (
   return buildCtx.buildResults;
 };
 
-const logHmr = (logger: d.Logger, buildCtx: d.BuildCtx) => {
-  // this is a rebuild, and we've got hmr data
-  // and this build hasn't been aborted
-  const hmr = buildCtx.buildResults.hmr;
+/**
+ * In a Hot Module Replacement (HMR) context, log what changed between builds
+ * @param logger the instance of the logger to report what's changed
+ * @param hmr the HMR data, which includes what's changed between builds
+ */
+const logHmr = (logger: d.Logger, hmr: d.HotModuleReplacement): void => {
   if (hmr.componentsUpdated) {
     cleanupUpdateMsg(logger, `updated component`, hmr.componentsUpdated);
   }


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We have quite a few SNC's in the codebase!

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
update `build-finish#logHmr` to take a reference to the `HotModuleReplacement` object from the build context, as we check for the object's truthiness right before calling `logHmr`. this prevents us from updating several accessor calls on `hmr`, the instance of the `HotModuleReplacement` object, or wrapping the majority of the function in an `if` statement.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing
First, let's build the branch:
```
npm run clean \
&& npm ci \
&& npm run build \
&& npm pack
```

Then installed it in the output of creating a new stencil component library:

```bash
cd /tmp \
&& npm init stencil@latest component hmr-test \
&& cd $_ \
&& npm i [PATH_TO_STENCIL]
```

Start the dev server (`npm start`), then edit the `my-component.css` file generated by the CLI. You should see 'updated style: my-component' in the output. Edit the `my-component.tsx` file, and you should see 'updated component: my-component' in the output. The image below shows an edited `my-component.tsx` file, and the last block of HMR output shows it being correctly reported as updated still:

![Screenshot 2023-12-15 at 2 57 31 PM](https://github.com/ionic-team/stencil/assets/1930213/18a404f8-d85b-4763-af07-0be593ba2b02)

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->


