### PR TITLE
fix(compiler): Allow OutputTargetCustom to be called on devMode

### DIFF
--- a/src/compiler/output-targets/index.ts
+++ b/src/compiler/output-targets/index.ts
@@ -6,6 +6,7 @@ import { outputCollection } from './dist-collection';
 import { outputCustomElements } from './dist-custom-elements';
 import { outputHydrateScript } from './dist-hydrate-script';
 import { outputLazy } from './dist-lazy/lazy-output';
+import { outputCustom } from './output-custom';
 import { outputDocs } from './output-docs';
 import { outputLazyLoader } from './output-lazy-loader';
 import { outputTypes } from './output-types';
@@ -45,6 +46,7 @@ export const generateOutputTargets = async (
   // since it validates files were created
   await outputDocs(config, compilerCtx, buildCtx);
   await outputTypes(config, compilerCtx, buildCtx);
+  await outputCustom(config, compilerCtx, buildCtx);
 
   timeSpan.finish('generate outputs finished');
 };

--- a/src/compiler/output-targets/output-custom.ts
+++ b/src/compiler/output-targets/output-custom.ts
@@ -1,15 +1,14 @@
 import { catchError, isOutputTargetCustom } from '@utils';
 
 import type * as d from '../../declarations';
+import { generateDocData } from '../docs/generate-doc-data';
 
