### PR TITLE
fix(build): compile pixel-match file correctly

### DIFF
--- a/scripts/esbuild/screenshot.ts
+++ b/scripts/esbuild/screenshot.ts
@@ -7,6 +7,11 @@ import { BuildOptions } from '../utils/options';
 import { writePkgJson } from '../utils/write-pkg-json';
 import { getBaseEsbuildOptions, getEsbuildAliases, getEsbuildExternalModules, runBuilds } from './util';
 
+const screenshotBuilds = {
+  'Stencil Screenshot': 'index',
+  'Stencil Screenshot Pixel Match': 'pixel-match',
+};
+
 export async function buildScreenshot(opts: BuildOptions) {
   const inputScreenshotDir = join(opts.buildDir, 'screenshot');
   const inputScreenshotSrcDir = join(opts.srcDir, 'screenshot');
@@ -45,23 +50,18 @@ export async function buildScreenshot(opts: BuildOptions) {
     platform: 'node',
   } satisfies ESBuildOptions;
 
-  const screenshotEsbuildOptions = {
-    ...baseScreenshotOptions,
-    banner: {
-      js: getBanner(opts, 'Stencil Screenshot'),
-    },
-    entryPoints: [join(inputScreenshotSrcDir, 'index.ts')],
-    outfile: join(opts.output.screenshotDir, 'index.js'),
-  } satisfies ESBuildOptions;
-
-  const pixelmatchEsbuildOptions = {
-    ...baseScreenshotOptions,
-    banner: {
-      js: getBanner(opts, 'Stencil Screenshot Pixel Match'),
-    },
-    entryPoints: [join(inputScreenshotSrcDir, 'index.ts')],
-    outfile: join(opts.output.screenshotDir, 'pixel-match.js'),
-  } satisfies ESBuildOptions;
-
-  return runBuilds([screenshotEsbuildOptions, pixelmatchEsbuildOptions], opts);
+  return runBuilds(
+    Object.entries(screenshotBuilds).map(
+      ([label, file]) =>
+        ({
+          ...baseScreenshotOptions,
+          banner: {
+            js: getBanner(opts, label),
+          },
+          entryPoints: [join(inputScreenshotSrcDir, `${file}.ts`)],
+          outfile: join(opts.output.screenshotDir, `${file}.js`),
+        }) satisfies ESBuildOptions,
+    ),
+    opts,
+  );
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The ESBuild task to build the screenshot component of Stencil doesn't re-compile pixel-match.

GitHub Issue Number: N/A


## What is the new behavior?
Make sure that the core screenshot component and pixel-match are compiled correctly. I changed the implementation of it to make this type of error less likely to happen again with the compromise of making the code less flexible. Happy to revert that if seen needed.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a