### PR TITLE
fix(e2e): allow to fetch CSS variables assigned to host elements

### DIFF
--- a/src/testing/puppeteer/puppeteer-element.ts
+++ b/src/testing/puppeteer/puppeteer-element.ts
@@ -385,11 +385,29 @@ export class E2EElement extends MockHTMLElement implements pd.E2EElementInternal
 
         const computedStyle = window.getComputedStyle(elm, pseudoElt);
 
-        const keys = Object.keys(computedStyle);
+        const keys = [
+          ...Object.keys(computedStyle),
+          /**
+           * include CSS variables defined within the style attribute
+           * of an element, e.g.:
+           * ```
+           * <my-component style="--my-component-text-color: rgb(255, 0, 0);"></my-component>
+           * ```
+           */
+          ...Array.from((elm as HTMLElement).style),
+        ];
 
         keys.forEach((key) => {
           if (isNaN(key as any)) {
-            const value = computedStyle[key as any];
+            const value =
+              /**
+               * access property directly for any known css property
+               */
+              computedStyle[key as any] ||
+              /**
+               * use `getPropertyValue` for css variables
+               */
+              computedStyle.getPropertyValue(key);
             if (value != null) {
               rtn[key] = value;
             }

--- a/test/end-to-end/src/element-cmp/element-cmp.e2e.ts
+++ b/test/end-to-end/src/element-cmp/element-cmp.e2e.ts
@@ -56,4 +56,14 @@ describe('@Element', () => {
 
     expect(elm).toEqualText('inner content');
   });
+
+  it('should get computed styles of CSS vars assigned on host element', async () => {
+    const page = await newE2EPage({
+      html: `
+      <element-cmp id="my-elm" style="--my-component-text-color: rgb(255, 0, 0);"></element-cmp>
+    `,
+    });
+    const el = await page.find('element-cmp');
+    expect((await el.getComputedStyle()).getPropertyValue('--my-component-text-color')).toEqual('rgb(255, 0, 0)');
+  });
 });


### PR DESCRIPTION
## What is the current behavior?

The `E2EElement.getComputedStyle()` method would not return values for CSS variables assigned to the element directly.

GitHub Issue Number: #5681

## What is the new behavior?
This small tweak includes CSS variables assigned to the host element directly.

## Documentation

n/a

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Added an e2e test.

## Other information

n/a
