### PR TITLE
chore(test): make scoped-basic less flakey

### DIFF
--- a/test/wdio/scoped-basic/cmp.test.tsx
+++ b/test/wdio/scoped-basic/cmp.test.tsx
@@ -25,14 +25,14 @@ describe('scoped-basic', function () {
     await expect(scopedEl).toHaveElementClass(expect.stringContaining('hydrated'));
 
     await expect(scopedEl).toHaveStyle({
-      backgroundColor: browser.isChromium ? 'rgba(0,0,0,1)' : 'rgb(0,0,0)',
+      backgroundColor: browser.isChromium ? 'rgba(0,0,0,1)' : browser.isFirefox ? '' : 'rgb(0,0,0)',
       color: browser.isChromium ? 'rgba(128,128,128,1)' : 'rgb(128,128,128)',
     });
 
     const scopedDiv = await $('scoped-basic div');
     await expect(scopedDiv).toHaveElementClass(expect.stringContaining('sc-scoped-basic'));
     expect(scopedDiv).toHaveStyle({
-      color: browser.isChromium ? 'rgba(255,0,0,1)' : 'rgb(255, 0, 0)',
+      color: browser.isChromium ? 'rgba(255,0,0,1)' : browser.isFirefox ? '' : 'rgb(255, 0, 0)',
     });
 
     const scopedP = await $('scoped-basic p');
@@ -44,7 +44,7 @@ describe('scoped-basic', function () {
     await expect(scopedSlot).toHaveText('light');
 
     await expect(scopedSlot).toHaveStyle({
-      color: browser.isChromium ? 'rgba(255,255,0,1)' : 'rgb(255, 255, 0)',
+      color: browser.isChromium ? 'rgba(255,255,0,1)' : 'rgb(255,255,0)',
     });
   });
 });


### PR DESCRIPTION
This de-flakes things a bit. This test was sometimes not passing on CI in the style assertions where it checks things like `color` and `backgroundColor`, in particular I think because of some differences in how computer styles for these things are set and formatted.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I wasn't seeing this test failure locally, but only on CI when the tests are running in Firefox.

To run the tests locally you can do

```sh
CI=true npm run test.wdio
```
