### PR TITLE
test(docs): unit test style doc generation

### DIFF
--- a/src/compiler/docs/generate-doc-data.ts
+++ b/src/compiler/docs/generate-doc-data.ts
@@ -305,18 +305,26 @@ const getDocsEvents = (events: d.ComponentCompilerEvent[]): d.JsonDocsEvent[] =>
     }));
 };
 
-const getDocsStyles = (cmpMeta: d.ComponentCompilerMeta): d.JsonDocsStyle[] => {
+/**
+ * Transforms the {@link d.CompilerStyleDoc} metadata for a component into a {@link d.JsonDocsStyle}, providing sensible
+ * defaults where needed.
+ * @param cmpMeta the metadata for a single Stencil component, which contains the compiler style metadata
+ * @returns a new series containing a {@link d.JsonDocsStyle} entry for each {@link d.CompilerStyleDoc} entry.
+ */
+export const getDocsStyles = (cmpMeta: d.ComponentCompilerMeta): d.JsonDocsStyle[] => {
   if (!cmpMeta.styleDocs) {
     return [];
   }
 
-  return sortBy(cmpMeta.styleDocs, (o) => o.name.toLowerCase()).map((styleDoc) => {
-    return {
-      name: styleDoc.name,
-      annotation: styleDoc.annotation || '',
-      docs: styleDoc.docs || '',
-    };
-  });
+  return sortBy(cmpMeta.styleDocs, (compilerStyleDoc) => compilerStyleDoc.name.toLowerCase()).map(
+    (compilerStyleDoc) => {
+      return {
+        name: compilerStyleDoc.name,
+        annotation: compilerStyleDoc.annotation || '',
+        docs: compilerStyleDoc.docs || '',
+      };
+    },
+  );
 };
 
 const getDocsListeners = (listeners: d.ComponentCompilerListener[]): d.JsonDocsListener[] => {


### PR DESCRIPTION



<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See 'new behavior' for the motivation here. But tl;dr - we didn't have tests, now we do 😉 

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

add unit tests for `src/compiler/docs/generate-doc-data.ts#getDocsStyles`. this was pulled out into a separate pull request from another effort, where we wish to add the `mode` that a stylesheet is associated with by a component's `@Component({})` decorator to the output of `docs-json`. these tests aren't strictly needed for that effort, but establish a baseline for tests taht will be added in the future.

the `getDocsStyles` function was exported in order to test it.

additional jsdoc and type annotations have been added to differentiate fields that are compiler metadata, and those that are used in our documentation intermediate representation.


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Tests were made to fail/'red' during the dev process. Only then did I make them pass/'green'
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
split from: STENCIL-1269 - CSS Documentation Should Account for Modes