### PR TITLE
test(docs): add a gh actions workflow for testing docs output targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,13 @@ jobs:
     with:
       build_name: stencil-core
 
+  docs_build_tests:
+    name: Docs Build Tests
+    needs: [build_core]
+    uses: ./.github/workflows/test-docs-build.yml
+    with:
+      build_name: stencil-core
+
   bundler_tests:
     name: Bundler Tests
     needs: [build_core]

--- a/.github/workflows/test-docs-build.yml
+++ b/.github/workflows/test-docs-build.yml
@@ -1,0 +1,47 @@
+name: Docs OT Build Tests
+
+on:
+  workflow_call:
+    # Make this a reusable workflow, no value needed
+    # https://docs.github.com/en/actions/using-workflows/reusing-workflows
+    inputs:
+      build_name:
+        description: Name for the build, used to resolve the correct build artifact
+        required: true
+        type: string
+
+jobs:
+  docs_build_test:
+    name: (${{ matrix.os }}.${{ matrix.node }})
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['16', '18', '20']
+        os: ['ubuntu-latest', 'windows-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Get Core Dependencies
+        uses: ./.github/workflows/actions/get-core-dependencies
+
+      - name: Use Node ${{ matrix.node }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+
+      - name: Download Build Archive
+        uses: ./.github/workflows/actions/download-archive
+        with:
+          name: ${{ inputs.build_name }}
+          path: .
+          filename: stencil-core-build.zip
+
+      - name: Docs Build Tests
+        run: npm run test.docs-build
+        shell: bash
+
+      - name: Check Git Context
+        uses: ./.github/workflows/actions/check-git-context

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "test.wdio.testOnly": "cd test/wdio && npm ci && npm run wdio",
     "test.prod": "npm run test.dist && npm run test.end-to-end && npm run test.jest && npm run test.wdio && npm run test.testing && npm run test.analysis",
     "test.testing": "node scripts/test/validate-testing.js",
+    "test.docs-build": "cd test && npm run build.docs-json && npm run build.docs-readme",
     "test.watch": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --watch",
     "test.watch-all": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --watchAll --coverage",
     "tsc": "tsc --incremental",

--- a/test/package.json
+++ b/test/package.json
@@ -5,7 +5,7 @@
     "TODO-STENCIL-389": "echo Remove the exit call below",
     "analysis": "exit 0 && node ./.scripts/analysis.js",
     "analysis.build-and-analyze": "npm run build && npm run analysis",
-    "build": "npm run build.browser-compile && npm run build.hello-world && npm run build.hello-vdom && npm run build.todo && npm run build.end-to-end && npm run build.ionic && npm run build.docs-json && npm run build.docs-readme",
+    "build": "npm run build.browser-compile && npm run build.hello-world && npm run build.hello-vdom && npm run build.todo && npm run build.end-to-end && npm run build.ionic",
     "bundlers": "cd ./bundler && npm run start",
     "build.browser-compile": "cd ./browser-compile && npm run build",
     "build.end-to-end": "cd ./end-to-end && npm ci && npm run build",


### PR DESCRIPTION
This adds a new GH actions workflow (`.github/workflows/test-docs-build.yml`) which runs `stencil build` in the `test/docs-json` and `test/docs-readme` directories. These two directories contain Stencil projects which exercise the `docs-json` and `docs-readme` output targets, respectively. The output for each project is checked in to the repo, so running a build on CI and then checking for a dirty git context serves as a test that the output of the output targets hasn't changed.

STENCIL-1272

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
