### PR TITLE
chore(node): update support to node v22

### DIFF
--- a/.github/workflows/test-analysis.yml
+++ b/.github/workflows/test-analysis.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['16', '18', '20']
+        node: ['16', '18', '20', '22']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-component-starter.yml
+++ b/.github/workflows/test-component-starter.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         jest: ['24', '25', '26', '27', '28', '29']
-        node: ['16', '18', '20']
+        node: ['16', '18', '20', '22']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-docs-build.yml
+++ b/.github/workflows/test-docs-build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['16', '18', '20']
+        node: ['16', '18', '20', '22']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['16', '18', '20']
+        node: ['16', '18', '20', '22']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['16', '18', '20']
+        node: ['16', '18', '20', '22']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/graceful-fs": "^4.1.5",
         "@types/jest": "^27.0.3",
         "@types/listr": "^0.14.4",
-        "@types/node": "^20.1.1",
+        "@types/node": "^20.12.11",
         "@types/pixelmatch": "^5.2.4",
         "@types/pngjs": "^6.0.1",
         "@types/prompts": "^2.0.9",
@@ -2958,9 +2958,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.12.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.8.tgz",
-      "integrity": "sha512-NU0rJLJnshZWdE/097cdCBbyW1h4hEg0xpovcoAQYHl8dnEyp/NAOiE45pvc+Bd1Dt+2r94v2eGFpQJ4R7g+2w==",
+      "version": "20.12.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.11.tgz",
+      "integrity": "sha512-vDg9PZ/zi+Nqp6boSOT7plNuthRugEKixDv5sFTIpkE89MmNtEArAShI4mxuX2+UrLEe9pxC1vm2cjm9YlWbJw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@types/graceful-fs": "^4.1.5",
     "@types/jest": "^27.0.3",
     "@types/listr": "^0.14.4",
-    "@types/node": "^20.1.1",
+    "@types/node": "^20.12.11",
     "@types/pixelmatch": "^5.2.4",
     "@types/pngjs": "^6.0.1",
     "@types/prompts": "^2.0.9",
@@ -150,7 +150,7 @@
   ],
   "prettier": "@ionic/prettier-config",
   "volta": {
-    "node": "20.12.2",
+    "node": "22.1.0",
     "npm": "10.7.0"
   }
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -52,7 +52,7 @@
   packageRules: [
     {
       matchPackageNames: ['@types/node'],
-      allowedVersions: '<21.0.0',
+      allowedVersions: '<23.0.0',
     },
     {
       // Increment this value as a part of updating TypeScript

--- a/src/utils/test/util.spec.ts
+++ b/src/utils/test/util.spec.ts
@@ -160,7 +160,7 @@ describe('util', () => {
       const expectedDiagnostic: d.Diagnostic = stubDiagnostic({
         absFilePath: mockPackageJsonPath,
         header: 'Error Parsing JSON',
-        messageText: expect.stringMatching(/.*in JSON at position 13$/),
+        messageText: expect.stringMatching(/.*in JSON at position 13/),
         type: 'build',
       });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,6 +45,7 @@
     },
     "pretty": true,
     "resolveJsonModule": true,
+    "skipLibCheck": true,
     "sourceMap": true,
     "strictBindCallApply": true,
     "strictFunctionTypes": true,


### PR DESCRIPTION
Updating to support node v22

## What is the new behavior?

it's node v22! you can see some details about what's included in the release here: https://nodejs.org/en/blog/announcements/v22-release-announce

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

If all of our automated tests are passing and you can build a sample project without issues then this should be good!