### PR TITLE
chore(docs): add a step for creating a new version of the stencil docs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -69,10 +69,15 @@ manual release was performed.
       🎉 Thanks <GitHub_Usernames> for their contributions! 🎉
       ```
    1. Hit "Publish Release"    
-1. Navigate to the [Stencil Site](https://github.com/ionic-team/stencil-site/pulls) repository and merge PRs
-   containing documentation that has been approved, but not merged that is related to the release. Such PRs should be
-   labelled as `do not merge: waiting for next stencil release`. It's a good idea to review _all_ PRs though, just in
-   case.
+1. Navigate to the [Stencil Site](https://github.com/ionic-team/stencil-site/pulls) repository and:
+  1. Merge any open PRs containing documentation that has been approved, but
+     not merged that is related to the release. Such PRs should be labelled as
+     `do not merge: waiting for next stencil release`. It's a good idea to
+     review _all_ PRs though, just in case.
+  1. If the current release is a major or minor version, open a pull request
+     creating a new version of the docs by following the [guide in the
+     stencil-site
+     repo](https://github.com/ionic-team/stencil-site/blob/main/RELEASE.md#creating-a-new-version-section).
 1. If there are any 'next' branches in GitHub, say for a future major version of Stencil (e.g. `v5.0.0-dev`), now is a
    good time to rebase them against the `main` branch.
 1. End the code freeze in the Stencil team Slack channel.


### PR DESCRIPTION
This adds a step to the release flow which consists of creating a new version of the docs on the stencil-site repo, if necessary. Since we already have good documentation of how that process works over there (https://github.com/ionic-team/stencil-site/blob/main/RELEASE.md#creating-a-new-version-section) we can just point to that.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

documentation-only PR, no testing needed