### PR TITLE
chore(docs): update JSDoc for the `Logger` interface

### DIFF
--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -2054,9 +2054,12 @@ export const LOG_LEVELS = ['debug', 'info', 'warn', 'error'] as const;
 export type LogLevel = (typeof LOG_LEVELS)[number];
 
 /**
- * Common logger to be used by the compiler, dev-server and CLI. The CLI will use a
- * NodeJS based console logging and colors, and the web will use browser based
- * logs and colors.
+ * Abstract interface representing a logger with the capability to accept log
+ * messages at various levels (debug, info, warn, and error), set colors, log
+ * time spans, print diagnostic messages, and more.
+ *
+ * A Node.js-specific implementation of this interface is used when Stencil is
+ * building and compiling a project.
  */
 export interface Logger {
   enableColors: (useColors: boolean) => void;


### PR DESCRIPTION
This JSDoc comment is currently outdated because it makes reference to a browser-specific `Logger` impl which we no longer have (it was deleted in #4317).

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Documentation-only change