### PR TITLE
chore(compiler): resolve strictNullCheck for element-decorator

### DIFF
--- a/src/compiler/transformers/decorators-to-static/element-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/element-decorator.ts
@@ -14,7 +14,7 @@ export const elementDecoratorsToStatic = (
   const elementRefs = decoratedMembers
     .filter(ts.isPropertyDeclaration)
     .map((prop) => parseElementDecorator(prop, decoratorName))
-    .filter((element) => !!element);
+    .filter((element): element is string => !!element);
 
   if (elementRefs.length > 0) {
     newMembers.push(createStaticGetter('elementRef', ts.factory.createStringLiteral(elementRefs[0])));


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We have many strictNullChecks violations

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

fix a single strictNullCheck for the file by adding a type guard to the final `filter` call against a class's decorated members. this allows the typescript compiler to understand that the collection `elementRefs` is a collection of `string`, rather than a `(string | null)[]`, based on the return type of the local function `parseElementDecorator`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

This only affects the type system, and therefore shouldn't change any runtime values. As such, I only tested this by running our strict null checks counter, unit and karma tests locally.
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
