### PR TITLE
chore(repo): allow Renovate to update to TypeScript 5.3

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -62,7 +62,7 @@
     {
       // Increment this value as a part of updating TypeScript
       matchPackageNames: ['typescript'],
-      allowedVersions: '<5.3.0',
+      allowedVersions: '<5.4.0',
     },
     {
       // disable Jest updates until the new testing architecture is in place


### PR DESCRIPTION
## What is the current behavior?
We are currently not using the latest TypeScript version.

## What is the new behavior?
Have Renovate update to latest TypeScript.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

Given their v5.3 announcement I expect no breaking changes nor updates required to our current code base.
