### PR TITLE
fix(hmr): allow changes to component decorators when using HMR

### DIFF
--- a/src/client/client-host-ref.ts
+++ b/src/client/client-host-ref.ts
@@ -6,8 +6,21 @@ import type * as d from '../declarations';
 /**
  * A WeakMap mapping runtime component references to their corresponding host reference
  * instances.
+ *
+ * **Note**: If we're in an HMR context we need to store a reference to this
+ * value on `window` in order to maintain the mapping of {@link d.RuntimeRef}
+ * to {@link d.HostRef} across HMR updates.
+ *
+ * This is necessary because when HMR updates for a component are processed by
+ * the browser-side dev server client the JS bundle for that component is
+ * re-fetched. Since the module containing {@link hostRefs} is included in
+ * that bundle, if we do not store a reference to it the new iteration of the
+ * component will not have access to the previous hostRef map, leading to a
+ * bug where the new version of the component cannot properly initialize.
  */
-const hostRefs: WeakMap<d.RuntimeRef, d.HostRef> = /*@__PURE__*/ new WeakMap();
+const hostRefs: WeakMap<d.RuntimeRef, d.HostRef> = /*@__PURE__*/ BUILD.hotModuleReplacement
+  ? ((window as any).__STENCIL_HOSTREFS__ ||= new WeakMap())
+  : new WeakMap();
 
 /**
  * Given a {@link d.RuntimeRef} retrieve the corresponding {@link d.HostRef}


### PR DESCRIPTION
This fixes an issue where HMR updates which changed arguments to the `@Component` decorator would crash the application because a `HostRef` for the component could not be located.

This occurred because HMR updates caused a new version of the component's lazy bundle to be fetched, which in turn would bundle the `getHostRef` function and the corresponding `hostRefs` variable, which is declared here:

https://github.com/ionic-team/stencil/blob/0041dc27b9deb45cfd1434a3d82d563793e56056/src/client/client-host-ref.ts#L18

Because the newly fetched lazy entry point for the updated component did not have access to the `hostRefs` variable which was in-scope in the _old_ bundle, the `getHostRef` function would always return `undefined` on the first render after the HMR update, causing issues in functions like `setValue` which make use of a `HostRef`.

In order to fix the issue we can persist the `hostRefs` map across HMR updates by storing a reference to it on the `window` object. We can additionally constrain this persistence to only occur when we're building with HMR, so that we don't clutter up the `window` object of unsuspecting Stencil users in the context of a production build.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?

Unfortunately at present if you are using the hot-reload dev server and you make an edit to the `@Component` decorator of your component you'll see a big error in the browser console, and you'll be forced to reload 😢. The error will look something like this:

<img width="710" alt="Screenshot 2024-01-23 at 4 53 35 PM" src="https://github.com/ionic-team/stencil/assets/6207644/a3ad0b96-9b24-495d-8364-060e66224cb3">

Not such a nice time.

## What is the new behavior?

Now if you make an edit to your `@Component` decorator you'll just see your component get updated in the browser with no errors.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

In order to test this I would recommend the following:

- confirm that you can reproduce the issue
    - create a new project with
      ```sh
      cd /tmp && \
      npm init stencil@latest component hmr-issue && \
      cd hmr-issue && \
      npm install
      ```
    - then confirm that if you start the dev server (`npm start`) and edit a property in `@Component` you see an error in the console like above
- then confirm the fix
    - build and pack this branch:
      ```sh
      cd /tmp && \
      git clone git@github.com:ionic-team/stencil.git && \
      cd /tmp/stencil && \
      git checkout ap/allow-component-decorator-hmr && \
      npm install && \
      npm run install.jest && \
      npm run build && \
      npm pack
      ```
    - install into the sample project:
      ```sh
      cd /tmp/hmr-issue && \
      npm i ../stencil/stencil-core-4.11.0.tgz
      ```
    - then, as above, start the dev server (`npm start`) and confirm that editing the `@Component` decorator doesn't cause catastrophic issues anymore