### PR TITLE
feat(deps): upgrade rollup, commonjs plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@ionic/prettier-config": "^4.0.0",
-        "@rollup/plugin-commonjs": "15.1.0",
+        "@rollup/plugin-commonjs": "21.1.0",
         "@rollup/plugin-json": "6.1.0",
         "@rollup/plugin-node-resolve": "9.0.0",
         "@rollup/plugin-replace": "5.0.5",
@@ -72,7 +72,7 @@
         "prettier": "3.2.2",
         "prompts": "2.4.2",
         "puppeteer": "^21.0.0",
-        "rollup": "2.42.3",
+        "rollup": "2.56.3",
         "rollup-plugin-sourcemaps": "^0.6.3",
         "semver": "^7.3.7",
         "terser": "5.26.0",
@@ -2519,9 +2519,9 @@
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-15.1.0.tgz",
-      "integrity": "sha512-xCQqz4z/o0h2syQ7d9LskIMvBSH4PX5PjYdpSSvgS+pQik3WahkQVNWg3D8XJeYjZoVWnIUQYDghuEMRGrmQYQ==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-21.1.0.tgz",
+      "integrity": "sha512-6ZtHx3VHIp2ReNNDxHjuUml6ur+WcQ28N1yHgCQwsbNkQg2suhxGMDQGJOn/KuDxKtd1xuZP5xSTwBA4GQ8hbA==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^3.1.0",
@@ -2536,7 +2536,7 @@
         "node": ">= 8.0.0"
       },
       "peerDependencies": {
-        "rollup": "^2.22.0"
+        "rollup": "^2.38.3"
       }
     },
     "node_modules/@rollup/plugin-commonjs/node_modules/@rollup/pluginutils": {
@@ -11362,9 +11362,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.42.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.42.3.tgz",
-      "integrity": "sha512-JjaT9WaUS5vmjy6xUrnPOskjkQg2cN4WSACNCwbOvBz8VDmbiKVdmTFUoMPRqTud0tsex8Xy9/boLbDW9HKD1w==",
+      "version": "2.56.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.3.tgz",
+      "integrity": "sha512-Au92NuznFklgQCUcV96iXlxUbHuB1vQMaH76DHl5M11TotjOHwqk9CwcrT78+Tnv4FN9uTBxq6p4EJoYkpyekg==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -11373,7 +11373,7 @@
         "node": ">=10.0.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.1"
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/rollup-plugin-sourcemaps": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@ionic/prettier-config": "^4.0.0",
-    "@rollup/plugin-commonjs": "15.1.0",
+    "@rollup/plugin-commonjs": "21.1.0",
     "@rollup/plugin-json": "6.1.0",
     "@rollup/plugin-node-resolve": "9.0.0",
     "@rollup/plugin-replace": "5.0.5",
@@ -119,7 +119,7 @@
     "prettier": "3.2.2",
     "prompts": "2.4.2",
     "puppeteer": "^21.0.0",
-    "rollup": "2.42.3",
+    "rollup": "2.56.3",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "semver": "^7.3.7",
     "terser": "5.26.0",


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

**DO NOT MERGE!** I want to squash this as a `feat()` to surface the changes in the changelog. While I've tested this pretty well (subjective, I know 😉), I want folks to see this core piece of infra is being updated, as it impacts them as well. 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Our rollup infrastructure is lagging behind the latest. We're currently working on a few different modernization efforts for handling newer JS paradigms + infra; this is one of them.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

upgrade rollup to v2.56.3 and `@rollup/plugin-commonjs` to v21.1.

this commit raises these libraries to the highest version as possible
without introducing breaking changes. v2.57 has a bug in it that
requires `@rollup/plugin-commonjs@22` for handling CJS-ESM interop.
that version of `@rollup/plugin-commonjs` requires
`@rollup/plugin-node-resolve@13`. however,
`@rollup/plugin-node-resolve@11` has changes that would be breaking
for existing users (see https://github.com/ionic-team/stencil/pull/5269)

future upgrades will be slated to stencil v5.0.0.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No - We do not believe this is going to introduce any breaking changes. However, folks upgrading to the version of Stencil this upgrade lands in are encouraged to file bugs early/often.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
I created a dev build of Stencil, `4.10.0-dev.1705594858.56d0fba` and used that in a CI run of Framework, which passed https://github.com/ionic-team/ionic-framework/actions/runs/7573347378

I did a pretty comprehensive diff of the changes that are going to be applied to the Ionic Framework as a part of this. For every minor version of rollup of `@rollup/plugin-commonjs`, I:
- Built Stencil (`npm run clean && npm ci && npm run build && npm pack`)
- Installed the tarball into Ionic Framework Core
- Built Ionic Framework Core (`npm run build`)
- Diffed the `components`, `css`, `dist`, `hydrate`, `loader` directories of the latest version I just built with the previous

In doing so, I noticed minimal changes. Happy to discuss them in a jam session or otherwise. 

## Other information

My notes for this are an attachment on the JIRA ticket. 
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
