### PR TITLE
chore(snc): silence some SNC errors in validate-paths.spec.ts

### DIFF
--- a/src/compiler/config/test/validate-paths.spec.ts
+++ b/src/compiler/config/test/validate-paths.spec.ts
@@ -46,8 +46,8 @@ describe('validatePaths', () => {
 
   it('should set default wwwIndexHtml and convert to absolute path', () => {
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
-    expect(path.basename((config.outputTargets as d.OutputTargetWww[])[0].indexHtml)).toBe('index.html');
-    expect(path.isAbsolute((config.outputTargets as d.OutputTargetWww[])[0].indexHtml)).toBe(true);
+    expect(path.basename((config.outputTargets as d.OutputTargetWww[])[0].indexHtml!)).toBe('index.html');
+    expect(path.isAbsolute((config.outputTargets as d.OutputTargetWww[])[0].indexHtml!)).toBe(true);
   });
 
   it('should convert a custom wwwIndexHtml to absolute path', () => {
@@ -60,8 +60,8 @@ describe('validatePaths', () => {
       },
     ] as d.OutputTargetWww[];
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
-    expect(path.basename((config.outputTargets as d.OutputTargetWww[])[0].indexHtml)).toBe('custom-index.html');
-    expect(path.isAbsolute((config.outputTargets as d.OutputTargetWww[])[0].indexHtml)).toBe(true);
+    expect(path.basename((config.outputTargets as d.OutputTargetWww[])[0].indexHtml!)).toBe('custom-index.html');
+    expect(path.isAbsolute((config.outputTargets as d.OutputTargetWww[])[0].indexHtml!)).toBe(true);
   });
 
   it('should set default indexHtmlSrc and convert to absolute path', () => {
@@ -104,8 +104,8 @@ describe('validatePaths', () => {
       },
     ];
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
-    expect(path.basename((config.outputTargets as d.OutputTargetDist[])[0].collectionDir)).toBe('collection');
-    expect(path.isAbsolute((config.outputTargets as d.OutputTargetDist[])[0].collectionDir)).toBe(true);
+    expect(path.basename((config.outputTargets as d.OutputTargetDist[])[0].collectionDir!)).toBe('collection');
+    expect(path.isAbsolute((config.outputTargets as d.OutputTargetDist[])[0].collectionDir!)).toBe(true);
   });
 
   it('should set default types dir and convert to absolute path', () => {
@@ -115,17 +115,17 @@ describe('validatePaths', () => {
       },
     ];
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
-    expect(path.basename((config.outputTargets as d.OutputTargetDist[])[0].typesDir)).toBe('types');
-    expect(path.isAbsolute((config.outputTargets as d.OutputTargetDist[])[0].typesDir)).toBe(true);
+    expect(path.basename((config.outputTargets as d.OutputTargetDist[])[0].typesDir!)).toBe('types');
+    expect(path.isAbsolute((config.outputTargets as d.OutputTargetDist[])[0].typesDir!)).toBe(true);
   });
 
   it('should set default build dir and convert to absolute path', () => {
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
     // the path will be normalized by Stencil us use '/', split on that regardless of platform
-    const parts = (config.outputTargets as d.OutputTargetDist[])[0].buildDir.split('/');
+    const parts = (config.outputTargets as d.OutputTargetDist[])[0].buildDir!.split('/');
     expect(parts[parts.length - 1]).toBe('build');
     expect(parts[parts.length - 2]).toBe('www');
-    expect(path.isAbsolute((config.outputTargets as d.OutputTargetDist[])[0].buildDir)).toBe(true);
+    expect(path.isAbsolute((config.outputTargets as d.OutputTargetDist[])[0].buildDir!)).toBe(true);
   });
 
   it('should set build dir w/ custom www', () => {
@@ -137,10 +137,10 @@ describe('validatePaths', () => {
     ] as d.OutputTargetWww[];
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
     // the path will be normalized by Stencil us use '/', split on that regardless of platform
-    const parts = (config.outputTargets as d.OutputTargetDist[])[0].buildDir.split('/');
+    const parts = (config.outputTargets as d.OutputTargetDist[])[0].buildDir!.split('/');
     expect(parts[parts.length - 1]).toBe('build');
     expect(parts[parts.length - 2]).toBe('custom-www');
-    expect(path.isAbsolute((config.outputTargets as d.OutputTargetDist[])[0].buildDir)).toBe(true);
+    expect(path.isAbsolute((config.outputTargets as d.OutputTargetDist[])[0].buildDir!)).toBe(true);
   });
 
   it('should set default src dir and convert to absolute path', () => {
@@ -161,8 +161,8 @@ describe('validatePaths', () => {
     // tests are run on) for their input
     userConfig.globalScript = path.join('src', 'global', 'index.ts');
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
-    expect(path.basename(config.globalScript)).toBe('index.ts');
-    expect(path.isAbsolute(config.globalScript)).toBe(true);
+    expect(path.basename(config.globalScript!)).toBe('index.ts');
+    expect(path.isAbsolute(config.globalScript!)).toBe(true);
   });
 
   it('should convert globalStyle string to absolute path array, if a globalStyle property was provided', () => {
@@ -170,7 +170,7 @@ describe('validatePaths', () => {
     // tests are run on) for their input
     userConfig.globalStyle = path.join('src', 'global', 'styles.css');
     const { config } = validateConfig(userConfig, mockLoadConfigInit());
-    expect(path.basename(config.globalStyle)).toBe('styles.css');
-    expect(path.isAbsolute(config.globalStyle)).toBe(true);
+    expect(path.basename(config.globalStyle!)).toBe('styles.css');
+    expect(path.isAbsolute(config.globalStyle!)).toBe(true);
   });
 });


### PR DESCRIPTION
This eliminates some SNC errors via judicious use of `!`, in places where its use is well-justified (I think so anyway!).

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
