### PR TITLE
chore(snc): element.spec.ts strictNullChecks 

### DIFF
--- a/src/mock-doc/test/element.spec.ts
+++ b/src/mock-doc/test/element.spec.ts
@@ -141,6 +141,10 @@ describe('element', () => {
 
     const clonedWin = cloneWindow(win as any);
 
+    if (!clonedWin) {
+      throw new Error('The Window was not successfully cloned!');
+    }
+
     const elm = clonedWin.document.getElementById('test') as any;
     expect((elm as HTMLMetaElement).content).toBe('');
     expect(elm).toEqualHtml(`<meta id="test">`);
@@ -153,7 +157,8 @@ describe('element', () => {
     const titleElm = clonedWin.document.head.querySelector('title');
     expect(titleElm).toEqualHtml(`<title>Hello Title!</title>`);
 
-    titleElm.text = 'Hello Text!';
+    // we just asserted that this object isn't falsy, allowing us to use the bang operator here
+    titleElm!.text = 'Hello Text!';
     expect(titleElm).toEqualHtml(`<title>Hello Text!</title>`);
   });
 
@@ -209,6 +214,11 @@ describe('element', () => {
       expect(document.title).toBe('Hello Title');
 
       const titleElm = document.head.querySelector('title');
+
+      if (!titleElm) {
+        throw new Error('Unable to find title element in the DOM.');
+      }
+
       expect(titleElm.textContent).toBe('Hello Title');
       expect(titleElm.text).toBe('Hello Title');
 
@@ -231,7 +241,8 @@ describe('element', () => {
       expect(win.document.URL).toBe('http://stenciljs.com/path/to/page');
       expect(win.document.location.href).toBe('http://stenciljs.com/path/to/page');
 
-      win.document.querySelector('base').remove();
+      // use the bang operator here to fail in case 'base' can't be found
+      win.document.querySelector('base')!.remove();
       expect(win.document.baseURI).toBe('http://stenciljs.com/path/to/page');
       expect(win.document.URL).toBe('http://stenciljs.com/path/to/page');
       expect(win.document.location.href).toBe('http://stenciljs.com/path/to/page');
@@ -327,11 +338,12 @@ describe('element', () => {
       const elm = doc.createElement('div') as Element;
       const child = doc.createElement('div') as Element;
 
-      elm.append('text', 12 as any, child, null);
+      elm.append('text', 12 as any, child, null as unknown as Node);
       expect(elm.childNodes.length).toEqual(4);
       expect((elm.childNodes[0] as Text).data).toEqual('text');
       expect((elm.childNodes[1] as Text).data).toEqual('12');
       expect(elm.childNodes[2]).toEqual(child);
+      // we used type assertions above to verify that `null`'s text reads a 'null'
       expect((elm.childNodes[3] as Text).data).toEqual('null');
     });
   });

--- a/src/mock-doc/window.ts
+++ b/src/mock-doc/window.ts
@@ -821,7 +821,7 @@ export function createWindow(html: string | boolean = null): Window {
   return new MockWindow(html) as any;
 }
 
-export function cloneWindow(srcWin: Window, opts: { customElementProxy?: boolean } = {}) {
+export function cloneWindow(srcWin: Window, opts: { customElementProxy?: boolean } = {}): MockWindow | null {
   if (srcWin == null) {
     return null;
   }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->


resolve strict null checks related to mock-doc element tests - throw
an error when a window is not cloned (and we expect to be). this allows
us to assert that the cloned window is truthy, resolving errors related
to accessing a possibly undefined obj

add checks when querying the dom for title text, preventing snc errors
related to accessing an undefined field

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->
n/a
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing


Unit tests/type checks continue to pass
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information
n/a
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
