### PR TITLE
docs(contributing): fix path setting in tsconfig.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,8 +78,8 @@ Using `npm link` is beneficial to the development cycle in that consecutive buil
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@stencil/core/internal": ["node_modules/@stencil/core/internal"],
-      "@stencil/core/internal/*": ["node_modules/@stencil/core/internal/*"]
+      "@stencil/core/internal": ["./node_modules/@stencil/core/internal"],
+      "@stencil/core/internal/*": ["./node_modules/@stencil/core/internal/*"]
     }
   }
 }


### PR DESCRIPTION
## What is the current behavior?

Copy-pasting the `tsconfig.json` patch from the contributing guidelines causes an error:

```sh
[ ERROR ]  TypeScript: tsconfig.json:19:34
           Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a
           leading './'?

     L18:  "paths": {
     L19:    "@stencil/core/internal": ["node_modules/@stencil/core/internal"],
     L20:    "@stencil/core/internal/*": ["node_modules/@stencil/core/internal/*"]
```

Seems that this has changed at some point in TypeScript.

## What is the new behavior?

Making it a true relative path.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

- Create a new stencil project `npm init stencil`
- link stencil dependency to a local stencil project
- copy & paste the current snippet into the `tsconfig.json` and observe the error
- now apply the suggested change
- build passes now

## Other information

n/a
