### PR TITLE
chore(ci): update comment actions to same versions as tech debt burndown

### DIFF
--- a/.github/workflows/pack-and-comment.yml
+++ b/.github/workflows/pack-and-comment.yml
@@ -15,6 +15,13 @@ jobs:
     name: Pack and Comment
     runs-on: 'ubuntu-22.04'
     steps:
+      - name: Check event type
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "This workflow was not triggered by a pull request. Exiting..."
+            exit 0
+          fi
+
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
@@ -67,7 +74,7 @@ jobs:
           echo "$EOF" >> $GITHUB_OUTPUT
 
       - name: Find Comment
-        uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1 # v2.4.0
+        uses: peter-evans/find-comment@d5fe37641ad8451bdd80312415672ba26c86575e # v3.0.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -75,7 +82,7 @@ jobs:
           body-includes: '### PR built and packed!'
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@23ff15729ef2fc348714a3bb66d2f655ca9066f2 # v3.1.0
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Just a quick version bump to sync the versions in the `pack-and-comment` workflow with the ones we already use in the tech debt burndown.

I also realized we want to ensure that this workflow doesn't run on CI when not in the context of a pull request.


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
