### PR TITLE
chore(ci): ensure that the 'pack and comment' only runs on a PR

### DIFF
--- a/.github/workflows/pack-and-comment.yml
+++ b/.github/workflows/pack-and-comment.yml
@@ -14,14 +14,8 @@ jobs:
   pack:
     name: Pack and Comment
     runs-on: 'ubuntu-22.04'
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
-      - name: Check event type
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "This workflow was not triggered by a pull request. Exiting..."
-            exit 0
-          fi
-
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 


### PR DESCRIPTION
Put an `if` on the job so that things will only run when we're on a pull request.

I thought I'd gotten this right in #5333 but I had not!


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
