### PR TITLE
chore(repo): remove old release scripts pt2

### DIFF
--- a/.github/workflows/create-production-pr.yml
+++ b/.github/workflows/create-production-pr.yml
@@ -48,7 +48,7 @@ jobs:
 
       # TODO(STENCIL-927): Backport changes to the v3 branch
       - name: Run Publish Preparation Script
-        run: npm run release.ci.prepare -- --version ${{ inputs.version }} --any-branch
+        run: npm run release.ci.prepare -- --version ${{ inputs.version }}
         shell: bash
 
       - name: Log Generated Changes

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -63,5 +63,5 @@ jobs:
       - name: Run Publish Scripts
         # pass the generated version number instead of the input, since we've already incremented it in the prerelease
         # step
-        run: npm run release.ci -- --any-branch --tag ${{ inputs.tag }}
+        run: npm run release.ci -- --tag ${{ inputs.tag }}
         shell: bash

--- a/scripts/release-tasks.ts
+++ b/scripts/release-tasks.ts
@@ -2,15 +2,8 @@ import color from 'ansi-colors';
 import Listr, { ListrTask } from 'listr';
 
 import { bundleBuild } from './build';
-import { validateBuild } from './test/validate-build';
 import { BuildOptions } from './utils/options';
-import {
-  isPrereleaseVersion,
-  isValidVersionInput,
-  postGithubRelease,
-  SEMVER_INCREMENTS,
-  updateChangeLog,
-} from './utils/release-utils';
+import { isPrereleaseVersion, isValidVersionInput, SEMVER_INCREMENTS, updateChangeLog } from './utils/release-utils';
 
 /**
  * Runs a litany of tasks used to ensure a safe release of a new version of Stencil
@@ -23,7 +16,6 @@ export async function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<st
   const tasks: ListrTask[] = [];
   const newVersion = opts.version;
   const isDryRun = args.includes('--dry-run') || opts.version.includes('dryrun');
-  const isAnyBranch = args.includes('--any-branch');
   let tagPrefix: string;
 
   const { execa } = await import('execa');
@@ -61,71 +53,39 @@ export async function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<st
     });
   }
 
-  tasks.push(
-    {
-      /**
-       * When we both pre-release and release, it's beneficial to ensure that the tag does not already exist in git.
-       * Doing so ought to catch out of the ordinary circumstances that ought to be investigated.
-       */
-      title: 'Check git tag existence',
-      task: () =>
-        execa('git', ['fetch'])
-          // Retrieve the prefix for a version string - https://docs.npmjs.com/cli/v7/using-npm/config#tag-version-prefix
-          .then(() => execa('npm', ['config', 'get', 'tag-version-prefix']))
-          .then(
-            ({ stdout }) => (tagPrefix = stdout),
-            () => {},
-          )
-          // verify that a tag for the new version string does not already exist by checking the output of
-          // `git rev-parse --verify`
-          .then(() => execa('git', ['rev-parse', '--quiet', '--verify', `refs/tags/${tagPrefix}${newVersion}`]))
-          .then(
-            ({ stdout }) => {
-              if (stdout) {
-                throw new Error(`Git tag \`${tagPrefix}${newVersion}\` already exists.`);
-              }
-            },
-            (err) => {
-              // Command fails with code 1 and no output if the tag does not exist, even though `--quiet` is provided
-              // https://github.com/sindresorhus/np/pull/73#discussion_r72385685
-              if (err.stdout !== '' || err.stderr !== '') {
-                throw err;
-              }
-            },
-          ),
-      skip: () => isDryRun,
-    },
-    {
-      title: 'Check current branch',
-      task: () =>
-        execa('git', ['symbolic-ref', '--short', 'HEAD']).then(({ stdout }) => {
-          if (stdout !== 'main' && !isAnyBranch) {
-            throw new Error('Not on `main` branch. Use --any-branch to publish anyway.');
-          }
-        }),
-      skip: () => isDryRun || opts.isCI, // in CI, we may be publishing from another branch
-    },
-    {
-      title: 'Check local working tree',
-      task: () =>
-        execa('git', ['status', '--porcelain']).then(({ stdout }) => {
-          if (stdout !== '') {
-            throw new Error('Unclean working tree. Commit or stash changes first.');
-          }
-        }),
-      skip: () => opts.isCI, // skip in CI, as we may have files staged needed to publish
-    },
-    {
-      title: 'Check remote history',
-      task: () =>
-        execa('git', ['rev-list', '--count', '--left-only', '@{u}...HEAD']).then(({ stdout }) => {
-          if (stdout !== '0' && !isAnyBranch) {
-            throw new Error('Remote history differs. Please pull changes.');
-          }
-        }),
-      skip: () => isDryRun || opts.isCI, // no need to check remote history in CI, we just pulled it
-    },
-  );
+  tasks.push({
+    /**
+     * When we both pre-release and release, it's beneficial to ensure that the tag does not already exist in git.
+     * Doing so ought to catch out of the ordinary circumstances that ought to be investigated.
+     */
+    title: 'Check git tag existence',
+    task: () =>
+      execa('git', ['fetch'])
+        // Retrieve the prefix for a version string - https://docs.npmjs.com/cli/v7/using-npm/config#tag-version-prefix
+        .then(() => execa('npm', ['config', 'get', 'tag-version-prefix']))
+        .then(
+          ({ stdout }) => (tagPrefix = stdout),
+          () => {},
+        )
+        // verify that a tag for the new version string does not already exist by checking the output of
+        // `git rev-parse --verify`
+        .then(() => execa('git', ['rev-parse', '--quiet', '--verify', `refs/tags/${tagPrefix}${newVersion}`]))
+        .then(
+          ({ stdout }) => {
+            if (stdout) {
+              throw new Error(`Git tag \`${tagPrefix}${newVersion}\` already exists.`);
+            }
+          },
+          (err) => {
+            // Command fails with code 1 and no output if the tag does not exist, even though `--quiet` is provided
+            // https://github.com/sindresorhus/np/pull/73#discussion_r72385685
+            if (err.stdout !== '' || err.stderr !== '') {
+              throw err;
+            }
+          },
+        ),
+    skip: () => isDryRun,
+  });
 
   tasks.push(
     {
@@ -133,41 +93,26 @@ export async function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<st
       task: () => execa('npm', ['ci'], { cwd: rootDir }),
       // for pre-releases, this step will occur in GitHub after the PR has been created.
       // for actual releases, we'll need to build + bundle stencil in order to publish it to npm.
-      skip: () => !opts.isPublishRelease && opts.isCI,
+      skip: () => !opts.isPublishRelease,
     },
     {
       title: `Transpile Stencil ${color.dim('(tsc.prod)')}`,
       task: () => execa('npm', ['run', 'tsc.prod'], { cwd: rootDir }),
       // for pre-releases, this step will occur in GitHub after the PR has been created.
       // for actual releases, we'll need to build + bundle stencil in order to publish it to npm.
-      skip: () => !opts.isPublishRelease && opts.isCI,
+      skip: () => !opts.isPublishRelease,
     },
     {
       title: `Bundle @stencil/core ${color.dim('(' + opts.buildId + ')')}`,
       task: () => bundleBuild(opts),
       // for pre-releases, this step will occur in GitHub after the PR has been created.
       // for actual releases, we'll need to build + bundle stencil in order to publish it to npm.
-      skip: () => !opts.isPublishRelease && opts.isCI,
+      skip: () => !opts.isPublishRelease,
     },
   );
 
   if (!opts.isPublishRelease) {
     tasks.push(
-      {
-        title: 'Run jest tests',
-        task: () => execa('npm', ['run', 'test.jest'], { cwd: rootDir }),
-        skip: () => opts.isCI, // this step will occur in GitHub after the PR has been created
-      },
-      {
-        title: 'Run karma tests',
-        task: () => execa('npm', ['run', 'test.karma.prod'], { cwd: rootDir }),
-        skip: () => opts.isCI, // this step will occur in GitHub after the PR has been created
-      },
-      {
-        title: 'Validate build',
-        task: () => validateBuild(rootDir),
-        skip: () => opts.isCI, // this step will occur in GitHub after the PR has been created
-      },
       {
         title: `Set package.json version to ${color.bold.yellow(opts.version)}`,
         task: async () => {
@@ -190,9 +135,7 @@ export async function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<st
         title: 'Publish @stencil/core to npm',
         task: () => {
           const cmd = 'npm';
-          const cmdArgs = ['publish']
-            .concat(opts.tag ? ['--tag', opts.tag] : [])
-            .concat(opts.isCI ? ['--provenance'] : ['--otp', opts.otp]);
+          const cmdArgs = ['publish'].concat(opts.tag ? ['--tag', opts.tag] : []).concat(['--provenance']);
 
           if (isDryRun) {
             return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
@@ -223,29 +166,6 @@ export async function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<st
           }
           return execa(cmd, cmdArgs, { cwd: rootDir });
         },
-      },
-      {
-        title: 'Pushing git commits',
-        task: () => {
-          const cmd = 'git';
-          const cmdArgs = ['push'];
-
-          if (isDryRun) {
-            return console.log(`[dry-run] ${cmd} ${cmdArgs.join(' ')}`);
-          }
-          return execa(cmd, cmdArgs, { cwd: rootDir });
-        },
-        skip: () => opts.isCI, // The commit will have been pushed in CI already
-      },
-      {
-        title: 'Create Github Release',
-        task: () => {
-          if (isDryRun) {
-            return console.log('[dry-run] Create GitHub Release skipped');
-          }
-          return postGithubRelease(opts);
-        },
-        skip: () => opts.isCI,
       },
     );
   }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

**Do not merge, waiting for parent to land first**
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We have a good deal of code related to releases that no longer runs.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

now that stencil releases are largely automated, release tasks that
were skipped during manual releases can be removed. this commit removes
all tasks that were skipped with `isCI` is was `true` (as it's always
`true` these days).

additional conditionals that use logical-AND with `isCI` have been
updated, as that part of the conditional is now always `true`.

remove the `--otp` flag, as it is only used for manual releases

as a result of these removals, the `--any-branch` flag can be safely
removed from our release pipeline, as its no longer used.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->
N/A - this old process being removed had no documentation 🙈 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

I kicked off a dev publish of Stencil using this branch, which ran successfully (and published to NPM) https://github.com/ionic-team/stencil/actions/runs/7917891689

I was able to run this build (`4.12.2-dev.1708009206.09089a5`) locally in a basic Stencil project.

There's _some_ risk here as I haven't cut a prod release, but could cut a prerelease of our next version if someone wants to test that with me 🙂 
## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
