### PR TITLE
chore(build): port d.ts bundling for mock-doc from rollup to esbuild

### DIFF
--- a/scripts/bundles/mock-doc.ts
+++ b/scripts/bundles/mock-doc.ts
@@ -68,7 +68,7 @@ return exports;
 })({});
 `.trim();
 
-async function bundleMockDocDts(inputDir: string, outputDir: string) {
+export async function bundleMockDocDts(inputDir: string, outputDir: string) {
   // only reason we can do this is because we already know the shape
   // of mock-doc's dts files and how we want them to come together
   const srcDtsFiles = (await fs.readdir(inputDir)).filter((f) => {

--- a/scripts/esbuild/mock-doc.ts
+++ b/scripts/esbuild/mock-doc.ts
@@ -2,9 +2,9 @@ import type { BuildOptions as ESBuildOptions } from 'esbuild';
 import fs from 'fs-extra';
 import { join } from 'path';
 
+import { bundleMockDocDts } from '../bundles/mock-doc';
 import { bundleParse5 } from '../bundles/plugins/parse5-plugin';
 import { getBanner } from '../utils/banner';
-import { bundleDts } from '../utils/bundle-dts';
 import { BuildOptions, createReplaceData } from '../utils/options';
 import { writePkgJson } from '../utils/write-pkg-json';
 import { getBaseEsbuildOptions, getEsbuildAliases, runBuilds } from './util';
@@ -23,8 +23,7 @@ export async function buildMockDoc(opts: BuildOptions) {
   // clear out rollup stuff and ensure directory exists
   await fs.emptyDir(outputDir);
 
-  // bundle d.ts
-  await bundleMockDocDts(opts, inputDir, outputDir);
+  await bundleMockDocDts(inputDir, outputDir);
 
   writePkgJson(opts, outputDir, {
     name: '@stencil/core/mock-doc',
@@ -70,22 +69,4 @@ export async function buildMockDoc(opts: BuildOptions) {
   };
 
   return runBuilds([esmOptions, cjsOptions], opts);
-}
-
-async function bundleMockDocDts(opts: BuildOptions, inputDir: string, outputDir: string) {
-  const bundled = await bundleDts(
-    opts,
-    join(inputDir, 'index.ts'),
-    {
-      // we want to suppress the `dts-bundle-generator` banner here because we do
-      // our own later on
-      noBanner: true,
-      // we also don't want the types which are inlined into our bundled file to
-      // be re-exported, which will change the 'surface' of the module
-      exportReferencedTypes: false,
-    },
-    false,
-  );
-
-  await fs.writeFile(join(outputDir, 'index.d.ts'), bundled);
 }


### PR DESCRIPTION
In #5012 when we put together a script to build `mock-doc/` with Esbuild we refactored a custom, hand-built `.d.ts` bundler that was used in the Rollup build to instead use `dts-bundle-generator`, a library that we depend on elsewhere. Although in theory a better option for avoiding NIH syndrome the output is just too different, so we want to switch to using the old rollup approach in our new, Esbuild-based build script for `mock-doc/`.

To accomplish this we can just export the existing function from the Rollup script and then call it in the Esbuild script.

STENCIL-1246

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

To test this you can do the following:

```sh
# build Stencil with Rollup
npm run build.rollup
# copy mock-doc/index.d.ts
cp mock-doc/index.d.ts /tmp/rollup-mock-dock-index.d.ts
# build with esbuild
npm run build
# copy again!
co mock-doc/index.d.ts /tmp/esbuild-mock-doc-index.d.ts
```

then diff those two files however you like. For instance if you have the excellent [`delta`](https://github.com/dandavison/delta) installed on your system you can do

```sh
delta /tmp/rollup-mock-dock-index.d.ts /tmp/esbuild-mock-doc-index.d.ts
```

they should be the exact same now.
