### PR TITLE
chore(release): switch release scripts to use ESbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "build.rollup": "npm run tsc.scripts && npm run tsc.prod && npm run rollup.prod.ci",
-    "build": "npm run clean && npm run tsc.scripts && npm run tsc.prod && node scripts/build/esbuild/build.js --prod --ci",
+    "build": "npm run clean && npm run tsc.scripts && npm run tsc.prod && node scripts/build --prod --ci",
     "build.watch": "npm run build -- --watch",
     "build.updateSelectorEngine": "node scripts/build/updateSelectorEngine.js",
     "clean": "rm -rf build/ cli/ compiler/ dev-server/ internal/ mock-doc/ sys/ testing/ && npm run clean.scripts && npm run clean.screenshots",

--- a/scripts/esbuild/build.ts
+++ b/scripts/esbuild/build.ts
@@ -1,4 +1,6 @@
-import { getOptions } from '../utils/options';
+import { release } from '../release';
+import { validateBuild } from '../test/validate-build';
+import { BuildOptions, getOptions } from '../utils/options';
 import { buildCli } from './cli';
 import { buildCompiler } from './compiler';
 import { buildDevServer } from './dev-server';
@@ -8,14 +10,32 @@ import { buildScreenshot } from './screenshot';
 import { buildSysNode } from './sys-node';
 import { buildTesting } from './testing';
 
-// the main entry point for the Esbuild-based build
-async function main() {
+// the main entry point for the build
+export async function run(rootDir: string, args: ReadonlyArray<string>) {
   const opts = getOptions(process.cwd(), {
-    isProd: !!process.argv.includes('--prod'),
-    isCI: !!process.argv.includes('--ci'),
-    isWatch: !!process.argv.includes('--watch'),
+    isProd: args.includes('--prod'),
+    isCI: args.includes('--ci'),
+    isWatch: args.includes('--watch'),
   });
 
+  try {
+    if (args.includes('--release')) {
+      await release(rootDir, args);
+      return;
+    }
+
+    if (args.includes('--validate-build')) {
+      await validateBuild(rootDir);
+      return;
+    }
+    await buildAll(opts);
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+}
+
+export async function buildAll(opts: BuildOptions) {
   await Promise.all([
     buildCli(opts),
     buildCompiler(opts),
@@ -27,5 +47,3 @@ async function main() {
     buildInternal(opts),
   ]);
 }
-
-main();

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 
-import * as build from './build';
+import * as build from './esbuild/build';
 
 // This path is relative to the final location of the compiled script, not its TypeScript source
 const stencilProjectRoot = join(__dirname, '..', '..');

--- a/scripts/release-tasks.ts
+++ b/scripts/release-tasks.ts
@@ -1,7 +1,7 @@
 import color from 'ansi-colors';
 import Listr, { ListrTask } from 'listr';
 
-import { bundleBuild } from './build';
+import { buildAll } from './esbuild/build';
 import { BuildOptions } from './utils/options';
 import { isPrereleaseVersion, isValidVersionInput, SEMVER_INCREMENTS, updateChangeLog } from './utils/release-utils';
 
@@ -104,7 +104,7 @@ export async function runReleaseTasks(opts: BuildOptions, args: ReadonlyArray<st
     },
     {
       title: `Bundle @stencil/core ${color.dim('(' + opts.buildId + ')')}`,
-      task: () => bundleBuild(opts),
+      task: () => buildAll(opts),
       // for pre-releases, this step will occur in GitHub after the PR has been created.
       // for actual releases, we'll need to build + bundle stencil in order to publish it to npm.
       skip: () => !opts.isPublishRelease,


### PR DESCRIPTION
This changes our release process for `@stencil/core` to use the ESbuild-based build pipeline instead of our now-legacy Rollup-based build setup.

This change is intentionally made as small as possible in order to make it easy to diagnose any problems and easy to revert if needed. We have a follow-up ticket for removing the Rollup-related stuff more thoroughly.

STENCIL-1017

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

It's difficult for us to test this out thoroughly without actually running a release.
