### PR TITLE
chore(wdio): include the right path for the wdio-specific .d.ts file

### DIFF
--- a/test/wdio/tsconfig-stencil.json
+++ b/test/wdio/tsconfig-stencil.json
@@ -27,7 +27,7 @@
     "skipLibCheck": true
   },
   "include": [
-    "./components.d.ts",
+    "./src/components.d.ts",
     "./**/*.spec.ts",
     "./**/*.tsx",
     "./util.ts",


### PR DESCRIPTION


## What is the current behavior?

If you need to write a wdio test which references a host element interface the test will not compile correctly, complaining that it can't resolve the interface. I ran into that working on https://github.com/ionic-team/stencil/compare/ap/wdio/form-associated, where the component has a method like this:

```tsx
  formAssociatedCallback(form: HTMLFormAssociatedElement) {
    form.ariaLabel = 'formAssociated called';
    // this is a regression test for #5106 which ensures that `this` is
    // resolved correctly
    this.internals.setValidity({});
  }
```

The `HTMLFormAssociatedElement` interface is defined in `test/wdio/src/components.d.ts` and should be part of the global type namespace for the `test/wdio` project, but our `include/` in `test/wdio/tsconfig-stencil.json` wasn't including the component types correctly so that the interface wasn't being resolved.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

`test/wdio/src/components.d.ts` is now included correctly so the interface can be resolved!

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

If this same change is applied to my branch (https://github.com/ionic-team/stencil/compare/ap/wdio/form-associated) the tests should build repeatedly, without having to delete `test/wdio/src/components.d.ts`.
