### PR TITLE
chore(runtime): provide better error message for edge case where multiple runtimes are being used

### DIFF
--- a/cspell-wordlist.txt
+++ b/cspell-wordlist.txt
@@ -4,7 +4,6 @@
 !Typescript
 !nodejs
 BUILDID
-bromann
 Brotli
 Brunelle
 Compi

--- a/cspell-wordlist.txt
+++ b/cspell-wordlist.txt
@@ -4,6 +4,7 @@
 !Typescript
 !nodejs
 BUILDID
+bromann
 Brotli
 Brunelle
 Compi

--- a/src/runtime/set-value.ts
+++ b/src/runtime/set-value.ts
@@ -27,8 +27,8 @@ export const setValue = (ref: d.RuntimeRef, propName: string, newVal: any, cmpMe
         'unknown to this Stencil runtime. This usually happens when integrating ' +
         'a 3rd party Stencil component with another Stencil component or application. ' +
         'Please reach out to the maintainers of the 3rd party Stencil component or report ' +
-        'this on the Stencil Discord server (https://chat.stenciljs.com) or GitHub ' +
-        'repository (https://github.com/ionic-team/stencil).',
+        'this on the Stencil Discord server (https://chat.stenciljs.com) or comment ' +
+        'on this similar [GitHub issue](https://github.com/ionic-team/stencil/issues/5457).',
     );
   }
 

--- a/src/runtime/set-value.ts
+++ b/src/runtime/set-value.ts
@@ -19,7 +19,7 @@ export const setValue = (ref: d.RuntimeRef, propName: string, newVal: any, cmpMe
    * as there are multiple runtimes being loaded and/or different components used with different
    * loading strategies, e.g. lazy vs implicitly loaded.
    *
-   * Todo(@christian-bromann): remove, once a solution for this was identified in https://outsystemsrd.atlassian.net/browse/STENCIL-1308 and implemented
+   * Todo(STENCIL-1308): remove, once a solution for this was identified and implemented
    */
   if (BUILD.lazyLoad && !hostRef) {
     throw new Error(

--- a/src/runtime/set-value.ts
+++ b/src/runtime/set-value.ts
@@ -11,6 +11,27 @@ export const getValue = (ref: d.RuntimeRef, propName: string) => getHostRef(ref)
 export const setValue = (ref: d.RuntimeRef, propName: string, newVal: any, cmpMeta: d.ComponentRuntimeMeta) => {
   // check our new property value against our internal value
   const hostRef = getHostRef(ref);
+
+  /**
+   * If the host element is not found, let's fail with a better error message and provide
+   * details on why this may happen. In certain cases, e.g. see https://github.com/ionic-team/stencil/issues/5457,
+   * users might import a component through e.g. a loader script, which causes confusions in runtime
+   * as there are multiple runtimes being loaded and/or different components used with different
+   * loading strategies, e.g. lazy vs implicitly loaded.
+   *
+   * Todo(@christian-bromann): remove, once a solution for this was identified in https://outsystemsrd.atlassian.net/browse/STENCIL-1308 and implemented
+   */
+  if (BUILD.lazyLoad && !hostRef) {
+    throw new Error(
+      `Couldn't find host element for "${cmpMeta.$tagName$}" as it is ` +
+      'unknown to this Stencil runtime. This usually happens when integrating ' +
+      'a 3rd party Stencil component with another Stencil component or application. ' +
+      'Please reach out to the maintainers of the 3rd party Stencil component or report ' +
+      'this on the Stencil Discord server (https://chat.stenciljs.com) or GitHub ' +
+      'repository (https://github.com/ionic-team/stencil).'
+    );
+  }
+
   const elm = BUILD.lazyLoad ? hostRef.$hostElement$ : (ref as d.HostElement);
   const oldVal = hostRef.$instanceValues$.get(propName);
   const flags = hostRef.$flags$;

--- a/src/runtime/set-value.ts
+++ b/src/runtime/set-value.ts
@@ -24,11 +24,11 @@ export const setValue = (ref: d.RuntimeRef, propName: string, newVal: any, cmpMe
   if (BUILD.lazyLoad && !hostRef) {
     throw new Error(
       `Couldn't find host element for "${cmpMeta.$tagName$}" as it is ` +
-      'unknown to this Stencil runtime. This usually happens when integrating ' +
-      'a 3rd party Stencil component with another Stencil component or application. ' +
-      'Please reach out to the maintainers of the 3rd party Stencil component or report ' +
-      'this on the Stencil Discord server (https://chat.stenciljs.com) or GitHub ' +
-      'repository (https://github.com/ionic-team/stencil).'
+        'unknown to this Stencil runtime. This usually happens when integrating ' +
+        'a 3rd party Stencil component with another Stencil component or application. ' +
+        'Please reach out to the maintainers of the 3rd party Stencil component or report ' +
+        'this on the Stencil Discord server (https://chat.stenciljs.com) or GitHub ' +
+        'repository (https://github.com/ionic-team/stencil).',
     );
   }
 


### PR DESCRIPTION
## What is the current behavior?
There are case where user can load components that are not compatible to each other, e.g. loading a lazy-loading component into an application that doesn't use lazy loading. This can also happen when a component is loaded twice, e.g. via an import __and__ through the loader script.

## What is the new behavior?
A fix for this issue would be out of scope as it requires research on how to avoid this generally in Stencil. I created internal tickets to kick of this effort in the upcoming sprints. For now, this error message should better direct users on what to do.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
