### PR TITLE
fix(runtime): support watch for components with custom tag names

### DIFF
--- a/src/runtime/initialize-component.ts
+++ b/src/runtime/initialize-component.ts
@@ -92,10 +92,25 @@ export const initializeComponent = async (
       // sync constructor component
       Cstr = elm.constructor as any;
 
+      /**
+       * Instead of using e.g. `cmpMeta.$tagName$` we use `elm.localName` to get the tag name of the component.
+       * This is because we can't guarantee that the component class is actually registered with the tag name
+       * defined in the component class as use can very well also do this:
+       *
+       * ```html
+       * <script type="module">
+       *   import { MyComponent } from 'my-stencil-component-library';
+       *   console.log(1, MyComponent, customElements);
+       *   customElements.define('my-other-component', MyComponent);
+       * </script>
+       * ```
+       */
+      const cmpTag = elm.localName;
+
       // wait for the CustomElementRegistry to mark the component as ready before setting `isWatchReady`. Otherwise,
       // watchers may fire prematurely if `customElements.get()`/`customElements.whenDefined()` resolves _before_
       // Stencil has completed instantiating the component.
-      customElements.whenDefined(cmpMeta.$tagName$).then(() => (hostRef.$flags$ |= HOST_FLAGS.isWatchReady));
+      customElements.whenDefined(cmpTag).then(() => (hostRef.$flags$ |= HOST_FLAGS.isWatchReady));
     }
 
     if (BUILD.style && Cstr && Cstr.style) {

--- a/src/runtime/initialize-component.ts
+++ b/src/runtime/initialize-component.ts
@@ -100,7 +100,6 @@ export const initializeComponent = async (
        * ```html
        * <script type="module">
        *   import { MyComponent } from 'my-stencil-component-library';
-       *   console.log(1, MyComponent, customElements);
        *   customElements.define('my-other-component', MyComponent);
        * </script>
        * ```

--- a/src/runtime/initialize-component.ts
+++ b/src/runtime/initialize-component.ts
@@ -95,7 +95,7 @@ export const initializeComponent = async (
       /**
        * Instead of using e.g. `cmpMeta.$tagName$` we use `elm.localName` to get the tag name of the component.
        * This is because we can't guarantee that the component class is actually registered with the tag name
-       * defined in the component class as use can very well also do this:
+       * defined in the component class as users can very well also do this:
        *
        * ```html
        * <script type="module">

--- a/test/wdio/setup.ts
+++ b/test/wdio/setup.ts
@@ -13,7 +13,8 @@ const testRequiresManualSetup =
   window.__wdioSpec__.includes('custom-elements-output-tag-class-different') ||
   window.__wdioSpec__.includes('custom-elements-delegates-focus') ||
   window.__wdioSpec__.includes('custom-elements-output') ||
-  window.__wdioSpec__.includes('global-script');
+  window.__wdioSpec__.includes('global-script') ||
+  window.__wdioSpec__.endsWith('custom-tag-name.test.tsx');
 
 /**
  * setup all components defined in tests except for those where we want ot manually setup

--- a/test/wdio/watch-native-attributes/custom-tag-name.test.tsx
+++ b/test/wdio/watch-native-attributes/custom-tag-name.test.tsx
@@ -1,0 +1,25 @@
+import { h } from '@stencil/core';
+import { render } from '@wdio/browser-runner/stencil';
+
+import { WatchNativeAttributes } from '../test-components/watch-native-attributes.js';
+
+describe('watch native attributes', () => {
+  beforeEach(() => {
+    customElements.define('some-custom-element', WatchNativeAttributes);
+    render({
+      template: () => <some-custom-element aria-label="myStartingLabel"></some-custom-element>,
+    });
+  });
+
+  it('triggers the callback for the watched attribute', async () => {
+    const $cmp = $('some-custom-element');
+    await $cmp.waitForExist();
+
+    await expect($cmp).toHaveText('Label: myStartingLabel\nCallback triggered: false');
+
+    const cmp = document.querySelector('some-custom-element');
+    cmp.setAttribute('aria-label', 'myNewLabel');
+
+    await expect($cmp).toHaveText('Label: myNewLabel\nCallback triggered: true');
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
If users define their component with a custom tag name, the `@Watch` decorator doesn't work.

GitHub Issue Number: #3554
STENCIL-546

## What is the new behavior?
Instead of using the component meta data we just pick the tag name for the component directly.

## Documentation

n/a

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Added an unit test for this.

## Other information

n/a
