### PR TITLE
chore(build): remove obsolete rollup code

### DIFF
--- a/scripts/bundles/sys-node.ts
+++ b/scripts/bundles/sys-node.ts
@@ -108,22 +108,7 @@ export async function sysNodeExternalBundles(opts: BuildOptions) {
     bundleExternal(opts, opts.output.sysNodeDir, cachedDir, 'graceful-fs.js'),
     bundleExternal(opts, opts.output.sysNodeDir, cachedDir, 'node-fetch.js'),
     bundleExternal(opts, opts.output.sysNodeDir, cachedDir, 'prompts.js'),
-    // TODO(STENCIL-1052): remove next two entries once Rollup -> esbuild migration is complete
-    bundleExternal(opts, opts.output.devServerDir, cachedDir, 'open-in-editor-api.js'),
-    bundleExternal(opts, opts.output.devServerDir, cachedDir, 'ws.js'),
   ]);
-
-  // open-in-editor's visualstudio.vbs file
-  // TODO(STENCIL-1052): remove once Rollup -> esbuild migration is complete
-  const visualstudioVbsSrc = join(opts.nodeModulesDir, 'open-in-editor', 'lib', 'editors', 'visualstudio.vbs');
-  const visualstudioVbsDesc = join(opts.output.devServerDir, 'visualstudio.vbs');
-  await fs.copy(visualstudioVbsSrc, visualstudioVbsDesc);
-
-  // copy open's xdg-open file
-  // TODO(STENCIL-1052): remove once Rollup -> esbuild migration is complete
-  const xdgOpenSrcPath = join(opts.nodeModulesDir, 'open', 'xdg-open');
-  const xdgOpenDestPath = join(opts.output.devServerDir, 'xdg-open');
-  await fs.copy(xdgOpenSrcPath, xdgOpenDestPath);
 }
 
 export function bundleExternal(opts: BuildOptions, outputDir: string, cachedDir: string, entryFileName: string) {


### PR DESCRIPTION
## What is the current behavior?
We have some duplicated code for creating build files in rollup. This is the first PR of many to remove these obsolete artifacts.

## What is the new behavior?
Don't bundle these dev server assets anymore as have migrated this to Rollup.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
