### PR TITLE
chore(build): exclude graceful-fs from the sys/node/index.js bundle

### DIFF
--- a/scripts/esbuild/sys-node.ts
+++ b/scripts/esbuild/sys-node.ts
@@ -6,7 +6,7 @@ import { sysNodeExternalBundles } from '../bundles/sys-node';
 import { getBanner } from '../utils/banner';
 import type { BuildOptions } from '../utils/options';
 import { writePkgJson } from '../utils/write-pkg-json';
-import { getBaseEsbuildOptions, getEsbuildAliases, getEsbuildExternalModules, runBuilds } from './util';
+import { externalAlias, getBaseEsbuildOptions, getEsbuildAliases, getEsbuildExternalModules, runBuilds } from './util';
 
 export async function buildSysNode(opts: BuildOptions) {
   const inputDir = join(opts.buildDir, 'sys', 'node');
@@ -52,6 +52,7 @@ export async function buildSysNode(opts: BuildOptions) {
     minify: true,
     alias: sysNodeAliases,
     banner: { js: getBanner(opts, `Stencil Node System`, true) },
+    plugins: [externalAlias('graceful-fs', './graceful-fs.js')],
   };
 
   // sys/node/worker.js bundle


### PR DESCRIPTION
This uses the `externalAlias` plugin to 'externalize' the `graceful-fs` package from our `sys/node/index.js` bundle while also aliasing it to the file that we ship as part of the Stencil package at `sys/node/graceful-fs.js`.

We did a similar thing in #5625


## What is the current behavior?

Although we ship a bundled version of `graceful-fs` in `sys/node/graceful-fs.js` our bundle at `sys/node/index.js` is also inlining that module, so we have a little code duplication there.


## What is the new behavior?

The `sys/node/index.js` bundle now externalizes the bundled `graceful-fs` module so we're not duplicating it anymore.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

You can first convince yourself that `graceful-fs` is being bundled in the current build by running the build and then inspecting `sys/node/index.js`. It's not a huge file, but if you just search in there for `graceful-fs` you'll see inlined code.

> [!NOTE]
> If you want to make it more obvious that the module is being bundled, try setting `minify: false` in the relevant Esbuild script before you run the build:
> https://github.com/ionic-team/stencil/blob/ab5bc2bd25b267f100ba6cb3482c9d44c6c703b4/scripts/esbuild/sys-node.ts#L52

Then check out this branch and run the build again. Note that the code that was bundled in for `graceful-fs` is no longer present in `sys/node/index.js`, and the file is a little bit smaller.