### PR TITLE
chore(snc): resolve strictNullChecks for typescript-config

### DIFF
--- a/src/compiler/sys/typescript/typescript-config.ts
+++ b/src/compiler/sys/typescript/typescript-config.ts
@@ -119,10 +119,17 @@ export const validateTsConfig = async (config: d.ValidatedConfig, sys: d.Compile
   return tsconfig;
 };
 
-const getTsConfigPath = async (config: d.ValidatedConfig, sys: d.CompilerSystem, init: d.LoadConfigInit) => {
+const getTsConfigPath = async (
+  config: d.ValidatedConfig,
+  sys: d.CompilerSystem,
+  init: d.LoadConfigInit,
+): Promise<{
+  path: string;
+  content: string;
+} | null> => {
   const tsconfig = {
-    path: null as string,
-    content: null as string,
+    path: '',
+    content: '',
   };
 
   if (isString(config.tsconfig)) {


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We have several strictNullChecks in our code

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

resolve the two strictNullChecks for `typescript-config.ts` by removing type assertions on fields that are always assigned when an object is returned by the function

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I didn't do much testing on this beyond running tests locally - I can provide some examples of walking this through a debugger if folks would prefer, but AFAICT every code path that returns an object never returns a `null` property
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
