### PR TITLE
chore(lint): turn on linting for the `test/wdio` directory tree

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -89,6 +89,13 @@ module.exports = {
         'no-var': 'off',
       },
     },
+    {
+      // we don't want to use jest-related lint rules in the wdio tests
+      files: 'test/wdio/**/*.tsx',
+      rules: {
+        'jest/expect-expect': 'off',
+      },
+    },
   ],
   // inform ESLint about the global variables defined in a Jest context
   // see https://github.com/jest-community/eslint-plugin-jest/#usage

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "clean": "rm -rf build/ cli/ compiler/ dev-server/ internal/ mock-doc/ sys/ testing/ && npm run clean.scripts && npm run clean.screenshots",
     "clean.scripts": "rm -rf scripts/build",
     "clean.screenshots": "rm -rf test/end-to-end/screenshot/builds test/end-to-end/screenshot/images",
-    "lint": "eslint 'bin/*' 'scripts/*.ts' 'scripts/**/*.ts' 'src/*.ts' 'src/**/*.ts' 'src/**/*.tsx'",
+    "lint": "eslint 'bin/*' 'scripts/*.ts' 'scripts/**/*.ts' 'src/*.ts' 'src/**/*.ts' 'src/**/*.tsx' 'test/wdio/**/*.tsx'",
     "install.jest": "bash ./src/testing/jest/install-dependencies.sh",
     "prettier": "npm run prettier.base -- --write",
     "prettier.base": "prettier --cache \"./({bin,scripts,src,test}/**/*.{ts,tsx,js,jsx})|bin/stencil|.github/(**/)?*.(yml|yaml)|*.js\"",

