### PR TITLE
chore(repo): ignore eslint v9 from renovate updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -67,6 +67,12 @@
       allowedVersions: '<28.0.0',
     },
     {
+      // TODO(STENCIL-1274): Remove this block
+      // disable eslint v9 updates until typescript-eslint supports it
+      matchPackageNames: ['eslint'],
+      allowedVersions: '<9.0.0',
+    },
+    {
       matchPackagePrefixes: ['@typescript-eslint'],
       groupName: 'TypeScript-ESLint',
       // these packages can be released often, let's look at them every week


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

see 'new behavior' section

GitHub Issue Number: Supersedes https://github.com/ionic-team/stencil/pull/5666


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

add eslint v9 (and above) to our renovate configuration. with this change, any updates to v9 and higher will not result in a version bump pull request from renovatebot. this is temporary, as we are blocked from upgrading until typescript-eslint support eslint v9

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->
N/A
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I ran the renovate validator locally:
`npm i -g renovate && renovate-config-validator`

Otherwise, there's not much we can do here until we land it
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
