### PR TITLE
chore(docs): document `CopyTask` interface

### DIFF
--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1591,10 +1591,76 @@ export interface ConfigBundle {
   components: string[];
 }
 
+/**
+ * A file and/or directory copy operation that may be specified as part of
+ * certain output targets for Stencil (in particular `dist`,
+ * `dist-custom-elements`, and `www`).
+ */
 export interface CopyTask {
+  /**
+   * The source file path for a copy operation. This may be an absolute or
+   * relative path to a directory or a file, and may also include a glob
+   * pattern.
+   *
+   * If the path is a relative path it will be treated as relative to
+   * `Config.srcDir`.
+   */
   src: string;
+  /**
+   * An optional destination file path for a copy operation. This may be an
+   * absolute or relative path.
+   *
+   * If relative, this will be treated as relative to the output directory for
+   * the output target for which this copy operation is configured.
+   */
   dest?: string;
+  /**
+   * Whether or not Stencil should issue warnings if it cannot find the
+   * specified source files or directories. Defaults to `false`.
+   *
+   * To receive warnings if a copy task source can't be found set this to
+   * `true`.
+   */
   warn?: boolean;
+  /**
+   * Whether or not directory structure should be preserved when copying files
+   * from a source directory. Defaults to `true` if no `dest` path is supplied,
+   * else it defaults to `false`.
+   *
+   * If this is set to `false`, all the files from a source directory will be
+   * copied directly to the destination directory, but if it's set to `true` they
+   * will be copied to a new directory inside the destination directory with
+   * the same name as their original source directory.
+   *
+   * So if, for instance, `src` is set to `"images"` and `keepDirStructure` is
+   * set to `true` the copy task will then produce the following directory
+   * structure:
+   *
+   * ```
+   * images
+   * └── foo.png
+   * dist
+   * └── images
+   *     └── foo.png
+   * ```
+   *
+   * Conversely if `keepDirStructure` is set to `false` then files in `images/`
+   * will be copied to `dist` without first creating a new subdirectory,
+   * resulting in the following directory structure:
+   *
+   * ```
+   * images
+   * └── foo.png
+   * dist
+   * └── foo.png
+   * ```
+   *
+   * If a `dest` path is supplied then `keepDirStructure`
+   * will default to `false`, so that Stencil will write the
+   * copied files directly into the `dest` directory without creating a new
+   * subdirectory. This behavior can be overridden by setting
+   * `keepDirStructure` to `true`.
+   */
   keepDirStructure?: boolean;
 }
 


### PR DESCRIPTION
This interface is currently undocumented, so let's add some JSDoc. We can also reference this on the docs site in order to improve the quality of https://stenciljs.com/docs/copy-tasks.

STENCIL-1047

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
