### PR TITLE
chore(readme): remove broken image

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,5 +95,3 @@ Please note that this project is released with a [Contributor Code of Conduct](h
 
 ### Thanks
 Stencil's internal testing suite is supported by the [BrowserStack Open-Source Program](https://www.browserstack.com/open-source)
-<br>
-<a href="https://www.browserstack.com/" target="_blank" rel="noopener noref"><img width="200" src="https://www.browserstack.com/images/layout/browserstack-logo-600x315.png"></a>


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

stencil's README tries to resolve an image that no longer exists

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
the link to browserstack's logo currently no longer resolves. remove it, as a link out to their offerings ought to be enough

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I reviewed the preview of this markdown file beforehand, no broken image placeholder gets shown anymore

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
