### PR TITLE
fix(compiler): point crypto import at `crypto` instead of `node:crypto`

### DIFF
--- a/src/compiler/transformers/automatic-key-insertion/utils.ts
+++ b/src/compiler/transformers/automatic-key-insertion/utils.ts
@@ -1,5 +1,4 @@
-import { createHash } from 'node:crypto';
-
+import { createHash } from 'crypto';
 import ts from 'typescript';
 
 /**


### PR DESCRIPTION
This fixes an issue where this couldn't be resolved in some cases.

fixes https://github.com/ionic-team/stencil/issues/5358


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Testing

Check out hte reproduction case linked in #5358. First confirm you can reproduce the issue! Then build and install this branch in the repro, and confirm that it's fixed.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
