### PR TITLE
chore(scripts): swap from rollup to esbuild for main build

### DIFF
--- a/.github/workflows/build-rollup.yml
+++ b/.github/workflows/build-rollup.yml
@@ -1,4 +1,4 @@
-name: Build Stencil with Esbuild
+name: Build Stencil with Rollup
 
 on:
   workflow_call:
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/workflows/actions/get-core-dependencies
 
       - name: Core Build
-        run: npm run build.esbuild -- --ci
+        run: npm run build.rollup
         shell: bash
 
       - name: Validate Build
@@ -36,6 +36,6 @@ jobs:
       - name: Upload Build Artifacts
         uses: ./.github/workflows/actions/upload-archive
         with:
-          name: stencil-core-esbuild
+          name: stencil-core-rollup
           output: stencil-core-build.zip
           paths: build cli compiler dev-server internal mock-doc scripts/build screenshot sys testing

--- a/.github/workflows/main-rollup.yml
+++ b/.github/workflows/main-rollup.yml
@@ -1,4 +1,4 @@
-name: esbuild CI
+name: Rollup (legacy) CI
 
 on:
   push:
@@ -15,39 +15,39 @@ concurrency:
 jobs:
   build_core:
     name: Build
-    uses: ./.github/workflows/build-esbuild.yml
+    uses: ./.github/workflows/build-rollup.yml
 
   analysis_tests:
     name: Analysis Tests (Esbuild)
     needs: [build_core]
     uses: ./.github/workflows/test-analysis.yml
     with:
-      build_name: stencil-core-esbuild
+      build_name: stencil-core-rollup
 
   bundler_tests:
     name: Bundler Tests (Esbuild)
     needs: [build_core]
     uses: ./.github/workflows/test-bundlers.yml
     with:
-      build_name: stencil-core-esbuild
+      build_name: stencil-core-rollup
 
   component_starter_tests:
     name: Component Starter Smoke Test (Esbuild)
     needs: [build_core]
     uses: ./.github/workflows/test-component-starter.yml
     with:
-      build_name: stencil-core-esbuild
+      build_name: stencil-core-rollup
 
   e2e_tests:
     name: E2E Tests (Esbuild)
     needs: [build_core]
     uses: ./.github/workflows/test-e2e.yml
     with:
-      build_name: stencil-core-esbuild
+      build_name: stencil-core-rollup
 
   unit_tests:
     name: Unit Tests (Esbuild)
     needs: [build_core]
     uses: ./.github/workflows/test-unit.yml
     with:
-      build_name: stencil-core-esbuild
+      build_name: stencil-core-rollup

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "testing/"
   ],
   "scripts": {
-    "build": "npm run tsc.scripts && npm run tsc.prod && npm run rollup.prod.ci",
-    "build.esbuild": "npm run clean && npm run tsc.scripts && npm run tsc.prod && node scripts/build/esbuild/build.js --prod --ci",
-    "build.esbuild.watch": "npm run build.esbuild -- --watch",
+    "build.rollup": "npm run tsc.scripts && npm run tsc.prod && npm run rollup.prod.ci",
+    "build": "npm run clean && npm run tsc.scripts && npm run tsc.prod && node scripts/build/esbuild/build.js --prod --ci",
+    "build.watch": "npm run build -- --watch",
     "build.updateSelectorEngine": "node scripts/build/updateSelectorEngine.js",
     "clean": "rm -rf build/ cli/ compiler/ dev-server/ internal/ mock-doc/ sys/ testing/ && npm run clean-scripts",
     "clean-scripts": "rm -rf scripts/build",


### PR DESCRIPTION
This swaps over from Rollup to Esbuild for the main `npm run build` script in `package.json`. The existing Rollup based script is preserved as `build.rollup`.

This change causes our main CI run (`.github/workflows/main.yml`) to now use the Esbuild-based build, so the existing, supplemental CI run which previously was based on the Esbuild-based build pipeline now uses the 'legacy' (or nearly so) Rollup-based version. This requires a bit of renaming and so on.

STENCIL-1016

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

To test this out in the context of our GH-based releases I ran the dev and nightly releases against this branch:

- dev release: https://github.com/ionic-team/stencil/actions/runs/8087583103
- nightly release: https://github.com/ionic-team/stencil/actions/runs/8087594210

Both builds finished without error. The versions look _crazily_ similar:

- dev: `4.12.4-dev.1709157324.4664b01`
- nightly: `4.12.4-dev.1709157393.4664b01`