### PR TITLE
chore(esbuild): rm inline graceful-fs in dev-server

### DIFF
--- a/scripts/esbuild/dev-server.ts
+++ b/scripts/esbuild/dev-server.ts
@@ -70,9 +70,17 @@ export async function buildDevServer(opts: BuildOptions) {
     bundleExternal(opts, opts.output.devServerDir, cachedDir, 'open-in-editor-api.js'),
   ]);
 
-  const devServerAliases = getEsbuildAliases();
-  const external = [...builtinModules, './ws.js', './open-in-editor-api'];
+  const external = [
+    ...builtinModules,
+    // ws.js is externally bundled
+    './ws.js',
+    // open-in-editor-api is externally bundled
+    './open-in-editor-api',
+    // prevent graceful-fs from being inlined in the bundle, saving us ~20kb
+    'graceful-fs',
+  ];
 
+  const devServerAliases = getEsbuildAliases();
   const devServerIndexEsbuildOptions = {
     ...getBaseEsbuildOptions(),
     alias: devServerAliases,

--- a/scripts/esbuild/util.ts
+++ b/scripts/esbuild/util.ts
@@ -30,7 +30,6 @@ export function getEsbuildAliases(): Record<string, string> {
     // reference the same file
     prompts: './sys/node/prompts.js',
     glob: './sys/node/glob.js',
-    'graceful-fs': './sys/node/graceful-fs.js',
 
     // dev server related aliases
     ws: './ws.js',


### PR DESCRIPTION
update the building of the dev-server such that we no longer inline graceful-fs in the dev-server. this saves us approximately 10kb in total - 20kb get removed from dev-server/server-process.js, and 10kb are added to `sys/node/index.ts`.

this is accomplished by removing graceful-fs from the shared alias list, as it's only needed in `sys` and `dev-server`. we them mark the library as "external" so that esbuild resolves to the version held on to by the `sys` submodule

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
