### PR TITLE
chore(jsdoc): add JSDoc to `src/compiler/build/compiler-ctx.ts`

### DIFF
--- a/src/compiler/build/compiler-ctx.ts
+++ b/src/compiler/build/compiler-ctx.ts
@@ -62,7 +62,17 @@ export class CompilerContext implements d.CompilerCtx {
   }
 }
 
-export const getModuleLegacy = (compilerCtx: d.CompilerCtx, sourceFilePath: string) => {
+/**
+ * Get a {@link d.Module} from the current compiler context which corresponds
+ * to a supplied source file path. If a module record corresponding to the
+ * supplied path is not yet allocated, create one, save it in the compiler
+ * context, and then return the module record.
+ *
+ * @param compilerCtx the current compiler context
+ * @param sourceFilePath the path for which we want a module record
+ * @returns a module record corresponding to the supplied source file path
+ */
+export const getModuleLegacy = (compilerCtx: d.CompilerCtx, sourceFilePath: string): d.Module => {
   sourceFilePath = normalizePath(sourceFilePath);
 
   const moduleFile = compilerCtx.moduleMap.get(sourceFilePath);
@@ -114,6 +124,12 @@ export const getModuleLegacy = (compilerCtx: d.CompilerCtx, sourceFilePath: stri
   }
 };
 
+/**
+ * Reset a module record, mutating the supplied object to reset values to
+ * defaults.
+ *
+ * @param moduleFile the module record to reset
+ */
 export const resetModuleLegacy = (moduleFile: d.Module) => {
   moduleFile.cmps.length = 0;
   moduleFile.coreRuntimeApis.length = 0;


### PR DESCRIPTION
This adds some documentation for the two functions in here.

Just noticed this randomly and in particular wanted to call out how `getModuleLegacy` works.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Documentation only change, so as long as lint and spellcheck are passing I think we're good.
