### PR TITLE
chore(test): remove FF and Egde from the browser matrix

### DIFF
--- a/test/karma/karma.config.js
+++ b/test/karma/karma.config.js
@@ -16,18 +16,18 @@ const browserStackLaunchers = {
     os: 'Windows',
     os_version: '10',
   },
-  bs_firefox: {
-    base: 'BrowserStack',
-    browser: 'firefox',
-    os: 'Windows',
-    os_version: '10',
-  },
-  bs_edge: {
-    base: 'BrowserStack',
-    browser: 'edge',
-    os: 'Windows',
-    os_version: '10',
-  },
+  // bs_firefox: {
+  //   base: 'BrowserStack',
+  //   browser: 'firefox',
+  //   os: 'Windows',
+  //   os_version: '10',
+  // },
+  // bs_edge: {
+  //   base: 'BrowserStack',
+  //   browser: 'edge',
+  //   os: 'Windows',
+  //   os_version: '10',
+  // },
   // bs_ie: {
   //   base: 'BrowserStack',
   //   browser: 'ie',


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
We have seen BS/Karma test failing increasingly for no particular reason. I looked into these failures and they seem to be mostly caused by Firefox and Edge.

## What is the new behavior?
In order to not get blocked on these flaky tests I removed these browser from the matrix to get the last test PR merged faster.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