--- a/test/wdio/custom-event/cmp.tsx
+++ b/test/wdio/custom-event/cmp.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, State, h } from '@stencil/core';
+import { Component, Element, h, State } from '@stencil/core';
 
 @Component({
   tag: 'custom-event-root',

--- a/test/wdio/dynamic-css-variables/cmp.tsx
+++ b/test/wdio/dynamic-css-variables/cmp.tsx
@@ -1,4 +1,4 @@
-import { Component, State, h } from '@stencil/core';
+import { Component, h, State } from '@stencil/core';
 
 @Component({
   tag: 'dynamic-css-variable',

--- a/test/wdio/event-custom-type/cmp.tsx
+++ b/test/wdio/event-custom-type/cmp.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Event, EventEmitter, State, Listen } from '@stencil/core';
+import { Component, Event, EventEmitter, h, Listen, State } from '@stencil/core';
 
 import { EventCustomTypeCustomEvent } from '../src/components.js';
 

--- a/test/wdio/external-imports/cmp.test.tsx
+++ b/test/wdio/external-imports/cmp.test.tsx
@@ -14,7 +14,7 @@ describe('external-imports', () => {
     });
   });
   it('render all components without errors', async () => {
-    let elm = $('external-import-a');
+    const elm = $('external-import-a');
     await expect(elm).toHaveText('Marty McFly');
 
     const elm2 = $('external-import-b');

--- a/test/wdio/form-associated/cmp.test.tsx
+++ b/test/wdio/form-associated/cmp.test.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment } from '@stencil/core';
+import { Fragment, h } from '@stencil/core';
 import { render } from '@wdio/browser-runner/stencil';
 
 describe('form associated', function () {

--- a/test/wdio/json-basic/cmp.tsx
+++ b/test/wdio/json-basic/cmp.tsx
@@ -1,4 +1,5 @@
 import { Component, h } from '@stencil/core';
+
 import { foo } from './data.json';
 
 @Component({

--- a/test/wdio/key-reorder/cmp.tsx
+++ b/test/wdio/key-reorder/cmp.tsx
@@ -1,4 +1,4 @@
-import { Component, State, h } from '@stencil/core';
+import { Component, h, State } from '@stencil/core';
 
 @Component({
   tag: 'key-reorder',
@@ -11,7 +11,7 @@ export class KeyReorder {
   }
 
   render() {
-    let items = [0, 1, 2, 3, 4];
+    const items = [0, 1, 2, 3, 4];
     if (this.isReversed) {
       items.reverse();
     }

--- a/test/wdio/lifecycle-async/cmp-a.test.tsx
+++ b/test/wdio/lifecycle-async/cmp-a.test.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment } from '@stencil/core';
+import { Fragment, h } from '@stencil/core';
 import { render } from '@wdio/browser-runner/stencil';
 
 describe('lifecycle-async', function () {

--- a/test/wdio/lifecycle-async/cmp-a.tsx
+++ b/test/wdio/lifecycle-async/cmp-a.tsx
@@ -1,4 +1,4 @@
-import { Component, Listen, State, h } from '@stencil/core';
+import { Component, h, Listen, State } from '@stencil/core';
 
 @Component({
   tag: 'lifecycle-async-a',

--- a/test/wdio/lifecycle-async/cmp-b.tsx
+++ b/test/wdio/lifecycle-async/cmp-b.tsx
@@ -1,4 +1,5 @@
-import { Component, Event, EventEmitter, Prop, h } from '@stencil/core';
+import { Component, Event, EventEmitter, h, Prop } from '@stencil/core';
+
 import { timeout } from './util';
 
 @Component({

--- a/test/wdio/lifecycle-async/cmp-c.tsx
+++ b/test/wdio/lifecycle-async/cmp-c.tsx
@@ -1,4 +1,5 @@
-import { Component, Event, EventEmitter, Prop, h } from '@stencil/core';
+import { Component, Event, EventEmitter, h, Prop } from '@stencil/core';
+
 import { timeout } from './util';
 
 @Component({

--- a/test/wdio/lifecycle-basic/cmp-a.test.tsx
+++ b/test/wdio/lifecycle-basic/cmp-a.test.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment } from '@stencil/core';
+import { Fragment, h } from '@stencil/core';
 import { render } from '@wdio/browser-runner/stencil';
 
 describe('lifecycle-basic', function () {

--- a/test/wdio/lifecycle-basic/cmp-a.tsx
+++ b/test/wdio/lifecycle-basic/cmp-a.tsx
@@ -1,4 +1,4 @@
-import { Component, Listen, State, h } from '@stencil/core';
+import { Component, h, Listen, State } from '@stencil/core';
 
 @Component({
   tag: 'lifecycle-basic-a',

--- a/test/wdio/lifecycle-basic/cmp-b.tsx
+++ b/test/wdio/lifecycle-basic/cmp-b.tsx
@@ -1,4 +1,4 @@
-import { Component, Event, EventEmitter, Prop, State, h } from '@stencil/core';
+import { Component, Event, EventEmitter, h, Prop, State } from '@stencil/core';
 
 @Component({
   tag: 'lifecycle-basic-b',

--- a/test/wdio/lifecycle-basic/cmp-c.tsx
+++ b/test/wdio/lifecycle-basic/cmp-c.tsx
@@ -1,4 +1,4 @@
-import { Component, Event, EventEmitter, Prop, State, h } from '@stencil/core';
+import { Component, Event, EventEmitter, h, Prop, State } from '@stencil/core';
 
 @Component({
   tag: 'lifecycle-basic-c',

--- a/test/wdio/lifecycle-nested/cmp-a.test.tsx
+++ b/test/wdio/lifecycle-nested/cmp-a.test.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment } from '@stencil/core';
+import { Fragment, h } from '@stencil/core';
 import { render } from '@wdio/browser-runner/stencil';
 
 describe('lifecycle-nested', function () {

--- a/test/wdio/lifecycle-nested/cmp-a.tsx
+++ b/test/wdio/lifecycle-nested/cmp-a.tsx
@@ -1,4 +1,5 @@
 import { Component, h } from '@stencil/core';
+
 import output from './output';
 
 @Component({

--- a/test/wdio/lifecycle-nested/cmp-b.tsx
+++ b/test/wdio/lifecycle-nested/cmp-b.tsx
@@ -1,4 +1,5 @@
 import { Component, h } from '@stencil/core';
+
 import output from './output';
 
 @Component({

--- a/test/wdio/lifecycle-nested/cmp-c.tsx
+++ b/test/wdio/lifecycle-nested/cmp-c.tsx
@@ -1,4 +1,5 @@
-import { Host, Component, h } from '@stencil/core';
+import { Component, h, Host } from '@stencil/core';
+
 import output from './output';
 
 @Component({

--- a/test/wdio/lifecycle-update/cmp-a.test.tsx
+++ b/test/wdio/lifecycle-update/cmp-a.test.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment } from '@stencil/core';
+import { Fragment, h } from '@stencil/core';
 import { render } from '@wdio/browser-runner/stencil';
 
 describe('lifecycle-update', function () {

--- a/test/wdio/lifecycle-update/cmp-a.tsx
+++ b/test/wdio/lifecycle-update/cmp-a.tsx
@@ -1,4 +1,4 @@
-import { Component, State, h } from '@stencil/core';
+import { Component, h, State } from '@stencil/core';
 
 @Component({
   tag: 'lifecycle-update-a',

--- a/test/wdio/lifecycle-update/cmp-b.tsx
+++ b/test/wdio/lifecycle-update/cmp-b.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h } from '@stencil/core';
+import { Component, h, Prop } from '@stencil/core';
 
 @Component({
   tag: 'lifecycle-update-b',

--- a/test/wdio/lifecycle-update/cmp-c.tsx
+++ b/test/wdio/lifecycle-update/cmp-c.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h } from '@stencil/core';
+import { Component, h, Prop } from '@stencil/core';
 
 @Component({
   tag: 'lifecycle-update-c',

--- a/test/wdio/listen-jsx/cmp-root.tsx
+++ b/test/wdio/listen-jsx/cmp-root.tsx
@@ -1,4 +1,4 @@
-import { Component, State, h } from '@stencil/core';
+import { Component, h, State } from '@stencil/core';
 
 @Component({
   tag: 'listen-jsx-root',

--- a/test/wdio/listen-jsx/cmp.tsx
+++ b/test/wdio/listen-jsx/cmp.tsx
@@ -1,4 +1,4 @@
-import { Component, Listen, State, h } from '@stencil/core';
+import { Component, h, Listen, State } from '@stencil/core';
 
 @Component({
   tag: 'listen-jsx',

--- a/test/wdio/listen-reattach/cmp-a.test.tsx
+++ b/test/wdio/listen-reattach/cmp-a.test.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment } from '@stencil/core';
+import { Fragment, h } from '@stencil/core';
 import { render } from '@wdio/browser-runner/stencil';
 
 describe('listen-reattach', () => {

--- a/test/wdio/listen-reattach/cmp-a.tsx
+++ b/test/wdio/listen-reattach/cmp-a.tsx
@@ -1,4 +1,4 @@
-import { Component, Listen, State, h, Host } from '@stencil/core';
+import { Component, h, Host, Listen, State } from '@stencil/core';
 
 @Component({
   tag: 'listen-reattach',

--- a/test/wdio/listen-window/cmp-a.tsx
+++ b/test/wdio/listen-window/cmp-a.tsx
@@ -1,4 +1,4 @@
-import { Component, Listen, State, h } from '@stencil/core';
+import { Component, h, Listen, State } from '@stencil/core';
 
 @Component({
   tag: 'listen-window',

--- a/test/wdio/reflect-nan-attribute/reflect-nan-attribute.tsx
+++ b/test/wdio/reflect-nan-attribute/reflect-nan-attribute.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h } from '@stencil/core';
+import { Component, h, Prop } from '@stencil/core';
 
 @Component({
   tag: 'reflect-nan-attribute',


### PR DESCRIPTION
This just adds this to the `lint` command in `package.json`. Two details:

- I added an entry to `overrides` in `.eslintrc.js` to prevent the `jest/expect-expect` rule from being applied to `test/wdio`. If violations of other jest rules pop up in there too we should turn them off as well.
- It automatically fixed a `let` to `const` and reordered some imports


## What is the current behavior?

No linting!

## What is the new behavior?

Linting!

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

If CI passes we should be good.