### PR TITLE
chore(test): improve stability of some e2e tests

### DIFF
--- a/test/wdio/svg-attr/cmp.test.tsx
+++ b/test/wdio/svg-attr/cmp.test.tsx
@@ -9,17 +9,13 @@ describe('svg attr', () => {
   });
 
   it('adds and removes attribute', async () => {
-    const app = document.body;
-    await $('svg-attr').waitForStable();
-    let rect = app.querySelector('rect');
-    expect(rect.getAttribute('transform')).toBe(null);
+    const rect = $('rect');
+    await expect(rect).not.toHaveAttribute('transform');
 
     await $('button').click();
-    rect = app.querySelector('rect');
     await expect(rect).toHaveAttribute('transform', 'rotate(45 27 27)');
 
     await $('button').click();
-    rect = app.querySelector('rect');
-    expect(rect.getAttribute('transform')).toBe(null);
+    await expect(rect).not.toHaveAttribute('transform');
   });
 });

--- a/test/wdio/svg-class/cmp.test.tsx
+++ b/test/wdio/svg-class/cmp.test.tsx
@@ -21,21 +21,20 @@ describe('svg class', () => {
   });
 
   it('toggles svg class', async () => {
-    const app = document.body;
     await $('svg-class').waitForExist();
-    const svg = app.querySelector('svg');
-    const circle = app.querySelector('circle');
-    const rect = app.querySelector('rect');
+    const svg = $('svg');
+    const circle = $('circle');
+    const rect = $('rect');
 
-    expect(svg.getAttribute('class')).toBe(null);
-    expect(circle.getAttribute('class')).toBe(null);
-    expect(rect.getAttribute('class')).toBe(null);
+    await expect(svg).not.toHaveElementClass('primary');
+    await expect(circle).not.toHaveElementClass('red');
+    await expect(rect).not.toHaveElementClass('blue');
 
     await $('button').click();
     await $('svg-class').waitForStable();
 
-    expect(svg.getAttribute('class')).toBe('primary');
-    expect(circle.getAttribute('class')).toBe('red');
-    expect(rect.getAttribute('class')).toBe('blue');
+    await expect(svg).toHaveElementClass('primary');
+    await expect(circle).toHaveElementClass('red');
+    await expect(rect).toHaveElementClass('blue');
   });
 });

--- a/test/wdio/text-content-patch/cmp.test.tsx
+++ b/test/wdio/text-content-patch/cmp.test.tsx
@@ -40,9 +40,12 @@ describe('textContent patch', () => {
 
     it('should overwrite the default slot content', async () => {
       const elm = await $('text-content-patch-scoped-with-slot');
-      await browser.execute((elm) => {
-        elm.textContent = 'New slot content'
-      }, elm as any as HTMLElement);
+      await browser.execute(
+        (elm) => {
+          elm.textContent = 'New slot content';
+        },
+        elm as any as HTMLElement,
+      );
 
       await expect(elm.getText()).toMatchInlineSnapshot(`
         "Top content
@@ -53,9 +56,12 @@ describe('textContent patch', () => {
 
     it('should not insert the text node if there is no default slot', async () => {
       const elm = await $('text-content-patch-scoped');
-      await browser.execute((elm) => {
-        elm.textContent = 'New slot content'
-      }, elm as any as HTMLElement);
+      await browser.execute(
+        (elm) => {
+          elm.textContent = 'New slot content';
+        },
+        elm as any as HTMLElement,
+      );
 
       await expect(elm.getText()).toMatchInlineSnapshot(`
         "Top content

--- a/test/wdio/text-content-patch/cmp.test.tsx
+++ b/test/wdio/text-content-patch/cmp.test.tsx
@@ -20,28 +20,47 @@ describe('textContent patch', () => {
   });
 
   describe('scoped encapsulation', () => {
-    it('should return the content of all slots', () => {
-      const elm = document.querySelector('text-content-patch-scoped-with-slot');
-      expect(elm.textContent.trim()).toBe('Slot content Suffix content');
+    it('should return the content of all slots', async () => {
+      const elm = $('text-content-patch-scoped-with-slot');
+      await expect(elm.getText()).toMatchInlineSnapshot(`
+        "Top content
+        Slot content
+        Bottom content
+        Suffix content"
+      `);
     });
 
-    it('should return an empty string if there is no slotted content', () => {
-      const elm = document.querySelector('text-content-patch-scoped');
-      expect(elm.textContent.trim()).toBe('');
+    it('should return an empty string if there is no slotted content', async () => {
+      const elm = $('text-content-patch-scoped');
+      await expect(elm.getText()).toMatchInlineSnapshot(`
+        "Top content
+        Bottom content"
+      `);
     });
 
-    it('should overwrite the default slot content', () => {
-      const elm = document.querySelector('text-content-patch-scoped-with-slot');
-      elm.textContent = 'New slot content';
+    it('should overwrite the default slot content', async () => {
+      const elm = await $('text-content-patch-scoped-with-slot');
+      await browser.execute((elm) => {
+        elm.textContent = 'New slot content'
+      }, elm as any as HTMLElement);
 
-      expect(elm.textContent.trim()).toBe('New slot content');
+      await expect(elm.getText()).toMatchInlineSnapshot(`
+        "Top content
+        New slot content
+        Bottom content"
+      `);
     });
 
-    it('should not insert the text node if there is no default slot', () => {
-      const elm = document.querySelector('text-content-patch-scoped');
-      elm.textContent = 'New slot content';
+    it('should not insert the text node if there is no default slot', async () => {
+      const elm = await $('text-content-patch-scoped');
+      await browser.execute((elm) => {
+        elm.textContent = 'New slot content'
+      }, elm as any as HTMLElement);
 
-      expect(elm.textContent.trim()).toBe('');
+      await expect(elm.getText()).toMatchInlineSnapshot(`
+        "Top content
+        Bottom content"
+      `);
     });
   });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
Some e2e tests have shown to be not stable. This patch rewrites them to use WDIO primitives that run these tests in a more async fashion and therefor will make them more stable.

## What is the new behavior?
More stable tests.

## Documentation

n/a

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

n/a

## Other information

n/a