### PR TITLE
feat(dev-server): dark mode support

### DIFF
--- a/src/dev-server/templates/directory-index.html
+++ b/src/dev-server/templates/directory-index.html
@@ -9,6 +9,9 @@
       * {
         box-sizing: border-box;
       }
+      html {
+        color-scheme: light dark;
+      }
       body {
         padding: 40px 140px;
         margin: 0;
@@ -43,7 +46,9 @@
         padding: 0;
       }
       li a {
-        display: inline-block;
+        display: flex;
+        align-items: center;
+        gap: 6px;
         margin: 0;
         padding: 6px 12px;
         min-width: 50%;
@@ -53,22 +58,28 @@
       }
       li a:focus,
       li a:hover {
+        color: #555;
         background: rgba(221, 235, 255, 0.65);
       }
       .icon {
         display: inline-block;
-        width: 20px;
+        width: 14px;
         min-height: 14px;
         opacity: 0.6;
-        background-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-repeat: no-repeat;
       }
       .directory .icon {
-        background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48cGF0aCBkPSJNMjEzLjMzOCA5Nkg3NC42NjZDNTEuMTk3IDk2IDMyIDExNS4xOTggMzIgMTM4LjY2N3YyMzQuNjY2QzMyIDM5Ni44MDIgNTEuMTk3IDQxNiA3NC42NjYgNDE2aDM2Mi42NjhDNDYwLjgwMyA0MTYgNDgwIDM5Ni44MDIgNDgwIDM3My4zMzNWMTg2LjY2N0M0ODAgMTYzLjE5OCA0NjAuODAzIDE0NCA0MzcuMzM0IDE0NEgyNTYuMDA2bC00Mi42NjgtNDh6Ii8+PC9zdmc+);
+        mask-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48cGF0aCBkPSJNMjEzLjMzOCA5Nkg3NC42NjZDNTEuMTk3IDk2IDMyIDExNS4xOTggMzIgMTM4LjY2N3YyMzQuNjY2QzMyIDM5Ni44MDIgNTEuMTk3IDQxNiA3NC42NjYgNDE2aDM2Mi42NjhDNDYwLjgwMyA0MTYgNDgwIDM5Ni44MDIgNDgwIDM3My4zMzNWMTg2LjY2N0M0ODAgMTYzLjE5OCA0NjAuODAzIDE0NCA0MzcuMzM0IDE0NEgyNTYuMDA2bC00Mi42NjgtNDh6Ii8+PC9zdmc+);
+        -webkit-mask-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48cGF0aCBkPSJNMjEzLjMzOCA5Nkg3NC42NjZDNTEuMTk3IDk2IDMyIDExNS4xOTggMzIgMTM4LjY2N3YyMzQuNjY2QzMyIDM5Ni44MDIgNTEuMTk3IDQxNiA3NC42NjYgNDE2aDM2Mi42NjhDNDYwLjgwMyA0MTYgNDgwIDM5Ni44MDIgNDgwIDM3My4zMzNWMTg2LjY2N0M0ODAgMTYzLjE5OCA0NjAuODAzIDE0NCA0MzcuMzM0IDE0NEgyNTYuMDA2bC00Mi42NjgtNDh6Ii8+PC9zdmc+);
         background-position: 0px 2px;
