### PR TITLE
chore(repo): fix test.prod package.json script

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test.jest": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js",
     "test.wdio": "cd test/wdio && npm ci && npm run test",
     "test.wdio.testOnly": "cd test/wdio && npm ci && npm run wdio",
-    "test.prod": "npm run test.dist && npm run test.end-to-end && npm run test.jest && npm run test.wdio && npm run test.sys.node && npm run test.testing && npm run test.analysis",
+    "test.prod": "npm run test.dist && npm run test.end-to-end && npm run test.jest && npm run test.wdio && npm run test.testing && npm run test.analysis",
     "test.testing": "node scripts/test/validate-testing.js",
     "test.watch": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --watch",
     "test.watch-all": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --watchAll --coverage",


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`npm run test.prod` fails due to the missing `test.sys.node` command in `package.json`. We removed this in #3332 and never caught this 😬 (just goes to show how often I actually run this command these days 🙃) 

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

fix the `test.prod` npm script, which attempts to run the `test.sys.node` command, which was removed in #3332


## Documentation
N/A
<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

`npm run test.prod` runs locally again 🎉 
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
