### PR TITLE
chore(ci): add a version number output from the release-dev task

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -4,6 +4,11 @@ on:
   workflow_dispatch:
     # Make this a reusable workflow, no value needed
     # https://docs.github.com/en/actions/using-workflows/reusing-workflows
+  workflow_call:
+    outputs:
+      dev-version:
+        description: The version that was just published to npm.
+        value: ${{ jobs.get-dev-version.outputs.dev-version }}
 
 jobs:
   build_core:


### PR DESCRIPTION
This adds an output from the `release-dev` workflow which will let other calling workflows get the version which has just been released.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?

Right now if the `release-dev` workflow is called by another workflow there isn't a way for the calling workflow to get the version number which was just released.


## What is the new behavior?

This adds an `output` to the whole workflow so that a calling workflow can get the version number, for instance so that something like #5229 can run a dev release, get the version number, and then write a comment out to the user.

See the documentation for workflow outputs (as opposed to _job_ outputs) here: https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-outputs-from-a-reusable-workflow

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

There's not a great way to test this without it being on `main` unfortunately.

However! I think that:

- this is a pretty straightforward change and I believe is something we can hand-check against the [relevant documentation](https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-outputs-from-a-reusable-workflow)
- we could introduce this on `main` and then test it (I think we should be able to see the outputs using [debug logging](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging))