### PR TITLE
feat(compiler): deprecate customResolveOptions config option

### DIFF
--- a/src/compiler/config/test/validate-custom.spec.ts
+++ b/src/compiler/config/test/validate-custom.spec.ts
@@ -26,6 +26,24 @@ describe('validateCustom', () => {
       },
     ];
     const { diagnostics } = validateConfig(userConfig, mockLoadConfigInit());
-    expect(diagnostics.length).toBe(1);
+    // TODO(STENCIL-1107): Decrement the right-hand side value from 2 to 1
+    expect(diagnostics.length).toBe(2);
+    // TODO(STENCIL-1107): Keep this assertion
+    expect(diagnostics[0]).toEqual({
+      header: 'Build Warn',
+      level: 'warn',
+      lines: [],
+      messageText: 'test warning',
+      type: 'build',
+    });
+    // TODO(STENCIL-1107): Remove this assertion
+    expect(diagnostics[1]).toEqual({
+      header: 'Build Warn',
+      level: 'warn',
+      lines: [],
+      messageText:
+        'nodeResolve.customResolveOptions is a deprecated option in a Stencil Configuration file. If you need this option, please open a new issue in the Stencil repository (https://github.com/ionic-team/stencil/issues/new/choose)',
+      type: 'build',
+    });
   });
 });

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -1,5 +1,5 @@
 import { createNodeLogger, createNodeSys } from '@sys-api-node';
-import { buildError, isBoolean, isNumber, isString, sortBy } from '@utils';
+import { buildError, buildWarn, isBoolean, isNumber, isString, sortBy } from '@utils';
 
 import {
   ConfigBundle,
@@ -264,6 +264,15 @@ export const validateConfig = (
     }
     return arr;
   }, [] as RegExp[]);
+
+  // TODO(STENCIL-1107): Remove this check. It'll be unneeded (and raise a compilation error when we build Stencil) once
+  // this property is removed.
+  if (validatedConfig.nodeResolve?.customResolveOptions) {
+    const warn = buildWarn(diagnostics);
+    // this message is particularly long - let the underlying logger implementation take responsibility for breaking it
+    // up to fit in a terminal window
+    warn.messageText = `nodeResolve.customResolveOptions is a deprecated option in a Stencil Configuration file. If you need this option, please open a new issue in the Stencil repository (https://github.com/ionic-team/stencil/issues/new/choose)`;
+  }
 
   CACHED_VALIDATED_CONFIG = validatedConfig;
 

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1613,8 +1613,12 @@ export interface NodeResolveConfig {
   only?: Array<string | RegExp>;
   modulesOnly?: boolean;
 
+  // TODO(STENCIL-1107): Remove this field [BREAKING_CHANGE]
   /**
    * @see https://github.com/browserify/resolve#resolveid-opts-cb
+   * @deprecated the `customResolveOptions` field is no longer honored in future versions of
+   * `@rollup/plugin-node-resolve`. If you are currently using it, please open a new issue in the Stencil repo to
+   * describe your use case & provide input (https://github.com/ionic-team/stencil/issues/new/choose)
    */
   customResolveOptions?: {
     basedir?: string;

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -99,6 +99,8 @@ export function mockConfig(overrides: Partial<UnvalidatedConfig> = {}): Unvalida
     minifyJs: false,
     namespace: 'Testing',
     nodeResolve: {
+      // TODO(STENCIL-1107): Remove this field - it's currently overriding Stencil's default options to pass into
+      // the `@rollup/plugin-node-resolve` plugin.
       customResolveOptions: {},
     },
     outputTargets: null,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

we have a stencil configuration option that is part of our public configuration api, `nodeResolve#customResolveOptions`. This option will no longer be honored by newer options of `@rollup/plugin-node-resolve` - we need to remove it in the future (a breaking change). for now, we can start the process by logging a warning.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

deprecate the `nodeResolve#customResolveOptions` configuration option in a Stencil configuration. this field is used to configure `@rollup/plugin-node-resolve` when generating any non-documentation output target artifacts. the contents of this option get propagated by the rollup plugin to `resolve`, which does the actual resolution of files in stencil's in-memory filesystem.

in newer versions of `@rollup/plugin-node-resolve`, this option has been removed, which no option to override defaults (creating a separation of concerns between the plugin and `resolve`). since stencil exposes this configuration in its public api, we cannot remove it without causing a breaking change (nor could we find a suitable way to reuse an existing configuration).

this change is a prerequisite to upgrading `@rollup/plugin-node-resolve`. we will not remove the configuration option/upgrade the plugin until stencil v5. in the interim, we add a warning message at config validation time to try to elicit feedback on this change



## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

1. Create a new Stencil project in your directory of choice with the create-stencil cli - `npm init stencil@latest component`
2. In the project, install the following dev build `npm i @stencil/core@4.10.0-dev.1705521704.ea55603`
3. In the project's `stencil.config.ts` file, add the top level configuration `nodeResolve: customRollupOptions: {}`. Observe a deprecation notice.
```diff
  testing: {
    browserHeadless: "new",
  },
+  nodeResolve: {customResolveOptions: {}}
```
![Screenshot 2024-01-17 at 3 21 44 PM](https://github.com/ionic-team/stencil/assets/1930213/0b014df4-d7cd-4b23-ac6f-68261ab01bcb)
4. Build the project - `npm run build`. Observe the following warning:
```
> warn-custom-resolve@0.0.1 build
> stencil build

[22:12.8]  @stencil/core
[22:13.0]  [LOCAL DEV] v4.10.0-dev.1705521704.ea55603 🚘

[ WARN  ]  Build Warn
           nodeResolve.customResolveOptions is a deprecated option in a Stencil Configuration file. If you need this
           option, please open a new issue in the Stencil repository
           (https://github.com/ionic-team/stencil/issues/new/choose)
```
Note: The build will fail since we're providing empty options to `resolve`
5. Revert the changes to `stencil.config.ts`
```diff
  testing: {
    browserHeadless: "new",
  },
-  nodeResolve: {customResolveOptions: {}}
```
6. Build the project - `npm run build`. Observe the warning is gone.
## Other information

i've marked this as a 'feat' to raise awareness to it (i want it surfaced in the changelog). if you think 'fix' is more appropriate, happy to change it.
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
