### PR TITLE
chore(deps): upgrade rollup/plugin-replace to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@rollup/plugin-commonjs": "15.1.0",
         "@rollup/plugin-json": "6.1.0",
         "@rollup/plugin-node-resolve": "9.0.0",
-        "@rollup/plugin-replace": "2.3.4",
+        "@rollup/plugin-replace": "5.0.5",
         "@rollup/pluginutils": "5.1.0",
         "@types/eslint": "^8.4.6",
         "@types/exit": "^0.1.31",
@@ -2689,54 +2689,24 @@
       "dev": true
     },
     "node_modules/@rollup/plugin-replace": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.3.4.tgz",
-      "integrity": "sha512-waBhMzyAtjCL1GwZes2jaE9MjuQ/DQF2BatH3fRivUF3z0JBFrU0U6iBNC/4WR+2rLKhaAhPWDNPYp4mI6RqdQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.5.tgz",
+      "integrity": "sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==",
       "dev": true,
       "dependencies": {
-        "@rollup/pluginutils": "^3.1.0",
-        "magic-string": "^0.25.7"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0 || ^2.0.0"
-      }
-    },
-    "node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
       },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
-      }
-    },
-    "node_modules/@rollup/plugin-replace/node_modules/@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true
-    },
-    "node_modules/@rollup/plugin-replace/node_modules/estree-walker": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true
-    },
-    "node_modules/@rollup/plugin-replace/node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dev": true,
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@rollup/plugin-commonjs": "15.1.0",
     "@rollup/plugin-json": "6.1.0",
     "@rollup/plugin-node-resolve": "9.0.0",
-    "@rollup/plugin-replace": "2.3.4",
+    "@rollup/plugin-replace": "5.0.5",
     "@rollup/pluginutils": "5.1.0",
     "@types/eslint": "^8.4.6",
     "@types/exit": "^0.1.31",

--- a/renovate.json5
+++ b/renovate.json5
@@ -11,10 +11,8 @@
   ignoreDeps: [
     // TODO(STENCIL-596): Remove once rollup upgrade is unblocked
     'rollup',
-    'rollup-plugin-sourcemaps',
     '@rollup/plugin-commonjs',
     '@rollup/plugin-node-resolve',
-    '@rollup/plugin-replace',
     // TODO(STENCIL-912): Upgrade these two dependencies
     'glob',
     'minimatch',

--- a/scripts/bundles/plugins/replace-plugin.ts
+++ b/scripts/bundles/plugins/replace-plugin.ts
@@ -12,5 +12,5 @@ export function replacePlugin(opts: BuildOptions): Plugin {
   const replaceData = createReplaceData(opts);
   replaceData[`process.env.NODE_DEBUG`] = false;
   replaceData[`process.binding('natives')`] = '';
-  return rollupReplace(replaceData);
+  return rollupReplace({ ...replaceData, preventAssignment: true });
 }

--- a/src/compiler/bundle/bundle-output.ts
+++ b/src/compiler/bundle/bundle-output.ts
@@ -140,6 +140,7 @@ export const getRollupOptions = (
       }),
       rollupReplacePlugin({
         'process.env.NODE_ENV': config.devMode ? '"development"' : '"production"',
+        preventAssignment: true,
       }),
       fileLoadPlugin(compilerCtx.fs),
     ],


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We're on quite an old version of `@rollup/plugin-replace`! The version here is from 2020 😱 

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

upgrade stencil's dependency on `@rollup/plugin-replace` from v2.x to
v5.x. this package is being done as a part of a larger effort to upgrade
stencil's version of rollup to v2 (which itself is a part of a larger
effort to move to v4). this package has been updated on its own, as:

1. doing so allows us to cut scope/size of other upgrade PRs
2. this package relies on rollup v1.20.0+, and no other sibling
   packages, making this upgrade less involved than others.

update replace plugin calls to use preventAssignment.

`preventAssignment` was added in rollup v2.40.0. when we attempt to
build stencil with the latest v5.x release of the replace-plugin, we
received the following error:

```
(!) Plugin replace: @rollup/plugin-replace: 'preventAssignment'
currently defaults to false. It is recommended to set this option to
`true`, as the next major version will default this option to `true`.
```

explicitly set it to suppress this error. doing so does not change the
stencil binary itself, nor does it appear to change the output of the
generated code.

remove @rollup/plugin-replace & rollup-plugin-sourcemaps from renovate config

remove the former so that renovate can begin to update this package. do
the same for `rollup-plugin-sourcemaps`, which is already up to date.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

### Stencil Output

I cut three different local builds of Stencil using `npm run clean && npm ci && npm run build`:
1. One from `main` (https://github.com/ionic-team/stencil/commit/af6e45bc87e18c44da841a1abe11c4d388957326)
2. One prior to setting `preventAssignment` (commit 1)
3. One after setting `preventAssignment` (commit 2)

Comparing the Builds:

1 vs 2 - In upgrading the plugin, a good deal of boilerplate was able to be removed that the plugin was inlining. This led to deduplicated identifiers (e.g. `Chunk$2`) to have their numeric aspect decremented (and in some cases, removed - e.g. `Chunk$2` -> `Chunk$1` || `Chunk$1` -> `Chunk`). There's some ~460 instances of this occurring, but all seem to map back to the deleted code

2 vs 3 - Only code related to inserting the `preventAssignment` configurations have changed. To test this further, I needed to test with the Ionic Framework.

### Ionic Framework

I built framework with Stencil v4.9.1 and [a build of this branch](
https://github.com/ionic-team/stencil/actions/runs/7452395185). The only differences between the generated code was the Stencil version between the two builds.

I [ran the Stencil Nightly Build with this build](https://github.com/ionic-team/ionic-framework/actions/runs/7452455311) and everything passed.
 
## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

**NOTE TO SELF**: SQUASH THIS PLEASE
