### PR TITLE
chore(snc): resolve final build-finish error

### DIFF
--- a/src/compiler/build/build-finish.ts
+++ b/src/compiler/build/build-finish.ts
@@ -186,7 +186,7 @@ const cleanupUpdateMsg = (logger: d.Logger, msg: string, fileNames: string[]) =>
  */
 const cleanDiagnosticsRelativePath = (config: d.Config, diagnostics: ReadonlyArray<d.Diagnostic>): void => {
   diagnostics.forEach((diagnostic) => {
-    if (!diagnostic.relFilePath && !isRemoteUrl(diagnostic.absFilePath) && diagnostic.absFilePath && config.rootDir) {
+    if (!diagnostic.relFilePath && diagnostic.absFilePath && !isRemoteUrl(diagnostic.absFilePath) && config.rootDir) {
       diagnostic.relFilePath = relative(config.rootDir, diagnostic.absFilePath);
     }
   });


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

after https://github.com/ionic-team/stencil/pull/5185, there's one SNC left in this file
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
reorder an `if` statement such that a strictNullCheck violation for `diagnostic.absFilePath` being of type `string|undefined` where `isRemoteUrl` only accepts `string`s is reported. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

since `isRemoteUrl` returns `false` for falsy values with no side effects, this was deemed a safe change to make - let me know if there's anything specific you'd like to see here
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
