### PR TITLE
chore(jsdoc): clarify how `parseStaticComponentMeta` behaves

### DIFF
--- a/src/compiler/transformers/static-to-meta/component.ts
+++ b/src/compiler/transformers/static-to-meta/component.ts
@@ -22,10 +22,17 @@ import { parseStaticStyles } from './styles';
 import { parseStaticWatchers } from './watchers';
 
 /**
- * Given an instance of TypeScript's Intermediate Representation (IR) for a
- * class declaration ({@see ts.ClassDeclaration}) which represents a Stencil
- * component class declaration, parse and format various pieces of data about
- * static class members which we use in the compilation process
+ * Given a {@see ts.ClassDeclaration} which represents a Stencil component
+ * class declaration, parse and format various pieces of data about static class
+ * members which we use in the compilation process.
+ *
+ * This performs some checks that this class is indeed a Stencil component
+ * and, if it is, will perform a side-effect, adding an object containing
+ * metadata about the component to the module map and the node map.
+ *
+ * Additionally, it will optionally transform the supplied class declaration
+ * node to add a static getter for the component metadata if the transformation
+ * options specify to do so.
  *
  * @param compilerCtx the current compiler context
  * @param typeChecker a TypeScript type checker instance


### PR DESCRIPTION
This fleshes out a bit further how this functions behaves, in particular that it will perform a side-effect of creating a `ComponentCompilerMeta` object and then sticking that into a few other objects.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->




## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Documentation-only change, so if lint, spellcheck, and format are passing we're good I think.
