### PR TITLE
chore(wdio): expand wdio-related readme content

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -65,6 +65,16 @@ Those are handled by a [separate workflow](#browserstack-browserstackyml).
 
 This workflow is responsible for running the Stencil unit testing suite.
 
+### WebdriverIO Tests (`test-wdio.yml`)
+
+This workflow runs our integration tests which assert that various Stencil
+features work correctly when components using them are built and then rendered
+in actual browsers. We run these tests using
+[WebdriverIO](https://webdriver.io/) against Firefox, Chrome, and Edge.
+
+For more information on how those tests are set up please see the [WebdriverIO
+test README](../../test/wdio/README.md).
+
 ### Design
 
 #### Overview

--- a/test/wdio/README.md
+++ b/test/wdio/README.md
@@ -1,6 +1,7 @@
 # WebdriverIO Component Tests
 
-This directory contains a set of Stencil component tests that verify various scenarios where user interaction or rendering of a component is included.
+This directory contains a set of Stencil component tests that verify various
+scenarios involving user interaction or rendering of a component.
 
 The following scripts are available:
 
@@ -27,7 +28,45 @@ This allows to make changes to the test and have it re-run automatically. If you
 
 All components have to be compiled into a lazy-loaded Stencil component before executing the WebdriverIO test. WebdriverIO runs a set-up script (see `test/wdio/setup.ts`) to register all compiled custom components and have them available in your test. No additional imports are required.
 
-## Writing Test
+## Creating a new Test Suite
+
+WebdriverIO tests live in subdirectories within `test/wdio` alongside the
+components that they test. This keeps everything colocated and tidy!
+
+To start a new test suite, first create a new, descriptively-named directory:
+
+```sh
+mkdir test/wdio/my-excellent-new-test-suite
+```
+
+These are descriptively named, with a title that is either a noun or verb that
+succinctly describes the test (`svg-class`, `slot-nested-order`,
+`slot-hide-content`, etc).
+
+After you've got a directory to work with, create a new Stencil component in
+that directory which is a minimal example of the behavior you're trying to
+test. The convention is to write this to a file called `cmp.tsx` within your
+directory. You can set the tag name and component class name to whatever you
+like, but try to ensure that your naming is relevant to what is being tested
+(prefer `<slot-relocation>` over `<my-test-component-2>`).
+
+> [!IMPORTANT]
+> Your new component must have a unique tag name that does not collide with
+> another component's tag name!
+
+You'll want to also create a new test file in that same directory. Your file
+must end with `.test.tsx`. The convention is to take the filename used for the
+test suite's main component and change the extension, so if our component was
+saved in `cmp.tsx` we'd put our tests in `cmp.test.tsx`.
+
+Once you've created your component and test file proceed to write some tests!
+
+> [!NOTE]
+> You'll need to run `npm run build` in `test/wdio` in order for your component
+> to be available in tests. If you run WebdriverIO tests from the root of the
+> project using `npm run test.wdio` this will be run automatically.
+
+## Writing Tests
 
 To render a given component, use the `render` helper method from `@wdio/browser-runner/stencil`, e.g.:
 


### PR DESCRIPTION
this change:

- adds an entry to the README in `.github/workflows` which briefly describes what the webdriverio workflow does
- adds a section to `test/wdio/README.md` which outlines how to create a new test suite from scratch

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
