### PR TITLE
chore(repo): add puppeteer to the renovate ignore list

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -149,6 +149,11 @@
     {
       matchPackageNames: ['open'],
       allowedVersions: '<10',
+    },
+    // TODO(STENCIL-1141): remove once support for Node v16 is dropped
+    {
+      matchPackageNames: ['puppeteer'],
+      allowedVersions: '<21',
     }
   ],
   // Never rebase the branch or update it unless manually requested to avoid noisy PR emails

--- a/renovate.json5
+++ b/renovate.json5
@@ -153,7 +153,7 @@
     // TODO(STENCIL-1141): remove once support for Node v16 is dropped
     {
       matchPackageNames: ['puppeteer'],
-      allowedVersions: '<21',
+      allowedVersions: '<=21',
     }
   ],
   // Never rebase the branch or update it unless manually requested to avoid noisy PR emails


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See 'new behavior' section

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

ignore dependency bumps for puppeteer for versions 22 and higher. starting with v22, puppeteer dropped support for node 16, which stencil v4 still supports.


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->
N/A - internal change

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I tested the using Renovate's validator tool:
```
`npm i -g renovate`
`renovate-config-validator`
```

This section also matches others that we have for ignoring Node 16-related packages

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
