### PR TITLE
chore(jsdoc): add jsdoc to `src/compiler/style/scope-css.ts`

### DIFF
--- a/src/compiler/style/scope-css.ts
+++ b/src/compiler/style/scope-css.ts
@@ -1,5 +1,16 @@
 import { DEFAULT_STYLE_MODE } from '@utils';
 
+/**
+ * Get a unique component ID which incorporates the component tag name and
+ * (optionally) a style mode
+ *
+ * e.g. for the tagName `'my-component'` and the mode `'ios'` this would be
+ * `'sc-my-component-ios'`.
+ *
+ * @param tagName the tag name for the component of interest
+ * @param mode an optional mode
+ * @returns a scope ID
+ */
 export const getScopeId = (tagName: string, mode?: string) => {
   return 'sc-' + tagName + (mode && mode !== DEFAULT_STYLE_MODE ? '-' + mode : '');
 };


### PR DESCRIPTION
There's only one function exported from that module (`getScopeId`) but let's document it!

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->





## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No