### PR TITLE
fix(mock-doc): provide a local name

### DIFF
--- a/src/mock-doc/document.ts
+++ b/src/mock-doc/document.ts
@@ -49,6 +49,10 @@ export class MockDocument extends MockHTMLElement {
     this.documentElement.dir = value;
   }
 
+  override get localName(): undefined {
+    return undefined;
+  }
+
   get location() {
     if (this.defaultView != null) {
       return (this.defaultView as Window).location;

--- a/src/mock-doc/node.ts
+++ b/src/mock-doc/node.ts
@@ -266,6 +266,19 @@ Testing components with ElementInternals is fully supported in e2e tests.`,
     );
   }
 
+  get localName() {
+    /**
+     * The `localName` of an element should be always given, however the way
+     * MockDoc is constructed, it won't allow us to guarantee that. Let's throw
+     * and error we get into the situation where we don't have a `nodeName` set.
+     *
+     */
+    if (!this.nodeName) {
+      throw new Error(`Can't compute elements localName without nodeName`);
+    }
+    return this.nodeName.toLocaleLowerCase();
+  }
+
   get namespaceURI() {
     return this.__namespaceURI;
   }

--- a/src/mock-doc/test/element.spec.ts
+++ b/src/mock-doc/test/element.spec.ts
@@ -6,7 +6,7 @@ import { cloneWindow, MockWindow } from '../window';
 describe('element', () => {
   let doc: MockDocument;
   beforeEach(() => {
-    doc = new MockDocument();
+    doc = new MockDocument('');
   });
 
   it('document.documentElement dir', () => {
@@ -505,5 +505,14 @@ describe('element', () => {
       elm.textContent = 'this is an item in an unordered list';
       expect(elm.textContent).toBe('this is an item in an unordered list');
     });
+  });
+
+  it('provides a localName', () => {
+    expect(doc.createElement('input').localName).toBe('input');
+    expect(doc.createElement('a').localName).toBe('a');
+    expect(doc.createElement('datalist').localName).toBe('datalist');
+    expect(doc.localName).toBe(undefined);
+    expect(doc.createElement('svg').localName).toBe('svg');
+    expect((document.childNodes[1] as any).localName).toBe('html');
   });
 });


### PR DESCRIPTION
## What is the current behavior?
Currently MockDoc doesn't provide a [`localName`](https://developer.mozilla.org/en-US/docs/Web/API/Element/localName) property for elements.

GitHub Issue Number: #5342

## What is the new behavior?
Adding that property.

## Documentation

n/a

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Added some unit tests. Let me know if I should extend these.

## Other information

n/a
