### PR TITLE
fix(hydrate): output track elements as void elms

### DIFF
--- a/src/mock-doc/serialize-node.ts
+++ b/src/mock-doc/serialize-node.ts
@@ -474,6 +474,7 @@ function isWithinWhitespaceSensitive(node: Node) {
   return false;
 }
 
+// TODO(STENCIL-1299): Audit this list, remove unsupported/deprecated elements
 /*@__PURE__*/ export const NON_ESCAPABLE_CONTENT = new Set([
   'STYLE',
   'SCRIPT',
@@ -485,6 +486,7 @@ function isWithinWhitespaceSensitive(node: Node) {
   'PLAINTEXT',
 ]);
 
+// TODO(STENCIL-1299): Audit this list, remove unsupported/deprecated elements
 /**
  * A list of whitespace sensitive tag names, such as `code`, `pre`, etc.
  */
@@ -498,7 +500,8 @@ function isWithinWhitespaceSensitive(node: Node) {
   'TEXTAREA',
 ]);
 
-/*@__PURE__*/ const EMPTY_ELEMENTS = new Set([
+// TODO(STENCIL-1299): Audit this list, remove unsupported/deprecated elements
+/*@__PURE__*/ export const EMPTY_ELEMENTS = new Set([
   'area',
   'base',
   'basefont',
@@ -520,8 +523,10 @@ function isWithinWhitespaceSensitive(node: Node) {
   'wbr',
 ]);
 
+// TODO(STENCIL-1299): Audit this list, remove unsupported/deprecated attr
 /*@__PURE__*/ const REMOVE_EMPTY_ATTR = new Set(['class', 'dir', 'id', 'lang', 'name', 'title']);
 
+// TODO(STENCIL-1299): Audit this list, remove unsupported/deprecated attr
 /*@__PURE__*/ const BOOLEAN_ATTR = new Set([
   'allowfullscreen',
   'async',

--- a/src/mock-doc/serialize-node.ts
+++ b/src/mock-doc/serialize-node.ts
@@ -516,6 +516,7 @@ function isWithinWhitespaceSensitive(node: Node) {
   'param',
   'source',
   'trace',
+  'track',
   'wbr',
 ]);
 

--- a/src/mock-doc/test/serialize-node.spec.ts
+++ b/src/mock-doc/test/serialize-node.spec.ts
@@ -1,5 +1,5 @@
 import { MockDocument } from '../document';
-import { serializeNodeToHtml } from '../serialize-node';
+import { EMPTY_ELEMENTS, serializeNodeToHtml } from '../serialize-node';
 
 describe('serializeNodeToHtml', () => {
   let doc: MockDocument;
@@ -277,5 +277,20 @@ describe('serializeNodeToHtml', () => {
     const scriptElm = doc.createElement('script');
     scriptElm.innerHTML = input;
     expect(scriptElm.innerHTML).toBe(input);
+  });
+
+  it.each([...EMPTY_ELEMENTS])("does not add a closing tag for '%s'", (voidElm) => {
+    if (voidElm === 'frame') {
+      // 'frame' is a non-HTML5 compatible/deprecated element.
+      // Stencil technically still supports it, but it doesn't get rendered as a child element, so let's just skip it
+      return;
+    }
+
+    const elm = doc.createElement('div');
+
+    elm.innerHTML = `<${voidElm}>`;
+
+    const html = serializeNodeToHtml(elm, { prettyHtml: true });
+    expect(html).toBe(`<${voidElm}>`);
   });
 });


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See 'new behavior' section

GitHub Issue Number: Fixes: #2994


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

add `track` to the list of "EMPTY" elements (void elements) that is referenced when we serialize nodes.

prior to this fix, the output of running `renderToString` as such:
```js
const hydrate = require('./hydrate/index.js');

const src = `<video>
<source src="x" type="video/mp4">
<track
    kind="subtitles"
    src="x"
>
</video>`;

hydrate.renderToString(src, { prettyHtml: true })
    .then(result => console.log(result.html));
```

would result in the following being printed:

```html
<!doctype html>
<html class="hydrated" data-stencil-build="shc9pw4e">
  <head>
    <meta charset="utf-8">
  </head>
  <body>
    <video>
      <source src="x" type="video/mp4">
      <!-- NOTE: track has a closing tag -->
      <track kind="subtitles" src="x"></track>
    </video>
  </body>
</html>
```

With this fix applied, we print `track` as a void element:
```html
<!doctype html>
<html class="hydrated" data-stencil-build="z6oqy2b2">
  <head>
    <meta charset="utf-8">
  </head>
  <body>
    <video>
      <source src="x" type="video/mp4">
      <track kind="subtitles" src="x">
    </video>
  </body>
</html>
```


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

1. First, I spun up a little stencil component starter locally:
```bash
$ npm init stencil@latest component track-test && \
  cd $_ && \
  npm i && \
  git add . && \
  git commit -m 'commit package-lock'
```

Note - this just adds some boilerplate. We won't use (much) of this code.

2. Next, add the `dist-hydrate` to your `stencil.config.ts`
```diff
diff --git a/stencil.config.ts b/stencil.config.ts
index 0d78965..09a0a24 100644
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -19,6 +19,9 @@ export const config: Config = {
       type: 'www',
       serviceWorker: null, // disable service workers
     },
+    {
+      type: 'dist-hydrate-script',
+    }
   ],
   testing: {
     browserHeadless: "new",
```

3. Run `npm run build` to generate the `hydrate` output.
4. Create the following `index.js` file at the root of the project:
```js
const hydrate = require('./hydrate/index.js');

const src = `<video>
<source src="x" type="video/mp4">
<track
    kind="subtitles"
    src="x"
>
</video>`;

hydrate.renderToString(src, { prettyHtml: true })
    .then(result => console.log(result.html));

```
5. Run `node index.js`, observe the output:
```html
<!doctype html>
<html class="hydrated" data-stencil-build="shc9pw4e">
  <head>
    <meta charset="utf-8">
  </head>
  <body>
    <video>
      <source src="x" type="video/mp4">
      <track kind="subtitles" src="x"></track>
    </video>
  </body>
</html>
```
6. Checkout this branch, build it, and install it into your project
7. Run `npm run build` again to regenerate the hydrate bundle
8. Re-run `node index.js`, observe the difference in output:
```diff
<!doctype html>
<html class="hydrated" data-stencil-build="z6oqy2b2">
  <head>
    <meta charset="utf-8">
  </head>
  <body>
    <video>
      <source src="x" type="video/mp4">
-      <track kind="subtitles" src="x"></track>
+      <track kind="subtitles" src="x">
    </video>
  </body>
</html>
```
## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

STENCIL-94: Using hydrate.renderToString produces "invalid" HTML with <track>