### PR TITLE
fix(cli): fix a bug in CLI argument parsing

### DIFF
--- a/src/cli/parse-flags.ts
+++ b/src/cli/parse-flags.ts
@@ -173,7 +173,7 @@ const parseCLITerm = (flags: ConfigFlags, args: string[]) => {
 
 /**
  * Normalize a 'negative' flag name, just to do a little pre-processing before
- * we pass it to `setCLIArg`.
+ * we pass it to {@link setCLIArg}.
  *
  * @param flagName the flag name to normalize
  * @returns a normalized flag name
@@ -221,12 +221,19 @@ const setCLIArg = (flags: ConfigFlags, rawArg: string, normalizedArg: string, va
 
   // We're setting a boolean!
   if (readOnlyArrayHasStringMember(BOOLEAN_CLI_FLAGS, normalizedArg)) {
-    flags[normalizedArg] =
+    const parsed =
       typeof value === 'string'
-        ? Boolean(value)
+        ? // check if the value is `'true'`
+          value === 'true'
         : // no value was supplied, default to true
           true;
+
+    flags[normalizedArg] = parsed;
     flags.knownArgs.push(rawArg);
+
+    if (typeof value === 'string' && value !== '') {
+      flags.knownArgs.push(value);
+    }
   }
 
   // We're setting a string!

--- a/src/cli/test/parse-flags.spec.ts
+++ b/src/cli/test/parse-flags.spec.ts
@@ -89,6 +89,12 @@ describe('parseFlags', () => {
       expect(flags.knownArgs).toEqual([]);
       expect(flags[cliArg]).toBe(undefined);
     });
+
+    it.each([true, false])(`should set the value with --${cliArg}=%p`, (value) => {
+      const flags = parseFlags([`--${cliArg}=${value}`]);
+      expect(flags.knownArgs).toEqual([`--${cliArg}`, String(value)]);
+      expect(flags[cliArg]).toBe(value);
+    });
   });
 
   describe.each(STRING_CLI_FLAGS)('should parse string flag %s', (cliArg) => {


### PR DESCRIPTION
This fixes a bug related to parsing of Boolean CLI arguments using the `--argName=value` type syntax.
We intend to support using that syntax to pass a boolean CLI flag (like `--watch`) but actually at present the way it is 'parsed' will result in such flags always being set to true! Not good!

This is because we were setting the value of the boolean CLI flag to `Boolean('false')` if you pass `--argName=false`, which does _not_ result in a value of `false` but instead a value of `true`. This is changed to instead use a check that the value equals `'true'` to turn the value into a boolean, and regression tests are added.

This was noticed when investigating #5640, but that bug actually has to do with how we convert CLI arguments into a Jest configuration.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?

If you pass a boolean CLI flag with the `=value` syntax it will always be set to `true`.

One sort of amusing way to reproduce this is to do:

```sh
npx stencil build --watch=false
```

which, contrary to expectations, starts the compiler in watch mode.


## What is the new behavior?

now if you do something like `--watch=false` we correctly parse the actual value after the equals sign for a boolean CLI flag.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Here's how you can test this:

1. create a test project
2. try doing `npx stencil build --watch=false` and note that the compiler is started in watch mode
3. build, pack, and then install this branch in your test project
4. note how the same command now does _not_ start the compiler in watch mode