### PR TITLE
fix(cli): move version logging earlier in CLI to allow `-v`, `--version`

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -37,6 +37,16 @@ export const run = async (init: d.CliInitOptions) => {
       sys.applyGlobalPatch(sys.getCurrentDirectory());
     }
 
+    if ((task && task === 'version') || flags.version) {
+      // we need to load the compiler here to get the version, but we don't
+      // want to load it in the case that we're going to just log the help
+      // message and then exit below (if there's no `task` defined) so we load
+      // it just within our `if` scope here.
+      const coreCompiler = await loadCoreCompiler(sys);
+      console.log(coreCompiler.version);
+      return;
+    }
+
     if (!task || task === 'help' || flags.help) {
       await taskHelp(createConfigFlags({ task: 'help', args }), logger, sys);
 
@@ -52,11 +62,6 @@ export const run = async (init: d.CliInitOptions) => {
     }
 
     const coreCompiler = await loadCoreCompiler(sys);
-
-    if (task === 'version' || flags.version) {
-      console.log(coreCompiler.version);
-      return;
-    }
 
     startupLogVersion(logger, task, coreCompiler);
 


### PR DESCRIPTION
This moves the version logging earlier in the `run` function for our CLI so that it's possible to log the version by doing any of

- `stencil version`
- `stencil -v`
- `stencil --version`

Prior to this change only `stencil version` would work, although we had code which was clearly intended to log the version in the case that `-v` or `--version` is passed.

Background: Stencil's CLI distinguishes between _tasks_ and _flags_.

A _task_ is the first CLI argument and does not start with a leading dash. It's basically treated as a subcommand, so in a CLI invocation of Stencil like `stencil build` the _task_ for Stencil will be `build`. We already support `version` as a valid task.

A _flag_, by contrast, is a CLI option which controls an aspect of how Stencil runs. It's passed at the command-line like `--foo`, `--foo=bar`, or something along those lines.

When there's no task passed to the stencil CLI we normally log the help text, in-line with conventional CLI UX. This means that if you do something like `stencil --build` by accident you'll get help text explaining how to invoke Stencil correctly.

All well and good. However, although we've long supported `stencil version` we also have code in `main` which clearly intends to special-case the `version` _flag_ and treat it as if it is a _task_, so that if you do `stencil -v` or `stencil --version` it will be treated as if you'd done `stencil version`. The code is here:

https://github.com/ionic-team/stencil/blob/1eec9a82a4d623d46228e84798adbf2f88d7f3e8/src/cli/run.ts#L56-L59

The reason that this wasn't running as intended is that earlier in the same function we would log the help text if a _task_ wasn't provided:

https://github.com/ionic-team/stencil/blob/1eec9a82a4d623d46228e84798adbf2f88d7f3e8/src/cli/run.ts#L40-L44

Note the `if (!task` there. So because of this is you did `stencil -v` we would log the help text and execution wouldn't reach the lower version-related block.

To fix this we just move the version logging code above the help text logging code.

STENCIL-997

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?

`stencil -v` and `stencil --version` don't do what you might think they do! Instead of printing the version they print the 'help' text.


## What is the new behavior?

They now print the version.

## Documentation
https://github.com/ionic-team/stencil-site/pull/1366
<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Create a test project with

```sh
npm init stencil component test-version-logging
```

then

```sh
cd test-version-logging
npm i
```

and confirm you can reproduce the issue.

```sh
npx stencil version   # works!
npx stencil -v        # doesn't work
npx stencil --version # also doesn't work
```

Then download and install the tarball from this PR into your project, and confirm that all three variants of the 'version' command now print the version.
