### PR TITLE
fix(build): run Esbuild build script without Rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "build": "npm run tsc.scripts && npm run tsc.prod && npm run rollup.prod.ci",
-    "build.esbuild": "npm run clean && npm run build && node scripts/build/esbuild/build.js",
+    "build.esbuild": "npm run clean && npm run tsc.scripts && npm run tsc.prod && node scripts/build/esbuild/build.js",
     "build.esbuild.watch": "npm run clean && npm run build && node scripts/build/esbuild/build.js --watch",
     "build.updateSelectorEngine": "node scripts/build/updateSelectorEngine.js",
     "clean": "rm -rf build/ cli/ compiler/ dev-server/ internal/ mock-doc/ sys/ testing/ && npm run clean-scripts",


### PR DESCRIPTION
## What is the current behavior?
When building Stencil using Esbuild we still run Rollup.

## What is the new behavior?
As we have covered build steps for all Stencil components, we can remove the rollup build as part of the esbuild script.

## Documentation

n/a

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
