### PR TITLE
chore(scripts): remove an unused option from BuildOptions

### DIFF
--- a/scripts/utils/options.ts
+++ b/scripts/utils/options.ts
@@ -199,7 +199,6 @@ export interface BuildOptions {
   isPublishRelease: boolean;
   isWatch: boolean;
   jqueryVersion: string;
-  otp?: string;
   packageJson: PackageData;
   packageJsonPath: string;
   packageLockJsonPath: string;


### PR DESCRIPTION
After we removed the old release scripts recently this option is no longer used anywhere, so we can delete it.



## What is the new behavior?

No behavior change, just removing an unused field from an interface.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

This is just a type-level change, so if CI is passing I think we're good!
