### PR TITLE
chore(ci): fix puppeteer downloads

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,3 +4,5 @@
 # If this value is changed, please ensure that it works both locally and in a continuous integration environment in
 # a repeatable manner (i.e. it can run many times, one after the other, without failing due to out-of-memory errors).
 node_options=--max-old-space-size=4096
+# TODO(STENCIL-1141): remove `PUPPETEER_DOWNLOAD_BASE_URL` once support for Node v16 is dropped
+PUPPETEER_DOWNLOAD_BASE_URL=https://storage.googleapis.com/chrome-for-testing-public


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See the 'new bheavior' section

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
the url that pulls down chrome images seems to be intermittently failing
in github actions. when we go to install dependencies (`npm ci`), we're
greeted with an error:

```
npm ERR! code 1
npm ERR! path /home/runner/work/stencil/stencil/node_modules/puppeteer
npm ERR! command failed
npm ERR! command sh -c node install.mjs
npm ERR! Error: ERROR: Failed to set up chrome-headless-shell v121.0.6167.85! Set "PUPPETEER_SKIP_DOWNLOAD" env variable to skip download.
```

this appears to be a result of an intermittent failure (if it's
intermittent it to-be-determined). reports online suggest bumping to
puppeteer v22, which we cannot do at this moment due to it dropping
support for node 16. instead, set the base url environment variable to
tell puppeteer where to pull chrome from


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->
N/A - CI fix

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

CI begins to pass again (everything but the tech debt burndown)
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

We will need to force this PR through, as the tech debt burndown (which pulls from `main` for some of its steps) will not have the fix applied to it (because we haven't landed the code). That's the only section of CI that should fail though