### PR TITLE
chore(lint): add eslint-plugin-wdio, turn on rule for awaiting `expect`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint', 'jsdoc', 'jest', 'simple-import-sort'],
+  plugins: ['@typescript-eslint', 'jsdoc', 'jest', 'simple-import-sort', 'wdio'],
   extends: [
     'plugin:jest/recommended',
     // including prettier here ensures that we don't set any rules which will conflict
@@ -94,6 +94,7 @@ module.exports = {
       files: 'test/wdio/**/*.tsx',
       rules: {
         'jest/expect-expect': 'off',
+        'wdio/await-expect': 'error',
       },
     },
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "eslint-plugin-jest": "^27.0.4",
         "eslint-plugin-jsdoc": "^48.0.0",
         "eslint-plugin-simple-import-sort": "^12.0.0",
+        "eslint-plugin-wdio": "^8.24.12",
         "execa": "8.0.1",
         "exit": "^0.1.2",
         "fs-extra": "^11.0.0",
@@ -5811,6 +5812,15 @@
       "dev": true,
       "peerDependencies": {
         "eslint": ">=5.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-wdio": {
+      "version": "8.24.12",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-wdio/-/eslint-plugin-wdio-8.24.12.tgz",
+      "integrity": "sha512-OmzGteXFOQnJDdkTNnTfksaVa18WlFCyeLjZXHvDpkbomLWAg9wc296Pr0wnTCagqNj8qfEHpy+N2XVew5VCMA==",
+      "dev": true,
+      "engines": {
+        "node": "^16.13 || >=18"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "eslint-plugin-jest": "^27.0.4",
     "eslint-plugin-jsdoc": "^48.0.0",
     "eslint-plugin-simple-import-sort": "^12.0.0",
+    "eslint-plugin-wdio": "^8.24.12",
     "execa": "8.0.1",
     "exit": "^0.1.2",
     "fs-extra": "^11.0.0",

--- a/test/wdio/scoped-basic/cmp.test.tsx
+++ b/test/wdio/scoped-basic/cmp.test.tsx
@@ -31,8 +31,8 @@ describe('scoped-basic', function () {
 
     const scopedDiv = await $('scoped-basic div');
     await expect(scopedDiv).toHaveElementClass(expect.stringContaining('sc-scoped-basic'));
-    expect(scopedDiv).toHaveStyle({
-      color: browser.isChromium ? 'rgba(255,0,0,1)' : browser.isFirefox ? '' : 'rgb(255, 0, 0)',
+    await expect(scopedDiv).toHaveStyle({
+      color: browser.isChromium ? 'rgba(255,0,0,1)' : browser.isFirefox ? 'rgb(255,0,0)' : 'rgb(255, 0, 0)',
     });
 
     const scopedP = await $('scoped-basic p');

--- a/test/wdio/scoped-conditional/cmp.test.tsx
+++ b/test/wdio/scoped-conditional/cmp.test.tsx
@@ -36,19 +36,12 @@ This div will be slotted in
     // toggle the 'Hello' message, which should insert a new <div/> into the DOM & _not_ remove the slotted content
     await $('#toggleHello').click();
     await $('scoped-conditional').waitForStable();
-    const hostDiv = await $('scoped-conditional div');
-    const outerDivChildren = (await browser.execute((el) => el.children, hostDiv)).map((elementReference) =>
-      $(elementReference),
-    );
 
-    expect(outerDivChildren).toBeElementsArrayOfSize(2);
-
-    await expect(outerDivChildren[0]).toHaveText('Hello');
-    await expect(outerDivChildren[1]).toHaveText(
-      `before slot->
-This div will be slotted in
-<-after slot`,
-    );
+    const host = document.body.querySelector('scoped-conditional');
+    const outerDivChildren = host.querySelector('div').childNodes;
+    expect(outerDivChildren.length).toBe(2);
+    expect(outerDivChildren[0].textContent).toBe('Hello');
+    expect(outerDivChildren[1].textContent).toBe(`before slot->This div will be slotted in<-after slot`);
   });
 
   it('renders the slotted content after toggling the twice message', async () => {


### PR DESCRIPTION
This adds `eslint-plugin-wdio` so that we can get some Webdriver-specific linting rules added to our configuration. In particular, we can specify that the `expect` function is prefixed with `await`, ensuring that we don't have dangling promises.

This rule is activated only for files in `test/wdio`.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?

We don't have a linting rule for this and I, in particular, keep forgetting to `await` everything.

## What is the new behavior?

Everything must be awaited!

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

If CI passes we're good.
