### PR TITLE
fix(compiler): deprecate `scriptDataOpts`

### DIFF
--- a/src/app-data/index.ts
+++ b/src/app-data/index.ts
@@ -88,6 +88,7 @@ export const BUILD: BuildConditionals = {
   cloneNodeFix: false,
   hydratedAttribute: false,
   hydratedClass: true,
+  // TODO(STENCIL-1305): remove this option
   scriptDataOpts: false,
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
   scopedSlotTextContentFix: false,

--- a/src/compiler/app-core/app-data.ts
+++ b/src/compiler/app-core/app-data.ts
@@ -176,6 +176,7 @@ export const updateBuildConditionals = (config: ValidatedConfig, b: BuildConditi
   b.lifecycleDOMEvents = !!(b.isDebug || config._isTesting || config.extras.lifecycleDOMEvents);
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
   b.scopedSlotTextContentFix = !!config.extras.scopedSlotTextContentFix;
+  // TODO(STENCIL-1305): remove this option
   b.scriptDataOpts = config.extras.scriptDataOpts;
   b.attachStyles = true;
   b.invisiblePrehydration = typeof config.invisiblePrehydration === 'undefined' ? true : config.invisiblePrehydration;

--- a/src/compiler/output-targets/dist-hydrate-script/hydrate-build-conditionals.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/hydrate-build-conditionals.ts
@@ -34,6 +34,7 @@ export const getHydrateBuildConditionals = (cmps: d.ComponentCompilerMeta[]) => 
   build.shadowDomShim = true;
   build.hydratedAttribute = false;
   build.hydratedClass = true;
+  // TODO(STENCIL-1305): remove this option
   build.scriptDataOpts = false;
   build.attachStyles = true;
 

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -181,6 +181,7 @@ export interface BuildConditionals extends Partial<BuildFeatures> {
   hydratedAttribute?: boolean;
   hydratedClass?: boolean;
   initializeNextTick?: boolean;
+  // TODO(STENCIL-1305): remove this option
   scriptDataOpts?: boolean;
   // TODO(STENCIL-854): Remove code related to legacy shadowDomShim field
   shadowDomShim?: boolean;

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -327,7 +327,7 @@ interface ConfigExtrasBase {
    * It is possible to assign data to the actual `<script>` element's `data-opts` property,
    * which then gets passed to Stencil's initial bootstrap. This feature is only required
    * for very special cases and rarely needed. Defaults to `false`.
-   * @deprecated This option has been deprecated and will be removed in a future version of Stencil.
+   * @deprecated This option has been deprecated and will be removed in a future major version of Stencil.
    */
   scriptDataOpts?: boolean;
 

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -327,6 +327,7 @@ interface ConfigExtrasBase {
    * It is possible to assign data to the actual `<script>` element's `data-opts` property,
    * which then gets passed to Stencil's initial bootstrap. This feature is only required
    * for very special cases and rarely needed. Defaults to `false`.
+   * @deprecated This option has been deprecated and will be removed in a future version of Stencil.
    */
   scriptDataOpts?: boolean;
 

--- a/src/testing/reset-build-conditionals.ts
+++ b/src/testing/reset-build-conditionals.ts
@@ -50,6 +50,7 @@ export function resetBuildConditionals(b: d.BuildConditionals) {
   b.appendChildSlotFix = false;
   b.cloneNodeFix = false;
   b.hotModuleReplacement = false;
+  // TODO(STENCIL-1305): remove this option
   b.scriptDataOpts = false;
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
   b.scopedSlotTextContentFix = false;


### PR DESCRIPTION
## What is the current behavior?
Stencil supports a way to inject options into the script tag that then will be parsed into the runtime e.g. to set the `syncQueue` flag in [`CustomElementsDefineOptions`](https://github.com/ionic-team/stencil/blob/1d0fd962ed2211afea4a7e5e42222723b0a6184a/src/declarations/stencil-public-runtime.ts#L1865). This doesn't seem to be commonly used anymore so it is fine to deprecated and remove in v5.

## What is the new behavior?
Depcreate the `scriptDataOpts` option.

## Documentation

Raised PR with docs updates in https://github.com/ionic-team/stencil-site/pull/1425

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
