### PR TITLE
chore(renovate): have renovate mark typescript bumps as 'feat'

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -61,6 +61,7 @@
       // Increment this value as a part of updating TypeScript
       matchPackageNames: ['typescript'],
       allowedVersions: '<5.4.0',
+      commitMessagePrefix: "feat(typescript):"
     },
     {
       // disable Jest updates until the new testing architecture is in place


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See 'new behavior' section

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

update the renovate configuration such that typescript version bumps will be prefixed with 'feat(typescript):', rather than the default value of `chore(deps):`. this will allow us to properly call out typescript version bumps in the stencil changelog generator, which do not occur today (as chore()'s are ignored)



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->
N/A - renovate config

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

### Locally

I ran `npm i -g renovate && renovate-config-validator` to verify this config filewas still valid.

### Integration-ish
Since I couldn't test this directly in our repo, I spun up a private one to verify the behavior here.

For a package.json file with TS 5.3.2 as a dev dep:
<img width="527" alt="package.json file with a dev dependency of typescript 5.3.2" src="https://github.com/ionic-team/stencil/assets/1930213/0b211be1-40b7-4714-87e5-c65aebab9496">
And a configuration that matches this repo's:
<img width="435" alt="A renovate configuration file that configures the TypeScript package to have a prefix of feat" src="https://github.com/ionic-team/stencil/assets/1930213/b76dedac-dd00-494f-9088-09bd3067f925">
The following well formatted PR was created by renovate
<img width="571" alt="A pull request with the title feat(deps): upgrade typescript to 5.3.3" src="https://github.com/ionic-team/stencil/assets/1930213/901d4b3c-d874-42b8-88a3-2201b03f82db">

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

The reproduction I put above begs the question "Is a patch bump worthy of a minor bump of Stencil?" - for now, I'd say yes, for the sake of getting a little more automation in place here
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
STENCIL-1098: Configure renovate to mark TypeScript as feat()