### PR TITLE
feat(runtime): add extras flag for scoped slot changes

### DIFF
--- a/src/compiler/app-core/app-data.ts
+++ b/src/compiler/app-core/app-data.ts
@@ -169,6 +169,8 @@ export const updateBuildConditionals = (config: ValidatedConfig, b: BuildConditi
   b.slotChildNodesFix = config.extras.slotChildNodesFix;
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
   b.experimentalSlotFixes = config.extras.experimentalSlotFixes;
+  // TODO(STENCIL-1086): remove this option when it's the default behavior
+  b.experimentalScopedSlotChanges = config.extras.experimentalScopedSlotChanges;
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
   b.cloneNodeFix = config.extras.cloneNodeFix;
   b.lifecycleDOMEvents = !!(b.isDebug || config._isTesting || config.extras.lifecycleDOMEvents);

--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -392,6 +392,7 @@ describe('validation', () => {
     expect(config.extras.slotChildNodesFix).toBe(false);
     expect(config.extras.initializeNextTick).toBe(false);
     expect(config.extras.tagNameTransform).toBe(false);
+    expect(config.extras.scopedSlotTextContentFix).toBe(false);
   });
 
   it('should set slot config based on `experimentalSlotFixes`', () => {
@@ -419,6 +420,14 @@ describe('validation', () => {
     expect(config.extras.cloneNodeFix).toBe(true);
     expect(config.extras.slotChildNodesFix).toBe(true);
     expect(config.extras.scopedSlotTextContentFix).toBe(true);
+  });
+
+  it('should set extras experimentalScopedSlotChanges `true` if set in user config', () => {
+    userConfig.extras = {
+      experimentalScopedSlotChanges: true,
+    };
+    const { config } = validateConfig(userConfig, bootstrapConfig);
+    expect(config.extras.experimentalScopedSlotChanges).toBe(true);
   });
 
   it('should set taskQueue "async" by default', () => {

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -182,6 +182,9 @@ export const validateConfig = (
     validatedConfig.extras.scopedSlotTextContentFix = !!validatedConfig.extras.scopedSlotTextContentFix;
   }
 
+  // TODO(STENCIL-1086): remove this option when it's the default behavior
+  validatedConfig.extras.experimentalScopedSlotChanges = !!validatedConfig.extras.experimentalScopedSlotChanges;
+
   setBooleanConfig(
     validatedConfig,
     'sourceMap',

--- a/src/compiler/output-targets/dist-hydrate-script/hydrate-build-conditionals.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/hydrate-build-conditionals.ts
@@ -25,6 +25,8 @@ export const getHydrateBuildConditionals = (cmps: d.ComponentCompilerMeta[]) => 
   build.slotChildNodesFix = false;
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
   build.experimentalSlotFixes = false;
+  // TODO(STENCIL-1086): remove this option when it's the default behavior
+  build.experimentalScopedSlotChanges = false;
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
   build.cloneNodeFix = false;
   build.cssAnnotations = true;

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -190,6 +190,8 @@ export interface BuildConditionals extends Partial<BuildFeatures> {
 
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
   experimentalSlotFixes?: boolean;
+  // TODO(STENCIL-1086): remove this option when it's the default behavior
+  experimentalScopedSlotChanges?: boolean;
 }
 
 export type ModuleFormat =

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -336,6 +336,16 @@ interface ConfigExtrasBase {
    * can be customized at runtime. Defaults to `false`.
    */
   tagNameTransform?: boolean;
+
+  // TODO(STENCIL-1086): remove this option when it's the default behavior
+  /**
+   * Experimental flag.
+   * Updates the behavior of scoped components to align more closely with the behavior of the native
+   * Shadow DOM when using `slot`s.
+   *
+   * Defaults to `false`.
+   */
+  experimentalScopedSlotChanges?: boolean;
 }
 
 // TODO(STENCIL-914): delete this interface when `experimentalSlotFixes` is the default behavior

--- a/src/runtime/dom-extras.ts
+++ b/src/runtime/dom-extras.ts
@@ -257,7 +257,7 @@ export const patchTextContent = (hostElementPrototype: HTMLElement): void => {
 
   Object.defineProperty(hostElementPrototype, '__textContent', descriptor);
 
-  if (BUILD.experimentalSlotFixes) {
+  if (BUILD.experimentalScopedSlotChanges) {
     // Patch `textContent` to mimic shadow root behavior
     Object.defineProperty(hostElementPrototype, 'textContent', {
       // To mimic shadow root behavior, we need to return the text content of all

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -1151,7 +1151,7 @@ render() {
   // Hide any elements that were projected through, but don't have a slot to go to.
   // Only an issue if there were no "slots" rendered. Otherwise, nodes are hidden correctly.
   // This _only_ happens for `scoped` components!
-  if (BUILD.experimentalSlotFixes && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
+  if (BUILD.experimentalScopedSlotChanges && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
     for (const childNode of rootVnode.$elm$.childNodes) {
       if (childNode['s-hn'] !== hostTagName && !childNode['s-sh']) {
         // Store the initial value of `hidden` so we can reset it later when

--- a/src/testing/reset-build-conditionals.ts
+++ b/src/testing/reset-build-conditionals.ts
@@ -57,4 +57,6 @@ export function resetBuildConditionals(b: d.BuildConditionals) {
   b.slotChildNodesFix = false;
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
   b.experimentalSlotFixes = false;
+  // TODO(STENCIL-1086): remove this option when it's the default behavior
+  b.experimentalScopedSlotChanges = false;
 }

--- a/test/karma/stencil.config.ts
+++ b/test/karma/stencil.config.ts
@@ -31,6 +31,7 @@ export const config: Config = {
     lifecycleDOMEvents: true,
     scriptDataOpts: true,
     experimentalSlotFixes: true,
+    experimentalScopedSlotChanges: true,
   },
   devServer: {
     // when running `npm start`, serve from the root directory, rather than the `www` output target location


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We made changes in #5146 and #5135 to alter the behavior of `slot`s inside scoped components. The changes aligned Stencil's slot polyfill with behavior in the native shadow DOM and were placed behind the `experimentalSlotFixes` extra flag in a project's Stencil config. However, these changes negatively impacted the Ionic Framework causing automated tests to fail.

GitHub Issue Number: N/A

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This commit adds a new extras flag, `experimentalScopedSlotChanges`, that is used to change logic in a few places to align Stencil's `scoped` encapsulation to work more like the native Shadow DOM when using slots.

Changes in #5146 and #5135 are changed from being gated by the `experimentalSlotFixes` flag to this new flag so they can be toggled independently.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
This will be considered a breaking change once we remove the ability to opt-in/opt-out

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

**Manual tests**
Changes can be tested by enabling `experimentalScopedSlotChanges` in a starter project's Stencil config and following the test cases from either #5146 and/or #5135

**Automated tests**
Stencil unit and e2e tests continue to pass (with the new flag enabled). Ionic Framework screenshot tests pass with the flag disabled (expected). 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

We'll need to coordinate with the Framework team to update their components before we can enable this flag by default (and eventually remove it altogether).

Related doc changes: https://github.com/ionic-team/stencil-site/pull/1307
