### PR TITLE
fix(runtime): always throw if component can not be loaded

### DIFF
--- a/src/client/client-load-module.ts
+++ b/src/client/client-load-module.ts
@@ -27,7 +27,7 @@ export const loadModule = (
   cmpMeta: d.ComponentRuntimeMeta,
   hostRef: d.HostRef,
   hmrVersionId?: string,
-): Promise<d.ComponentConstructor> | d.ComponentConstructor => {
+): Promise<d.ComponentConstructor | undefined> | d.ComponentConstructor => {
   // loadModuleImport
   const exportName = cmpMeta.$tagName$.replace(/-/g, '_');
   const bundleId = cmpMeta.$lazyBundleId$;

--- a/src/hydrate/platform/index.ts
+++ b/src/hydrate/platform/index.ts
@@ -6,7 +6,7 @@ let customError: d.ErrorHandler;
 
 export const cmpModules = new Map<string, { [exportName: string]: d.ComponentConstructor }>();
 
-const getModule = (tagName: string): d.ComponentConstructor => {
+const getModule = (tagName: string): d.ComponentConstructor | null => {
   if (typeof tagName === 'string') {
     tagName = tagName.toLowerCase();
     const cmpModule = cmpModules.get(tagName);
@@ -17,7 +17,11 @@ const getModule = (tagName: string): d.ComponentConstructor => {
   return null;
 };
 
-export const loadModule = (cmpMeta: d.ComponentRuntimeMeta, _hostRef: d.HostRef, _hmrVersionId?: string): any => {
+export const loadModule = (
+  cmpMeta: d.ComponentRuntimeMeta,
+  _hostRef: d.HostRef,
+  _hmrVersionId?: string,
+): d.ComponentConstructor | null => {
   return getModule(cmpMeta.$tagName$);
 };
 


### PR DESCRIPTION
## What is the current behavior?
Due to the fact we don't have strict null checks we missed this area where `Cstr` can be null at a point where we wanted to access a property (e.g. `isProxied`).

GitHub Issue Number:
fixes #5759

## What is the new behavior?
I removed the condition that errors are only thrown if `(BUILD.isDev || BUILD.isDebug)` is truthy. It doesn't make much sense to me why we only would want this error to be elevated in these conditions.

## Documentation

n/a

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
