### PR TITLE
chore(wdio): fix build issues

### DIFF
--- a/test/wdio/event-custom-type/cmp.tsx
+++ b/test/wdio/event-custom-type/cmp.tsx
@@ -1,6 +1,6 @@
 import { Component, h, Event, EventEmitter, State, Listen } from '@stencil/core';
 
-import { EventCustomTypeCustomEvent } from '../components';
+import { EventCustomTypeCustomEvent } from '../src/components.js';
 
 export interface TestEventDetail {
   value: string;


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A

See "New Behavior"

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

fix a build issue where running `npm run build` twice in the `test/wdio` directory would result in the following failure:
```
 [47:48.5]  aborted build, 343ms  MEM: 359.2MB

[ ERROR ]  TypeScript: event-custom-type/cmp.tsx:3:44
           Cannot find module '../components' or its corresponding type declarations.

      L3:  import { EventCustomTypeCustomEvent } from '../components';

[47:48.5]  build failed in 343 ms
```

This was introduced in https://github.com/ionic-team/stencil/pull/5493, where the import statement was not correctly ported over. As a result, type resolution would fail under `tsconfig.json#moduleResoution` having a value of 'Node16'


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Check out this branch and run `npm run build` 2+ times. You should not see an error
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
