### PR TITLE
fix(runtime): add root scope id to the nested child as classname

### DIFF
--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -1100,6 +1100,13 @@ export interface HostElement extends HTMLElement {
   ['s-sc']?: string;
 
   /**
+   * Root Scope Id
+   * The scope id of the root component when using scoped css encapsulation
+   * or using shadow dom but the browser doesn't support it
+   */
+  ['s-rsc']?: string;
+
+  /**
    * Hot Module Replacement, dev mode only
    *
    * This function should be defined by the HMR-supporting runtime and should

--- a/src/runtime/test/scoped.spec.tsx
+++ b/src/runtime/test/scoped.spec.tsx
@@ -42,7 +42,7 @@ describe('scoped', () => {
     <cmp-a class="hydrated sc-cmp-a-h sc-cmp-a-s">
       <cmp-b class="hydrated sc-cmp-a sc-cmp-b-h sc-cmp-b-s">
         <!---->
-        <div class="sc-cmp-b sc-cmp-b-s">
+        <div class="sc-cmp-a sc-cmp-b sc-cmp-b-s">
           <span class="sc-cmp-a">
             Hola
           </span>

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -111,7 +111,7 @@ const createElm = (oldParentVNode: d.VNode, newParentVNode: d.VNode, childIndex:
       elm.classList.add((elm['s-si'] = scopeId));
     }
 
-    if (BUILD.shadowDom || BUILD.scoped) {
+    if (BUILD.scoped) {
       // to be able to style the deep nested scoped component from the root component,
       // root component's scope id needs to be added to the child nodes since sass compiler
       // adds scope id to the nested selectors during compilation phase

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -112,6 +112,9 @@ const createElm = (oldParentVNode: d.VNode, newParentVNode: d.VNode, childIndex:
     }
 
     if (BUILD.shadowDom || BUILD.scoped) {
+      // to be able to style the deep nested scoped component from the root component,
+      // root component's scope id needs to be added to the child nodes since sass compiler
+      // adds scope id to the nested selectors during compilation phase
       const rootScopeId =
         newParentVNode.$elm$?.['s-rsc'] || newParentVNode.$elm$?.['s-si'] || newParentVNode.$elm$?.['s-sc'];
 

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -111,6 +111,16 @@ const createElm = (oldParentVNode: d.VNode, newParentVNode: d.VNode, childIndex:
       elm.classList.add((elm['s-si'] = scopeId));
     }
 
+    if (BUILD.shadowDom || BUILD.scoped) {
+      const rootScopeId =
+        newParentVNode.$elm$?.['s-rsc'] || newParentVNode.$elm$?.['s-si'] || newParentVNode.$elm$?.['s-sc'];
+
+      if (rootScopeId) {
+        elm['s-rsc'] = rootScopeId;
+        !elm.classList.contains(rootScopeId) && elm.classList.add(rootScopeId);
+      }
+    }
+
     if (newVNode.$children$) {
       for (i = 0; i < newVNode.$children$.length; ++i) {
         // create the node

--- a/test/wdio/scoped-id-in-nested-classname/cmp-level-1.scss
+++ b/test/wdio/scoped-id-in-nested-classname/cmp-level-1.scss
@@ -1,0 +1,7 @@
+:host {
+  cmp-level-2 {
+    cmp-level-3 {
+      padding: 32px;
+    }
+  }
+}

--- a/test/wdio/scoped-id-in-nested-classname/cmp-level-1.tsx
+++ b/test/wdio/scoped-id-in-nested-classname/cmp-level-1.tsx
@@ -1,0 +1,13 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'cmp-level-1',
+  styleUrl: 'cmp-level-1.scss',
+  shadow: false,
+  scoped: true,
+})
+export class CmpLevel1 {
+  render() {
+    return <cmp-level-2></cmp-level-2>;
+  }
+}

--- a/test/wdio/scoped-id-in-nested-classname/cmp-level-2.tsx
+++ b/test/wdio/scoped-id-in-nested-classname/cmp-level-2.tsx
@@ -1,0 +1,16 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'cmp-level-2',
+  shadow: false,
+  scoped: true,
+})
+export class CmpLevel2 {
+  render() {
+    return (
+      <cmp-level-3>
+        <slot />
+      </cmp-level-3>
+    );
+  }
+}

--- a/test/wdio/scoped-id-in-nested-classname/cmp-level-3.scss
+++ b/test/wdio/scoped-id-in-nested-classname/cmp-level-3.scss
@@ -1,0 +1,3 @@
+:host {
+  padding: 8px;
+}

--- a/test/wdio/scoped-id-in-nested-classname/cmp-level-3.tsx
+++ b/test/wdio/scoped-id-in-nested-classname/cmp-level-3.tsx
@@ -1,0 +1,17 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'cmp-level-3',
+  styleUrl: 'cmp-level-3.scss',
+  shadow: false,
+  scoped: true,
+})
+export class CmpLevel3 {
+  render() {
+    return (
+      <div>
+        <slot>DEFAULT</slot>
+      </div>
+    );
+  }
+}

--- a/test/wdio/scoped-id-in-nested-classname/cmp.test.tsx
+++ b/test/wdio/scoped-id-in-nested-classname/cmp.test.tsx
@@ -10,5 +10,8 @@ describe('scope-id-in-nested-classname', function () {
 
   it('should have root scope id in the nested element as classname', async () => {
     await expect($('cmp-level-3')).toHaveElementClass('sc-cmp-level-1');
+
+    const appliedCss = await (await $('cmp-level-3')).getCSSProperty('padding');
+    await expect(appliedCss.parsed.value).toBe(32);
   });
 });

--- a/test/wdio/scoped-id-in-nested-classname/cmp.test.tsx
+++ b/test/wdio/scoped-id-in-nested-classname/cmp.test.tsx
@@ -1,0 +1,14 @@
+import { h } from '@stencil/core';
+import { render } from '@wdio/browser-runner/stencil';
+
+describe('scope-id-in-nested-classname', function () {
+  beforeEach(() => {
+    render({
+      template: () => <cmp-level-1></cmp-level-1>,
+    });
+  });
+
+  it('should have root scope id in the nested element as classname', async () => {
+    await expect($('cmp-level-3')).toHaveElementClass('sc-cmp-level-1');
+  });
+});


### PR DESCRIPTION
sass compiler adds root scope id to the nested child elements too, therefore nested element selectors are not working from the root component since the root scope id is not adding as classname to the nested children elements

#5702

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #5702 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
