### PR TITLE
chore(build): make esbuild standalone

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   ],
   "scripts": {
     "build": "npm run tsc.scripts && npm run tsc.prod && npm run rollup.prod.ci",
-    "build.esbuild": "npm run clean && npm run build && node scripts/build/esbuild/build.js",
-    "build.esbuild.watch": "npm run clean && npm run build && node scripts/build/esbuild/build.js --watch",
+    "build.esbuild": "npm run clean && npm run tsc.scripts && npm run tsc.prod && node scripts/build/esbuild/build.js",
+    "build.esbuild.watch": "npm run build.esbuild -- --watch",
     "build.updateSelectorEngine": "node scripts/build/updateSelectorEngine.js",
     "clean": "rm -rf build/ cli/ compiler/ dev-server/ internal/ mock-doc/ sys/ testing/ && npm run clean-scripts",
     "clean-scripts": "rm -rf scripts/build",


### PR DESCRIPTION
This removes the dependence of the esbuild-based build on the existing Rollup-based build. Previously we needed to run the Rollup-based build first so that certain files which could not yet be built with Esbuild would be present on disk, but since we can now build everything with Esbuild we don't need to take this step anymore.

We do, however, continue to need to run the TypeScript compiler in order to generate up-to-date typedef files.

Part of STENCIL-1016

This is blocked by #5276 and CI will not pass until that merges


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

If CI is passing this is a strong indication that we're in a good position to make this change.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
