### PR TITLE
chore(build): remove sourcemaps, minified compiler build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ dist/
 /screenshot/index.js.map
 /screenshot/package.json
 /screenshot/pixel-match.js
+/screenshot/pixel-match.js.map
 /screenshot/*.d.ts
 
 test/**/www/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,17 @@ stuck, your debugger may not have switched to a worker process that has halted o
 avoid this altogether by setting `--max-workers=1` when you launch Stencil (with the possibility of not being able to
 reproduce timing issues between workers as a side effect).
 
+> [!NOTE]
+> If you want to have access to sourcemaps when debugging the compiler locally
+> you can run the `build` script in `package.json` with the `DEBUG` environment
+> variable set to `true` like so:
+>
+> ```sh
+> DEBUG=true npm run build
+> ```
+>
+> this will write a `.js.map` file to disk next to each JavaScript file.
+
 #### Debugging the Compiler in VSCode
 
 Two launch configurations for debugging the compiler can be found in the `.vscode/launch.json` configuration found in

--- a/scripts/esbuild/cli.ts
+++ b/scripts/esbuild/cli.ts
@@ -36,7 +36,6 @@ export async function buildCli(opts: BuildOptions) {
     entryPoints: [join(inputDir, 'index.ts')],
     external,
     platform: 'node',
-    sourcemap: 'linked',
   } satisfies ESBuildOptions;
 
   // ESM build options

--- a/scripts/esbuild/compiler.ts
+++ b/scripts/esbuild/compiler.ts
@@ -82,29 +82,18 @@ export async function buildCompiler(opts: BuildOptions) {
     banner: { js: getBanner(opts, 'Stencil Compiler', true) },
     entryPoints: [join(srcDir, 'index.ts')],
     platform: 'node',
-    sourcemap: 'linked',
     external,
     format: 'cjs',
     alias,
     plugins: [replace(replaceData)],
-  };
-
-  const compilerBuild = {
-    ...compilerEsbuildOptions,
     outfile: join(opts.output.compilerDir, compilerFileName),
-  };
-
-  const minifiedCompilerBuild = {
-    ...compilerEsbuildOptions,
-    outfile: join(opts.output.compilerDir, 'stencil.min.js'),
-    minify: true,
   };
 
   // copy typescript default lib dts files
   const tsLibNames = await getTypeScriptDefaultLibNames(opts);
   await Promise.all(tsLibNames.map((f) => fs.copy(join(opts.typescriptLibDir, f), join(opts.output.compilerDir, f))));
 
-  return runBuilds([compilerBuild, minifiedCompilerBuild], opts);
+  return runBuilds([compilerEsbuildOptions], opts);
 }
 
 /**

--- a/scripts/esbuild/dev-server.ts
+++ b/scripts/esbuild/dev-server.ts
@@ -149,7 +149,6 @@ export async function buildDevServer(opts: BuildOptions) {
     outfile: join(opts.output.devServerDir, 'client', 'index.js'),
     format: 'esm',
     platform: 'node',
-    sourcemap: false,
     plugins: [appErrorCssPlugin(opts), replace(createReplaceData(opts))],
     banner: {
       js: getBanner(opts, `Stencil Dev Server Client`, true),

--- a/scripts/esbuild/util.ts
+++ b/scripts/esbuild/util.ts
@@ -109,12 +109,23 @@ export function runBuilds(builds: ESBuildOptions[], opts: BuildOptions): Promise
  * @returns a base set of options
  */
 export function getBaseEsbuildOptions(): ESBuildOptions {
-  return {
+  const options: ESBuildOptions = {
     bundle: true,
     legalComments: 'inline',
     logLevel: 'info',
     target: getEsbuildTargets(),
   };
+
+  // if the `build` sub-command is called with the `DEBUG` env var, like
+  //
+  // DEBUG=true npm run build
+  //
+  // then we should produce sourcemaps.
+  if (process.env.DEBUG) {
+    options.sourcemap = 'linked';
+  }
+
+  return options;
 }
 
 /**

--- a/src/compiler/sys/stencil-sys.ts
+++ b/src/compiler/sys/stencil-sys.ts
@@ -143,7 +143,7 @@ export const createSystem = (c?: { logger?: Logger }): CompilerSystem => {
   const getCurrentDirectory = () => '/';
 
   const getCompilerExecutingPath = () => {
-    return sys.getRemoteModuleUrl({ moduleId: '@stencil/core', path: 'compiler/stencil.min.js' });
+    return sys.getRemoteModuleUrl({ moduleId: '@stencil/core', path: 'compiler/stencil.js' });
   };
 
   const isSymbolicLink = async (_p: string) => false;


### PR DESCRIPTION
This removes sourcemaps from the cli, compiler, and dev-server bundles and also removes the unused minified compiler build. All these changes are made to the esbuild-based build.

We realized recently that the minified compiler is no longer necessary (it was previously used for in-browser compilation support, and was removed in #4317) and the sourcemaps are similarly not useful, but do take up a significant amount of space.

Without this change a packed Stencil tarball is around 12MB, and with this change it drops to 3.5MB.

STENCIL-1242



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Test that you can build and use Stencil with this change.

Also try out the 'debug' build, which is building like so:

```sh
DEBUG=true npm run build
```

that should produce sourcemaps for all the files bundled with Esbuild.
