### PR TITLE
fix(runtime): remove `forceUpdate` in `appendChild` patch

### DIFF
--- a/src/runtime/dom-extras.ts
+++ b/src/runtime/dom-extras.ts
@@ -1,5 +1,5 @@
 import { BUILD } from '@app-data';
-import { forceUpdate, getHostRef, plt, supportsShadow } from '@platform';
+import { getHostRef, plt, supportsShadow } from '@platform';
 import { NODE_TYPES } from '@stencil/core/mock-doc';
 import { CMP_FLAGS, HOST_FLAGS } from '@utils';
 
@@ -88,8 +88,6 @@ export const patchSlotAppendChild = (HostElementPrototype: any) => {
 
       // Check if there is fallback content that should be hidden
       updateFallbackSlotVisibility(this);
-      // Force a re-render of the host element
-      forceUpdate(this);
 
       return insertedNode;
     }

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -1041,7 +1041,7 @@ render() {
           // If the node we're currently planning on inserting the new node before is an element,
           // we need to do some additional checks to make sure we're inserting the node in the correct order.
           // The use case here would be that we have multiple nodes being relocated to the same slot. So, we want
-          // to make sure they get inserted into their new how in the same order they were declared in their original location.
+          // to make sure they get inserted into their new home in the same order they were declared in their original location.
           //
           // TODO(STENCIL-914): Remove `experimentalSlotFixes` check
           if (


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Stencil's patch for `appendChild` for slot emulation includes a call to `forceUpdate()` that is no longer needed and should not have been included in the first place (see new behavior section for more info).

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This commit removes a call to `forceUpdate` that was added to Stencil's patch for `appendChild` for slot emulation. The call was originally added to fix a failing test in Framework that we've now identified was the result of the patch's DOM manipulation in tandem with a mutation observer in framework.

Instead, the mutation observer in framework was modified to observe changes in the element subtree, removing the need for this call.

STENCIL-1192

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->
N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Automated unit and e2e tests continue to pass.

Tested this in a use case in Framework (see [STENCIL-1192](https://outsystemsrd.atlassian.net/browse/STENCIL-1192))

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
