### PR TITLE
chore(snc): drop three snc errors in src/testing/test-transpile.ts

### DIFF
--- a/src/testing/test-transpile.ts
+++ b/src/testing/test-transpile.ts
@@ -5,14 +5,14 @@ import { isString } from '@utils';
 export function transpile(input: string, opts: TranspileOptions = {}): TranspileResults {
   opts = {
     ...opts,
-    componentExport: null,
+    componentExport: undefined,
     componentMetadata: 'compilerstatic',
     coreImportPath: isString(opts.coreImportPath) ? opts.coreImportPath : '@stencil/core/internal/testing',
     currentDirectory: opts.currentDirectory || process.cwd(),
     module: 'cjs', // always use commonjs since we're in a node environment
-    proxy: null,
+    proxy: undefined,
     sourceMap: 'inline',
-    style: null,
+    style: undefined,
     styleImportData: 'queryparams',
     target: 'es2015', // default to es2015
     transformAliasedImportPaths: parseStencilTranspilePaths(process.env.__STENCIL_TRANSPILE_PATHS__),


### PR DESCRIPTION
Just taking down three snc errors here

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Automated tests should be good for this