### PR TITLE
fix(testing): support functional components in unit tests

### DIFF
--- a/src/testing/platform/testing-platform.ts
+++ b/src/testing/platform/testing-platform.ts
@@ -105,7 +105,7 @@ export async function startAutoApplyChanges(): Promise<void> {
  * @param Cstrs the component constructors to register
  */
 export const registerComponents = (Cstrs: d.ComponentTestingConstructor[]): void => {
-  Cstrs.forEach((Cstr) => {
+  Cstrs.filter((Cstr) => Cstr.COMPILER_META).forEach((Cstr) => {
     cstrs.set(Cstr.COMPILER_META.tagName, Cstr);
   });
 };

--- a/src/testing/spec-page.ts
+++ b/src/testing/spec-page.ts
@@ -31,6 +31,12 @@ import { getBuildFeatures } from '../compiler/app-core/app-data';
 import { resetBuildConditionals } from './reset-build-conditionals';
 
 /**
+ * Generates a random number for use in generating a bundle id
+ * @returns a random number between 100000 and 999999
+ */
+const generateRandBundleId = () => Math.round(Math.random() * 899999) + 100000;
+
+/**
  * Creates a new spec page for unit testing
  * @param opts the options to apply to the spec page that influence its configuration and operation
  * @returns the created spec page
@@ -92,7 +98,7 @@ export async function newSpecPage(opts: NewSpecPageOptions): Promise<SpecPage> {
       /**
        * the bundleId can be arbitrary, but must be unique
        */
-      const arbitraryBundleId = `fc.${Math.round(Math.random() * 899999) + 100000}`;
+      const arbitraryBundleId = `fc.${generateRandBundleId()}`;
       return formatLazyBundleRuntimeMeta(arbitraryBundleId, []);
     }
 
@@ -101,7 +107,7 @@ export async function newSpecPage(opts: NewSpecPageOptions): Promise<SpecPage> {
 
     proxyComponentLifeCycles(Cstr);
 
-    const bundleId = `${Cstr.COMPILER_META.tagName}.${Math.round(Math.random() * 899999) + 100000}`;
+    const bundleId = `${Cstr.COMPILER_META.tagName}.${generateRandBundleId()}`;
     const stylesMeta = Cstr.COMPILER_META.styles;
     if (Array.isArray(stylesMeta)) {
       if (stylesMeta.length > 1) {

--- a/src/testing/spec-page.ts
+++ b/src/testing/spec-page.ts
@@ -85,8 +85,15 @@ export async function newSpecPage(opts: NewSpecPageOptions): Promise<SpecPage> {
   };
 
   const lazyBundles: LazyBundlesRuntimeData = opts.components.map((Cstr: ComponentTestingConstructor) => {
+    /**
+     * just pass through functional components that don't have styles nor any other metadata
+     */
     if (Cstr.COMPILER_META == null) {
-      throw new Error(`Invalid component class: Missing static "COMPILER_META" property.`);
+      /**
+       * the bundleId can be arbitrary, but must be unique
+       */
+      const arbitraryBundleId = `fc.${Math.round(Math.random() * 899999) + 100000}`;
+      return formatLazyBundleRuntimeMeta(arbitraryBundleId, []);
     }
 
     cmpTags.add(Cstr.COMPILER_META.tagName);
@@ -113,7 +120,9 @@ export async function newSpecPage(opts: NewSpecPageOptions): Promise<SpecPage> {
     return lazyBundleRuntimeMeta;
   });
 
-  const cmpCompilerMeta = opts.components.map((Cstr) => Cstr.COMPILER_META as ComponentCompilerMeta);
+  const cmpCompilerMeta = opts.components
+    .filter((Cstr) => Cstr.COMPILER_META != null)
+    .map((Cstr) => Cstr.COMPILER_META as ComponentCompilerMeta);
   const cmpBuild = getBuildFeatures(cmpCompilerMeta);
   if (opts.strictBuild) {
     Object.assign(BUILD, cmpBuild);

--- a/src/testing/test/__fixtures__/cmp.tsx
+++ b/src/testing/test/__fixtures__/cmp.tsx
@@ -6,9 +6,11 @@ import { Component, h } from '@stencil/core';
 })
 export class ClassComponent {
   render() {
-    return <div>
-      <h1>I am a class component</h1>
-      <slot></slot>
-    </div>;
+    return (
+      <div>
+        <h1>I am a class component</h1>
+        <slot></slot>
+      </div>
+    );
   }
 }

--- a/src/testing/test/__fixtures__/cmp.tsx
+++ b/src/testing/test/__fixtures__/cmp.tsx
@@ -1,0 +1,14 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'class-component',
+  shadow: true,
+})
+export class ClassComponent {
+  render() {
+    return <div>
+      <h1>I am a class component</h1>
+      <slot></slot>
+    </div>;
+  }
+}

--- a/src/testing/test/functional.spec.tsx
+++ b/src/testing/test/functional.spec.tsx
@@ -1,4 +1,4 @@
-import { h } from '@stencil/core';
+import { Fragment, h } from '@stencil/core';
 import { newSpecPage, SpecPage } from '@stencil/core/testing';
 
 import { ClassComponent } from './__fixtures__/cmp';
@@ -23,7 +23,7 @@ describe('testing function and class components', () => {
   });
 
   it('can render a single functional component with children', async () => {
-    const MyFunctionalComponent = (props: never, children) => <div>{children}</div>;
+    const MyFunctionalComponent: Fragment = (props: never, children: Fragment) => <div>{children}</div>;
     const page: SpecPage = await newSpecPage({
       components: [MyFunctionalComponent],
       template: () => <MyFunctionalComponent>Hello World</MyFunctionalComponent>,
@@ -32,7 +32,7 @@ describe('testing function and class components', () => {
   });
 
   it('can render a single functional component with children and props', async () => {
-    const MyFunctionalComponent = (props: { foo: 'bar' }, children) => (
+    const MyFunctionalComponent = (props: { foo: 'bar' }, children: Fragment) => (
       <div>
         {children} - {props.foo}
       </div>
@@ -45,7 +45,7 @@ describe('testing function and class components', () => {
   });
 
   it('can render a class component with a functional component', async () => {
-    const MyFunctionalComponent = (props: never, children: string) => (
+    const MyFunctionalComponent = (props: never, children: Fragment) => (
       <div>I am a functional component - {children}</div>
     );
     const page: SpecPage = await newSpecPage({
@@ -73,7 +73,7 @@ describe('testing function and class components', () => {
   });
 
   it('can render a functional component within a class component', async () => {
-    const MyFunctionalComponent = (props: never, children: string) => (
+    const MyFunctionalComponent = (props: never, children: Fragment) => (
       <div>
         <h1>I am a functional component</h1>
         {children}

--- a/src/testing/test/functional.spec.tsx
+++ b/src/testing/test/functional.spec.tsx
@@ -56,7 +56,7 @@ describe('testing function and class components', () => {
         </class-component>
       ),
     });
-    expect(page.bo).toEqualHtml(`<class-component>
+    expect(page.root).toEqualHtml(`<class-component>
   <mock:shadow-root>
     <div>
       <h1>

--- a/src/testing/test/functional.spec.tsx
+++ b/src/testing/test/functional.spec.tsx
@@ -5,7 +5,7 @@ import { ClassComponent } from './__fixtures__/cmp';
 
 describe('testing function and class components', () => {
   it('can render a single functional component', async () => {
-    const MyFunctionalComponent = () => (<div>Hello World</div>)
+    const MyFunctionalComponent = () => <div>Hello World</div>;
     const page: SpecPage = await newSpecPage({
       components: [MyFunctionalComponent],
       template: () => <MyFunctionalComponent></MyFunctionalComponent>,
@@ -14,7 +14,7 @@ describe('testing function and class components', () => {
   });
 
   it('can render a single functional component with props', async () => {
-    const MyFunctionalComponent = (props: { foo: 'bar' }) => (<div>{props.foo}</div>)
+    const MyFunctionalComponent = (props: { foo: 'bar' }) => <div>{props.foo}</div>;
     const page: SpecPage = await newSpecPage({
       components: [MyFunctionalComponent],
       template: () => <MyFunctionalComponent foo="bar"></MyFunctionalComponent>,
@@ -23,7 +23,7 @@ describe('testing function and class components', () => {
   });
 
   it('can render a single functional component with children', async () => {
-    const MyFunctionalComponent = (props: never, children) => (<div>{children}</div>)
+    const MyFunctionalComponent = (props: never, children) => <div>{children}</div>;
     const page: SpecPage = await newSpecPage({
       components: [MyFunctionalComponent],
       template: () => <MyFunctionalComponent>Hello World</MyFunctionalComponent>,
@@ -32,7 +32,11 @@ describe('testing function and class components', () => {
   });
 
   it('can render a single functional component with children and props', async () => {
-    const MyFunctionalComponent = (props: { foo: 'bar' }, children) => (<div>{children} - {props.foo}</div>)
+    const MyFunctionalComponent = (props: { foo: 'bar' }, children) => (
+      <div>
+        {children} - {props.foo}
+      </div>
+    );
     const page: SpecPage = await newSpecPage({
       components: [MyFunctionalComponent],
       template: () => <MyFunctionalComponent foo="bar">Hello World</MyFunctionalComponent>,
@@ -41,12 +45,16 @@ describe('testing function and class components', () => {
   });
 
   it('can render a class component with a functional component', async () => {
-    const MyFunctionalComponent = (props: never, children: string) => (<div>I am a functional component - {children}</div>)
+    const MyFunctionalComponent = (props: never, children: string) => (
+      <div>I am a functional component - {children}</div>
+    );
     const page: SpecPage = await newSpecPage({
       components: [ClassComponent],
-      template: () => <class-component>
-        <MyFunctionalComponent>Yes I am!</MyFunctionalComponent>
-      </class-component>,
+      template: () => (
+        <class-component>
+          <MyFunctionalComponent>Yes I am!</MyFunctionalComponent>
+        </class-component>
+      ),
     });
     expect(page.bo).toEqualHtml(`<class-component>
   <mock:shadow-root>
@@ -65,15 +73,19 @@ describe('testing function and class components', () => {
   });
 
   it('can render a functional component within a class component', async () => {
-    const MyFunctionalComponent = (props: never, children: string) => (<div>
-      <h1>I am a functional component</h1>
-      {children}
-    </div>)
+    const MyFunctionalComponent = (props: never, children: string) => (
+      <div>
+        <h1>I am a functional component</h1>
+        {children}
+      </div>
+    );
     const page: SpecPage = await newSpecPage({
       components: [ClassComponent],
-      template: () => <MyFunctionalComponent>
-        <class-component>Yes I am!</class-component>
-      </MyFunctionalComponent>,
+      template: () => (
+        <MyFunctionalComponent>
+          <class-component>Yes I am!</class-component>
+        </MyFunctionalComponent>
+      ),
     });
     expect(page.body).toEqualHtml(`<div>
     <h1>
@@ -90,6 +102,6 @@ describe('testing function and class components', () => {
       </mock:shadow-root>
       Yes I am!
     </class-component>
-  </div>`)
+  </div>`);
   });
 });

--- a/src/testing/test/functional.spec.tsx
+++ b/src/testing/test/functional.spec.tsx
@@ -1,12 +1,12 @@
 import { h } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
 
 import { ClassComponent } from './__fixtures__/cmp';
 
 describe('testing function and class components', () => {
   it('can render a single functional component', async () => {
     const MyFunctionalComponent = () => (<div>Hello World</div>)
-    const page = await newSpecPage({
+    const page: SpecPage = await newSpecPage({
       components: [MyFunctionalComponent],
       template: () => <MyFunctionalComponent></MyFunctionalComponent>,
     });
@@ -15,7 +15,7 @@ describe('testing function and class components', () => {
 
   it('can render a single functional component with props', async () => {
     const MyFunctionalComponent = (props: { foo: 'bar' }) => (<div>{props.foo}</div>)
-    const page = await newSpecPage({
+    const page: SpecPage = await newSpecPage({
       components: [MyFunctionalComponent],
       template: () => <MyFunctionalComponent foo="bar"></MyFunctionalComponent>,
     });
@@ -24,7 +24,7 @@ describe('testing function and class components', () => {
 
   it('can render a single functional component with children', async () => {
     const MyFunctionalComponent = (props: never, children) => (<div>{children}</div>)
-    const page = await newSpecPage({
+    const page: SpecPage = await newSpecPage({
       components: [MyFunctionalComponent],
       template: () => <MyFunctionalComponent>Hello World</MyFunctionalComponent>,
     });
@@ -33,7 +33,7 @@ describe('testing function and class components', () => {
 
   it('can render a single functional component with children and props', async () => {
     const MyFunctionalComponent = (props: { foo: 'bar' }, children) => (<div>{children} - {props.foo}</div>)
-    const page = await newSpecPage({
+    const page: SpecPage = await newSpecPage({
       components: [MyFunctionalComponent],
       template: () => <MyFunctionalComponent foo="bar">Hello World</MyFunctionalComponent>,
     });
@@ -42,13 +42,13 @@ describe('testing function and class components', () => {
 
   it('can render a class component with a functional component', async () => {
     const MyFunctionalComponent = (props: never, children: string) => (<div>I am a functional component - {children}</div>)
-    const page = await newSpecPage({
+    const page: SpecPage = await newSpecPage({
       components: [ClassComponent],
       template: () => <class-component>
         <MyFunctionalComponent>Yes I am!</MyFunctionalComponent>
       </class-component>,
     });
-    expect(page.root).toEqualHtml(`<class-component>
+    expect(page.bo).toEqualHtml(`<class-component>
   <mock:shadow-root>
     <div>
       <h1>
@@ -64,21 +64,32 @@ describe('testing function and class components', () => {
 `);
   });
 
-  /**
-   * This will not work as Stencil can only render a class component as a root
-   * TODO(@christian-bromann): create a Jira ticket for this?
-   */
-  it.skip('can render a functional component within a class component', async () => {
+  it('can render a functional component within a class component', async () => {
     const MyFunctionalComponent = (props: never, children: string) => (<div>
       <h1>I am a functional component</h1>
       {children}
     </div>)
-    const page = await newSpecPage({
+    const page: SpecPage = await newSpecPage({
       components: [ClassComponent],
       template: () => <MyFunctionalComponent>
         <class-component>Yes I am!</class-component>
       </MyFunctionalComponent>,
     });
-    expect(page.root).toEqualHtml('')
+    expect(page.body).toEqualHtml(`<div>
+    <h1>
+      I am a functional component
+    </h1>
+    <class-component>
+      <mock:shadow-root>
+        <div>
+          <h1>
+            I am a class component
+          </h1>
+          <slot></slot>
+        </div>
+      </mock:shadow-root>
+      Yes I am!
+    </class-component>
+  </div>`)
   });
 });

--- a/src/testing/test/functional.spec.tsx
+++ b/src/testing/test/functional.spec.tsx
@@ -1,0 +1,84 @@
+import { h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+import { ClassComponent } from './__fixtures__/cmp';
+
+describe('testing function and class components', () => {
+  it('can render a single functional component', async () => {
+    const MyFunctionalComponent = () => (<div>Hello World</div>)
+    const page = await newSpecPage({
+      components: [MyFunctionalComponent],
+      template: () => <MyFunctionalComponent></MyFunctionalComponent>,
+    });
+    expect(page.root).toEqualHtml(`<div>Hello World</div>`);
+  });
+
+  it('can render a single functional component with props', async () => {
+    const MyFunctionalComponent = (props: { foo: 'bar' }) => (<div>{props.foo}</div>)
+    const page = await newSpecPage({
+      components: [MyFunctionalComponent],
+      template: () => <MyFunctionalComponent foo="bar"></MyFunctionalComponent>,
+    });
+    expect(page.root).toEqualHtml(`<div>bar</div>`);
+  });
+
+  it('can render a single functional component with children', async () => {
+    const MyFunctionalComponent = (props: never, children) => (<div>{children}</div>)
+    const page = await newSpecPage({
+      components: [MyFunctionalComponent],
+      template: () => <MyFunctionalComponent>Hello World</MyFunctionalComponent>,
+    });
+    expect(page.root).toEqualHtml(`<div>Hello World</div>`);
+  });
+
+  it('can render a single functional component with children and props', async () => {
+    const MyFunctionalComponent = (props: { foo: 'bar' }, children) => (<div>{children} - {props.foo}</div>)
+    const page = await newSpecPage({
+      components: [MyFunctionalComponent],
+      template: () => <MyFunctionalComponent foo="bar">Hello World</MyFunctionalComponent>,
+    });
+    expect(page.root).toEqualHtml(`<div>Hello World - bar</div>`);
+  });
+
+  it('can render a class component with a functional component', async () => {
+    const MyFunctionalComponent = (props: never, children: string) => (<div>I am a functional component - {children}</div>)
+    const page = await newSpecPage({
+      components: [ClassComponent],
+      template: () => <class-component>
+        <MyFunctionalComponent>Yes I am!</MyFunctionalComponent>
+      </class-component>,
+    });
+    expect(page.root).toEqualHtml(`<class-component>
+  <mock:shadow-root>
+    <div>
+      <h1>
+        I am a class component
+      </h1>
+      <slot></slot>
+    </div>
+  </mock:shadow-root>
+  <div>
+    I am a functional component - Yes I am!
+  </div>
+</class-component>
+`);
+  });
+
+  /**
+   * This will not work as Stencil can only render a class component as a root
+   * TODO(@christian-bromann): create a Jira ticket for this?
+   */
+  it.skip('can render a functional component within a class component', async () => {
+    const MyFunctionalComponent = (props: never, children: string) => (<div>
+      <h1>I am a functional component</h1>
+      {children}
+    </div>)
+    const page = await newSpecPage({
+      components: [ClassComponent],
+      template: () => <MyFunctionalComponent>
+        <class-component>Yes I am!</class-component>
+      </MyFunctionalComponent>,
+    });
+    expect(page.root).toEqualHtml('')
+  });
+});

--- a/src/testing/test/tsconfig.json
+++ b/src/testing/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../testing/tsconfig.internal.json"
+}

--- a/src/testing/test/tsconfig.json
+++ b/src/testing/test/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../../testing/tsconfig.internal.json"
+  "extends": "../../testing/tsconfig.internal.json",
+  "compilerOptions": {
+    "paths": {
+      "@stencil/core": ["../../index.ts"],
+      "@stencil/core/testing": ["../../testing/index.ts"],
+      "@platform": ["../../client/index.ts"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
 }


### PR DESCRIPTION
## What is the current behavior?

The original issue claimed a Rollup error when writing functional components in tests. However I wasn't able to reproduce this behavior.

Instead, trying to render a functional component in unit tests would fail with the error:

```
    TypeError: Cannot read properties of undefined (reading 'tagName')

      3122 | var registerComponents = (Cstrs) => {
      3123 |   Cstrs.forEach((Cstr) => {
    > 3124 |     cstrs.set(Cstr.COMPILER_META.tagName, Cstr);
           |                                  ^
      3125 |   });
      3126 | };
      3127 | function registerModule(bundleId, Cstr) {

      at ../../../Users/christian.bromann/Sites/Ionic/projects/stencil/internal/testing/index.js:3124:34
          at Array.forEach (<anonymous>)
      at registerComponents (../../../Users/christian.bromann/Sites/Ionic/projects/stencil/internal/testing/index.js:3123:9)
      at newSpecPage (../../../Users/christian.bromann/Sites/Ionic/projects/stencil/testing/index.js:10655:44)
      at Object.<anonymous> (src/components/my-component/my-component.spec.tsx:12:29)
```

STENCIL-751
fixes #4063

## What is the new behavior?

Changing the testing module to accept functional components by essentially just skipping the parts where it tries to access the component meta data.

STENCIL-751

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Added some unit tests where I render functional and class components and mix them together. Probably not exhaustive but it validates that both types of components can be rendered.

## Other information

n/a
