### PR TITLE
chore(build): improve esbuild logging in release context

### DIFF
--- a/scripts/esbuild/cli.ts
+++ b/scripts/esbuild/cli.ts
@@ -33,7 +33,7 @@ export async function buildCli(opts: BuildOptions) {
   const external = getEsbuildExternalModules(opts, opts.output.cliDir);
 
   const cliEsbuildOptions = {
-    ...getBaseEsbuildOptions(),
+    ...getBaseEsbuildOptions(opts),
     alias: cliAliases,
     entryPoints: [join(inputDir, 'index.ts')],
     external,

--- a/scripts/esbuild/compiler.ts
+++ b/scripts/esbuild/compiler.ts
@@ -78,7 +78,7 @@ export async function buildCompiler(opts: BuildOptions) {
   alias['parse5'] = parse5path;
 
   const compilerEsbuildOptions: ESBuildOptions = {
-    ...getBaseEsbuildOptions(),
+    ...getBaseEsbuildOptions(opts),
     banner: { js: getBanner(opts, 'Stencil Compiler', true) },
     entryPoints: [join(srcDir, 'index.ts')],
     platform: 'node',

--- a/scripts/esbuild/dev-server.ts
+++ b/scripts/esbuild/dev-server.ts
@@ -80,7 +80,7 @@ export async function buildDevServer(opts: BuildOptions) {
 
   const devServerAliases = getEsbuildAliases();
   const devServerIndexEsbuildOptions = {
-    ...getBaseEsbuildOptions(),
+    ...getBaseEsbuildOptions(opts),
     alias: devServerAliases,
     entryPoints: [join(inputDir, 'index.js')],
     outfile: join(opts.output.devServerDir, 'index.js'),
@@ -95,7 +95,7 @@ export async function buildDevServer(opts: BuildOptions) {
   } satisfies ESBuildOptions;
 
   const devServerProcessEsbuildOptions = {
-    ...getBaseEsbuildOptions(),
+    ...getBaseEsbuildOptions(opts),
     alias: {
       ...devServerAliases,
       '@sys-api-node': '../sys/node/index.js',
@@ -121,7 +121,7 @@ export async function buildDevServer(opts: BuildOptions) {
     '@stencil/core/dev-server/client': join(inputDir, 'client', 'index.js'),
   };
   const connectorEsbuildOptions = {
-    ...getBaseEsbuildOptions(),
+    ...getBaseEsbuildOptions(opts),
     alias: connectorAlias,
     entryPoints: [join(inputDir, 'dev-server-client', 'index.js')],
     outfile: join(opts.output.devServerDir, CONNECTOR_NAME),
@@ -155,7 +155,7 @@ export async function buildDevServer(opts: BuildOptions) {
   });
 
   const devServerClientEsbuildOptions = {
-    ...getBaseEsbuildOptions(),
+    ...getBaseEsbuildOptions(opts),
     entryPoints: [join(opts.buildDir, 'dev-server', 'client', 'index.js')],
     outfile: join(opts.output.devServerDir, 'client', 'index.js'),
     format: 'esm',

--- a/scripts/esbuild/internal-app-data.ts
+++ b/scripts/esbuild/internal-app-data.ts
@@ -35,7 +35,7 @@ export async function getInternalAppDataBundles(opts: BuildOptions): Promise<ESB
   });
 
   const appDataBaseOptions: ESBuildOptions = {
-    ...getBaseEsbuildOptions(),
+    ...getBaseEsbuildOptions(opts),
     entryPoints: [join(appDataSrcDir, 'index.ts')],
     platform: 'node',
   };

--- a/scripts/esbuild/internal-platform-client.ts
+++ b/scripts/esbuild/internal-platform-client.ts
@@ -42,7 +42,7 @@ export async function getInternalClientBundles(opts: BuildOptions): Promise<ESBu
   const clientExternal = getEsbuildExternalModules(opts, opts.output.internalDir);
 
   const internalClientBundle: ESBuildOptions = {
-    ...getBaseEsbuildOptions(),
+    ...getBaseEsbuildOptions(opts),
     entryPoints: [join(inputClientDir, 'index.ts')],
     format: 'esm',
     // we do 'write: false' here because we write the build to disk in our
@@ -77,7 +77,7 @@ export async function getInternalClientBundles(opts: BuildOptions): Promise<ESBu
   ];
 
   const internalClientPatchBrowserBundle: ESBuildOptions = {
-    ...getBaseEsbuildOptions(),
+    ...getBaseEsbuildOptions(opts),
     entryPoints: [join(inputClientDir, 'client-patch-browser.ts')],
     format: 'esm',
     outfile: join(outputInternalClientDir, 'patch-browser.js'),

--- a/scripts/esbuild/internal-platform-hydrate.ts
+++ b/scripts/esbuild/internal-platform-hydrate.ts
@@ -41,7 +41,7 @@ export async function getInternalPlatformHydrateBundles(opts: BuildOptions): Pro
   internalHydrateAliases['@platform'] = hydratePlatformInput;
 
   const internalHydratePlatformBundle: ESBuildOptions = {
-    ...getBaseEsbuildOptions(),
+    ...getBaseEsbuildOptions(opts),
     entryPoints: [hydratePlatformInput],
     format: 'esm',
     platform: 'node',
@@ -58,7 +58,7 @@ export async function getInternalPlatformHydrateBundles(opts: BuildOptions): Pro
   };
 
   const internalHydrateRunnerBundle: ESBuildOptions = {
-    ...getBaseEsbuildOptions(),
+    ...getBaseEsbuildOptions(opts),
     entryPoints: [join(hydrateSrcDir, 'runner', 'index.js')],
     external,
     format: 'esm',

--- a/scripts/esbuild/internal-platform-testing.ts
+++ b/scripts/esbuild/internal-platform-testing.ts
@@ -36,13 +36,12 @@ export async function getInternalTestingBundle(opts: BuildOptions): Promise<ESBu
   const external = getEsbuildExternalModules(opts, opts.output.internalDir);
 
   const internalTestingBuildOptions: ESBuildOptions = {
-    ...getBaseEsbuildOptions(),
+    ...getBaseEsbuildOptions(opts),
     entryPoints: [inputTestingPlatform],
     bundle: true,
     format: 'cjs',
     outfile: join(outputTestingPlatformDir, 'index.js'),
     platform: 'node',
-    logLevel: 'info',
     external,
     alias: internalTestingAliases,
     plugins: [

--- a/scripts/esbuild/internal.ts
+++ b/scripts/esbuild/internal.ts
@@ -46,7 +46,7 @@ export async function buildInternal(opts: BuildOptions) {
 
   // this is used in several of our bundles, so we bundle it here in one spot
   const shadowCSSBundle: ESBuildOptions = {
-    ...getBaseEsbuildOptions(),
+    ...getBaseEsbuildOptions(opts),
     entryPoints: [join(opts.srcDir, 'utils', 'shadow-css.ts')],
     format: 'esm',
     outfile: join(opts.output.internalDir, 'client', 'shadow-css.js'),

--- a/scripts/esbuild/mock-doc.ts
+++ b/scripts/esbuild/mock-doc.ts
@@ -47,11 +47,10 @@ export async function buildMockDoc(opts: BuildOptions) {
   mockDocAliases['parse5'] = parse5Path;
 
   const mockDocBuildOptions: ESBuildOptions = {
-    ...getBaseEsbuildOptions(),
+    ...getBaseEsbuildOptions(opts),
     entryPoints: [join(srcDir, 'index.ts')],
     bundle: true,
     alias: mockDocAliases,
-    logLevel: 'info',
   };
 
   const esmOptions: ESBuildOptions = {

--- a/scripts/esbuild/screenshot.ts
+++ b/scripts/esbuild/screenshot.ts
@@ -43,7 +43,7 @@ export async function buildScreenshot(opts: BuildOptions) {
   const external = getEsbuildExternalModules(opts, opts.output.screenshotDir);
 
   const baseScreenshotOptions = {
-    ...getBaseEsbuildOptions(),
+    ...getBaseEsbuildOptions(opts),
     alias: aliases,
     external,
     format: 'cjs',

--- a/scripts/esbuild/sys-node.ts
+++ b/scripts/esbuild/sys-node.ts
@@ -41,13 +41,12 @@ export async function buildSysNode(opts: BuildOptions) {
   const sysNodeAliases = getEsbuildAliases();
 
   const sysNodeOptions: ESBuildOptions = {
-    ...getBaseEsbuildOptions(),
+    ...getBaseEsbuildOptions(opts),
     entryPoints: [inputFile],
     bundle: true,
     format: 'cjs',
     outfile: outputFile,
     platform: 'node',
-    logLevel: 'info',
     external,
     minify: true,
     alias: sysNodeAliases,
@@ -60,13 +59,12 @@ export async function buildSysNode(opts: BuildOptions) {
   const outputWorkerFile = join(opts.output.sysNodeDir, 'worker.js');
 
   const workerOptions: ESBuildOptions = {
-    ...getBaseEsbuildOptions(),
+    ...getBaseEsbuildOptions(opts),
     entryPoints: [inputWorkerFile],
     bundle: true,
     format: 'cjs',
     outfile: outputWorkerFile,
     platform: 'node',
-    logLevel: 'info',
     external,
     minify: true,
     alias: sysNodeAliases,

--- a/scripts/esbuild/testing.ts
+++ b/scripts/esbuild/testing.ts
@@ -54,13 +54,12 @@ export async function buildTesting(opts: BuildOptions) {
   aliases['@stencil/core/cli'] = './cli/index.cjs';
 
   const testingEsbuildOptions: ESBuildOptions = {
-    ...getBaseEsbuildOptions(),
+    ...getBaseEsbuildOptions(opts),
     entryPoints: [join(sourceDir, 'index.ts')],
     bundle: true,
     format: 'cjs',
     outfile: join(opts.output.testingDir, 'index.js'),
     platform: 'node',
-    logLevel: 'info',
     external,
     /**
      * set `write: false` so that we can run the `onEnd` hook

--- a/scripts/esbuild/util.ts
+++ b/scripts/esbuild/util.ts
@@ -88,7 +88,7 @@ export function getEsbuildExternalModules(opts: BuildOptions, ownEntryPoint: str
  * @param opts Stencil build options
  * @returns a Promise representing the execution of the builds
  */
-export function runBuilds(builds: ESBuildOptions[], opts: BuildOptions): Promise<(void | ESBuildResult)[]> {
+export async function runBuilds(builds: ESBuildOptions[], opts: BuildOptions): Promise<void[] | ESBuildResult[]> {
   if (opts.isWatch) {
     return Promise.all(
       builds.map(async (buildConfig) => {
@@ -105,13 +105,14 @@ export function runBuilds(builds: ESBuildOptions[], opts: BuildOptions): Promise
  * Get base esbuild options which we want to always have set for all of our
  * bundles
  *
+ * @param opts build options for the current build
  * @returns a base set of options
  */
-export function getBaseEsbuildOptions(): ESBuildOptions {
+export function getBaseEsbuildOptions(opts: BuildOptions): ESBuildOptions {
   const options: ESBuildOptions = {
     bundle: true,
     legalComments: 'inline',
-    logLevel: 'info',
+    logLevel: opts.esbuildLogLevel,
     target: getEsbuildTargets(),
   };
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -22,6 +22,9 @@ export async function release(rootDir: string, args: ReadonlyArray<string>): Pro
       isCI: true,
       isPublishRelease: false,
       isProd: true,
+      // we set the log level for esbuild to silent so it doesn't log its own
+      // messages and interfere with Listr's control of the terminal
+      esbuildLogLevel: 'silent',
     });
 
     const versionIdx = args.indexOf('--version');
@@ -77,6 +80,9 @@ export async function release(rootDir: string, args: ReadonlyArray<string>): Pro
       isPublishRelease: true,
       isProd: true,
       tag: newTag ?? undefined,
+      // we set the log level for esbuild to silent so it doesn't log its own
+      // messages and interfere with Listr's control of the terminal
+      esbuildLogLevel: 'silent',
     });
     return await publishRelease(publishOpts, args);
   }

--- a/scripts/utils/options.ts
+++ b/scripts/utils/options.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'child_process';
+import type { BuildOptions as ESBuildOptions } from 'esbuild';
 import { readFileSync } from 'fs-extra';
 import { join } from 'path';
 
@@ -31,6 +32,7 @@ export function getOptions(rootDir: string, inputOpts: Partial<BuildOptions> = {
   const packageJson: PackageData = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
   const buildId = inputOpts.buildId ?? getBuildId();
   const version = inputOpts.version ?? getDevVersionId({ buildId, semverVersion: packageJson?.version });
+  const logLevel: ESBuildOptions['logLevel'] = inputOpts.esbuildLogLevel ?? 'info';
 
   const vermoji =
     inputOpts.isProd && !inputOpts.vermoji
@@ -89,6 +91,7 @@ export function getOptions(rootDir: string, inputOpts: Partial<BuildOptions> = {
     tag: 'dev',
     jqueryVersion,
     parse5Version,
+    esbuildLogLevel: logLevel,
     rollupVersion,
     terserVersion,
     typescriptVersion,
@@ -180,6 +183,10 @@ export interface BuildOptions {
   srcDir: string;
   typescriptDir: string;
   typescriptLibDir: string;
+  /**
+   * The log level used when executing esbuild
+   */
+  esbuildLogLevel: ESBuildOptions['logLevel'];
 
   output: {
     cliDir: string;


### PR DESCRIPTION
This improves the logging experience when running a release of Stencil by:

- allowing the log level for esbuild to be set centrally via the `BuildOptions` object that we pass around
- setting it to `"silent"` when running a build in a release context
- manually logging out any errors or warnings that may have occurred when the build is finished

Together these changes will mean that when a build exits cleanly with no errors the logging should all look as you'd expect when running the release scripts, which use the `Listr` package to run tasks.

STENCIL-1290

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
