### PR TITLE
fix(build): do not copy polyfills to the `dist` OT unless building es5

### DIFF
--- a/src/compiler/output-targets/dist-lazy/generate-esm.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-esm.ts
@@ -58,7 +58,9 @@ export const generateEsm = async (
         '',
       );
 
-      await copyPolyfills(config, compilerCtx, esmOutputs);
+      if (config.buildEs5) {
+        await copyPolyfills(config, compilerCtx, esmOutputs);
+      }
       await generateShortcuts(config, compilerCtx, outputTargets, output);
     }
   }
@@ -66,6 +68,15 @@ export const generateEsm = async (
   return { name: 'esm', buildCtx };
 };
 
+/**
+ * Copy polyfills from `$INSTALL_DIR/internal/client/polyfills` to the lazy
+ * loader output directory where $INSTALL_DIR is the directory in which the
+ * `@stencil/core` package is installed.
+ *
+ * @param config a validated Stencil configuration
+ * @param compilerCtx the current compiler context
+ * @param outputTargets dist-lazy output targets
+ */
 const copyPolyfills = async (
   config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,

--- a/src/compiler/output-targets/test/output-lazy-loader.spec.ts
+++ b/src/compiler/output-targets/test/output-lazy-loader.spec.ts
@@ -1,0 +1,73 @@
+import type * as d from '@stencil/core/declarations';
+import { mockBuildCtx, mockCompilerCtx, mockCompilerSystem, mockValidatedConfig } from '@stencil/core/testing';
+import { DIST, resolve } from '@utils';
+
+import { validateDist } from '../../config/outputs/validate-dist';
+import { outputLazyLoader } from '../output-lazy-loader';
+
+function setup(configOverrides: Partial<d.ValidatedConfig> = {}) {
+  const sys = mockCompilerSystem();
+  const config: d.ValidatedConfig = mockValidatedConfig({
+    ...configOverrides,
+    configPath: '/testing-path',
+    buildAppCore: true,
+    namespace: 'TestApp',
+    outputTargets: [
+      {
+        type: DIST,
+        dir: 'my-test-dir',
+      },
+    ],
+    srcDir: '/src',
+    sys,
+  });
+
+  config.outputTargets = validateDist(config, config.outputTargets);
+
+  const compilerCtx = mockCompilerCtx(config);
+  const writeFileSpy = jest.spyOn(compilerCtx.fs, 'writeFile');
+  const buildCtx = mockBuildCtx(config, compilerCtx);
+
+  return { config, compilerCtx, buildCtx, writeFileSpy };
+}
+
+describe('Lazy Loader Output Target', () => {
+  let config: d.ValidatedConfig;
+  let compilerCtx: d.CompilerCtx;
+  let writeFileSpy: jest.SpyInstance;
+
+  afterEach(() => {
+    writeFileSpy.mockRestore();
+  });
+
+  it('should write code for initializing polyfills when buildEs5=true', async () => {
+    ({ config, compilerCtx, writeFileSpy } = setup({ buildEs5: true }));
+    await outputLazyLoader(config, compilerCtx);
+
+    const expectedIndexOutput = `export * from '../esm/polyfills/index.js';
+export * from '../esm-es5/loader.js';`;
+    expect(writeFileSpy).toHaveBeenCalledWith(resolve('/my-test-dir/loader/index.js'), expectedIndexOutput);
+
+    const expectedCjsIndexOutput = `module.exports = require('../cjs/loader.cjs.js');
+module.exports.applyPolyfills = function() { return Promise.resolve() };`;
+    expect(writeFileSpy).toHaveBeenCalledWith(resolve('/my-test-dir/loader/index.cjs.js'), expectedCjsIndexOutput);
+
+    const expectedES2017Output = `export * from '../esm/polyfills/index.js';
+export * from '../esm/loader.js';`;
+    expect(writeFileSpy).toHaveBeenCalledWith(resolve('/my-test-dir/loader/index.es2017.js'), expectedES2017Output);
+  });
+
+  it('should exclude polyfill code when buildEs5=false', async () => {
+    ({ config, compilerCtx, writeFileSpy } = setup({ buildEs5: false }));
+    await outputLazyLoader(config, compilerCtx);
+
+    const expectedIndexOutput = `export * from '../esm/loader.js';`;
+    expect(writeFileSpy).toHaveBeenCalledWith(resolve('/my-test-dir/loader/index.js'), expectedIndexOutput);
+
+    const expectedCjsIndexOutput = `module.exports = require('../cjs/loader.cjs.js');`;
+    expect(writeFileSpy).toHaveBeenCalledWith(resolve('/my-test-dir/loader/index.cjs.js'), expectedCjsIndexOutput);
+
+    const expectedES2017Output = `export * from '../esm/loader.js';`;
+    expect(writeFileSpy).toHaveBeenCalledWith(resolve('/my-test-dir/loader/index.es2017.js'), expectedES2017Output);
+  });
+});


### PR DESCRIPTION
Prior to this change Stencil will copy polyfills to the `dist` output target whether or not the user has indicated they'll be necessary.

The polyfills comprise two things: copying the polyfills themselves into the 'loader' path, and adding code to the lazy-loader entry points which loads those polyfills. Instead of just assuming that the user wants this, we now gate this behavior on whether `buildEs5` is set on the Stencil configuration.

fixes #5416
STENCIL-1288

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?

Right now we copy a bunch of polyfills which won't be necessary outside of an ES5-only environment even when `buildEs5` is not set. This adds some extra bulk to the `dist` build output.

See #5416 for more details.


## What is the new behavior?

If the user has set `buildEs5` to true then we copy the polyfills, otherwise we don't do anything.


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

The best way to test this is to build a sample stencil project with `@stencil/core@latest` and then with a version based on this build and then compare the output.

First do:

```sh
cd /tmp
npm init stencil@latest component test-no-polyfills
cd test-no-polyfills
npm install
npm run build
```

then edit `.gitignore` to remove `dist/` and `loader/` from the ignore. Then you can follow the setup steps in [`CONTRIBUTING.md`](https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md) for local dev (e.g. the tsconfig `paths` stuff).

Then if you check out this branch in your stencil repo locally and run `npm link` you should be able to use this script to test things out in your new stencil project:

```bash
#!/bin/bash

npm unlink @stencil/core

npm install @stencil/core@latest

npm run build

git add .

git commit -m "build with @stencil/core@latest"

npm link @stencil/core

npm run build

git add .

git commit -m "build with dev build"
```

save that to like `test.sh` or something in your little project, throw a `chmod +x` on there and you're good to go.

Then you can do

```sh
git diff $(git rev-parse @~)
```

to see the diff between the `@stencil/core@latest` build and the dev build