### PR TITLE
fix(mock-doc): support toDataURL method in canvas

### DIFF
--- a/src/mock-doc/element.ts
+++ b/src/mock-doc/element.ts
@@ -505,8 +505,8 @@ export class MockUListElement extends MockHTMLElement {
 type CanvasContext = '2d' | 'webgl' | 'webgl2' | 'bitmaprenderer';
 export class CanvasRenderingContext {
   context: CanvasContext;
-  contextAttributes: any;
-  constructor(context: CanvasContext, contextAttributes?: any) {
+  contextAttributes: WebGLContextAttributes;
+  constructor(context: CanvasContext, contextAttributes?: WebGLContextAttributes) {
     this.context = context;
     this.contextAttributes = contextAttributes;
   }
@@ -523,8 +523,8 @@ export class CanvasRenderingContext {
     return 'data:,'; // blank image
   }
   putImageData() {}
-  createImageData(): any[] {
-    return [];
+  createImageData(): ImageData {
+    return {} as ImageData;
   }
   setTransform() {}
   drawImage() {}
@@ -553,7 +553,7 @@ export class MockCanvasElement extends MockHTMLElement {
   constructor(ownerDocument: any) {
     super(ownerDocument, 'canvas');
   }
-  getContext(context: CanvasContext, contextAttributes?: any): CanvasRenderingContext {
+  getContext(context: CanvasContext, contextAttributes?: WebGLContextAttributes): CanvasRenderingContext {
     return new CanvasRenderingContext(context, contextAttributes);
   }
 }

--- a/src/mock-doc/element.ts
+++ b/src/mock-doc/element.ts
@@ -502,47 +502,59 @@ export class MockUListElement extends MockHTMLElement {
   }
 }
 
+type CanvasContext = '2d' | 'webgl' | 'webgl2' | 'bitmaprenderer';
+export class CanvasRenderingContext {
+  context: CanvasContext;
+  contextAttributes: any;
+  constructor(context: CanvasContext, contextAttributes?: any) {
+    this.context = context;
+    this.contextAttributes = contextAttributes;
+  }
+  fillRect() {
+    return;
+  }
+  clearRect() {}
+  getImageData() {
+    return {
+      data: new Array(10 * 10 * 4),
+    };
+  }
+  toDataURL() {
+    return 'data:,'; // blank image
+  }
+  putImageData() {}
+  createImageData(): any[] {
+    return [];
+  }
+  setTransform() {}
+  drawImage() {}
+  save() {}
+  fillText() {}
+  restore() {}
+  beginPath() {}
+  moveTo() {}
+  lineTo() {}
+  closePath() {}
+  stroke() {}
+  translate() {}
+  scale() {}
+  rotate() {}
+  arc() {}
+  fill() {}
+  measureText() {
+    return { width: 0 };
+  }
+  transform() {}
+  rect() {}
+  clip() {}
+}
+
 export class MockCanvasElement extends MockHTMLElement {
   constructor(ownerDocument: any) {
     super(ownerDocument, 'canvas');
   }
-  getContext() {
-    return {
-      fillRect() {
-        return;
-      },
-      clearRect() {},
-      getImageData: function (_: number, __: number, w: number, h: number) {
-        return {
-          data: new Array(w * h * 4),
-        };
-      },
-      putImageData() {},
-      createImageData: function (): any[] {
-        return [];
-      },
-      setTransform() {},
-      drawImage() {},
-      save() {},
-      fillText() {},
-      restore() {},
-      beginPath() {},
-      moveTo() {},
-      lineTo() {},
-      closePath() {},
-      stroke() {},
-      translate() {},
-      scale() {},
-      rotate() {},
-      arc() {},
-      fill() {},
-      measureText() {
-        return { width: 0 };
-      },
-      transform() {},
-      rect() {},
-      clip() {},
-    };
+  getContext(context: CanvasContext, contextAttributes?: any): CanvasRenderingContext {
+    return new CanvasRenderingContext(context, contextAttributes);
   }
 }
 

--- a/src/mock-doc/element.ts
+++ b/src/mock-doc/element.ts
@@ -514,9 +514,9 @@ export class CanvasRenderingContext {
     return;
   }
   clearRect() {}
-  getImageData() {
+  getImageData(_: number, __: number, w: number, h: number) {
     return {
-      data: new Array(10 * 10 * 4),
+      data: new Array(w * h * 4),
     };
   }
   toDataURL() {

--- a/src/mock-doc/test/element.spec.ts
+++ b/src/mock-doc/test/element.spec.ts
@@ -514,4 +514,11 @@ describe('element', () => {
     expect(doc.createElement('svg').localName).toBe('svg');
     expect((document.childNodes[1] as any).localName).toBe('html');
   });
+
+  it('has provides a canvas object with getContext', () => {
+    const canvas = doc.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    expect(ctx).toBeDefined();
+    expect(ctx.toDataURL()).toBe('data:,');
+  });
 });


### PR DESCRIPTION
## What is the current behavior?
The current canvas class in Mock Doc didn't support `toDataURL`.

## What is the new behavior?
Support method.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Added a unit test.

## Other information

This was originally proposed in https://github.com/ionic-team/stencil/pull/2923 which I closed in favor of this one. @rwaskiewicz I hope this addresses your comment.
