### PR TITLE
chore(esbuild): add esbuild-based testing bundle

### DIFF
--- a/scripts/bundles/testing.ts
+++ b/scripts/bundles/testing.ts
@@ -116,7 +116,7 @@ export async function testing(opts: BuildOptions) {
   return [testingBundle];
 }
 
-async function copyTestingInternalDts(opts: BuildOptions, inputDir: string) {
+export async function copyTestingInternalDts(opts: BuildOptions, inputDir: string) {
   // copy testing d.ts files
 
   await fs.copy(join(inputDir), join(opts.output.testingDir), {

--- a/scripts/esbuild/build.ts
+++ b/scripts/esbuild/build.ts
@@ -5,6 +5,7 @@ import { buildDevServer } from './dev-server';
 import { buildMockDoc } from './mock-doc';
 import { buildScreenshot } from './screenshot';
 import { buildSysNode } from './sys-node';
+import { buildTesting } from './testing';
 
 // the main entry point for the Esbuild-based build
 async function main() {
@@ -21,6 +22,7 @@ async function main() {
     buildMockDoc(opts),
     buildScreenshot(opts),
     buildSysNode(opts),
+    buildTesting(opts),
   ]);
 }
 

--- a/scripts/esbuild/mock-doc.ts
+++ b/scripts/esbuild/mock-doc.ts
@@ -53,7 +53,6 @@ export async function buildMockDoc(opts: BuildOptions) {
     bundle: true,
     alias: mockDocAliases,
     logLevel: 'info',
-    target: 'node16',
   };
 
   const esmOptions: ESBuildOptions = {

--- a/scripts/esbuild/testing.ts
+++ b/scripts/esbuild/testing.ts
@@ -1,0 +1,144 @@
+import type { BuildOptions as ESBuildOptions, Plugin } from 'esbuild';
+import fs from 'fs-extra';
+import { join } from 'path';
+
+import { copyTestingInternalDts } from '../bundles/testing';
+import { getBanner } from '../utils/banner';
+import type { BuildOptions } from '../utils/options';
+import { writePkgJson } from '../utils/write-pkg-json';
+import { getBaseEsbuildOptions, getEsbuildAliases, getEsbuildExternalModules, runBuilds } from './util';
+
+const EXTERNAL_TESTING_MODULES = [
+  'assert',
+  'buffer',
+  'child_process',
+  'console',
+  'constants',
+  'crypto',
+  'fs',
+  '@jest/core',
+  'jest-cli',
+  'jest',
+  'expect',
+  '@jest/reporters',
+  'jest-environment-node',
+  'jest-message-id',
+  'jest-runner',
+  'net',
+  'os',
+  'path',
+  'process',
+  'puppeteer',
+  'puppeteer-core',
+  'readline',
+  'rollup',
+  '@rollup/plugin-commonjs',
+  '@rollup/plugin-node-resolve',
+  'stream',
+  'tty',
+  'url',
+  'util',
+  'vm',
+  'yargs',
+  'zlib',
+];
+
+export async function buildTesting(opts: BuildOptions) {
+  const inputDir = join(opts.buildDir, 'testing');
+  const sourceDir = join(opts.srcDir, 'testing');
+
+  await Promise.all([
+    // copy jest testing entry files
+    fs.copy(join(opts.scriptsBundlesDir, 'helpers', 'jest'), opts.output.testingDir),
+    copyTestingInternalDts(opts, inputDir),
+  ]);
+
+  // write package.json
+  writePkgJson(opts, opts.output.testingDir, {
+    name: '@stencil/core/testing',
+    description: 'Stencil testing suite.',
+    main: 'index.js',
+    types: 'index.d.ts',
+  });
+
+  const external = [
+    ...EXTERNAL_TESTING_MODULES,
+    ...getEsbuildExternalModules(opts, opts.output.testingDir),
+    '@rollup/plugin-commonjs',
+    '@rollup/plugin-node-resolve',
+    'rollup',
+    '../compiler/stencil.js',
+  ];
+
+  const testingEsbuildOptions: ESBuildOptions = {
+    ...getBaseEsbuildOptions(),
+    entryPoints: [join(sourceDir, 'index.ts')],
+    bundle: true,
+    format: 'cjs',
+    outfile: join(opts.output.testingDir, 'index.js'),
+    platform: 'node',
+    logLevel: 'info',
+    external,
+    write: false,
+    alias: getEsbuildAliases(),
+    banner: { js: getBanner(opts, `Stencil Testing`, true) },
+    plugins: [
+      externalAliases('@app-data', '@stencil/core/internal/app-data'),
+      externalAliases('@platform', '@stencil/core/internal/testing'),
+      externalAliases('../internal/testing/index.js', '@stencil/core/internal/testing'),
+      externalAliases('@stencil/core/dev-server', '../dev-server/index.js'),
+      lazyRequirePlugin(
+        opts,
+        [
+          '@stencil/core/internal/app-data',
+          '@stencil/core/internal/testing',
+          '../dev-server/index.js',
+          '../internal/testing/index.js',
+          '../mock-doc/index.cjs'
+        ]
+      )
+    ],
+  };
+
+  return runBuilds([testingEsbuildOptions], opts);
+}
+
+function getLazyRequireFn(opts: BuildOptions) {
+  return fs.readFileSync(join(opts.bundleHelpersDir, 'lazy-require.js'), 'utf8').trim();
+}
+
+function externalAliases(moduleId: string, resolveToPath: string): Plugin {
+  return {
+    name: 'externalAliases',
+    setup(build) {
+      build.onResolve({ filter: new RegExp(`^${moduleId}$`) }, () => {
+        return {
+          path: resolveToPath,
+          external: true,
+        };
+      });
+    },
+  };
+};
+
+function lazyRequirePlugin(opts: BuildOptions, moduleIds: string[]): Plugin {
+  return {
+    name: 'lazyRequirePlugin',
+    setup(build) {
+      build.onEnd(async (buildResult) => {
+        const bundle = buildResult.outputFiles[0];
+        let code = Buffer.from(bundle.contents).toString();
+
+        for (const moduleId of moduleIds) {
+          const str = `require("${moduleId}")`
+          while (code.includes(str)) {
+            code = code.replace(str, `_lazyRequire("${moduleId}")`);
+          }
+        }
+
+        code = code.replace(`"use strict";`, `"use strict";\n\n${getLazyRequireFn(opts)}`);
+        return fs.writeFile(bundle.path, code);
+      });
+    }
+  }
+}

--- a/scripts/esbuild/testing.ts
+++ b/scripts/esbuild/testing.ts
@@ -24,10 +24,7 @@ export async function buildTesting(opts: BuildOptions) {
 
   await Promise.all([
     // copy jest testing entry files
-    fs.copy(
-      join(opts.scriptsBundlesDir, 'helpers', 'jest'),
-      opts.output.testingDir
-    ),
+    fs.copy(join(opts.scriptsBundlesDir, 'helpers', 'jest'), opts.output.testingDir),
     copyTestingInternalDts(opts, inputDir),
   ]);
 

--- a/scripts/esbuild/testing.ts
+++ b/scripts/esbuild/testing.ts
@@ -66,6 +66,7 @@ export async function buildTesting(opts: BuildOptions) {
       externalAliases('@platform', '@stencil/core/internal/testing'),
       externalAliases('../internal/testing/index.js', '@stencil/core/internal/testing'),
       externalAliases('@stencil/core/dev-server', '../dev-server/index.js'),
+      externalAliases('@stencil/core/mock-doc', '../mock-doc/index.cjs'),
       lazyRequirePlugin(opts, [
         '@stencil/core/internal/app-data',
         '@stencil/core/internal/testing',

--- a/scripts/esbuild/testing.ts
+++ b/scripts/esbuild/testing.ts
@@ -87,16 +87,13 @@ export async function buildTesting(opts: BuildOptions) {
       externalAliases('@platform', '@stencil/core/internal/testing'),
       externalAliases('../internal/testing/index.js', '@stencil/core/internal/testing'),
       externalAliases('@stencil/core/dev-server', '../dev-server/index.js'),
-      lazyRequirePlugin(
-        opts,
-        [
-          '@stencil/core/internal/app-data',
-          '@stencil/core/internal/testing',
-          '../dev-server/index.js',
-          '../internal/testing/index.js',
-          '../mock-doc/index.cjs'
-        ]
-      )
+      lazyRequirePlugin(opts, [
+        '@stencil/core/internal/app-data',
+        '@stencil/core/internal/testing',
+        '../dev-server/index.js',
+        '../internal/testing/index.js',
+        '../mock-doc/index.cjs',
+      ]),
     ],
   };
 
@@ -119,7 +116,7 @@ function externalAliases(moduleId: string, resolveToPath: string): Plugin {
       });
     },
   };
-};
+}
 
 function lazyRequirePlugin(opts: BuildOptions, moduleIds: string[]): Plugin {
   return {
@@ -130,7 +127,7 @@ function lazyRequirePlugin(opts: BuildOptions, moduleIds: string[]): Plugin {
         let code = Buffer.from(bundle.contents).toString();
 
         for (const moduleId of moduleIds) {
-          const str = `require("${moduleId}")`
+          const str = `require("${moduleId}")`;
           while (code.includes(str)) {
             code = code.replace(str, `_lazyRequire("${moduleId}")`);
           }
@@ -139,6 +136,6 @@ function lazyRequirePlugin(opts: BuildOptions, moduleIds: string[]): Plugin {
         code = code.replace(`"use strict";`, `"use strict";\n\n${getLazyRequireFn(opts)}`);
         return fs.writeFile(bundle.path, code);
       });
-    }
-  }
+    },
+  };
 }

