### PR TITLE
chore(ci): refactor pack-and-comment workflow to support community PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,10 +57,3 @@ jobs:
     uses: ./.github/workflows/test-unit.yml
     with:
       build_name: stencil-core
-
-  pack_and_comment:
-    name: Pack and Comment
-    needs: [build_core]
-    uses: ./.github/workflows/pack-and-comment.yml
-    with:
-      build_name: stencil-core

--- a/.github/workflows/pack-and-comment.yml
+++ b/.github/workflows/pack-and-comment.yml
@@ -1,33 +1,32 @@
 name: Pack and Comment
+# for each PR this workflow builds and then packs a Stencil tarball and then
+# posts a comment on the PR with a link to download the tarball, as well as an
+# example command for installing the tarball in a project.
 
 on:
-  workflow_call:
-    # Make this a reusable workflow, no value needed
-    # https://docs.github.com/en/actions/using-workflows/reusing-workflows
-    inputs:
-      build_name:
-        description: Name for the build, used to resolve the correct build artifact
-        required: true
-        type: string
+  pull_request_target:
+    branches:
+      - '**'
 
 jobs:
   pack:
     name: Pack and Comment
     runs-on: 'ubuntu-22.04'
-    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          # the pull_request_target event will consider the HEAD of `main` to be the SHA to use.
+          # attempt to use the SHA associated with a pull request and fallback to HEAD of `main`
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.number) || '' }}
+          persist-credentials: false
 
       - name: Get Core Dependencies
         uses: ./.github/workflows/actions/get-core-dependencies
 
-      - name: Download Build Archive
-        uses: ./.github/workflows/actions/download-archive
-        with:
-          name: ${{ inputs.build_name }}
-          path: .
-          filename: stencil-core-build.zip
+      - name: Core Build
+        run: npm run build -- --ci
+        shell: bash
 
       - name: Set Version
         run: npm version --no-git-tag-version $(./bin/stencil version)


### PR DESCRIPTION
This changes the workflow from being a `workflow_call` triggered workflow which is intended to be called from _another_ workflow (`main`) and instead makes it a `pull_request_target` workflow which is "standalone". This means that no special privileges will be necessary to run it and that will in turn allow the `create-or-update-comment` action to work properly.

See these resources for more details:

- https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#restrictions-on-repository-forks
- https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?

Our little tarball packing / commenting workflow doesn't work on community PRs! E.g. https://github.com/ionic-team/stencil/pull/5337

## What is the new behavior?

This should enable it to work on any PR by moving to `pull_request_target`.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

As I understand it this has to be merged to `main` before it will start to be triggered on newer PRs, so we'll have to do something like merge this and then open another PR to test whether it does what we think it should.