### PR TITLE
chore(repo): prevent renovate from upgrading open

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -139,6 +139,11 @@
       matchPackageNames: ['rollup'],
       matchPackagePrefixes: ['@rollup'],
       groupName: 'rollup,'
+    },
+    // TODO(STENCIL-1088): remove once support for Node v16 is dropped
+    {
+      matchPackageNames: ['open'],
+      allowedVersions: '<10',
     }
   ],
   // Never rebase the branch or update it unless manually requested to avoid noisy PR emails


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Renovate tries to upgrade `open`
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Open v10 has a single breaking change, in that it requires Node v18+ to be used. Stencil v4 still supports Node 16, and must continue to use Open v9 as a result. We cannot drop support for Node 16 without a breaking change, so we’ll hold off on this work until Stencil v5.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

We can't fully test this until it's merged unfortunately.
I did validate the config is correct locally with: `npm i -g renovate && renovate-config-validator`.
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

Replaces: #5213 
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
