### PR TITLE
chore(jsdoc): fix some JSDoc `@link` tags

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -121,7 +121,7 @@ export const run = async (init: d.CliInitOptions) => {
  * @param coreCompiler an instance of a minimal, bootstrap compiler for running the specified task
  * @param config a configuration for the Stencil project to apply to the task run
  * @param task the task to run
- * @param sys the {@link CompilerSystem} for interacting with the operating system
+ * @param sys the {@link d.CompilerSystem} for interacting with the operating system
  * @public
  * @returns a void promise
  */

--- a/src/compiler/transformers/add-static-style.ts
+++ b/src/compiler/transformers/add-static-style.ts
@@ -147,9 +147,9 @@ const createStyleLiteral = (cmp: d.ComponentCompilerMeta, style: d.StyleCompiler
 };
 
 /**
- * Helper method to create a style identifier for a component using {@link createStyleIdentifierFromUrl}.
- * The method ensures that duplicate styles are removed and that the order of the styles is preserved.
- * It also ensures that the style identifier is unique.
+ * Helper method to create a style identifier for a component. The method
+ * ensures that duplicate styles are removed and that the order of the styles is
+ * preserved. It also ensures that the style identifier is unique.
  *
  * @param cmp the metadata associated with the component being evaluated
  * @param style style meta data

--- a/src/compiler/transformers/core-runtime-apis.ts
+++ b/src/compiler/transformers/core-runtime-apis.ts
@@ -26,7 +26,7 @@ export const RUNTIME_APIS = {
 /**
  * Update a Stencil Module entity to include a {@link RUNTIME_APIS} entry if it does not already exist.
  * This allows Stencil to keep `moduleFile` easily serializable, where this helper function treats the data structure
- * that stores {@link Module#coreRuntimeApis} similar to a JS `Set`.
+ * that stores {@link d.Module#coreRuntimeApis} similar to a JS `Set`.
  * @param moduleFile the Module entity to update
  * @param coreRuntimeApi the API to add to the provided module
  */
@@ -40,7 +40,7 @@ export const addCoreRuntimeApi = (moduleFile: d.Module, coreRuntimeApi: string):
  * Update a Stencil Module entity to include a {@link RUNTIME_APIS} entry for a specific output target, if it does not
  * already exist.
  * This allows Stencil to keep `moduleFile` easily serializable, where this helper function treats the data structure
- * that stores {@link Module#outputTargetCoreRuntimeApis} similar to a JS `Set`.
+ * that stores {@link d.Module#outputTargetCoreRuntimeApis} similar to a JS `Set`.
  * @param moduleFile the Module entity to update
  * @param outputTarget the output target to assign the provided runtime api under
  * @param coreRuntimeApi the API to add to the provided module

--- a/src/compiler/transpile/transpiled-module.ts
+++ b/src/compiler/transpile/transpiled-module.ts
@@ -4,7 +4,7 @@ import ts from 'typescript';
 import type * as d from '../../declarations';
 
 /**
- * Helper function for retrieving a Stencil {@link Module} from the provided compiler context
+ * Helper function for retrieving a Stencil {@link d.Module} from the provided compiler context
  * @param compilerCtx the compiler context to retrieve the `Module` from
  * @param filePath the path of the file corresponding to the `Module` to lookup
  * @returns the `Module`, or `undefined` if one cannot be found
@@ -13,7 +13,7 @@ export const getModule = (compilerCtx: d.CompilerCtx, filePath: string): d.Modul
   compilerCtx.moduleMap.get(normalizePath(filePath));
 
 /**
- * Creates a {@link Module} entity with reasonable defaults
+ * Creates a {@link d.Module} entity with reasonable defaults
  * @param staticSourceFile the TypeScript representation of the source file. This may not be the original
  * representation of the file, but instead a new `SourceFile` created using the TypeScript API
  * @param staticSourceFileText the text from the `SourceFile`. This text may originate from the original representation

--- a/src/compiler/types/tests/ComponentCompilerEvent.stub.ts
+++ b/src/compiler/types/tests/ComponentCompilerEvent.stub.ts
@@ -1,7 +1,7 @@
 import * as d from '@stencil/core/declarations';
 
 /**
- * Generates a stub {@link ComponentCompilerEvent}. This function uses sensible defaults for the initial stub. However,
+ * Generates a stub {@link d.ComponentCompilerEvent}. This function uses sensible defaults for the initial stub. However,
  * any field in the object may be overridden via the `overrides` argument.
  * @param overrides a partial implementation of `ComponentCompilerEvent`. Any provided fields will override the
  * defaults provided by this function.

--- a/src/compiler/types/tests/ComponentCompilerMeta.stub.ts
+++ b/src/compiler/types/tests/ComponentCompilerMeta.stub.ts
@@ -1,7 +1,7 @@
 import * as d from '@stencil/core/declarations';
 
 /**
- * Generates a stub {@link ComponentCompilerMeta}. This function uses sensible defaults for the initial stub. However,
+ * Generates a stub {@link d.ComponentCompilerMeta}. This function uses sensible defaults for the initial stub. However,
  * any field in the object may be overridden via the `overrides` argument.
  * @param overrides a partial implementation of `ComponentCompilerMeta`. Any provided fields will override the
  * defaults provided by this function.

--- a/src/compiler/types/tests/ComponentCompilerMethod.stub.ts
+++ b/src/compiler/types/tests/ComponentCompilerMethod.stub.ts
@@ -1,7 +1,7 @@
 import * as d from '@stencil/core/declarations';
 
 /**
- * Generates a stub {@link ComponentCompilerMethod}. This function uses sensible defaults for the initial stub. However,
+ * Generates a stub {@link d.ComponentCompilerMethod}. This function uses sensible defaults for the initial stub. However,
  * any field in the object may be overridden via the `overrides` argument.
  * @param overrides a partial implementation of `ComponentCompilerMethod`. Any provided fields will override the
  * defaults provided by this function.

--- a/src/compiler/types/tests/ComponentCompilerProperty.stub.ts
+++ b/src/compiler/types/tests/ComponentCompilerProperty.stub.ts
@@ -1,7 +1,7 @@
 import * as d from '@stencil/core/declarations';
 
 /**
- * Generates a stub {@link ComponentCompilerProperty}. This function uses sensible defaults for the initial stub.
+ * Generates a stub {@link d.ComponentCompilerProperty}. This function uses sensible defaults for the initial stub.
  * However, any field in the object may be overridden via the `overrides` argument.
  * @param overrides a partial implementation of `ComponentCompilerProperty`. Any provided fields will override the
  * defaults provided by this function.

--- a/src/compiler/types/tests/ComponentCompilerTypeReference.stub.ts
+++ b/src/compiler/types/tests/ComponentCompilerTypeReference.stub.ts
@@ -1,7 +1,7 @@
 import * as d from '@stencil/core/declarations';
 
 /**
- * Generates a stub {@link ComponentCompilerTypeReference}. This function uses sensible defaults for the initial stub.
+ * Generates a stub {@link d.ComponentCompilerTypeReference}. This function uses sensible defaults for the initial stub.
  * However, any field in the object may be overridden via the `overrides` argument.
  * @param overrides a partial implementation of `ComponentCompilerTypeReference`. Any provided fields will override the
  * defaults provided by this function.

--- a/src/compiler/types/tests/ComponentCompilerVirtualProperty.stub.ts
+++ b/src/compiler/types/tests/ComponentCompilerVirtualProperty.stub.ts
@@ -1,7 +1,7 @@
 import * as d from '@stencil/core/declarations';
 
 /**
- * Generates a stub {@link ComponentCompilerVirtualProperty}. This function uses sensible defaults for the initial
+ * Generates a stub {@link d.ComponentCompilerVirtualProperty}. This function uses sensible defaults for the initial
  * stub. However, any field in the object may be overridden via the `overrides` argument.
  * @param overrides a partial implementation of `ComponentCompilerVirtualProperty`. Any provided fields will override the
  * defaults provided by this function.

--- a/src/compiler/types/tests/TypesImportData.stub.ts
+++ b/src/compiler/types/tests/TypesImportData.stub.ts
@@ -1,7 +1,8 @@
 import * as d from '@stencil/core/declarations';
 
 /**
- * Generates a stub {@link TypesImportData}.
+ * Generates a stub {@link d.TypesImportData}.
+ *
  * @param overrides a partial implementation of `TypesImportData`. Any provided fields will override the defaults
  * provided by this function.
  * @returns the stubbed `TypesImportData`

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -1480,7 +1480,7 @@ export interface ComponentRuntimeMeta {
   /**
    * This number is used to hold a series of bitflags for various features we
    * support on components. The flags which this value is intended to store are
-   * documented in the {@link CMP_FLAGS} enum.
+   * documented in the `CMP_FLAGS` enum.
    */
   $flags$: number;
   /**
@@ -1526,7 +1526,7 @@ export interface ComponentRuntimeMembers {
  * The fields are:
  *
  * 1. A number used to hold bitflags for component members. The bit flags which
- * this is intended to store are documented in the {@link MEMBER_FLAGS} enum.
+ * this is intended to store are documented in the `MEMBER_FLAGS` enum.
  * 2. The attribute name to observe.
  */
 export type ComponentRuntimeMember = [number, string?];
@@ -1536,7 +1536,7 @@ export type ComponentRuntimeMember = [number, string?];
  * runtime. The field are:
  *
  * 1. A number used to hold bitflags for listeners. The bit flags which this is
- * intended to store are documented in the {@link LISTENER_FLAGS} enum.
+ * intended to store are documented in the `LISTENER_FLAGS` enum.
  * 2. The event name.
  * 3. The method name.
  */
@@ -2416,7 +2416,7 @@ export interface CompilerWorkerContext {
 }
 
 /**
- * The methods that are supported on a {@link d.CompilerWorkerContext}
+ * The methods that are supported on a {@link CompilerWorkerContext}
  */
 export type WorkerContextMethod = keyof CompilerWorkerContext;
 

--- a/src/testing/mocks.ts
+++ b/src/testing/mocks.ts
@@ -1,13 +1,5 @@
 import { createWorkerContext } from '@stencil/core/compiler';
-import type {
-  BuildCtx,
-  Cache,
-  CompilerCtx,
-  LoadConfigInit,
-  Module,
-  UnvalidatedConfig,
-  ValidatedConfig,
-} from '@stencil/core/internal';
+import type * as d from '@stencil/core/internal';
 import { MockWindow } from '@stencil/core/mock-doc';
 import { noop } from '@utils';
 import path from 'path';
@@ -27,7 +19,7 @@ import { createTestingSystem, TestingSystem } from './testing-sys';
  * provided by this function.
  * @returns the mock Stencil configuration
  */
-export function mockValidatedConfig(overrides: Partial<ValidatedConfig> = {}): ValidatedConfig {
+export function mockValidatedConfig(overrides: Partial<d.ValidatedConfig> = {}): d.ValidatedConfig {
   const baseConfig = mockConfig(overrides);
   const rootDir = path.resolve('/');
 
@@ -72,7 +64,7 @@ export function mockValidatedConfig(overrides: Partial<ValidatedConfig> = {}): V
  * provided by this function.
  * @returns the mock Stencil configuration
  */
-export function mockConfig(overrides: Partial<UnvalidatedConfig> = {}): UnvalidatedConfig {
+export function mockConfig(overrides: Partial<d.UnvalidatedConfig> = {}): d.UnvalidatedConfig {
   const rootDir = path.resolve('/');
 
   let { sys } = overrides;
@@ -127,8 +119,8 @@ export function mockConfig(overrides: Partial<UnvalidatedConfig> = {}): Unvalida
  * @param overrides the properties on the default entity to manually override
  * @returns the default configuration initialization object, with any overrides applied
  */
-export const mockLoadConfigInit = (overrides?: Partial<LoadConfigInit>): LoadConfigInit => {
-  const defaults: LoadConfigInit = {
+export const mockLoadConfigInit = (overrides?: Partial<d.LoadConfigInit>): d.LoadConfigInit => {
+  const defaults: d.LoadConfigInit = {
     config: {},
     configPath: undefined,
     initTsConfig: true,
@@ -139,9 +131,9 @@ export const mockLoadConfigInit = (overrides?: Partial<LoadConfigInit>): LoadCon
   return { ...defaults, ...overrides };
 };
 
-export function mockCompilerCtx(config?: ValidatedConfig) {
+export function mockCompilerCtx(config?: d.ValidatedConfig) {
   const innerConfig = config || mockValidatedConfig();
-  const compilerCtx: CompilerCtx = {
+  const compilerCtx: d.CompilerCtx = {
     version: 1,
     activeBuildId: 0,
     activeDirsAdded: [],
@@ -196,19 +188,19 @@ export function mockCompilerCtx(config?: ValidatedConfig) {
   return compilerCtx;
 }
 
-export function mockBuildCtx(config?: ValidatedConfig, compilerCtx?: CompilerCtx): BuildCtx {
+export function mockBuildCtx(config?: d.ValidatedConfig, compilerCtx?: d.CompilerCtx): d.BuildCtx {
   const validatedConfig = config || mockValidatedConfig();
   const validatedCompilerCtx = compilerCtx || mockCompilerCtx(validatedConfig);
 
   const buildCtx = new BuildContext(validatedConfig, validatedCompilerCtx);
-  return buildCtx as BuildCtx;
+  return buildCtx as d.BuildCtx;
 }
 
-function mockCache(config: ValidatedConfig, compilerCtx: CompilerCtx) {
+function mockCache(config: d.ValidatedConfig, compilerCtx: d.CompilerCtx) {
   config.enableCache = true;
   const cache = new CompilerCache(config, compilerCtx.fs);
   cache.initCacheDir();
-  return cache as Cache;
+  return cache as d.Cache;
 }
 
 export function mockLogger() {
@@ -216,11 +208,11 @@ export function mockLogger() {
 }
 
 /**
- * Create a {@link CompilerSystem} entity for testing the compiler.
+ * Create a {@link d.CompilerSystem} entity for testing the compiler.
  *
  * This function acts as a thin wrapper around a {@link TestingSystem} entity creation. It exists to provide a logical
  * place in the codebase where we might expect Stencil engineers to reach for when attempting to mock a
- * {@link CompilerSystem} base type. Should there prove to be usage of both this function and the one it wraps,
+ * {@link d.CompilerSystem} base type. Should there prove to be usage of both this function and the one it wraps,
  * reconsider if this wrapper is necessary.
  *
  * @returns a System instance for testing purposes.
@@ -247,7 +239,7 @@ export function mockWindow(html?: string) {
  * @param mod is an override module that you can supply to set particular values
  * @returns a module object ready to use in tests!
  */
-export const mockModule = (mod: Partial<Module> = {}): Module => ({
+export const mockModule = (mod: Partial<d.Module> = {}): d.Module => ({
   cmps: [],
   coreRuntimeApis: [],
   outputTargetCoreRuntimeApis: {},

--- a/src/utils/output-target.ts
+++ b/src/utils/output-target.ts
@@ -103,7 +103,7 @@ export const isEligiblePrimaryPackageOutputTarget = (o: d.OutputTarget): o is d.
   isOutputTargetDistTypes(o);
 
 /**
- * Retrieve the Stencil component compiler metadata from a collection of Stencil {@link Module}s
+ * Retrieve the Stencil component compiler metadata from a collection of Stencil {@link d.Module}s
  * @param moduleFiles the collection of `Module`s to retrieve the metadata from
  * @returns the metadata, lexicographically sorted by the tag names of the components
  */


### PR DESCRIPTION
This fixes some `@link` tags in JSDoc which weren't resolving correctly. Since the Typedoc tool reports on `@link` tags which it can't resolve we can use that to find them.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?

Some of these links don't actually resolve! It's a bit hard to see this, but one way that I can test if the `{@link Foo}` is correctly resolving the symbol `Foo` is to ask the LSP about it in my editor. If the name can be resolved then I'll see some info about it, otherwise I won't. This shows the before and after of this in `src/cli/run.ts`:

https://github.com/ionic-team/stencil/assets/6207644/5b416c3b-af86-4c17-85d2-08407fbc8271

We have `import type * as d from '../declarations';` at the top of the file, so `d.CompilerSystem` can be resolved but `CompilerSystem` cannot. 


## What is the new behavior?

Several of these are fixed! A few where it would be required to add a new import to a module in order to get something to resolve I just turned into comments instead.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Try to make sure that these actually resolve, possibly using the method outlined above with the LSP in an editor. Or just try to reason about it.
