### PR TITLE
fix(testing): prevent `find` from throwing error when query has no match

### DIFF
--- a/src/testing/puppeteer/puppeteer-element.ts
+++ b/src/testing/puppeteer/puppeteer-element.ts
@@ -549,6 +549,11 @@ export async function find(page: pd.E2EPageInternal, rootHandle: puppeteer.Eleme
 
   if (typeof selector === 'string' && selector.includes('>>>')) {
     const handle = await page.$(selector);
+
+    if (!handle) {
+      return null;
+    }
+
     const elm = new E2EElement(page, handle);
     await elm.e2eSync();
     return elm;

--- a/test/end-to-end/src/components.d.ts
+++ b/test/end-to-end/src/components.d.ts
@@ -36,6 +36,8 @@ export namespace Components {
     }
     interface ElementCmp {
     }
+    interface EmptyCmp {
+    }
     interface EnvData {
     }
     interface EventCmp {
@@ -187,6 +189,12 @@ declare global {
         prototype: HTMLElementCmpElement;
         new (): HTMLElementCmpElement;
     };
+    interface HTMLEmptyCmpElement extends Components.EmptyCmp, HTMLStencilElement {
+    }
+    var HTMLEmptyCmpElement: {
+        prototype: HTMLEmptyCmpElement;
+        new (): HTMLEmptyCmpElement;
+    };
     interface HTMLEnvDataElement extends Components.EnvData, HTMLStencilElement {
     }
     var HTMLEnvDataElement: {
@@ -284,6 +292,7 @@ declare global {
         "dom-interaction": HTMLDomInteractionElement;
         "dom-visible": HTMLDomVisibleElement;
         "element-cmp": HTMLElementCmpElement;
+        "empty-cmp": HTMLEmptyCmpElement;
         "env-data": HTMLEnvDataElement;
         "event-cmp": HTMLEventCmpElement;
         "import-assets": HTMLImportAssetsElement;
@@ -327,6 +336,8 @@ declare namespace LocalJSX {
     interface DomVisible {
     }
     interface ElementCmp {
+    }
+    interface EmptyCmp {
     }
     interface EnvData {
     }
@@ -376,6 +387,7 @@ declare namespace LocalJSX {
         "dom-interaction": DomInteraction;
         "dom-visible": DomVisible;
         "element-cmp": ElementCmp;
+        "empty-cmp": EmptyCmp;
         "env-data": EnvData;
         "event-cmp": EventCmp;
         "import-assets": ImportAssets;
@@ -408,6 +420,7 @@ declare module "@stencil/core" {
             "dom-interaction": LocalJSX.DomInteraction & JSXBase.HTMLAttributes<HTMLDomInteractionElement>;
             "dom-visible": LocalJSX.DomVisible & JSXBase.HTMLAttributes<HTMLDomVisibleElement>;
             "element-cmp": LocalJSX.ElementCmp & JSXBase.HTMLAttributes<HTMLElementCmpElement>;
+            "empty-cmp": LocalJSX.EmptyCmp & JSXBase.HTMLAttributes<HTMLEmptyCmpElement>;
             "env-data": LocalJSX.EnvData & JSXBase.HTMLAttributes<HTMLEnvDataElement>;
             "event-cmp": LocalJSX.EventCmp & JSXBase.HTMLAttributes<HTMLEventCmpElement>;
             "import-assets": LocalJSX.ImportAssets & JSXBase.HTMLAttributes<HTMLImportAssetsElement>;

--- a/test/end-to-end/src/non-existent-element/empty-cmp.tsx
+++ b/test/end-to-end/src/non-existent-element/empty-cmp.tsx
@@ -1,0 +1,11 @@
+import { Component, h, Host } from '@stencil/core';
+
+@Component({
+  tag: 'empty-cmp',
+  shadow: true,
+})
+export class EmptyComponent {
+  render() {
+    return <Host>I have no children!</Host>;
+  }
+}

--- a/test/end-to-end/src/non-existent-element/non-existent-element.e2e.ts
+++ b/test/end-to-end/src/non-existent-element/non-existent-element.e2e.ts
@@ -1,0 +1,27 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('Querying non-existent element(s)', () => {
+  it('returns `null` if the element does not exist', async () => {
+    // create a new puppeteer page
+    const page = await newE2EPage({
+      html: `
+        <empty-cmp></empty-cmp>
+      `,
+    });
+
+    const elm = await page.find('empty-cmp >>> .non-existent');
+    expect(elm).toBeNull();
+  });
+
+  it('returns an empty array if no elements match the selector', async () => {
+    // create a new puppeteer page
+    const page = await newE2EPage({
+      html: `
+        <empty-cmp></empty-cmp>
+      `,
+    });
+
+    const elm = await page.findAll('empty-cmp >>> .non-existent');
+    expect(elm).toBe([]);
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

An error will get thrown when using `page.find()` for Puppeteer e2e tests if a query returns no elements.

Fixes: #5639


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This commit fixes an issue w/ our Puppeteer testing implementation where the `find()` method would throw an error if the query had no matching elements.

We do not need to make any changes to `findAll` since the logic there will only attempt to use any returned handles if they exist in an array. Otherwise, no entries will be pushed to the returned array so the result will be an empty array as expected.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Tested changes in the linked issue reproduction case.

Also added tests to our e2e suite so we can avoid regressions related to these functions moving forward.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
