### PR TITLE
docs(compiler): add type docs for `esmLoaderPath`

### DIFF
--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -2057,6 +2057,14 @@ export interface OutputTargetDist extends OutputTargetValidationConfig {
   transformAliasedImportPathsInCollection?: boolean | null;
 
   typesDir?: string;
+
+  /**
+   * Provide a custom path for the ESM loader directory, containing files you can import
+   * in an initiation script within your application to register all your components for
+   * lazy loading.
+   *
+   * @default /dist/loader
+   */
   esmLoaderPath?: string;
   copy?: CopyTask[];
   polyfills?: boolean;


### PR DESCRIPTION
## What is the current behavior?

`esmLoaderPath` has currently no type documentation.

## What is the new behavior?
`esmLoaderPath` has type documentation

## Documentation

Addition PR to the Stencil docs has been raised in https://github.com/ionic-team/stencil-site/pull/1364

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
