### PR TITLE
feat(dev-server): add "ping" route

### DIFF
--- a/src/compiler/config/test/validate-dev-server.spec.ts
+++ b/src/compiler/config/test/validate-dev-server.spec.ts
@@ -276,4 +276,23 @@ describe('validateDevServer', () => {
     const { config } = validateConfig(inputConfig, mockLoadConfigInit());
     expect(config.devServer.prerenderConfig).toBe(wwwOutputTarget.prerenderConfig);
   });
+
+  describe('pingRoute', () => {
+    it('should default to /ping', () => {
+      const { config } = validateConfig(inputConfig, mockLoadConfigInit());
+      expect(config.devServer.pingRoute).toBe('/ping');
+    });
+
+    it('should set user defined pingRoute', () => {
+      inputConfig.devServer = { ...inputDevServerConfig, pingRoute: '/my-ping' };
+      const { config } = validateConfig(inputConfig, mockLoadConfigInit());
+      expect(config.devServer.pingRoute).toBe('/my-ping');
+    });
+
+    it('should clear ping route if set to null', () => {
+      inputConfig.devServer = { ...inputDevServerConfig, pingRoute: null };
+      const { config } = validateConfig(inputConfig, mockLoadConfigInit());
+      expect(config.devServer.pingRoute).toBe(null);
+    });
+  });
 });

--- a/src/compiler/config/test/validate-dev-server.spec.ts
+++ b/src/compiler/config/test/validate-dev-server.spec.ts
@@ -292,6 +292,12 @@ describe('validateDevServer', () => {
       expect(config.devServer.pingRoute).toBe('/my-ping');
     });
 
