### PR TITLE
fix(compiler): don't validate references for @Prop, @Method and @Event decorator

### DIFF
--- a/src/compiler/transformers/decorators-to-static/event-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/event-decorator.ts
@@ -9,7 +9,6 @@ import {
   resolveType,
   retrieveTsDecorators,
   serializeSymbol,
-  validateReferences,
 } from '../transform-utils';
 import { getDecoratorParameters, isDecoratorNamed } from './decorator-utils';
 
@@ -76,7 +75,6 @@ const parseEventDecorator = (
     docs: serializeSymbol(typeChecker, symbol),
     complexType: getComplexType(typeChecker, program, prop),
   };
-  validateReferences(diagnostics, eventMeta.complexType.references, prop.type);
   return eventMeta;
 };
 

--- a/src/compiler/transformers/decorators-to-static/method-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/method-decorator.ts
@@ -12,7 +12,6 @@ import {
   retrieveTsDecorators,
   retrieveTsModifiers,
   typeToString,
-  validateReferences,
 } from '../transform-utils';
 import { isDecoratorNamed } from './decorator-utils';
 
@@ -111,7 +110,6 @@ const parseMethodDecorator = (
       tags: mapJSDocTagInfo(signature.getJsDocTags()),
     },
   };
-  validateReferences(diagnostics, methodMeta.complexType.references, method.type || method.name);
 
   const staticProp = ts.factory.createPropertyAssignment(
     ts.factory.createStringLiteral(methodName),

--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -14,7 +14,6 @@ import {
   serializeSymbol,
   tsPropDeclNameAsString,
   typeToString,
-  validateReferences,
 } from '../transform-utils';
 import { getDecoratorParameters, isDecoratorNamed } from './decorator-utils';
 
@@ -102,7 +101,6 @@ const parsePropDecorator = (
     optional: prop.questionToken !== undefined,
     docs: serializeSymbol(typeChecker, symbol),
   };
-  validateReferences(diagnostics, propMeta.complexType.references, prop.type);
 
   // prop can have an attribute if type is NOT "unknown"
   if (typeStr !== 'unknown') {

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -457,20 +457,6 @@ export const getAllTypeReferences = (checker: ts.TypeChecker, node: ts.Node): Re
   return referencedTypes;
 };
 
-export const validateReferences = (
-  diagnostics: d.Diagnostic[],
-  references: d.ComponentCompilerTypeReferences,
-  node: ts.Node,
-) => {
-  Object.keys(references).forEach((refName) => {
-    const ref = references[refName];
-    if (ref.path === '@stencil/core' && readOnlyArrayHasStringMember(MEMBER_DECORATORS_TO_REMOVE, refName)) {
-      const err = buildError(diagnostics);
-      augmentDiagnosticWithNode(err, node);
-    }
-  });
-};
-
 /**
  * Determine where a TypeScript type reference originates from. This is accomplished by interrogating the AST node in
  * which the type's name appears

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -1,8 +1,8 @@
-import { augmentDiagnosticWithNode, buildError, normalizePath, readOnlyArrayHasStringMember } from '@utils';
+import { normalizePath } from '@utils';
 import ts from 'typescript';
 
 import type * as d from '../../declarations';
-import { MEMBER_DECORATORS_TO_REMOVE, StencilStaticGetter } from './decorators-to-static/decorators-constants';
+import { StencilStaticGetter } from './decorators-to-static/decorators-constants';
 import { addToLibrary, findTypeWithName, getHomeModule, getOriginalTypeName } from './type-library';
 
 export const getScriptTarget = () => {


### PR DESCRIPTION
## What is the current behavior?
It currently seems that we have implemented a validation that would prevent returning a type that collides with the name of any imported Stencil type. As far as I understood the situation is as following: given I have a type name that has the same name as one of Stencils decorators (e.g. `Element`, `Event`, `Listen`, `Method`, `Prop`, `PropDidChange`, `PropWillChange`, `State` or `Watch`) it will throw a meaningless error. This can be easily reproduced in many ways:

```ts
// in src/utils/utils.ts
interface Method {}

export function returnSomethingInvalid(): Method {
  return {}
}
```

Then having the following component decorator will fail:

```ts
// in src/components/my-component/my-component.tsx
import { Component, Prop, h, Method, EventEmitter, Event } from '@stencil/core';
import { returnSomethingInvalid } from '../../utils/utils';

@Component({
  tag: 'my-component',
  styleUrl: 'my-component.css',
  shadow: true,
})
export class MyComponent {
  // ...
  @Method()
  async didDismiss() {
    return returnSomethingInvalid()
  }
  // ...
}
```

This behavior was introduced in https://github.com/ionic-team/stencil/commit/ca60073da7733d4e40ccc7bd1ad35b891462aeb2 and was suppose to fix an issue reported in #1352.

## What is the new behavior?
Remove this validation as I don't think it makes sense here. I don't totally understand the reasoning behind it but it seems unnecessary to validate if the returning type matches with one of Stencils decorators. It seems safe to me to just remove this completely. 

STENCIL-980

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I can add some compiler tests for this if we think we want to move forward with this.

## Other information

n/a
