### PR TITLE
fix(runtime): prevent ref callbacks from being called too early

### DIFF
--- a/src/runtime/vdom/update-element.ts
+++ b/src/runtime/vdom/update-element.ts
@@ -23,7 +23,7 @@ export const updateElement = (
 
   if (BUILD.updatable) {
     // remove attributes no longer present on the vnode by setting them to undefined
-    for (memberName in oldVnodeAttrs) {
+    for (memberName of sortedAttrNames(Object.keys(oldVnodeAttrs))) {
       if (!(memberName in newVnodeAttrs)) {
         setAccessor(elm, memberName, oldVnodeAttrs[memberName], undefined, isSvgMode, newVnode.$flags$);
       }
@@ -31,7 +31,26 @@ export const updateElement = (
   }
 
   // add new & update changed attributes
-  for (memberName in newVnodeAttrs) {
+  for (memberName of sortedAttrNames(Object.keys(newVnodeAttrs))) {
     setAccessor(elm, memberName, oldVnodeAttrs[memberName], newVnodeAttrs[memberName], isSvgMode, newVnode.$flags$);
   }
 };
+
+/**
+ * Sort a list of attribute names to ensure that all the attribute names which
+ * are _not_ `"ref"` come before `"ref"`. Preserve the order of the non-ref
+ * attributes.
+ *
+ * **Note**: if the supplied attributes do not include `'ref'` then the same
+ * (by reference) array will be returned without modification.
+ *
+ * @param attrNames attribute names to sort
+ * @returns a list of attribute names, sorted if they include `"ref"`
+ */
+function sortedAttrNames(attrNames: string[]): string[] {
+  return attrNames.includes('ref')
+    ? // we need to sort these to ensure that `'ref'` is the last attr
+      [...attrNames.filter((attr) => attr !== 'ref'), 'ref']
+    : // no need to sort, return the original array
+      attrNames;
+}

--- a/test/wdio/ref-attr-order/cmp.test.tsx
+++ b/test/wdio/ref-attr-order/cmp.test.tsx
@@ -1,0 +1,16 @@
+import { h } from '@stencil/core';
+import { render } from '@wdio/browser-runner/stencil';
+
+describe('ref-attr-order', () => {
+  beforeEach(() => {
+    render({
+      template: () => <ref-attr-order></ref-attr-order>,
+    });
+  });
+
+  it('should call the `ref` callback after handling other attrs', async () => {
+    const cmp = await $('ref-attr-order');
+    await cmp.waitForStable();
+    await expect(cmp).toHaveText('my tabIndex: 0');
+  });
+});

--- a/test/wdio/ref-attr-order/cmp.tsx
+++ b/test/wdio/ref-attr-order/cmp.tsx
@@ -1,0 +1,28 @@
+import { Component, h, State } from '@stencil/core';
+
+@Component({
+  tag: 'ref-attr-order',
+  shadow: true,
+})
+export class RefAttrOrder {
+  @State() index: number = -1;
+
+  // order matters for the attributes in the test below!
+  //
+  // this is testing that even though the `ref` attribute is declared first in
+  // the JSX for the `div` the `ref` callback will nonetheless be called after
+  // the `tabIndex` attribute is applied to the element.
+  // See https://github.com/ionic-team/stencil/issues/4074
+  render() {
+    return (
+      <div
+        ref={(el) => {
+          this.index = el.tabIndex;
+        }}
+        tabIndex={0}
+      >
+        my tabIndex: {this.index}
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
Sort attribute names before calling `setAccessor` with their changed values in order to ensure that the `ref` attribute is handled by `setAccessor` after all other attributes have been handled. This prevents the execution order for `ref` callbacks from being dependency on the order in which attributes are declared in the JSX.

STENCIL-737
fixes #4074

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?

At present `ref` callbacks are, like other attributes, handled in declaration-order, i.e. they are called based on the order in which they are declared in the JSX for a component.

This means that in a component like this:

```tsx
import { Component, h, State } from '@stencil/core';

@Component({
  tag: 'ref-attr-order',
  shadow: true,
})
export class RefAttrOrder {
  render() {
    return (
      <div
        ref={(el) => {
          console.log(el.tabIndex);
        }}
        tabIndex={0}
      >
        my tabIndex: {this.index}
      </div>
    );
  }
}
```

The `tabIndex` attribute won't be set on the element when the `ref` is called. This leads to unexpected behavior when trying to get a reference to an element. There is a workaround, namely ensuring that the `ref` is the last attribute declared in the JSX, but we can do better by sorting the attributes when we're updating them to ensure that we handle `ref` after the others.


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Not in my view, rather this fixes a bug (#4074).

## Testing

I added a webdriverio regression test and confirmed that the test fails without the fix. I also built and then installed this in Framework, where it didn't cause any test failures.
