### PR TITLE
fix(runtime): resolve memory leak caused by global content ref

### DIFF
--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -1127,6 +1127,9 @@ render() {
       }
     }
   }
+
+  // Clear the content ref so we don't create a memory leak
+  contentRef = null;
 };
 
 // slot comment debug nodes only created with the `--debug` flag

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -16,7 +16,7 @@ import { h, isHost, newVNode } from './h';
 import { updateElement } from './update-element';
 
 let scopeId: string;
-let contentRef: d.RenderNode;
+let contentRef: d.RenderNode | undefined;
 let hostTagName: string;
 let useNativeShadowDom = false;
 let checkSlotFallbackVisibility = false;
@@ -1129,7 +1129,7 @@ render() {
   }
 
   // Clear the content ref so we don't create a memory leak
-  contentRef = null;
+  contentRef = undefined;
 };
 
 // slot comment debug nodes only created with the `--debug` flag


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There is a memory leak in the Stencil runtime related to a retained reference to a "content ref" comment. This is only an issue when the runtime patches slot behavior for use outside the Shadow DOM.

GitHub Issue Number: N/A

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This commit resolves a memory leak in the runtime related to a global reference that existed in the vDOM algorithm. The content ref would get set when entering the render cycle for a component, but was never cleared so the reference would exist after execution. So, now we clear that value at the end of the `renderVdom()` function execution.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

**Automated testing**
Automated unit & e2e tests continue to pass.

**Manual testing**

1. Perform all steps using [this](https://github.com/ionic-team/ionic-framework/tree/ld/5519) branch of the Ionic Framework
2. Navigate to http://localhost:3333/src/components/footer/test/basic in a Chromium-based browser (Chrome, Brave, Edge, etc).
3. Open Developer Tools and switch to the “Memory” tab.
4. Press CMD/CTRL+E to take a heap snapshot. (Or press the record icon in the top left”.
5. Click “Toggle Footer”. Observe that the text “hello” appears.
6. Click “Toggle Footer” again. Observe that the text “hello” disappears.
7. Press CMD/CTRL+E to take a heap snapshot. (Or press the record icon in the top left”.
8. In Snapshot 2, change from “Summary” to “Comparison” in the dropdown.
9. In the “Class filter” searchbox, search for “Detached”.
10. Expand the “Detached HTMLElement” entry that shows up.
11. Select the detached HTMLElement in the expanded “Detached HTMLElement” menu. You can hover over this entry to verify that this element is ion-footer. 
12. In the “Retainers” section, observe that the element (ion-footer) is being retained by the comment node inside of the component.
13. Repeat with a build of this branch installed and confirm there are no detached HTML elements this time

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
Also confirmed this does not cause issues with subsequent re-renders of the component
