### PR TITLE
feat(docs): add style mode to `docs-json` output

### DIFF
--- a/src/compiler/bundle/ext-transforms-plugin.ts
+++ b/src/compiler/bundle/ext-transforms-plugin.ts
@@ -164,7 +164,7 @@ export const extTransformsPlugin = (
         // Set style docs
         if (cmp) {
           cmp.styleDocs ||= [];
-          mergeIntoWith(cmp.styleDocs, cssTransformResults.styleDocs, (docs) => docs.name);
+          mergeIntoWith(cmp.styleDocs, cssTransformResults.styleDocs, (docs) => `${docs.name},${docs.mode}`);
         }
 
         // Track dependencies

--- a/src/compiler/docs/generate-doc-data.ts
+++ b/src/compiler/docs/generate-doc-data.ts
@@ -1,4 +1,13 @@
-import { flatOne, isOutputTargetDocsJson, join, normalizePath, relative, sortBy, unique } from '@utils';
+import {
+  DEFAULT_STYLE_MODE,
+  flatOne,
+  isOutputTargetDocsJson,
+  join,
+  normalizePath,
+  relative,
+  sortBy,
+  unique,
+} from '@utils';
 import { basename, dirname } from 'path';
 
 import type * as d from '../../declarations';
@@ -316,15 +325,17 @@ export const getDocsStyles = (cmpMeta: d.ComponentCompilerMeta): d.JsonDocsStyle
     return [];
   }
 
