### PR TITLE
fix(declarations): use correct TypeScript JSX typings

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -596,12 +596,12 @@ export interface ChildNode {
  *
  * For further information: https://stenciljs.com/docs/host-element
  */
-export declare const Host: FunctionalComponent<HostAttributes>;
+export declare const Host: (props: HostAttributes) => VNode;
 
 /**
  * Fragment
  */
-export declare const Fragment: FunctionalComponent<{}>;
+export declare const Fragment: (props: {}) => VNode;
 
 /* eslint-disable jsdoc/require-param, jsdoc/require-returns -- we don't want to JSDoc these overloads at this time */
 /**
@@ -619,6 +619,7 @@ export declare namespace h {
   export function h(sel: any, data: VNodeData | null, children: VNode): VNode;
 
   export namespace JSX {
+    type Element = VNode;
     interface IntrinsicElements extends LocalJSX.IntrinsicElements, JSXBase.IntrinsicElements {
       [tagName: string]: any;
     }


### PR DESCRIPTION
## What is the current behavior?

Fix incorrect JSX typings, as described in great detail in https://github.com/ionic-team/stencil/issues/5306

GitHub Issue Number: #5306

## What is the new behavior?

TypeScript compiler is able to resolve Stencil's JSX typings correctly, thus working well with third-party tools that use TypeScript compiler types

## Documentation

Described in great detail in https://github.com/ionic-team/stencil/issues/5306

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

The error affects tools that use the TypeScript compiler. It is unfortunate that typescript does not report this error directly - instead, it just settles for an implicit `any`, which is how I discovered this bug in the first place.

Thus suggested testing:
1. In an app that is using Stencil and TypeScript, install typescript-eslint and enable the [@typescript-eslint/no-unsafe-return](https://typescript-eslint.io/rules/no-unsafe-return) rule
2. Create a small test file like this:
  ```tsx
  import { type VNode, h } from "@stencil/core/internal";
  
  export function a(): VNode {
    return <br />;
  }
  ```

  Before this PR there would be an error on line `return <br />;`. After this PR, there should not be an error there
