### PR TITLE
chore(repo): add wdio directory to renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -107,6 +107,13 @@
       allowedVersions: '<=16'
     },
     {
+      // We intentionally run the WebdriverIO tests against the oldest LTS of Node we support.
+      // Prevent renovate from trying to bump node
+      matchFileNames: ['test/wdio/package.json'],
+      matchDepNames: ['node'],
+      allowedVersions: '<=16'
+    },
+    {
       // We intentionally run the karma tests against the oldest LTS of Node we support.
       // Prevent renovate from trying to bump node
       matchFileNames: ['test/karma/package.json'],


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We just merged our initial WebdriverIO infrastructure. Renovate is trying to upgrade our Node version in https://github.com/ionic-team/stencil/pull/5466. We don't want that, as we want to continue to test against our oldest Node version
GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->


block node from being upgraded by renovate for the wdio directory, as we wish to continue to run these tests on the oldest version of node that stencil supports
## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I did the following to test this the best I could (as Renovate doesn't have dry runs):
- `npm i -g renovate && renovate-config-validator` to verify I hadn't copy/pasted this incorrectly (this verifies the json5 is still well formed) 😆 
- `cat test/wdio/package.json` to verify the path was correct

Otherwise, this is a near copy of the Karma directory rule directly above it

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