-  return sortBy(cmpMeta.styleDocs, (compilerStyleDoc) => compilerStyleDoc.name.toLowerCase()).map(
-    (compilerStyleDoc) => {
-      return {
-        name: compilerStyleDoc.name,
-        annotation: compilerStyleDoc.annotation || '',
-        docs: compilerStyleDoc.docs || '',
-      };
-    },
-  );
+  return sortBy(
+    cmpMeta.styleDocs,
+    (compilerStyleDoc) => `${compilerStyleDoc.name.toLowerCase()},${compilerStyleDoc.mode.toLowerCase()}}`,
+  ).map((compilerStyleDoc) => {
+    return {
+      name: compilerStyleDoc.name,
+      annotation: compilerStyleDoc.annotation || '',
+      docs: compilerStyleDoc.docs || '',
+      mode: compilerStyleDoc.mode && compilerStyleDoc.mode !== DEFAULT_STYLE_MODE ? compilerStyleDoc.mode : undefined,
+    };
+  });
 };
 
 const getDocsListeners = (listeners: d.ComponentCompilerListener[]): d.JsonDocsListener[] => {

--- a/src/compiler/docs/style-docs.ts
+++ b/src/compiler/docs/style-docs.ts
@@ -9,8 +9,9 @@ import type * as d from '../../declarations';
  *
  * @param styleDocs the array to hold formatted CSS docstrings
  * @param styleText the CSS text we're working with
+ * @param mode a mode associated with the parsed style, if applicable (e.g. this is not applicable for global styles)
  */
-export function parseStyleDocs(styleDocs: d.StyleDoc[], styleText: string | null) {
+export function parseStyleDocs(styleDocs: d.StyleDoc[], styleText: string | null, mode?: string | undefined) {
   if (typeof styleText !== 'string') {
     return;
   }
@@ -27,7 +28,7 @@ export function parseStyleDocs(styleDocs: d.StyleDoc[], styleText: string | null
     }
 
     const comment = styleText.substring(0, endIndex);
-    parseCssComment(styleDocs, comment);
+    parseCssComment(styleDocs, comment, mode);
 
     styleText = styleText.substring(endIndex + CSS_DOC_END.length);
     match = styleText.match(CSS_DOC_START);
@@ -40,8 +41,9 @@ export function parseStyleDocs(styleDocs: d.StyleDoc[], styleText: string | null
  *
  * @param styleDocs an array which will be modified with the docstring
  * @param comment the comment string
+ * @param mode a mode associated with the parsed style, if applicable (e.g. this is not applicable for global styles)
  */
-function parseCssComment(styleDocs: d.StyleDoc[], comment: string): void {
+function parseCssComment(styleDocs: d.StyleDoc[], comment: string, mode: string | undefined): void {
   /**
    * @prop --max-width: Max width of the alert
    */
@@ -77,6 +79,7 @@ function parseCssComment(styleDocs: d.StyleDoc[], comment: string): void {
       name: splt[0].trim(),
       docs: (splt.shift() && splt.join(`:`)).trim(),
       annotation: 'prop',
+      mode,
     };
 
     if (!styleDocs.some((c) => c.name === cssDoc.name && c.annotation === 'prop')) {

--- a/src/compiler/docs/test/style-docs.spec.ts
+++ b/src/compiler/docs/test/style-docs.spec.ts
@@ -1,4 +1,5 @@
 import type * as d from '@stencil/core/declarations';
+import { DEFAULT_STYLE_MODE } from '@utils';
 
 import { parseStyleDocs } from '../style-docs';
 
@@ -165,5 +166,20 @@ describe('style-docs', () => {
       { name: `--max-width`, docs: `Max width of the alert`, annotation: 'prop' },
       { name: `--max-width-loud`, docs: `Max width of the alert (loud)`, annotation: 'prop' },
     ]);
+  });
+
+  it.each(['ios', 'md', undefined, '', DEFAULT_STYLE_MODE])("attaches mode metadata for a style mode '%s'", (mode) => {
+    const styleText = `
+    /*!
+     * @prop --max-width: Max width of the alert
+     */
+    body {
+      color: red;
+    }
+  `;
+
+    parseStyleDocs(styleDocs, styleText, mode);
+
+    expect(styleDocs).toEqual([{ name: `--max-width`, docs: `Max width of the alert`, annotation: 'prop', mode }]);
   });
 });

--- a/src/compiler/style/css-to-esm.ts
+++ b/src/compiler/style/css-to-esm.ts
@@ -107,7 +107,7 @@ const transformCssToEsmModule = (input: d.TransformCssToEsmInput): d.TransformCs
   };
 
   if (input.docs) {
-    parseStyleDocs(results.styleDocs, input.input);
+    parseStyleDocs(results.styleDocs, input.input, input.mode);
   }
 
   try {

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -849,10 +849,29 @@ export interface CompilerJsDocTagInfo {
   text?: string;
 }
 
+/**
+ * The (internal) representation of a CSS block comment in a CSS, Sass, etc. file. This data structure is used during
+ * the initial compilation phases of Stencil, as a piece of {@link ComponentCompilerMeta}.
+ */
 export interface CompilerStyleDoc {
+  /**
+   * The name of the CSS property
+   */
   name: string;
+  /**
+   * The user-defined description of the CSS property
+   */
   docs: string;
+  /**
+   * The JSDoc-style annotation (e.g. `@prop`) that was used in the block comment to detect the comment.
+   * Used to inform Stencil where the start of a new property's description starts (and where the previous description
+   * ends).
+   */
   annotation: 'prop';
+  /**
+   * The Stencil style-mode that is associated with this property.
+   */
+  mode: string;
 }
 
 export interface CompilerAssetDir {
@@ -1887,6 +1906,22 @@ export interface TransformCssToEsmInput {
   file?: string;
   tag?: string;
   encapsulation?: string;
+  /**
+   * The mode under which the CSS will be applied.
+   *
+   * Corresponds to a key used when `@Component`'s `styleUrls` field is an object:
+   * ```ts
+   * @Component({
+   *   tag: 'todo-list',
+   *   styleUrls: {
+   *      ios: 'todo-list.ios.scss',
+   *      md: 'todo-list.md.scss',
+   *   }
+   * })
+   * ```
+   * In the example above, two `TransformCssToEsmInput`s should be created, one for 'ios' and one for 'md' (this field
+   * is not shared by multiple fields, nor is it a composite of multiple modes).
+   */
   mode?: string;
   commentOriginalSelector?: boolean;
   sourceMap?: boolean;

--- a/src/declarations/stencil-public-docs.ts
+++ b/src/declarations/stencil-public-docs.ts
@@ -300,10 +300,26 @@ export interface JsonDocsEvent {
   detail: string;
 }
 
+/**
+ * Type describing a CSS Style, as described by a JSDoc-style comment
+ */
 export interface JsonDocsStyle {
+  /**
+   * The name of the style
+   */
   name: string;
+  /**
+   * The type/description associated with the style
+   */
   docs: string;
+  /**
+   * The annotation used in the JSDoc of the style (e.g. `@prop`)
+   */
   annotation: string;
+  /**
+   * The mode associated with the style
+   */
+  mode: string | undefined;
 }
 
 export interface JsonDocsListener {
@@ -346,8 +362,26 @@ export interface JsonDocsPart {
   docs: string;
 }
 
+/**
+ * Represents a parsed block comment in a CSS, Sass, etc. file for a custom property.
+ */
 export interface StyleDoc {
+  /**
+   * The name of the CSS property
+   */
   name: string;
+  /**
+   * The user-defined description of the CSS property
+   */
   docs: string;
+  /**
+   * The JSDoc-style annotation (e.g. `@prop`) that was used in the block comment to detect the comment.
+   * Used to inform Stencil where the start of a new property's description starts (and where the previous description
+   * ends).
+   */
   annotation: 'prop';
+  /**
+   * The Stencil style-mode that is associated with this property.
+   */
+  mode: string | undefined;
 }

--- a/test/docs-json/docs.d.ts
+++ b/test/docs-json/docs.d.ts
@@ -347,10 +347,26 @@ export interface JsonDocsEvent {
   deprecation?: string;
   detail: string;
 }
+/**
+ * Type describing a CSS Style, as described by a JSDoc-style comment
+ */
 export interface JsonDocsStyle {
+  /**
+   * The name of the style
+   */
   name: string;
+  /**
+   * The type/description associated with the style
+   */
   docs: string;
+  /**
+   * The annotation used in the JSDoc of the style (e.g. `@prop`)
+   */
   annotation: string;
+  /**
+   * The mode associated with the style
+   */
+  mode: string | undefined;
 }
 export interface JsonDocsListener {
   event: string;
@@ -389,10 +405,28 @@ export interface JsonDocsPart {
    */
   docs: string;
 }
+/**
+ * Represents a parsed block comment in a CSS, Sass, etc. file for a custom property.
+ */
 export interface StyleDoc {
+  /**
+   * The name of the CSS property
+   */
   name: string;
+  /**
+   * The user-defined description of the CSS property
+   */
   docs: string;
+  /**
+   * The JSDoc-style annotation (e.g. `@prop`) that was used in the block comment to detect the comment.
+   * Used to inform Stencil where the start of a new property's description starts (and where the previous description
+   * ends).
+   */
   annotation: "prop";
+  /**
+   * The Stencil style-mode that is associated with this property.
+   */
+  mode: string | undefined;
 }
 
 export {};

--- a/test/docs-json/docs.json
+++ b/test/docs-json/docs.json
@@ -55,7 +55,20 @@
       ],
       "events": [],
       "listeners": [],
-      "styles": [],
+      "styles": [
+        {
+          "name": "--background",
+          "annotation": "prop",
+          "docs": "the background color",
+          "mode": "ios"
+        },
+        {
+          "name": "--background",
+          "annotation": "prop",
+          "docs": "the background color",
+          "mode": "md"
+        }
+      ],
       "slots": [],
       "parts": [],
       "dependents": [],

--- a/test/docs-json/src/components/my-component/my-component.ios.css
+++ b/test/docs-json/src/components/my-component/my-component.ios.css
@@ -1,0 +1,6 @@
+:host {
+  /**
+   * @prop --background: the background color
+   */
+  background: blue;
+}

--- a/test/docs-json/src/components/my-component/my-component.md.css
+++ b/test/docs-json/src/components/my-component/my-component.md.css
@@ -1,0 +1,6 @@
+:host {
+  /**
+   * @prop --background: the background color
+   */
+  background: red;
+}

--- a/test/docs-json/src/components/my-component/my-component.tsx
+++ b/test/docs-json/src/components/my-component/my-component.tsx
@@ -1,8 +1,13 @@
 import { Component, h, Method } from '@stencil/core';
-import { importedInterface, ImportedInterface } from './imported-interface';
+
+import { ImportedInterface, importedInterface } from './imported-interface';
 
 @Component({
   tag: 'my-component',
+  styleUrls: {
+    ios: './my-component.ios.css',
+    md: './my-component.md.css',
+  },
   shadow: true,
 })
 export class MyComponent {

--- a/test/docs-json/stencil.config.ts
+++ b/test/docs-json/stencil.config.ts
@@ -1,8 +1,12 @@
 import { Config } from '@stencil/core';
-
 export const config: Config = {
   namespace: 'json-docs-testbed',
   outputTargets: [
+    {
+      // needed to generate additional doc-metadata for styles, as the `ext-transform-plugin` does not run solely when
+      // 'docs-json' is run
+      type: 'dist-custom-elements',
+    },
     {
       type: 'docs-json',
       file: 'docs.json',


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

add a style mode to the output of the `docs-json` output target. when a stencil component is declared using the `styleUrls` property, a user may choose to apply styles depending on a "mode" that they set at runtime:
```tsx
// https://stenciljs.com/docs/component#styleurls
import { Component } from '@stencil/core';

@Component({
  tag: 'todo-list',
  styleUrls: {
     ios: 'todo-list.ios.scss',
     md: 'todo-list.md.scss',
  }
})
export class TodoList {}
```

where the `todo-list.ios.scss` stylesheet will be applied with the mode is set to 'ios' at runtime, and `todo-list.md.scss` will be applied if the mode 'md' is set at runtime.

with this change, documented css properties will be associated with their respective modes in the output of the `docs-json` output target.

for `todo-list.md.scss`:
```sass
/**
 * @prop --button-background: Background of the button
 */
:host {}
```

the mode will now be reported in `docs-json`:
```diff
{
    "name": "--button-background",
    "annotation": "prop",
    "docs": "Background of the button",
+   "mode": "md"
},
```

if a property of the same name exists in more than one mode - e.g. if `--button-background` _also_ existed in the ios mode stylesheet, two separate entries will be generated. this is accomplished by using a composite key for deduplicating/merging arrays consisting of the name and mode of the property/stylesheet



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->
https://github.com/ionic-team/stencil-site/pull/1417/files

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

1. Additional unit tests have been added
2. The `test/docs-json` was rerun to rebuild its output file
3. I tested this in Ionic Framework (expand section below for details)
<details>
  <summary>Details (Click Me)</summary>

  ### Changes to Framework
  1. Checkout `0873dc2ffbc623439a74926937a75f54a28b9709` in Framework, cd into `core`
  2. `npm run build` to get a baseline
  3. `npm run build` this branch, `npm pack` to tarball, `npm i <TARBALL>` in core
  4. Update `stencil.config.ts`
      ```diff
      diff --git a/core/stencil.config.ts b/core/stencil.config.ts
      index cdc5e76fe4..0415de6afa 100644
      --- a/core/stencil.config.ts
      +++ b/core/stencil.config.ts
      @@ -231,7 +231,7 @@ export const config: Config = {
           },
           {
             type: 'docs-json',
      -      file: '../packages/docs/core.json'
      +      file: '../packages/docs/core-new.json'
           },
           {
             type: 'dist-hydrate-script'
      ```
  5. `npm run build` to get a new `docs-json` file
  6. Diff the old docs-json and new docs-json file (attached)
  
[core-json-output.txt](https://github.com/ionic-team/stencil/files/15153537/core-json-output.txt)

</details>
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
STENCIL-1269 CSS Documentation Should Account for Modes