### PR TITLE
chore(testing): improve stability of component test

### DIFF
--- a/test/wdio/shadow-dom-mode/cmp.test.tsx
+++ b/test/wdio/shadow-dom-mode/cmp.test.tsx
@@ -14,16 +14,14 @@ describe('shadow-dom-mode', () => {
   });
 
   it('renders', async () => {
-    await $('shadow-dom-mode[id="blue"]').waitForExist();
+    const blueElm = $('shadow-dom-mode[id="blue"]');
+    await expect(blueElm).toHaveStyle({
+      'background-color': browser.isChromium ? 'rgba(0,0,255,1)' : 'rgb(0,0,255)'
+    });
 
-    const blueElm = document.querySelector('shadow-dom-mode[id="blue"]');
-    const blueBg = window.getComputedStyle(blueElm).backgroundColor;
-    expect(blueBg).toBe('rgb(0, 0, 255)');
-
-    await $('shadow-dom-mode[id="red"]').waitForExist();
-
-    const redElm = document.querySelector('shadow-dom-mode[id="red"]');
-    const redBg = window.getComputedStyle(redElm).backgroundColor;
-    expect(redBg).toBe('rgb(255, 0, 0)');
+    const redElm = $('shadow-dom-mode[id="red"]');
+    await expect(redElm).toHaveStyle({
+      'background-color': browser.isChromium ? 'rgba(255,0,0,1)' : 'rgb(255,0,0)'
+    });
   });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
In Firefox this test has been failing much more recently and caused us some re-runs


## What is the new behavior?
Make this test more stable by using async matchers.



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
