### PR TITLE
fix(screenshot): recognise clip options

### DIFF
--- a/src/screenshot/screenshot-compare.ts
+++ b/src/screenshot/screenshot-compare.ts
@@ -104,15 +104,11 @@ export async function compareScreenshot(
       // compare the two images pixel by pixel to
       // figure out a mismatch value
 
-      // figure out the actual width and height of the screenshot
-      const naturalWidth = Math.round(emulateConfig.viewport.width * emulateConfig.viewport.deviceScaleFactor);
-      const naturalHeight = Math.round(emulateConfig.viewport.height * emulateConfig.viewport.deviceScaleFactor);
-
       const pixelMatchInput: d.PixelMatchInput = {
         imageAPath: join(screenshotBuildData.imagesDir, screenshot.diff.imageA),
         imageBPath: join(screenshotBuildData.imagesDir, screenshot.diff.imageB),
-        width: naturalWidth,
-        height: naturalHeight,
+        width,
+        height,
         pixelmatchThreshold: pixelmatchThreshold,
       };
 

--- a/src/screenshot/screenshot-compare.ts
+++ b/src/screenshot/screenshot-compare.ts
@@ -107,8 +107,8 @@ export async function compareScreenshot(
       const pixelMatchInput: d.PixelMatchInput = {
         imageAPath: join(screenshotBuildData.imagesDir, screenshot.diff.imageA),
         imageBPath: join(screenshotBuildData.imagesDir, screenshot.diff.imageB),
-        width,
-        height,
+        width: Math.round(width),
+        height: Math.round(height),
         pixelmatchThreshold: pixelmatchThreshold,
       };
 


### PR DESCRIPTION
## What is the current behavior?
Currently the `ScreenshotOptions` passed into the `compareScreenshot` command aren't recognised as fully as `width` and `height` are overwritten by the value stored in the `emulateConfig` which is hard coded in [`validateConfig`](https://github.com/ionic-team/stencil/blob/bb0b1d46f63175dc09d0a23445be4d4a0d891a01/src/compiler/config/validate-testing.ts#L173-L174).

refs #4866
fixes #5208

## What is the new behavior?
Just take `width` and `height` provided by the command.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

To verify this change:

- `git clone git@github.com:Spirielle/bug-stencil-getMismatchedPixels.git`
- `cd bug-stencil-getMismatchedPixels`
- `npm i`
- `npm test` -> test pass
- go into `src/components/my-component/my-component.e2e.ts` and comment out line 13 and comment in line 16
- `npm run test` -> test fail due to `Image data size does not match width/height.`

This is because the clip parameter were not recognised so the image size differs from the baseline image.

Verify fix:

- install dev build: `npm install @stencil/core@4.9.1-dev.1704841621.8f08cf1`
- `npm test` -> test now pass

## Other information

n/a
