### PR TITLE
test(wdio): make svg-attr test more robust

### DIFF
--- a/test/wdio/svg-attr/cmp.test.tsx
+++ b/test/wdio/svg-attr/cmp.test.tsx
@@ -16,7 +16,7 @@ describe('svg attr', () => {
 
     await $('button').click();
     rect = app.querySelector('rect');
-    expect(rect.getAttribute('transform')).toBe('rotate(45 27 27)');
+    await expect(rect).toHaveAttribute('transform', 'rotate(45 27 27)');
 
     await $('button').click();
     rect = app.querySelector('rect');


### PR DESCRIPTION
I've noticed an intermittent failure of the `svg-attr` webdriver test suite that looks like this:

```
Expected: null
Received: "rotate(45 27 27)"
[chrome-headless-shell 123.0.6312.58 linux #0-0] Error: expect(received).toBe(expected) // Object.is equality
[chrome-headless-shell 123.0.6312.58 linux #0-0]
[chrome-headless-shell 123.0.6312.58 linux #0-0] Expected: null
[chrome-headless-shell 123.0.6312.58 linux #0-0] Received: "rotate(45 27 27)"
[chrome-headless-shell 123.0.6312.58 linux #0-0]     at Context.<anonymous> (http://localhost:36575/home/runner/work/stencil/stencil/test/wdio/svg-attr/cmp.test.tsx:24:44)
```

The test looks like this on `main`:

https://github.com/ionic-team/stencil/blob/b62c28dbc275c8a9692b2427f9503d2eccff3adc/test/wdio/svg-attr/cmp.test.tsx#L17-L19

This PR changes the `expect` like to use the async matcher, which seems to be more reliable. I've re-run the tests on CI and locally a bunch with this change and I haven't gotten it to fail yet.


## What is the current behavior?

This test fails intermittently, like for instance here: https://github.com/ionic-team/stencil/actions/runs/8481871588/job/23240094371


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

If CI is passing and this looks legit then we're good.
