### PR TITLE
fix(compiler): fix generated import statement

### DIFF
--- a/src/compiler/output-targets/dist-custom-elements/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements/index.ts
@@ -205,8 +205,7 @@ export const addCustomElementInputs = (
 
     if (cmp.isPlain) {
       exp.push(`export { ${importName} as ${exportName} } from '${cmp.sourceFilePath}';`);
-      // TODO(STENCIL-855): Invalid syntax generation, note the unbalanced left curly brace
-      indexExports.push(`export { {${exportName} } from '${coreKey}';`);
+      indexExports.push(`export { ${exportName} } from '${coreKey}';`);
     } else {
       // the `importName` may collide with the `exportName`, alias it just in case it does with `importAs`
       exp.push(

--- a/src/compiler/output-targets/dist-custom-elements/test/dist-custom-elements.spec.ts
+++ b/src/compiler/output-targets/dist-custom-elements/test/dist-custom-elements.spec.ts
@@ -3,22 +3,23 @@ import { addCustomElementInputs } from '../index';
 describe('dist-custom-elements', () => {
   it('should add custom element inputs', () => {
     const buildCtx: any = {
-      components: [{
-        isPlain: true,
-        sourceFilePath: './foo/bar.tsx',
-        tagName: 'my-tag'
-      }]
+      components: [
+        {
+          isPlain: true,
+          sourceFilePath: './foo/bar.tsx',
+          tagName: 'my-tag',
+        },
+      ],
     };
     const bundleOpts: any = {
       inputs: {},
-      loader: {}
-    }
+      loader: {},
+    };
     const outputTarget: any = {
       type: 'dist-custom-elements',
-      customElementsExportBehavior: 'single-export-module'
+      customElementsExportBehavior: 'single-export-module',
     };
     addCustomElementInputs(buildCtx, bundleOpts, outputTarget);
-    expect(bundleOpts.loader['\x00core']).toContain(
-      `export { MyTag } from '\x00MyTag';\n`)
+    expect(bundleOpts.loader['\x00core']).toContain(`export { MyTag } from '\x00MyTag';\n`);
   });
 });

--- a/src/compiler/output-targets/dist-custom-elements/test/dist-custom-elements.spec.ts
+++ b/src/compiler/output-targets/dist-custom-elements/test/dist-custom-elements.spec.ts
@@ -1,21 +1,22 @@
+import type * as d from '@stencil/core/declarations';
+import { mockBuildCtx } from '@stencil/core/testing';
+
+import { BundleOptions } from '../../../bundle/bundle-interface';
+import { stubComponentCompilerMeta } from '../../../types/tests/ComponentCompilerMeta.stub';
 import { addCustomElementInputs } from '../index';
 
 describe('dist-custom-elements', () => {
   it('should add custom element inputs', () => {
-    const buildCtx: any = {
-      components: [
-        {
-          isPlain: true,
-          sourceFilePath: './foo/bar.tsx',
-          tagName: 'my-tag',
-        },
-      ],
-    };
-    const bundleOpts: any = {
+    const cmpMeta = stubComponentCompilerMeta({ isPlain: true, sourceFilePath: './foo/bar.tsx', tagName: 'my-tag' });
+    const buildCtx = mockBuildCtx();
+    buildCtx.components = [cmpMeta];
+    const bundleOpts: BundleOptions = {
+      id: 'customElements',
+      platform: 'client',
       inputs: {},
       loader: {},
     };
-    const outputTarget: any = {
+    const outputTarget: d.OutputTargetDistCustomElements = {
       type: 'dist-custom-elements',
       customElementsExportBehavior: 'single-export-module',
     };

--- a/src/compiler/output-targets/dist-custom-elements/test/dist-custom-elements.spec.ts
+++ b/src/compiler/output-targets/dist-custom-elements/test/dist-custom-elements.spec.ts
@@ -1,0 +1,24 @@
+import { addCustomElementInputs } from '../index';
+
+describe('dist-custom-elements', () => {
+  it('should add custom element inputs', () => {
+    const buildCtx: any = {
+      components: [{
+        isPlain: true,
+        sourceFilePath: './foo/bar.tsx',
+        tagName: 'my-tag'
+      }]
+    };
+    const bundleOpts: any = {
+      inputs: {},
+      loader: {}
+    }
+    const outputTarget: any = {
+      type: 'dist-custom-elements',
+      customElementsExportBehavior: 'single-export-module'
+    };
+    addCustomElementInputs(buildCtx, bundleOpts, outputTarget);
+    expect(bundleOpts.loader['\x00core']).toContain(
+      `export { MyTag } from '\x00MyTag';\n`)
+  });
+});

--- a/src/compiler/output-targets/dist-custom-elements/test/dist-custom-elements.spec.ts
+++ b/src/compiler/output-targets/dist-custom-elements/test/dist-custom-elements.spec.ts
@@ -21,10 +21,8 @@ describe('dist-custom-elements', () => {
       customElementsExportBehavior: 'single-export-module',
     };
     addCustomElementInputs(buildCtx, bundleOpts, outputTarget);
-    expect(bundleOpts.loader['\x00MyTag']).toContain(
-      'export { StubCmp as MyTag } from \'./foo/bar.tsx\';')
-    expect(bundleOpts.loader['\x00core']).toContain(
-      `export { MyTag } from '\x00MyTag';\n`);
+    expect(bundleOpts.loader['\x00MyTag']).toContain("export { StubCmp as MyTag } from './foo/bar.tsx';");
+    expect(bundleOpts.loader['\x00core']).toContain(`export { MyTag } from '\x00MyTag';\n`);
   });
 
   it('should export component with a defineCustomElement function', () => {
@@ -42,11 +40,12 @@ describe('dist-custom-elements', () => {
       customElementsExportBehavior: 'single-export-module',
     };
     addCustomElementInputs(buildCtx, bundleOpts, outputTarget);
+    expect(bundleOpts.loader['\x00MyTag']).toContain('export const defineCustomElement = cmpDefCustomEle;');
     expect(bundleOpts.loader['\x00MyTag']).toContain(
-      'export const defineCustomElement = cmpDefCustomEle;')
-    expect(bundleOpts.loader['\x00MyTag']).toContain(
-      'import { StubCmp as $CmpMyTag, defineCustomElement as cmpDefCustomEle } from \'./foo/bar.tsx\';')
+      "import { StubCmp as $CmpMyTag, defineCustomElement as cmpDefCustomEle } from './foo/bar.tsx';",
+    );
     expect(bundleOpts.loader['\x00core']).toContain(
-      `export { MyTag, defineCustomElement as defineCustomElementMyTag } from '\x00MyTag';\n`);
-  })
+      `export { MyTag, defineCustomElement as defineCustomElementMyTag } from '\x00MyTag';\n`,
+    );
+  });
 });


### PR DESCRIPTION
## What is the current behavior?
If you have a plain component like this:

```ts
@Component({
  tag: 'my-component',
  // styleUrl: 'my-component.css',
  shadow: true,
})
export class MyComponent {
  /**
   * The first name
   */
  first: string;
}
```

and try to export it via:

```ts
{
  type: 'dist-custom-elements',
  customElementsExportBehavior: 'single-export-module'
},
```

the compiler will fail with:

```
[ ERROR ]  Rollup: Parse Error
           Unexpected token (Note that you need plugins to import files that are not
           JavaScript) 2: export { getAssetPath, setAssetPath, setNonce,
           setPlatformOptions } from '@stencil/core/internal/client'; 3: export * from
           '@user-index-entrypoint'; 4: export { {MyComponent } from 'MyComponent'; ^ 5:
           6: globalScripts();
```

The change was originally introduced here: https://github.com/ionic-team/stencil/pull/3368/files#diff-df2741ac09fef4bbb750d864b2b96bdc4f8e649f347c7cc7def8edc977e1004eR198 and seems to be not intentional.

## What is the new behavior?
Removed the additional bracket.

## Documentation

n/a

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I added a unit test for this particular use case.

## Other information

n/a