+    it('should prefix pingRoute with a "/"', () => {
+      inputConfig.devServer = { ...inputDevServerConfig, pingRoute: 'my-ping' };
+      const { config } = validateConfig(inputConfig, mockLoadConfigInit());
+      expect(config.devServer.pingRoute).toBe('/my-ping');
+    });
+
     it('should clear ping route if set to null', () => {
       inputConfig.devServer = { ...inputDevServerConfig, pingRoute: null };
       const { config } = validateConfig(inputConfig, mockLoadConfigInit());

--- a/src/compiler/config/test/validate-dev-server.spec.ts
+++ b/src/compiler/config/test/validate-dev-server.spec.ts
@@ -279,6 +279,9 @@ describe('validateDevServer', () => {
 
   describe('pingRoute', () => {
     it('should default to /ping', () => {
+      // Ensure the pingRoute is not set in the inputConfig so we know we're testing the
+      // default value added during validation
+      delete inputConfig.devServer.pingRoute;
       const { config } = validateConfig(inputConfig, mockLoadConfigInit());
       expect(config.devServer.pingRoute).toBe('/ping');
     });

--- a/src/compiler/config/validate-dev-server.ts
+++ b/src/compiler/config/validate-dev-server.ts
@@ -29,6 +29,16 @@ export const validateDevServer = (config: d.ValidatedConfig, diagnostics: d.Diag
 
   devServer.address = devServer.address.split('/')[0];
 
+  // Validate "ping" route option
+  if (devServer.pingRoute !== null) {
+    let pingRoute = isString(devServer.pingRoute) ? devServer.pingRoute : '/ping';
+    if (!pingRoute.startsWith('/')) {
+      pingRoute = `/${pingRoute}`;
+    }
+
+    devServer.pingRoute = pingRoute;
+  }
+
   // split on `:` to get the domain and the (possibly present) port
   // separately. we've already sliced off the protocol (if present) above
   // so we can safely split on `:` here.

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -651,6 +651,15 @@ export interface DevServerConfig extends StencilDevServerConfig {
   prerenderConfig?: string;
   protocol?: 'http' | 'https';
   srcIndexHtml?: string;
+
+  /**
+   * Route to be used for the "ping" sub-route of the Stencil dev server.
+   * This route will return a 200 status code once the Stencil build has finished.
+   * Setting this to `null` will disable the ping route.
+   *
+   * Defaults to `/ping`
+   */
+  pingRoute?: string | null;
 }
 
 export interface HistoryApiFallback {

--- a/src/dev-server/request-handler.ts
+++ b/src/dev-server/request-handler.ts
@@ -26,13 +26,12 @@ export function createRequestHandler(devServerConfig: d.DevServerConfig, serverC
           return serverCtx.serve302(req, res);
         }
 
-        // TODO: Make path configurable
-        if (req.pathname === '/ping') {
+        if (devServerConfig.pingRoute !== null && req.pathname === devServerConfig.pingRoute) {
           return serverCtx
             .getBuildResults()
             .then(() => {
               res.statusCode = 200;
-              res.write('Yo');
+              res.write('OK');
               res.end();
             })
             .catch(() => serverCtx.serve500(incomingReq, res, 'Error getting build results', 'ping error'));

--- a/src/dev-server/request-handler.ts
+++ b/src/dev-server/request-handler.ts
@@ -26,6 +26,18 @@ export function createRequestHandler(devServerConfig: d.DevServerConfig, serverC
           return serverCtx.serve302(req, res);
         }
 
+        // TODO: Make path configurable
+        if (req.pathname === '/ping') {
+          return serverCtx
+            .getBuildResults()
+            .then(() => {
+              res.statusCode = 200;
+              res.write('Yo');
+              res.end();
+            })
+            .catch(() => serverCtx.serve500(incomingReq, res, 'Error getting build results', 'ping error'));
+        }
+
         if (isDevClient(req.pathname) && devServerConfig.websocket) {
           return serveDevClient(devServerConfig, serverCtx, req, res);
         }

--- a/src/dev-server/request-handler.ts
+++ b/src/dev-server/request-handler.ts
@@ -34,7 +34,7 @@ export function createRequestHandler(devServerConfig: d.DevServerConfig, serverC
                 return serverCtx.serve500(incomingReq, res, 'Build not successful', 'build error');
               }
 
-              res.statusCode = 200;
+              res.writeHead(200, 'OK');
               res.write('OK');
               res.end();
             })

--- a/src/dev-server/request-handler.ts
+++ b/src/dev-server/request-handler.ts
@@ -29,7 +29,11 @@ export function createRequestHandler(devServerConfig: d.DevServerConfig, serverC
         if (devServerConfig.pingRoute !== null && req.pathname === devServerConfig.pingRoute) {
           return serverCtx
             .getBuildResults()
-            .then(() => {
+            .then((result) => {
+              if (!result.hasSuccessfulBuild) {
+                return serverCtx.serve500(incomingReq, res, 'Build not successful', 'build error');
+              }
+
               res.statusCode = 200;
               res.write('OK');
               res.end();

--- a/src/dev-server/test/req-handler.spec.ts
+++ b/src/dev-server/test/req-handler.spec.ts
@@ -439,6 +439,32 @@ describe('request-handler', () => {
       expect(h).toBe(`88mph<iframe></iframe>`);
     });
   });
+
+  describe('pingRoute', () => {
+    it('should return a 200 for successful build', async () => {
+      serverCtx.getBuildResults = () =>
+        Promise.resolve({ hasSuccessfulBuild: true }) as Promise<d.CompilerBuildResults>;
+
+      const handler = createRequestHandler(devServerConfig, serverCtx);
+
+      req.url = '/ping';
+
+      await handler(req, res);
+      expect(res.$statusCode).toBe(200);
+    });
+
+    it('should return a 500 for unsuccessful build', async () => {
+      serverCtx.getBuildResults = () =>
+        Promise.resolve({ hasSuccessfulBuild: false }) as Promise<d.CompilerBuildResults>;
+
+      const handler = createRequestHandler(devServerConfig, serverCtx);
+
+      req.url = '/ping';
+
+      await handler(req, res);
+      expect(res.$statusCode).toBe(500);
+    });
+  });
 });
 
 interface TestServerResponse extends ServerResponse {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The Stencil dev server will "spin up" prior to the accompanying project build completing. This can cause issues for processes (such as E2E testing tools like Playwright), that rely on the dev server to work correctly. 

GitHub Issue Number: N/A

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

A new route is added to the dev server request handler. This route will return a 200 response once the Stencil build is completed and successful. If a build fails, or another error is encountered, the route will return a 500 error.

This route is configurable via the `devServer` object on the Stencil config. If the route is explicitly set to `null`, no route will be registered with the handler. 

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

https://github.com/ionic-team/stencil-site/pull/1363

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

**Automated tests**

Unit tests were added to the request handler and validation test suites.

**Manual tests**

Functionality can be tested by installing a build of this branch into any Stencil project. After running `npm start`, navigate to `/ping`. Can also test changing the value in the project's config or setting it `null`.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

This change was made as a part of work to implement a Playwright testing adapter for Stencil. Prior to this change, tests would start execution prematurely, leading to quick failures.