### PR TITLE
chore(changelog): fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Bug Fixes
 
-* **custom-elements:** hydrate on client side ([#5317](https://github.com/ionic-team/stencil/issues/5317)) ([d809658](https://github.com/ionic-team/stencil/commit/d809658635280e115d67f1403dba946cce1bb01b)), closes [#5317](https://github.com/ionic-team/stencil/issues/5317)
+* **custom-elements:** hydrate on client side ([#5317](https://github.com/ionic-team/stencil/issues/5317)) ([d809658](https://github.com/ionic-team/stencil/commit/d809658635280e115d67f1403dba946cce1bb01b)), closes [#3319](https://github.com/ionic-team/stencil/issues/3319)
 
 
 


### PR DESCRIPTION
I meant to add a link to the _issue_, but I added a link to the _pr_. This fixes that.



## What is the current behavior?

Fixing a typo in the changelog

## Does this introduce a breaking change?

- [ ] Yes
- [x] No