--- a/scripts/esbuild/util.ts
+++ b/scripts/esbuild/util.ts
@@ -56,6 +56,7 @@ const externalNodeModules = [
   'jest-config',
   'jest-message-id',
   'jest-pnp-resolver',
+  'jest-environment-node',
   'jest-runner',
   'puppeteer',
   'puppeteer-core',

--- a/scripts/esbuild/util.ts
+++ b/scripts/esbuild/util.ts
@@ -112,5 +112,15 @@ export function getBaseEsbuildOptions(): ESBuildOptions {
     bundle: true,
     legalComments: 'inline',
     logLevel: 'info',
+    target: getEsbuildTargets(),
   };
+}
+
+/**
+ * Get build targets with minimal supported browser versions
+ * @see https://stenciljs.com/docs/support-policy#browser-support
+ * @returns an array of build targets
+ */
+export function getEsbuildTargets(): string[] {
+  return ['node16', 'chrome79', 'edge79', 'firefox70', 'safari14'];
 }

--- a/src/testing/jest/jest-27-and-under/test/jest-setup-test-framework.spec.ts
+++ b/src/testing/jest/jest-27-and-under/test/jest-setup-test-framework.spec.ts
@@ -1,4 +1,5 @@
-import { MockHTMLElement, MockNode } from '../../../../mock-doc/node';
+import { MockHTMLElement, MockNode } from '@stencil/core/mock-doc';
+
 import { removeDomNodes } from '../jest-setup-test-framework';
 
 describe('jest setup test framework', () => {

--- a/src/testing/jest/jest-28/test/jest-setup-test-framework.spec.ts
+++ b/src/testing/jest/jest-28/test/jest-setup-test-framework.spec.ts
@@ -1,4 +1,5 @@
-import { MockHTMLElement, MockNode } from '../../../../mock-doc/node';
+import { MockHTMLElement, MockNode } from '@stencil/core/mock-doc';
+
 import { removeDomNodes } from '../jest-setup-test-framework';
 
 describe('jest setup test framework', () => {

--- a/src/testing/jest/jest-29/test/jest-setup-test-framework.spec.ts
+++ b/src/testing/jest/jest-29/test/jest-setup-test-framework.spec.ts
@@ -1,4 +1,5 @@
-import { MockHTMLElement, MockNode } from '../../../../mock-doc/node';
+import { MockHTMLElement, MockNode } from '@stencil/core/mock-doc';
+
 import { removeDomNodes } from '../jest-setup-test-framework';
 
 describe('jest setup test framework', () => {

--- a/src/testing/mock-fetch.ts
+++ b/src/testing/mock-fetch.ts
@@ -1,4 +1,4 @@
-import { MockHeaders, MockRequestInfo, MockResponse } from '../mock-doc';
+import { MockHeaders, MockRequestInfo, MockResponse } from '@stencil/core/mock-doc';
 
 const mockedResponses = new Map<string, MockedResponseData>();
 
@@ -165,4 +165,4 @@ export {
   MockRequestInit,
   MockResponse,
   MockResponseInit,
-} from '../mock-doc';
+} from '@stencil/core/mock-doc';


### PR DESCRIPTION
## What is the current behavior?
Testing module is compiled with Rollup.

GitHub Issue Number: N/A
STENCIL-993

## What is the new behavior?
Testing module is compiled with ESLint.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
