### PR TITLE
fix(types): move autofocus attr/prop definition to HTMLAttributes

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -883,7 +883,6 @@ export namespace JSXBase {
   }
 
   export interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
-    autoFocus?: boolean;
     disabled?: boolean;
     form?: string;
     formAction?: string;
@@ -1026,8 +1025,6 @@ export namespace JSXBase {
     autocapitalize?: string;
     autoComplete?: string;
     autocomplete?: string;
-    autoFocus?: boolean;
-    autofocus?: boolean | string;
     capture?: string; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
     checked?: boolean;
     crossOrigin?: string;
@@ -1087,8 +1084,6 @@ export namespace JSXBase {
   }
 
   export interface KeygenHTMLAttributes<T> extends HTMLAttributes<T> {
-    autoFocus?: boolean;
-    autofocus?: boolean | string;
     challenge?: string;
     disabled?: boolean;
     form?: string;
@@ -1257,7 +1252,6 @@ export namespace JSXBase {
   }
 
   export interface SelectHTMLAttributes<T> extends HTMLAttributes<T> {
-    autoFocus?: boolean;
     disabled?: boolean;
     form?: string;
     multiple?: boolean;
@@ -1296,8 +1290,6 @@ export namespace JSXBase {
   export interface TextareaHTMLAttributes<T> extends HTMLAttributes<T> {
     autoComplete?: string;
     autocomplete?: string;
-    autoFocus?: boolean;
-    autofocus?: boolean | string;
     cols?: number;
     disabled?: boolean;
     form?: string;
@@ -1359,6 +1351,8 @@ export namespace JSXBase {
 
     // Standard HTML Attributes
     accessKey?: string;
+    autoFocus?: boolean;
+    autofocus?: boolean | string;
     class?: string | { [className: string]: boolean };
     contentEditable?: boolean | string;
     contenteditable?: boolean | string;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #5726

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

`autofocus` is now defined in the base `HTMLAttributes` type. 


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Tested manually by running a successful build via `npm pack` per the [contributing doc](https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md#testing-with-npm-pack).

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
