### PR TITLE
chore(config): add some documentation to the `buildDist` option

### DIFF
--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -272,6 +272,13 @@ export interface StencilConfig {
   rollupPlugins?: { before?: any[]; after?: any[] };
 
   entryComponentsHint?: string[];
+  /**
+   * Sets whether Stencil will write files to `dist/` during the build or not.
+   *
+   * By default this value is set to the opposite value of {@link devMode},
+   * i.e. it will be `true` when building for production and `false` when
+   * building for development.
+   */
   buildDist?: boolean;
   buildLogFilePath?: string;
   devInspector?: boolean;


### PR DESCRIPTION
Add a JSDoc string to the `buildDist` config option, documenting the effect that it has on the Stencil build process.


## What is the current behavior?
No documentation!



## What is the new behavior?

Documentation!

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Testing

Documentation-only change

## Docs

I've also got a PR on the stencil site here: https://github.com/ionic-team/stencil-site/pull/1333