### PR TITLE
fix(compiler): recognize loud comments when generating style docs

### DIFF
--- a/src/compiler/docs/style-docs.ts
+++ b/src/compiler/docs/style-docs.ts
@@ -15,9 +15,11 @@ export function parseStyleDocs(styleDocs: d.StyleDoc[], styleText: string | null
     return;
   }
 
-  let startIndex: number;
-  while ((startIndex = styleText.indexOf(CSS_DOC_START)) > -1) {
-    styleText = styleText.substring(startIndex + CSS_DOC_START.length);
+  // Using `match` allows us to know which substring matched the regex and the starting
+  // index at which the match was found
+  let match = styleText.match(CSS_DOC_START);
+  while (match !== null) {
+    styleText = styleText.substring(match.index + match[0].length);
 
     const endIndex = styleText.indexOf(CSS_DOC_END);
     if (endIndex === -1) {
@@ -28,6 +30,7 @@ export function parseStyleDocs(styleDocs: d.StyleDoc[], styleText: string | null
     parseCssComment(styleDocs, comment);
 
     styleText = styleText.substring(endIndex + CSS_DOC_END.length);
+    match = styleText.match(CSS_DOC_START);
   }
 }
 
@@ -83,9 +86,10 @@ function parseCssComment(styleDocs: d.StyleDoc[], comment: string): void {
 }
 
 /**
- * Opening syntax for a CSS docstring
+ * Opening syntax for a CSS docstring.
+ * This will match a traditional docstring or a "loud" comment in sass
  */
-const CSS_DOC_START = '/**';
+const CSS_DOC_START = /\/\*(\*|\!)/;
 /**
  * Closing syntax for a CSS docstring
  */

--- a/src/compiler/docs/test/style-docs.spec.ts
+++ b/src/compiler/docs/test/style-docs.spec.ts
@@ -134,4 +134,17 @@ describe('style-docs', () => {
     parseStyleDocs(styleDocs, styleText);
     expect(styleDocs).toEqual([]);
   });
+
+  it('works with sass loud comments', () => {
+    const styleText = `
+      /*!
+       * @prop --max-width: Max width of the alert
+       */
+      body {
+        color: red;
+      }
+    `;
+    parseStyleDocs(styleDocs, styleText);
+    expect(styleDocs).toEqual([{ name: `--max-width`, docs: `Max width of the alert`, annotation: 'prop' }]);
+  });
 });

--- a/src/compiler/docs/test/style-docs.spec.ts
+++ b/src/compiler/docs/test/style-docs.spec.ts
@@ -147,4 +147,23 @@ describe('style-docs', () => {
     parseStyleDocs(styleDocs, styleText);
     expect(styleDocs).toEqual([{ name: `--max-width`, docs: `Max width of the alert`, annotation: 'prop' }]);
   });
+
+  it('works with multiple, mixed comment types', () => {
+    const styleText = `
+      /**
+       * @prop --max-width: Max width of the alert
+       */
+      /*!
+       * @prop --max-width-loud: Max width of the alert (loud)
+       */
+      body {
+        color: red;
+      }
+    `;
+    parseStyleDocs(styleDocs, styleText);
+    expect(styleDocs).toEqual([
+      { name: `--max-width`, docs: `Max width of the alert`, annotation: 'prop' },
+      { name: `--max-width-loud`, docs: `Max width of the alert (loud)`, annotation: 'prop' },
+    ]);
+  });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Stencil's doc generation does not support loud comments (comments starting with `/*!`). Loud comments prevent the comment block from being stripped from the output during the sass compilation.

Fixes: #5623 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The doc generation now matches against either a traditional comment block (`/**`) or a loud comment block (`/*!`).

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Added an automated test for loud comment blocks.

Manually tested various combinations of comment blocks in a started project. This included no comment blocks, only loud comments, only traditional comments, and mixing both loud and traditional blocks.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

I tested this with Stencil's postcss library as well ([`@stencil-community/poscss`](https://www.npmjs.com/package/@stencil-community/postcss)) and didn't run into any issues.