-export const outputCustom = async (
-  config: d.ValidatedConfig,
-  compilerCtx: d.CompilerCtx,
-  buildCtx: d.BuildCtx,
-  docs: d.JsonDocs,
-  outputTargets: d.OutputTarget[],
-) => {
-  const customOutputTargets = outputTargets.filter(isOutputTargetCustom);
+export const outputCustom = async (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
+  const task = config.devMode ? 'run' : 'build';
+  const docsData = await generateDocData(config, compilerCtx, buildCtx);
+  const customOutputTargets = config.outputTargets
+    .filter(isOutputTargetCustom)
+    .filter((o) => (o.task === undefined ? true : o.task === task));
   if (customOutputTargets.length === 0) {
     return;
   }
@@ -18,7 +17,7 @@ export const outputCustom = async (
     customOutputTargets.map(async (o) => {
       const timespan = buildCtx.createTimeSpan(`generating ${o.name} started`);
       try {
-        await o.generator(config, compilerCtx, buildCtx, docs);
+        await o.generator(config, compilerCtx, buildCtx, docsData);
       } catch (e: any) {
         catchError(buildCtx.diagnostics, e);
       }

--- a/src/compiler/output-targets/output-custom.ts
+++ b/src/compiler/output-targets/output-custom.ts
@@ -4,14 +4,15 @@ import type * as d from '../../declarations';
 import { generateDocData } from '../docs/generate-doc-data';
 
 export const outputCustom = async (config: d.ValidatedConfig, compilerCtx: d.CompilerCtx, buildCtx: d.BuildCtx) => {
-  const task = config.devMode ? 'run' : 'build';
-  const docsData = await generateDocData(config, compilerCtx, buildCtx);
+  const task = config.watch ? 'always' : 'onBuildOnly';
   const customOutputTargets = config.outputTargets
     .filter(isOutputTargetCustom)
-    .filter((o) => (o.task === undefined ? true : o.task === task));
+    .filter((o) => (o.taskShouldRun === undefined ? true : o.taskShouldRun === task));
+
   if (customOutputTargets.length === 0) {
     return;
   }
+  const docsData = await generateDocData(config, compilerCtx, buildCtx);
 
   await Promise.all(
     customOutputTargets.map(async (o) => {

--- a/src/compiler/output-targets/output-docs.ts
+++ b/src/compiler/output-targets/output-docs.ts
@@ -1,5 +1,4 @@
 import {
-  isOutputTargetCustom,
   isOutputTargetDocsCustom,
   isOutputTargetDocsJson,
   isOutputTargetDocsReadme,
@@ -12,7 +11,6 @@ import { generateDocData } from '../docs/generate-doc-data';
 import { generateJsonDocs } from '../docs/json';
 import { generateReadmeDocs } from '../docs/readme';
 import { generateVscodeDocs } from '../docs/vscode';
-import { outputCustom } from './output-custom';
 
 /**
  * Generate documentation-related output targets
@@ -30,7 +28,6 @@ export const outputDocs = async (
   }
   const docsOutputTargets = config.outputTargets.filter(
     (o) =>
-      isOutputTargetCustom(o) ||
       isOutputTargetDocsReadme(o) ||
       isOutputTargetDocsJson(o) ||
       isOutputTargetDocsCustom(o) ||
@@ -51,6 +48,5 @@ export const outputDocs = async (
     generateJsonDocs(config, compilerCtx, docsData, docsOutputTargets),
     generateVscodeDocs(compilerCtx, docsData, docsOutputTargets),
     generateCustomDocs(config, docsData, docsOutputTargets),
-    outputCustom(config, compilerCtx, buildCtx, docsData, docsOutputTargets),
   ]);
 };

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -2241,12 +2241,14 @@ export interface OutputTargetCustom extends OutputTargetBase {
   type: 'custom';
   name: string;
   /**
-   * Indicate in wich mode the output target has to be executed.
-   * By default if nothing is specified it run for both.
-   * - `"run"`: Executed in dev mode on every change in your code
-   * - `"build"`: Executed only on build
+   * Indicate when the output target should be executed.
+   * 
+   * - `"onBuildOnly"`: Executed only when `stencil build` is called without `--watch`.
+   * - `"always"`: Executed on every build, including in `watch` mode.
+   *
+   * Defaults to "always".
    */
-  task?: 'run' | 'build';
+  taskShouldRun?: 'onBuildOnly' | 'always';
   validate?: (config: Config, diagnostics: Diagnostic[]) => void;
   generator: (config: Config, compilerCtx: CompilerCtx, buildCtx: BuildCtx, docs: JsonDocs) => Promise<void>;
   copy?: CopyTask[];

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1,5 +1,6 @@
 import type { ConfigFlags } from '../cli/config-flags';
 import type { PrerenderUrlResults, PrintLine } from '../internal';
+import type { BuildCtx, CompilerCtx } from './stencil-private';
 import type { JsonDocs } from './stencil-public-docs';
 
 export * from './stencil-public-docs';
@@ -2239,8 +2240,15 @@ export interface OutputTargetHydrate extends OutputTargetBase {
 export interface OutputTargetCustom extends OutputTargetBase {
   type: 'custom';
   name: string;
+  /**
+   * Indicate in wich mode the output target has to be executed.
+   * By default if nothing is specified it run for both.
+   * - `"run"`: Executed in dev mode on every change in your code
+   * - `"build"`: Executed only on build
+   */
+  task?: 'run' | 'build';
   validate?: (config: Config, diagnostics: Diagnostic[]) => void;
-  generator: (config: Config, compilerCtx: any, buildCtx: any, docs: any) => Promise<void>;
+  generator: (config: Config, compilerCtx: CompilerCtx, buildCtx: BuildCtx, docs: JsonDocs) => Promise<void>;
   copy?: CopyTask[];
 }
 

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -2242,7 +2242,7 @@ export interface OutputTargetCustom extends OutputTargetBase {
   name: string;
   /**
    * Indicate when the output target should be executed.
-   * 
+   *
    * - `"onBuildOnly"`: Executed only when `stencil build` is called without `--watch`.
    * - `"always"`: Executed on every build, including in `watch` mode.
    *


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #5514


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
In this PR, I've added logic so that OutputTargetCustom can be called in dev mode and not just during build.
OutputTargetCustom can choose when it runs by adding a `task` property to the declaration object.


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Run stencil tests + manual test with npm link
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
