### PR TITLE
chore(esbuild): ensure that compiler dir is empty before we run esbuild

### DIFF
--- a/scripts/esbuild/compiler.ts
+++ b/scripts/esbuild/compiler.ts
@@ -17,6 +17,9 @@ export async function buildCompiler(opts: BuildOptions) {
   const compilerFileName = 'stencil.js';
   const compilerDtsName = compilerFileName.replace('.js', '.d.ts');
 
+  // clear out rollup stuff and ensure directory exists
+  await fs.emptyDir(opts.output.compilerDir);
+
   // create public d.ts
   let dts = await fs.readFile(join(inputDir, 'public.d.ts'), 'utf8');
   dts = dts.replace('@stencil/core/internal', '../internal/index');

--- a/scripts/esbuild/mock-doc.ts
+++ b/scripts/esbuild/mock-doc.ts
@@ -20,6 +20,9 @@ export async function buildMockDoc(opts: BuildOptions) {
   const srcDir = join(opts.srcDir, 'mock-doc');
   const outputDir = opts.output.mockDocDir;
 
+  // clear out rollup stuff and ensure directory exists
+  await fs.emptyDir(outputDir);
+
   // bundle d.ts
   await bundleMockDocDts(opts, inputDir, outputDir);
 


### PR DESCRIPTION
This adds a call to the fs-extra `emptyDir` before we run the whole esbuild-based bundle and build step for the `compiler/` and `mock-doc/` dirs to ensure that there's nothing hanging around from a previous build.

Just something I noticed was missing when reviewing #5200!

## What is the current behavior?

Currently we don't clear out the previous build before we run esbuild to bundle the compiler. Since we normally run the rollup-based build first (because we don't yet build everything with esbuild) this could potentially mean something from the rollup build is sticking around for the `compiler/` bundle, which could in turn give us a false confidence in the ability of the esbuild-based script to stand alone. This fixes that issue!

## What is the new behavior?

we call `fs.emptyDir` when we should.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Exercise the relevant functionality after building with `esbuild`.

To do so, you should be able to just

```sh
npm run build.esbuild && npm pack
```

and then install into a sample project. If the tests run and things are compiling and whatnot then I think we're good!