### PR TITLE
chore(renovate): group download & upload artifact

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -88,6 +88,11 @@
       schedule: ["before 11am on monday"]
     },
     {
+      // group these two, as they may rely on one another during major version bumps (see #5191)
+      matchPackageNames: ['actions/download-artifact', 'actions/upload-artifact'],
+      groupName: 'Download + Upload Artifacts',
+    },
+    {
       matchPackageNames: ['eslint-plugin-jsdoc'],
       // this package can be released often, let's look at it every week
       // Note: Timezone for the schedule is specified as UTC


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

see 'new behavior' section

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

group github's `actions/download-artifact` and `actions/upload-artifact` into a single renovate job. in #5191 and #5192, renovate created a pr for each of these individually for the v4.0 release of each library. however, they have a peer dependency on one another, making it such that we could merge neither.

this was solved by cherry-picking the commit from the latter onto the former. going forward, let's group these for all dependencies. we should (hopefully) only run into this across majors, but we'll err on the 'safe' side of things for now

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Not much we can do, other than tail the logs once we merge it.

I did run `renovate-config-validator` locally, which validated our config conforms to the JSON schema as a quick check (but that doesn't verify everything/is just a spot check)
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
