### PR TITLE
chore(scripts): turn on 'strict' tsconfig option

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -87,7 +87,7 @@ export async function bundleBuild(opts: BuildOptions): Promise<void> {
             await bundle.write(output);
           }),
         );
-      } else {
+      } else if (rollupOption.output) {
         await bundle.write(rollupOption.output);
       }
     }),

--- a/scripts/bundles/compiler.ts
+++ b/scripts/bundles/compiler.ts
@@ -144,7 +144,7 @@ export async function compiler(opts: BuildOptions) {
         name: 'compilerMinify',
         async generateBundle(_, bundleFiles) {
           if (opts.isProd) {
-            const compilerFilename = Object.keys(bundleFiles).find((f) => f.includes('stencil'));
+            const compilerFilename = Object.keys(bundleFiles).find((f) => f.includes('stencil')) as string;
             const compilerBundle = bundleFiles[compilerFilename] as OutputChunk;
             const minified = await minifyStencilCompiler(compilerBundle.code, opts);
             await fs.writeFile(join(opts.output.compilerDir, compilerFilename.replace('.js', '.min.js')), minified);

--- a/scripts/bundles/dev-server.ts
+++ b/scripts/bundles/dev-server.ts
@@ -60,7 +60,7 @@ export async function devServer(opts: BuildOptions) {
     'zlib',
   ];
 
-  const plugins = [
+  const plugins: Plugin[] = [
     contentTypesPlugin(opts),
     {
       name: 'devServerWorkerResolverPlugin',
@@ -174,7 +174,7 @@ export async function devServer(opts: BuildOptions) {
               },
             });
 
-            if (tsResults.diagnostics.length > 0) {
+            if (tsResults.diagnostics?.length) {
               throw new Error(tsResults.diagnostics as any);
             }
 
@@ -189,7 +189,9 @@ export async function devServer(opts: BuildOptions) {
                 compress: { hoist_vars: true, hoist_funs: true, ecma: 5 },
                 format: { ecma: 5 },
               });
-              code = minifyResults.code;
+              if (minifyResults.code) {
+                code = minifyResults.code;
+              }
             }
 
             code = banner + code + footer;

--- a/scripts/bundles/plugins/alias-plugin.ts
+++ b/scripts/bundles/plugins/alias-plugin.ts
@@ -36,7 +36,7 @@ export function aliasPlugin(opts: BuildOptions): Plugin {
      * @param id the importee exactly as it is written in an import statement in the source code
      * @returns a resolution to an import to a different id, potentially externalizing it from the bundle simultaneously
      */
-    resolveId(id: string): PartialResolvedId | string | null {
+    resolveId(id: string): PartialResolvedId | string | null | undefined {
       const externalId = alias.get(id);
       if (externalId) {
         return {

--- a/scripts/bundles/plugins/content-types-plugin.ts
+++ b/scripts/bundles/plugins/content-types-plugin.ts
@@ -33,7 +33,7 @@ export async function createContentTypeData(opts: BuildOptions) {
   Object.keys(mimeDbJson).forEach((mimeType) => {
     const mimeTypeData = mimeDbJson[mimeType];
     if (Array.isArray(mimeTypeData.extensions)) {
-      mimeTypeData.extensions.forEach((ext) => {
+      mimeTypeData.extensions.forEach((ext: string) => {
         extData.push({
           ext,
           mimeType,
@@ -42,14 +42,14 @@ export async function createContentTypeData(opts: BuildOptions) {
     }
   });
 
-  const exts = {};
+  const exts: Record<string, string> = {};
   extData
     .sort((a, b) => {
       if (a.ext < b.ext) return -1;
       if (a.ext > b.ext) return 1;
       return 0;
     })
-    .forEach((x) => (exts[x.ext] = x.mimeType));
+    .forEach((x: any) => (exts[x.ext] = x.mimeType));
 
   return `export default ${JSON.stringify(exts)}`;
 }

--- a/scripts/bundles/plugins/parse5-plugin.ts
+++ b/scripts/bundles/plugins/parse5-plugin.ts
@@ -31,7 +31,7 @@ export function parse5Plugin(opts: BuildOptions): Plugin {
      * @param id the path of the module to load
      * @returns parse5, pre-bundled
      */
-    async load(id: string): Promise<string> | null {
+    async load(id: string): Promise<string | null> {
       if (id === 'parse5') {
         const [contents] = await bundleParse5(opts);
         return contents;
@@ -115,7 +115,9 @@ export async function bundleParse5(opts: BuildOptions): Promise<[contents: strin
         comments: false,
       },
     });
-    code = minified.code;
+    if (minified.code) {
+      code = minified.code;
+    }
   }
 
   code = `// Parse5 ${opts.parse5Version}\n` + code;

--- a/scripts/bundles/plugins/pretty-minify.ts
+++ b/scripts/bundles/plugins/pretty-minify.ts
@@ -2,7 +2,7 @@ import type { OutputChunk, Plugin } from 'rollup';
 
 import type { BuildOptions } from '../../utils/options';
 
-export function prettyMinifyPlugin(opts: BuildOptions, preamble?: string): Plugin {
+export function prettyMinifyPlugin(opts: BuildOptions, preamble?: string): Plugin | undefined {
   if (opts.isProd) {
     return {
       name: 'prettyMinifyPlugin',
@@ -26,11 +26,15 @@ export function prettyMinifyPlugin(opts: BuildOptions, preamble?: string): Plugi
                 format: { ecma: 2018, indent_level: 1, beautify: true, comments: false, preamble },
                 sourceMap: false,
               });
-              b.code = minifyResults.code;
+              if (minifyResults.code) {
+                b.code = minifyResults.code;
+              }
             }
           }),
         );
       },
     };
+  } else {
+    return undefined;
   }
 }

--- a/scripts/bundles/plugins/terser-plugin.ts
+++ b/scripts/bundles/plugins/terser-plugin.ts
@@ -28,7 +28,7 @@ export function terserPlugin(opts: BuildOptions): Plugin {
      * @param id the path of the module to load
      * @returns the Terser source
      */
-    async load(id: string): Promise<string> | null {
+    async load(id: string): Promise<string | null> {
       if (id === 'terser') {
         const [content] = await bundleTerser(opts);
         return content;
@@ -45,6 +45,10 @@ export function terserPlugin(opts: BuildOptions): Plugin {
  * was written
  */
 export async function bundleTerser(opts: BuildOptions): Promise<[content: string, path: string]> {
+  if (!opts.terserVersion) {
+    throw new Error('Terser version not set on build opts!');
+  }
+
   const fileName = `terser-${opts.terserVersion.replace(/\./g, '_')}-bundle-cache${opts.isProd ? '.min' : ''}.js`;
   const cacheFile = join(opts.scriptsBuildDir, fileName);
 
@@ -80,7 +84,9 @@ export async function bundleTerser(opts: BuildOptions): Promise<[content: string
         comments: false,
       },
     });
-    code = minified.code;
+    if (minified.code) {
+      code = minified.code;
+    }
   }
 
   code = `// Terser ${opts.terserVersion}\n` + code;

--- a/scripts/esbuild/dev-server.ts
+++ b/scripts/esbuild/dev-server.ts
@@ -11,7 +11,7 @@ import { bundleExternal, sysNodeBundleCacheDir } from '../bundles/sys-node';
 import { getBanner } from '../utils/banner';
 import { type BuildOptions, createReplaceData } from '../utils/options';
 import { writePkgJson } from '../utils/write-pkg-json';
-import { getBaseEsbuildOptions, getEsbuildAliases, runBuilds } from './util';
+import { getBaseEsbuildOptions, getEsbuildAliases, getFirstOutputFile, runBuilds } from './util';
 
 const CONNECTOR_NAME = 'connector.html';
 
@@ -199,7 +199,10 @@ function clientConnectorPlugin(opts: BuildOptions): Plugin {
     name: 'clientConnectorPlugin',
     setup(build) {
       build.onEnd(async (buildResult) => {
-        const bundle = buildResult.outputFiles.find((b) => b.path.endsWith(CONNECTOR_NAME));
+        const bundle = buildResult.outputFiles?.find((b) => b.path.endsWith(CONNECTOR_NAME));
+        if (!bundle) {
+          throw "Couldn't find build result!";
+        }
         let code = Buffer.from(bundle.contents).toString();
 
         const tsResults = ts.transpileModule(code, {
@@ -208,7 +211,7 @@ function clientConnectorPlugin(opts: BuildOptions): Plugin {
           },
         });
 
-        if (tsResults.diagnostics.length > 0) {
+        if (tsResults.diagnostics?.length) {
           throw new Error(tsResults.diagnostics as any);
         }
 
@@ -221,7 +224,9 @@ function clientConnectorPlugin(opts: BuildOptions): Plugin {
             compress: { hoist_vars: true, hoist_funs: true, ecma: 5 },
             format: { ecma: 5 },
           });
-          code = minifyResults.code;
+          if (minifyResults.code) {
+            code = minifyResults.code;
+          }
         }
 
         code = banner + code + footer;
@@ -243,7 +248,7 @@ function serverProcessAliasPlugin(): Plugin {
     name: 'serverProcessAlias',
     setup(build) {
       build.onEnd(async (buildResult) => {
-        const bundle = buildResult.outputFiles[0];
+        const bundle = getFirstOutputFile(buildResult);
         let code = Buffer.from(bundle.contents).toString();
         code = code.replace('await import("@dev-server-process")', '(await import("./server-process.js")).default');
         return fs.writeFile(bundle.path, code);
@@ -262,7 +267,7 @@ function esm2CJSPlugin(): Plugin {
     name: 'esm2CJS',
     setup(build) {
       build.onEnd(async (buildResult) => {
-        const bundle = buildResult.outputFiles[0];
+        const bundle = getFirstOutputFile(buildResult);
         let code = Buffer.from(bundle.contents).toString();
         code = code.replace('import_meta.url', 'new (require("url").URL)("file:" + __filename).href');
         return fs.writeFile(bundle.path, code);
@@ -276,7 +281,7 @@ function esm2CJSPlugin(): Plugin {
  * @param opts build options
  * @returns an esbuild plugin
  */
-function contentTypesPlugin(opts) {
+function contentTypesPlugin(opts: BuildOptions): Plugin {
   return {
     name: 'contentTypesPlugin',
     setup(build) {

--- a/scripts/esbuild/testing.ts
+++ b/scripts/esbuild/testing.ts
@@ -6,7 +6,14 @@ import { copyTestingInternalDts } from '../bundles/testing';
 import { getBanner } from '../utils/banner';
 import type { BuildOptions } from '../utils/options';
 import { writePkgJson } from '../utils/write-pkg-json';
-import { externalAlias, getBaseEsbuildOptions, getEsbuildAliases, getEsbuildExternalModules, runBuilds } from './util';
+import {
+  externalAlias,
+  getBaseEsbuildOptions,
+  getEsbuildAliases,
+  getEsbuildExternalModules,
+  getFirstOutputFile,
+  runBuilds,
+} from './util';
 
 const EXTERNAL_TESTING_MODULES = [
   'constants',
@@ -86,7 +93,7 @@ function lazyRequirePlugin(opts: BuildOptions, moduleIds: string[]): Plugin {
     name: 'lazyRequirePlugin',
     setup(build) {
       build.onEnd(async (buildResult) => {
-        const bundle = buildResult.outputFiles[0];
+        const bundle = getFirstOutputFile(buildResult);
         let code = Buffer.from(bundle.contents).toString();
 
         for (const moduleId of moduleIds) {

--- a/scripts/esbuild/util.ts
+++ b/scripts/esbuild/util.ts
@@ -1,4 +1,4 @@
-import type { BuildOptions as ESBuildOptions, BuildResult as ESBuildResult, Plugin } from 'esbuild';
+import type { BuildOptions as ESBuildOptions, BuildResult as ESBuildResult, OutputFile, Plugin } from 'esbuild';
 import * as esbuild from 'esbuild';
 import { join } from 'path';
 
@@ -145,4 +145,21 @@ export function externalAlias(moduleId: string, resolveToPath: string): Plugin {
       });
     },
   };
+}
+
+/**
+ * Extract the first {@link OutputFile} record from an Esbuild
+ * {@link BuildResult}. This _may_ not be present, so in order to guarantee
+ * type safety this function throws if such an `OutputFile` cannot be found.
+ *
+ * @throws if no `OutputFile` can be found.
+ * @param buildResult the Esbuild build result in which to look
+ * @returns the OutputFile
+ */
+export function getFirstOutputFile(buildResult: ESBuildResult): OutputFile {
+  const bundle = buildResult.outputFiles?.[0];
+  if (!bundle) {
+    throw new Error('Could not find an output file in the BuildResult!');
+  }
+  return bundle;
 }

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -29,7 +29,9 @@ export async function release(rootDir: string, args: ReadonlyArray<string>): Pro
       console.log(`\n${color.bold.red('No `--version [VERSION]` argument was found. Exiting')}\n`);
       process.exit(1);
     }
-    prepareOpts.version = getNewVersion(prepareOpts.packageJson.version, args[versionIdx + 1]);
+    if (prepareOpts.packageJson.version) {
+      prepareOpts.version = getNewVersion(prepareOpts.packageJson.version, args[versionIdx + 1]);
+    }
 
     await prepareRelease(prepareOpts, args);
     console.log(`${color.bold.blue('Release Prepared!')}`);
@@ -42,7 +44,9 @@ export async function release(rootDir: string, args: ReadonlyArray<string>): Pro
       isProd: true,
     });
     // this was bumped already, we just need to copy it from package.json into this field
-    prepareOpts.version = prepareOpts.packageJson.version;
+    if (prepareOpts.packageJson.version) {
+      prepareOpts.version = prepareOpts.packageJson.version;
+    }
 
     // we generated a vermoji during the preparation step, let's grab it from the changelog
     prepareOpts.vermoji = getLatestVermoji(prepareOpts.changelogPath);
@@ -72,7 +76,7 @@ export async function release(rootDir: string, args: ReadonlyArray<string>): Pro
       isCI: prepareOpts.isCI,
       isPublishRelease: true,
       isProd: true,
-      tag: newTag,
+      tag: newTag ?? undefined,
     });
     return await publishRelease(publishOpts, args);
   }

--- a/scripts/test/validate-build.ts
+++ b/scripts/test/validate-build.ts
@@ -174,7 +174,7 @@ function validatePackage(opts: BuildOptions, testPkg: TestPackage, dtsEntries: s
         fs.accessSync(pkgFile);
       });
       testPkg.packageJsonFiles.forEach((testPkgFile) => {
-        if (!pkgJson.files.includes(testPkgFile)) {
+        if (!pkgJson.files?.includes(testPkgFile)) {
           throw new Error(testPkg.packageJson + ' missing file ' + testPkgFile);
         }
 
@@ -189,8 +189,10 @@ function validatePackage(opts: BuildOptions, testPkg: TestPackage, dtsEntries: s
 
     if (pkgJson.bin) {
       Object.keys(pkgJson.bin).forEach((k) => {
-        const binExe = join(pkgDir, pkgJson.bin[k]);
-        fs.accessSync(binExe);
+        if (pkgJson.bin?.[k]) {
+          const binExe = join(pkgDir, pkgJson.bin[k]);
+          fs.accessSync(binExe);
+        }
       });
     }
 
@@ -296,7 +298,7 @@ async function validateCompiler(opts: BuildOptions): Promise<void> {
   console.log(`🐋  Validated compiler.transpileSync()`);
 
   const orgConsoleLog = console.log;
-  let loggedVersion = null;
+  let loggedVersion = '';
   console.log = (value: string) => (loggedVersion = value);
 
   // this runTask is intentionally not wrapped in telemetry helpers

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "alwaysStrict": true,
+    "strict": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
@@ -10,6 +11,7 @@
     ],
     "module": "NodeNext",
     "moduleResolution": "nodenext",
+    "skipLibCheck": true,
     "outDir": "build/",
     "pretty": true,
     "target": "ES2020",
@@ -17,7 +19,8 @@
     "useUnknownInCatchVariables": true
   },
   "include": [
-    "**/*.ts"
+    "**/*.ts",
+    "types/*.d.ts"
   ],
   "exclude": [
     "**/*.spec.ts"

--- a/scripts/types/rollup-plugin-node-resolve.d.ts
+++ b/scripts/types/rollup-plugin-node-resolve.d.ts
@@ -1,0 +1,1 @@
+declare module '@rollup/plugin-node-resolve';

--- a/scripts/types/rollup-plugin-sourcemaps.d.ts
+++ b/scripts/types/rollup-plugin-sourcemaps.d.ts
@@ -1,0 +1,1 @@
+declare module 'rollup-plugin-sourcemaps';

--- a/scripts/utils/options.ts
+++ b/scripts/utils/options.ts
@@ -15,7 +15,7 @@ import { PackageData } from './write-pkg-json';
  * @param inputOpts any build options to override manually
  * @returns an entity containing various fields to be used by some process
  */
-export function getOptions(rootDir: string, inputOpts: BuildOptions = {}): BuildOptions {
+export function getOptions(rootDir: string, inputOpts: Partial<BuildOptions> = {}): BuildOptions {
   const srcDir = join(rootDir, 'src');
   const packageJsonPath = join(rootDir, 'package.json');
   const packageLockJsonPath = join(rootDir, 'package-lock.json');
@@ -28,6 +28,29 @@ export function getOptions(rootDir: string, inputOpts: BuildOptions = {}): Build
   const scriptsBuildDir = join(scriptsDir, 'build');
   const scriptsBundlesDir = join(scriptsDir, 'bundles');
   const bundleHelpersDir = join(scriptsBundlesDir, 'helpers');
+  const packageJson: PackageData = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  const buildId = inputOpts.buildId ?? getBuildId();
+  const version = inputOpts.version ?? getDevVersionId({ buildId, semverVersion: packageJson?.version });
+
+  const vermoji =
+    inputOpts.isProd && !inputOpts.vermoji
+      ? getVermoji(inputOpts.changelogPath ?? changelogPath)
+      : inputOpts.vermoji ?? '💎';
+
+  const typescriptPkg = require(join(typescriptDir, 'package.json'));
+  const typescriptVersion = typescriptPkg.version;
+
+  const terserPkg = getPkg(nodeModulesDir, 'terser');
+  const terserVersion = terserPkg.version;
+
+  const rollupPkg = getPkg(nodeModulesDir, 'rollup');
+  const rollupVersion = rollupPkg.version;
+
+  const parse5Pkg = getPkg(nodeModulesDir, 'parse5');
+  const parse5Version = parse5Pkg.version;
+
+  const jqueryPkg = getPkg(nodeModulesDir, 'jquery');
+  const jqueryVersion = jqueryPkg.version;
 
   const opts: BuildOptions = {
     ghRepoOrg: 'ionic-team',
@@ -40,6 +63,7 @@ export function getOptions(rootDir: string, inputOpts: BuildOptions = {}): Build
     nodeModulesDir,
     typescriptDir,
     typescriptLibDir,
+    packageJson,
     buildDir,
     scriptsDir,
     scriptsBuildDir,
@@ -55,38 +79,26 @@ export function getOptions(rootDir: string, inputOpts: BuildOptions = {}): Build
       sysNodeDir: join(rootDir, 'sys', 'node'),
       testingDir: join(rootDir, 'testing'),
     },
-    packageJson: JSON.parse(readFileSync(packageJsonPath, 'utf8')),
-    version: null,
-    buildId: null,
+    version,
+    buildId,
     isProd: false,
     isCI: false,
     isWatch: false,
     isPublishRelease: false,
-    vermoji: null,
+    vermoji,
     tag: 'dev',
+    jqueryVersion,
+    parse5Version,
+    rollupVersion,
+    terserVersion,
+    typescriptVersion,
   };
 
   Object.assign(opts, inputOpts);
 
-  if (!opts.buildId) {
-    opts.buildId = getBuildId();
-  }
-
-  if (!opts.version) {
-    opts.version = getDevVersionId({ buildId: opts.buildId, semverVersion: opts.packageJson?.version });
-  }
-
   if (opts.isPublishRelease) {
     if (!opts.isProd) {
       throw new Error('release must also be a prod build');
-    }
-  }
-
-  if (!opts.vermoji) {
-    if (opts.isProd) {
-      opts.vermoji = getVermoji(opts.changelogPath);
-    } else {
-      opts.vermoji = '💎';
     }
   }
 
@@ -107,28 +119,19 @@ export function createReplaceData(opts: BuildOptions): Record<string, any> {
   const CACHE_BUSTER = 7;
 
   const typescriptPkg = require(join(opts.typescriptDir, 'package.json'));
-  opts.typescriptVersion = typescriptPkg.version;
   const transpileId = typescriptPkg.name + typescriptPkg.version + '_' + CACHE_BUSTER;
 
-  const terserPkg = getPkg(opts, 'terser');
-  opts.terserVersion = terserPkg.version;
+  const terserPkg = getPkg(opts.nodeModulesDir, 'terser');
   const minifyJsId = terserPkg.name + terserPkg.version + '_' + CACHE_BUSTER;
 
-  const rollupPkg = getPkg(opts, 'rollup');
-  opts.rollupVersion = rollupPkg.version;
+  const rollupPkg = getPkg(opts.nodeModulesDir, 'rollup');
   const bundlerId = rollupPkg.name + rollupPkg.version + '_' + CACHE_BUSTER;
 
-  const autoprefixerPkg = getPkg(opts, 'autoprefixer');
-  const postcssPkg = getPkg(opts, 'postcss');
+  const autoprefixerPkg = getPkg(opts.nodeModulesDir, 'autoprefixer');
+  const postcssPkg = getPkg(opts.nodeModulesDir, 'postcss');
 
   const optimizeCssId =
     autoprefixerPkg.name + autoprefixerPkg.version + '_' + postcssPkg.name + postcssPkg.version + '_' + CACHE_BUSTER;
-
-  const parse5Pkg = getPkg(opts, 'parse5');
-  opts.parse5Version = parse5Pkg.version;
-
-  const jqueryPkg = getPkg(opts, 'jquery');
-  opts.jqueryVersion = jqueryPkg.version;
 
   return {
     __BUILDID__: opts.buildId,
@@ -138,41 +141,47 @@ export function createReplaceData(opts: BuildOptions): Record<string, any> {
     '__BUILDID:TRANSPILE__': transpileId,
 
     '__VERSION:STENCIL__': opts.version,
-    '__VERSION:PARSE5__': parse5Pkg.version,
-    '__VERSION:ROLLUP__': rollupPkg.version,
-    '__VERSION:JQUERY__': jqueryPkg.version,
-    '__VERSION:TERSER__': terserPkg.version,
-    '__VERSION:TYPESCRIPT__': typescriptPkg.version,
+    '__VERSION:PARSE5__': opts.parse5Version,
+    '__VERSION:ROLLUP__': opts.rollupVersion,
+    '__VERSION:JQUERY__': opts.jqueryVersion,
+    '__VERSION:TERSER__': opts.terserVersion,
+    '__VERSION:TYPESCRIPT__': opts.typescriptVersion,
 
     __VERMOJI__: opts.vermoji,
   };
 }
 
+type VersionedPackageData = PackageData & { version: string };
+
 /**
  * Retrieves a package from the `node_modules` directory in the given `opts` parameter
- * @param opts the options being used during a build
+ * @param nodeModulesDir the node modules directory to search
  * @param pkgName the name of the NPM package to retrieve
  * @returns information about the retrieved package
  */
-function getPkg(opts: BuildOptions, pkgName: string): PackageData {
-  return require(join(opts.nodeModulesDir, pkgName, 'package.json'));
+function getPkg(nodeModulesDir: string, pkgName: string): VersionedPackageData {
+  const packageJson = require(join(nodeModulesDir, pkgName, 'package.json'));
+  if (!packageJson.version) {
+    throw Error(`Didn't find a version in the packageJson for ${pkgName}!`);
+  }
+  return packageJson;
 }
 
 export interface BuildOptions {
-  buildDir?: string;
-  bundleHelpersDir?: string;
-  ghRepoName?: string;
-  ghRepoOrg?: string;
-  nodeModulesDir?: string;
-  rootDir?: string;
-  scriptsBuildDir?: string;
-  scriptsBundlesDir?: string;
-  scriptsDir?: string;
-  srcDir?: string;
-  typescriptDir?: string;
-  typescriptLibDir?: string;
+  buildDir: string;
+  bundleHelpersDir: string;
+  ghRepoName: string;
+  ghRepoOrg: string;
+  nodeModulesDir: string;
+  rootDir: string;
+  scriptsBuildDir: string;
+  scriptsBundlesDir: string;
+  scriptsDir: string;
+  srcDir: string;
+  typescriptDir: string;
+  typescriptLibDir: string;
 
-  output?: {
+  output: {
     cliDir: string;
     compilerDir: string;
     devServerDir: string;
@@ -183,24 +192,24 @@ export interface BuildOptions {
     testingDir: string;
   };
 
-  buildId?: string;
-  changelogPath?: string;
-  isCI?: boolean;
-  isProd?: boolean;
-  isPublishRelease?: boolean;
-  isWatch?: boolean;
+  buildId: string;
+  changelogPath: string;
+  isCI: boolean;
+  isProd: boolean;
+  isPublishRelease: boolean;
+  isWatch: boolean;
+  jqueryVersion: string;
   otp?: string;
-  packageJson?: PackageData;
-  packageJsonPath?: string;
-  packageLockJsonPath?: string;
-  parse5Version?: string;
-  rollupVersion?: string;
-  jqueryVersion?: string;
-  tag?: string;
-  terserVersion?: string;
-  typescriptVersion?: string;
-  vermoji?: string;
-  version?: string;
+  packageJson: PackageData;
+  packageJsonPath: string;
+  packageLockJsonPath: string;
+  parse5Version: string;
+  rollupVersion: string;
+  tag: string;
+  terserVersion: string;
+  typescriptVersion: string;
+  vermoji: string;
+  version: string;
 }
 
 /**

--- a/scripts/utils/test/options.spec.ts
+++ b/scripts/utils/test/options.spec.ts
@@ -5,7 +5,7 @@ import * as Vermoji from '../vermoji';
 
 describe('release options', () => {
   describe('getOptions', () => {
-    const ROOT_DIR = './';
+    const ROOT_DIR = path.join(__dirname, '../../..');
     // Friday, February 24, 2023 2:42:09.123 PM, GMT
     const FAKE_SYSTEM_TIME_MS = 1677249729123;
     const FAKE_SYSTEM_TIME_S = FAKE_SYSTEM_TIME_MS.toString(10).slice(0, -3);
@@ -22,48 +22,49 @@ describe('release options', () => {
     it('returns the correct default value', () => {
       const buildOpts = getOptions(ROOT_DIR);
 
-      // some paths exist in the expected object that are not normalized, so we store the OS-specific separator in a
-      // variable in order to call `join()` with it
-      const separator = path.sep;
-
       expect(buildOpts).toEqual<BuildOptions>({
-        buildDir: 'build',
+        buildDir: path.join(ROOT_DIR, 'build'),
         // More focused tests for `buildId` can be found in another testing suite in this file
         buildId: expect.any(String),
-        bundleHelpersDir: ['scripts', 'bundles', 'helpers'].join(separator),
-        changelogPath: 'CHANGELOG.md',
+        bundleHelpersDir: path.join(ROOT_DIR, 'scripts', 'bundles', 'helpers'),
+        changelogPath: path.join(ROOT_DIR, 'CHANGELOG.md'),
         ghRepoName: 'stencil',
         ghRepoOrg: 'ionic-team',
         isCI: false,
         isProd: false,
         isPublishRelease: false,
         isWatch: false,
-        nodeModulesDir: 'node_modules',
+        nodeModulesDir: path.join(ROOT_DIR, 'node_modules'),
         output: {
-          cliDir: 'cli',
-          compilerDir: 'compiler',
-          devServerDir: 'dev-server',
-          internalDir: 'internal',
-          mockDocDir: 'mock-doc',
-          screenshotDir: 'screenshot',
-          sysNodeDir: ['sys', 'node'].join(separator),
-          testingDir: 'testing',
+          cliDir: path.join(ROOT_DIR, 'cli'),
+          compilerDir: path.join(ROOT_DIR, 'compiler'),
+          devServerDir: path.join(ROOT_DIR, 'dev-server'),
+          internalDir: path.join(ROOT_DIR, 'internal'),
+          mockDocDir: path.join(ROOT_DIR, 'mock-doc'),
+          screenshotDir: path.join(ROOT_DIR, 'screenshot'),
+          sysNodeDir: path.join(ROOT_DIR, 'sys', 'node'),
+          testingDir: path.join(ROOT_DIR, 'testing'),
         },
         // reads in package.json, skip it verifying it
         packageJson: expect.any(Object),
-        packageJsonPath: 'package.json',
-        packageLockJsonPath: 'package-lock.json',
+        packageJsonPath: path.join(ROOT_DIR, 'package.json'),
+        packageLockJsonPath: path.join(ROOT_DIR, 'package-lock.json'),
         rootDir: ROOT_DIR,
-        scriptsBuildDir: ['scripts', 'build'].join(separator),
-        scriptsBundlesDir: ['scripts', 'bundles'].join(separator),
-        scriptsDir: 'scripts',
-        srcDir: 'src',
+        scriptsBuildDir: path.join(ROOT_DIR, 'scripts', 'build'),
+        scriptsBundlesDir: path.join(ROOT_DIR, 'scripts', 'bundles'),
+        scriptsDir: path.join(ROOT_DIR, 'scripts'),
+        srcDir: path.join(ROOT_DIR, 'src'),
         tag: 'dev',
-        typescriptDir: ['node_modules', 'typescript'].join(separator),
-        typescriptLibDir: ['node_modules', 'typescript', 'lib'].join(separator),
+        typescriptDir: path.join(ROOT_DIR, 'node_modules', 'typescript'),
+        typescriptLibDir: path.join(ROOT_DIR, 'node_modules', 'typescript', 'lib'),
         vermoji: '💎',
         // More focused tests for `version` can be found in another testing suite in this file
         version: expect.any(String),
+        jqueryVersion: expect.any(String),
+        parse5Version: expect.any(String),
+        terserVersion: expect.any(String),
+        rollupVersion: expect.any(String),
+        typescriptVersion: expect.any(String),
       });
     });
 

--- a/scripts/utils/write-pkg-json.ts
+++ b/scripts/utils/write-pkg-json.ts
@@ -29,7 +29,7 @@ export function writePkgJson(opts: BuildOptions, pkgDir: string, pkgData: Packag
   const formatedPkg: any = {};
   PROPS_ORDER.forEach((pkgProp) => {
     if (pkgProp in pkgData) {
-      formatedPkg[pkgProp] = pkgData[pkgProp];
+      formatedPkg[pkgProp] = pkgData[pkgProp as keyof PackageData];
     }
   });
 


### PR DESCRIPTION
This turns on the `strict` option in the tsconfig for our build scripts. I then fixed the resulting errors by:

- making optional types required on `BuildOptions`
- reconfiguring the function that builds a `BuildOptions` object so that when the object is created all those fields are present
- fixed various other random errors here and there, like the `.code` property on minification results and a few things like that.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

There are a few non-type-level changes but they're pretty contained, so I'm not terribly worried about the impact. I built and packed Stencil and installed it in Framework with no issues after these changes as well.
