### PR TITLE
chore(release): fix docs steps for release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -70,11 +70,11 @@ manual release was performed.
       ```
    1. Hit "Publish Release"    
 1. Navigate to the [Stencil Site](https://github.com/ionic-team/stencil-site/pulls) repository and:
-  1. Merge any open PRs containing documentation that has been approved, but
-     not merged that is related to the release. Such PRs should be labelled as
-     `do not merge: waiting for next stencil release`. It's a good idea to
-     review _all_ PRs though, just in case.
-  1. If the current release is a major or minor version, open a pull request
+   1. Merge any open PRs containing documentation that has been approved, but
+      not merged that is related to the release. Such PRs should be labelled as
+      `do not merge: waiting for next stencil release`. It's a good idea to
+      review _all_ PRs though, just in case.
+   1. If the current release is a major or minor version, open a pull request
      creating a new version of the docs by following the [guide in the
      stencil-site
      repo](https://github.com/ionic-team/stencil-site/blob/main/RELEASE.md#creating-a-new-version-section).


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

see 'new behavior' 
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
fix the indentation on documentation release steps so that the render properly in a rich markdown viewer. github's markdown renderer does not see the steps beginning with 'Merge any open PRs' and 'If the current release' as children of the doc site step, causing them to be rendered as follow up steps:
```md
2. Navigate to the Stencil Site repo and:
3. Merge any open PRs...
4. If the current release...
```


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->
N/A - fixes local documentation for releasing stencil

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Before (at 89816e1032c7dbd853e6a824d5cffeca0d6d4355): 
![Screenshot 2024-01-29 at 11 16 34 AM](https://github.com/ionic-team/stencil/assets/1930213/ec3f90ed-557f-4ac7-a344-3d00395dccd5)

After (apply this commit):
![Screenshot 2024-01-29 at 11 17 18 AM](https://github.com/ionic-team/stencil/assets/1930213/b43924b5-0223-43de-ac42-7e412bb6621a)

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
