### PR TITLE
fix(compiler): don't mistake aliased paths for collections imports

### DIFF
--- a/src/compiler/transformers/collections/add-external-import.ts
+++ b/src/compiler/transformers/collections/add-external-import.ts
@@ -1,4 +1,4 @@
-import { isString, parsePackageJson } from '@utils';
+import { isString, normalizePath, parsePackageJson } from '@utils';
 import { dirname } from 'path';
 
 import type * as d from '../../../declarations';
@@ -38,7 +38,9 @@ export const addExternalImport = (
     pkgJsonFilePath = realPkgJsonFilePath.path;
   }
 
-  if (pkgJsonFilePath === config.packageJsonFilePath) {
+  // realpathSync may return a path that uses Windows path separators ('\').
+  // normalize it for the purposes of this comparison
+  if (normalizePath(pkgJsonFilePath) === config.packageJsonFilePath) {
     // same package silly!
     return;
   }


### PR DESCRIPTION



<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
See 'new behavior`
GitHub Issue Number: #2319 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit fixes an issue where stencil builds that followed a successful build  would result in the following error:
```
[ ERROR ]  Component Tag Name "my-component" Must Be Unique
           Please update the components so "my-component" is only used once:
           ./src/components/my-component/my-component.tsx ./dist/collection/components/my-component/my-component.js
```

this issue manifested on windows machines when building the ionic framework after a successful build. we were able reproduce this with a minimal stencil-component-starter that included the following in its `tsconfig.json`:
```json
{
    paths: {
        "@utils/*": ["src/utils/*"]
    }
}
```

the import alias would be used as such:
```ts
// src/utils/helpers.ts
export const foo = () => console.log('hello');

// src/utils/other-file.ts
import { foo } from '@utils/helpers';

export const bar = () => { foo(); }
```

where in the example above, `helpers.ts` is imported by `other-file.ts`, and resolved via the `@utils/*` path alias. note that neither of these files needed to be imported into a stencil component in order for the error to be replicated - they just need to sit in the `src` directory of the project.

the reason the project would fail to compile is that the first build would create a `dist/collections` directory, as the `dist` output target would synthetically inject (automatically decide the project should also have) the collections output target in its output. on the second compilation, stencil would attempt to reconcile `@utils/helpers` as a collections output, and inadvertantly pull in `dist/collections/*` into the build context. this caused previously compiled versions of any components to be recommpiled.

when stencil tried to check for html tag uniqueness, it would detect multiples components with the same tag, with the previously mentioned
 error:
```
[ ERROR ]  Component Tag Name "my-component" Must Be Unique
           Please update the components so "my-component" is only used once:
           ./src/components/my-component/my-component.tsx ./dist/collection/components/my-component/my-component.js
```


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->
N/A
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

**Note: This requires a Windows machine**

Clone the following repo: https://github.com/liamdebeasi/blank-stencil-repro/tree/windows-name-alias

Steps to reproduce:

1. Make sure you are on the `windows-name-alias` branch
2. Run `npm install` to install dependencies
3. Run `npm run build`
4. Run `npm run start`. Observe that the reported error appears.
5. Run `npm i @stencil/core@4.14.0-dev.1712175610.74a443e`
3. Run `npm run build`
4. Run `npm run start`. Observe that the reported error no longer appears.
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
STENCIL-1252