### PR TITLE
chore(docs): add JSDoc to optimizeJs

### DIFF
--- a/src/compiler/optimize/optimize-js.ts
+++ b/src/compiler/optimize/optimize-js.ts
@@ -4,6 +4,15 @@ import { Config, OptimizeJsInput, OptimizeJsOutput } from '../../declarations';
 import { minifyJs } from './minify-js';
 import { getTerserOptions } from './optimize-module';
 
+/**
+ * Utility function used by the compiler to optimize JavaScript. Knowing the
+ * JavaScript target will further apply minification optimizations beyond usual
+ * minification.
+ *
+ * @param inputOpts options to control how the JS optimization should take
+ * place
+ * @returns a promise wrapping an output object
+ */
 export const optimizeJs = async (inputOpts: OptimizeJsInput) => {
   const result: OptimizeJsOutput = {
     output: inputOpts.input,


### PR DESCRIPTION
We already have JSDoc on the declaration for this function here:

https://github.com/ionic-team/stencil/blob/5b2c399f31cb689098f438eda4db2ee55c5412e1/src/compiler/public.ts#L73-L77

this ports it to the implementation.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Documentation-only change