+        background-color: currentColor;
       }
       .file .icon {
-        background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48cGF0aCBkPSJNMjg4IDQ4SDEzNmMtMjIuMDkyIDAtNDAgMTcuOTA4LTQwIDQwdjMzNmMwIDIyLjA5MiAxNy45MDggNDAgNDAgNDBoMjQwYzIyLjA5MiAwIDQwLTE3LjkwOCA0MC00MFYxNzZMMjg4IDQ4em0tMTYgMTQ0VjgwbDExMiAxMTJIMjcyeiIvPjwvc3ZnPg==);
+        mask-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48cGF0aCBkPSJNMjg4IDQ4SDEzNmMtMjIuMDkyIDAtNDAgMTcuOTA4LTQwIDQwdjMzNmMwIDIyLjA5MiAxNy45MDggNDAgNDAgNDBoMjQwYzIyLjA5MiAwIDQwLTE3LjkwOCA0MC00MFYxNzZMMjg4IDQ4em0tMTYgMTQ0VjgwbDExMiAxMTJIMjcyeiIvPjwvc3ZnPg==);
+        -webkit-mask-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48cGF0aCBkPSJNMjg4IDQ4SDEzNmMtMjIuMDkyIDAtNDAgMTcuOTA4LTQwIDQwdjMzNmMwIDIyLjA5MiAxNy45MDggNDAgNDAgNDBoMjQwYzIyLjA5MiAwIDQwLTE3LjkwOCA0MC00MFYxNzZMMjg4IDQ4em0tMTYgMTQ0VjgwbDExMiAxMTJIMjcyeiIvPjwvc3ZnPg==);
         background-position: 0px 2px;
+        background-color: currentColor;
       }
       li a:hover .icon {
         opacity: 1;
@@ -107,16 +118,49 @@
           background: #e0e0e0;
         }
         li a {
-          display: block;
+          display: flex;
           border-radius: 0;
           padding: 15px 10px;
         }
         .icon {
-          width: 32px;
+          width: 24px;
+          min-width: 24px;
           min-height: 24px;
         }
         .directory .icon {
           background-position: 0px 4px;
+        }
+      }
+
+      @media (prefers-color-scheme: dark) { 
+        body {
+          background: #000;
+        }
+        h1 {
+          color: #eaeaea;
+        }
+        a {
+          color: #ccc;
+        }
+        a:hover {
+          color: #eaeaea;
+        }
+        li a:focus,
+        li a:hover {
+          color: #ccc;
+          background: #1c1c1c;
+        }
+      }
+
+      @media (max-width: 768px) and (prefers-color-scheme: dark) {
+        ul {
+          border-top: 1px solid #333;
+        }
+        li {
+          border-bottom: 1px solid #333;
+        }
+        li:nth-child(odd) {
+          background: #333;
         }
       }
     </style>

--- a/src/dev-server/templates/initial-load.html
+++ b/src/dev-server/templates/initial-load.html
@@ -25,6 +25,9 @@
     * {
       box-sizing: border-box;
     }
+    html {
+      color-scheme: dark light;
+    }
     body {
       position: absolute;
       padding: 0;
@@ -41,7 +44,7 @@
       margin: auto;
       max-width: 700px;
       border-radius: 3px;
-      background: rgba(0,0,0,.9);
+      background: rgba(0, 0, 0, .9);
       -webkit-transform: translate3d(0px, -60px, 0px);
       transform: translate3d(0px, -60px, 0px);
       -webkit-transition: -webkit-transform 75ms ease-out;
@@ -122,8 +125,13 @@
       margin: auto;
       max-width: 700px;
       padding: 32px;
-      color: #5a5a5a;
       line-height: 1.5;
+    }
+
+    @media (prefers-color-scheme: dark) { 
+      .toast {
+        background: rgb(49, 49, 49, .9);
+      }
     }
   </style>
 </head>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Late at night when I am tippy tapping on my keyboard while working with my favorite web component compiler and in the safety of my dark mode color scheme, Stencil's dev server will open and blind my soul with the eternal brightness of its light theme. 

GitHub Issue Number: Resolves #5643


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Adds dark mode support to the dev server launcher and directory pages based on the system preferences. 

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

1. Work until late at night (this is important) with auto color scheme or manually set it to dark mode.
2. Launch Stencil's dev server.
2.5. Put on sunglasses. Solar eclipse glass will also work, get your money's worth out of them.
3. Observe: Stencil's super bright dev server. Don't stare too long though. 
4. Apply the changes from this PR.
4.5. Remove sunglasses.
5. Observe: Stencil super beautiful dark mode support.
6. Build amazing things.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
