### PR TITLE
chore(repo): revert 2023 holiday triage

### DIFF
--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -1,5 +1,5 @@
 triage:
-  label: 'holiday triage'
+  label: triage
   dryRun: false
 
 closeAndLock:
@@ -26,15 +26,6 @@ closeAndLock:
 
 comment:
   labels:
-    - label: 'holiday triage'
-      message: >
-        Thanks for the issue! This issue has been labeled as `holiday triage`. With the winter holidays quickly approaching, much of the Stencil Team will soon be taking time off. During this time, issue triaging and PR review will be delayed until the team begins to return. After this period, we will work to ensure that all new issues & PRs are properly triaged.
-
-
-        In the meantime, please read our [2023 Winter Holiday Triage Guide](https://github.com/ionic-team/stencil/issues/5183) for information on how to ensure that your issue is triaged correctly.
-
-
-        Thank you!
     - label: 'ionitron: needs reproduction'
       message: >
         Thanks for the issue! This issue has been labeled as `needs reproduction`. This label is added to issues that


### PR DESCRIPTION
## What is the current behavior?
Holiday triage is still enabled.

## What is the new behavior?
This patch reverts #5184 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
