### PR TITLE
chore(docs): add a bit of JSDoc to `run` in `src/cli/run.ts`

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -18,6 +18,16 @@ import { taskTelemetry } from './task-telemetry';
 import { taskTest } from './task-test';
 import { telemetryAction } from './telemetry/telemetry';
 
+/**
+ * Main entry point for the Stencil CLI
+ *
+ * Take care of parsing CLI arguments, initializing various components needed
+ * by the rest of the program, and kicking off the correct task (build, test,
+ * etc).
+ *
+ * @param init initial CLI options
+ * @returns an empty promise
+ */
 export const run = async (init: d.CliInitOptions) => {
   const { args, logger, sys } = init;
 


### PR DESCRIPTION
A conspicuous omission! Now it is corrected.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?

Add a JSDoc to this method.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No