### PR TITLE
chore(repo): group webdriverio + related pkgs in renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -140,6 +140,11 @@
       matchPackagePrefixes: ['@rollup'],
       groupName: 'rollup,'
     },
+    {
+      matchPackageNames: ['expect-webdriverio'],
+      matchPackagePrefixes: ['@wdio'],
+      groupName: 'webdriverio,'
+    },
     // TODO(STENCIL-1088): remove once support for Node v16 is dropped
     {
       matchPackageNames: ['open'],


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

webdriverio packages are going to get bumped separately of one another. after asking christian (see link below in 'new behavior' section), he suggested we group these

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

configure renovate to group all `@wdio/` scoped npm packages and the `expect-webdriverio` package into a single pr when renovate detects version bumps.

the impetus for this work was a comment made during the wdio migration, available [here](https://github.com/ionic-team/stencil/pull/5498#discussion_r1528771603)



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

1. Ran `npm i -g renovate && renovate-config-validator` locally to verify no syntax errors
2. This matches the setup of our rollup config, so it _should_ work 🤞 
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
STENCIL-1191