### PR TITLE
Update stencil-public-runtime.ts

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1816,9 +1816,7 @@ export namespace JSXBase {
     onPointerCancel?: (event: PointerEvent) => void;
     onPointerCancelCapture?: (event: PointerEvent) => void;
     onPointerEnter?: (event: PointerEvent) => void;
-    onPointerEnterCapture?: (event: PointerEvent) => void;
     onPointerLeave?: (event: PointerEvent) => void;
-    onPointerLeaveCapture?: (event: PointerEvent) => void;
     onPointerOver?: (event: PointerEvent) => void;
     onPointerOverCapture?: (event: PointerEvent) => void;
     onPointerOut?: (event: PointerEvent) => void;


### PR DESCRIPTION
Remove `onPointerEnterCapture` and `onPointerLeaveCapture` because of the definition change in 
 `@types/react` https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68984

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: 

https://github.com/ionic-team/ionic-framework/issues/29170

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [&check;] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
