### PR TITLE
fix(runtime): slot regressions from experimental slot fixes

### DIFF
--- a/src/runtime/bootstrap-custom-element.ts
+++ b/src/runtime/bootstrap-custom-element.ts
@@ -46,6 +46,8 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
   // TODO(STENCIL-914): this check and `else` block can go away and be replaced by just the `scoped` check
   if (BUILD.experimentalSlotFixes) {
     if (BUILD.scoped && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
+      // This check is intentionally not combined with the surrounding `experimentalSlotFixes` check
+      // since, moving forward, we only want to patch the pseudo shadow DOM when the component is scoped
       patchPseudoShadowDom(Cstr.prototype, cmpMeta);
     }
   } else {

--- a/src/runtime/bootstrap-custom-element.ts
+++ b/src/runtime/bootstrap-custom-element.ts
@@ -44,8 +44,10 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
   }
 
   // TODO(STENCIL-914): this check and `else` block can go away and be replaced by just the `scoped` check
-  if (BUILD.experimentalSlotFixes && BUILD.scoped && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
-    patchPseudoShadowDom(Cstr.prototype, cmpMeta);
+  if (BUILD.experimentalSlotFixes) {
+    if (BUILD.scoped && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
+      patchPseudoShadowDom(Cstr.prototype, cmpMeta);
+    }
   } else {
     if (BUILD.slotChildNodesFix) {
       patchChildSlotNodes(Cstr.prototype, cmpMeta);

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -147,8 +147,10 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
       };
 
       // TODO(STENCIL-914): this check and `else` block can go away and be replaced by just the `scoped` check
-      if (BUILD.experimentalSlotFixes && BUILD.scoped && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
-        patchPseudoShadowDom(HostElement.prototype, cmpMeta);
+      if (BUILD.experimentalSlotFixes) {
+        if (BUILD.scoped && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
+          patchPseudoShadowDom(HostElement.prototype, cmpMeta);
+        }
       } else {
         if (BUILD.slotChildNodesFix) {
           patchChildSlotNodes(HostElement.prototype, cmpMeta);

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -148,6 +148,8 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
 
       // TODO(STENCIL-914): this check and `else` block can go away and be replaced by just the `scoped` check
       if (BUILD.experimentalSlotFixes) {
+        // This check is intentionally not combined with the surrounding `experimentalSlotFixes` check
+        // since, moving forward, we only want to patch the pseudo shadow DOM when the component is scoped
         if (BUILD.scoped && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
           patchPseudoShadowDom(HostElement.prototype, cmpMeta);
         }

--- a/src/runtime/dom-extras.ts
+++ b/src/runtime/dom-extras.ts
@@ -88,7 +88,7 @@ export const patchSlotAppendChild = (HostElementPrototype: any) => {
 
       // Check if there is fallback content that should be hidden
       updateFallbackSlotVisibility(this);
-      // Fore a re-render of the host element
+      // Force a re-render of the host element
       forceUpdate(this);
 
       return insertedNode;

--- a/src/runtime/dom-extras.ts
+++ b/src/runtime/dom-extras.ts
@@ -1,5 +1,5 @@
 import { BUILD } from '@app-data';
-import { getHostRef, plt, supportsShadow } from '@platform';
+import { forceUpdate, getHostRef, plt, supportsShadow } from '@platform';
 import { NODE_TYPES } from '@stencil/core/mock-doc';
 import { CMP_FLAGS, HOST_FLAGS } from '@utils';
 
@@ -84,10 +84,14 @@ export const patchSlotAppendChild = (HostElementPrototype: any) => {
     if (slotNode) {
       const slotChildNodes = getHostSlotChildNodes(slotNode, slotName);
       const appendAfter = slotChildNodes[slotChildNodes.length - 1];
-      appendAfter.parentNode.insertBefore(newChild, appendAfter.nextSibling);
+      const insertedNode = appendAfter.parentNode.insertBefore(newChild, appendAfter.nextSibling);
+
       // Check if there is fallback content that should be hidden
       updateFallbackSlotVisibility(this);
-      return;
+      // Fore a re-render of the host element
+      forceUpdate(this);
+
+      return insertedNode;
     }
     return (this as any).__appendChild(newChild);
   };

--- a/test/karma/test-app/dom-reattach-clone/cmp-deep-slot.tsx
+++ b/test/karma/test-app/dom-reattach-clone/cmp-deep-slot.tsx
@@ -2,6 +2,7 @@ import { Component, h } from '@stencil/core';
 
 @Component({
   tag: 'dom-reattach-clone-deep-slot',
+  scoped: true,
 })
 export class DomReattachCloneDeep {
   render() {

--- a/test/karma/test-app/dom-reattach-clone/cmp-host.tsx
+++ b/test/karma/test-app/dom-reattach-clone/cmp-host.tsx
@@ -1,7 +1,8 @@
-import { Component, Host, h } from '@stencil/core';
+import { Component, h, Host } from '@stencil/core';
 
 @Component({
   tag: 'dom-reattach-clone-host',
+  scoped: true,
 })
 export class DomReattachCloneHost {
   render() {

--- a/test/karma/test-app/dom-reattach-clone/cmp.tsx
+++ b/test/karma/test-app/dom-reattach-clone/cmp.tsx
@@ -2,6 +2,7 @@ import { Component, h } from '@stencil/core';
 
 @Component({
   tag: 'dom-reattach-clone',
+  scoped: true,
 })
 export class DomReattachClone {
   render() {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
A few changes made behind the `experimentalSlotFixes` flag were resulting in screenshot test failures in the Ionic Framework

GitHub Issue Number: N/A

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixes the conditional responsible for patching element methods for the pseudo shadow DOM when `experimentalSlotFixes` is enabled.
- Updated the `appendChild` patch to force a re-render of the patched element

See commit messages for more information

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

**Automated tests**
- Stencil unit and e2e tests continue to pass.
- A build of Stencil containing these changes (and changes from the other "slot regressions" branches) was used in a manually triggered run of the Stencil nightly build and succeeded. Run results: https://github.com/ionic-team/ionic-framework/actions/runs/7280624127

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
