### PR TITLE
fix(declarations): Attribute ping is missing on AnchorHTMLAttributes

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -853,6 +853,7 @@ export namespace JSXBase {
     hrefLang?: string;
     hreflang?: string;
     media?: string;
+    ping?: string;
     rel?: string;
     target?: string;
     referrerPolicy?: ReferrerPolicy;


### PR DESCRIPTION
fixes: #5751


## What is the current behavior?
AnchorHTMLAttributes missing the ping attribute, compare

https://github.com/ionic-team/stencil/blob/main/src/declarations/stencil-public-runtime.ts#L850
with
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/18753976aad3956a963c3cafeeab6755b7c879a3/types/react/index.d.ts#L3105

GitHub Issue Number: #5751 

## What is the new behavior?
Added the optional `ping` to AnchorHTMLAttributes

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

Tests run fine, npm link to test project successfully showed issue gone now.

## Other information

Not sure if fix(declarations) or fix(runtime) is correct 
