### PR TITLE
fix(compiler): allow to set custom root directory

### DIFF
--- a/src/compiler/config/load-config.ts
+++ b/src/compiler/config/load-config.ts
@@ -57,7 +57,8 @@ export const loadConfig = async (init: LoadConfigInit = {}): Promise<LoadConfigR
       configPath = loadedConfigFile.configPath;
       unknownConfig.config = { ...loadedConfigFile, ...config };
       unknownConfig.config.configPath = configPath;
-      unknownConfig.config.rootDir = config.rootDir || normalizePath(dirname(configPath));
+      unknownConfig.config.rootDir =
+        typeof config.rootDir === 'string' ? config.rootDir : normalizePath(dirname(configPath));
     } else {
       // no stencil.config.ts or .js file, which is fine
       unknownConfig.config = { ...config };

--- a/src/compiler/config/load-config.ts
+++ b/src/compiler/config/load-config.ts
@@ -57,7 +57,7 @@ export const loadConfig = async (init: LoadConfigInit = {}): Promise<LoadConfigR
       configPath = loadedConfigFile.configPath;
       unknownConfig.config = { ...loadedConfigFile, ...config };
       unknownConfig.config.configPath = configPath;
-      unknownConfig.config.rootDir = normalizePath(dirname(configPath));
+      unknownConfig.config.rootDir = init.config.rootDir || normalizePath(dirname(configPath));
     } else {
       // no stencil.config.ts or .js file, which is fine
       unknownConfig.config = { ...config };

--- a/src/compiler/config/load-config.ts
+++ b/src/compiler/config/load-config.ts
@@ -57,7 +57,7 @@ export const loadConfig = async (init: LoadConfigInit = {}): Promise<LoadConfigR
       configPath = loadedConfigFile.configPath;
       unknownConfig.config = { ...loadedConfigFile, ...config };
       unknownConfig.config.configPath = configPath;
-      unknownConfig.config.rootDir = init.config.rootDir || normalizePath(dirname(configPath));
+      unknownConfig.config.rootDir = config.rootDir || normalizePath(dirname(configPath));
     } else {
       // no stencil.config.ts or .js file, which is fine
       unknownConfig.config = { ...config };

--- a/src/compiler/config/test/load-config.spec.ts
+++ b/src/compiler/config/test/load-config.spec.ts
@@ -36,6 +36,7 @@ describe('load config', () => {
       sys,
       config: {
         hashedFileNameLength: 9,
+        rootDir: '/foo/bar',
       },
       initTsConfig: true,
     });
@@ -50,6 +51,8 @@ describe('load config', () => {
     expect<ConfigFlags>(actualConfig.flags).toEqual({ dev: true });
     expect(actualConfig.extras).toBeDefined();
     expect(actualConfig.extras!.enableImportInjection).toBe(true);
+    // respects custom root dir
+    expect(actualConfig.rootDir).toBe('/foo/bar');
   });
 
   it('uses the provided config path when no initial config provided', async () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
It doesn't seem like `rootDir` is respected as part of Stencils config. As a developer building an unplugin for Stencil I need ot be able to create a stencil config on the fly in a temporary directory and tell the Stencil compiler that the root directory is somewhere else.

## What is the new behavior?
If the user provides a Stencil config path to the compiler we respect the `rootDir` property in there to define the root dir for Stencils compiler

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Added a small unit test. Let me know if you like to add more testing.

## Other information

n/a
