### PR TITLE
fix(esbuild): remove all `node:` imports from glob script to keep support for Jest v26

### DIFF
--- a/scripts/esbuild/sys-node.ts
+++ b/scripts/esbuild/sys-node.ts
@@ -103,7 +103,7 @@ async function sysNodeExternalBundles(opts: BuildOptions) {
    */
   const globOutputPath = join(opts.output.sysNodeDir, 'glob.js');
   const glob = fs.readFileSync(globOutputPath, 'utf8');
-  fs.writeFileSync(globOutputPath, glob.replace(/require\("node:/g, 'require("'))
+  fs.writeFileSync(globOutputPath, glob.replace(/require\("node:/g, 'require("'));
 
   // open-in-editor's visualstudio.vbs file
   // TODO(STENCIL-1052): remove once Rollup -> esbuild migration is complete

--- a/scripts/esbuild/sys-node.ts
+++ b/scripts/esbuild/sys-node.ts
@@ -96,6 +96,15 @@ async function sysNodeExternalBundles(opts: BuildOptions) {
     bundleExternal(opts, opts.output.devServerDir, cachedDir, 'ws.js'),
   ]);
 
+  /**
+   * Some of globs dependencies are using imports with a `node:` prefix which
+   * is not supported by Jest v26. This is a workaround to remove the `node:`.
+   * TODO(STENCIL-1323): remove once we deprecated Jest v26 support
+   */
+  const globOutputPath = join(opts.output.sysNodeDir, 'glob.js');
+  const glob = fs.readFileSync(globOutputPath, 'utf8');
+  fs.writeFileSync(globOutputPath, glob.replace(/require\("node:/g, 'require("'))
+
   // open-in-editor's visualstudio.vbs file
   // TODO(STENCIL-1052): remove once Rollup -> esbuild migration is complete
   const visualstudioVbsSrc = join(opts.nodeModulesDir, 'open-in-editor', 'lib', 'editors', 'visualstudio.vbs');


### PR DESCRIPTION
## What is the current behavior?
With Stencil v4.18.1 Stencil broke support for Jest v26 due to the fact that transient dependencies for `glob` in `sys/node/glob.js` started to use imports with `node:` prefixes.

GitHub Issue Number: #5766

## What is the new behavior?
I enhanced the sys node build script to remove these prefixes. This won't have any impact on the script and allows us to keep support for Jest v26.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

- Check out https://github.com/deleonio/kolibri-library/tree/reproduction-5766
- run `pnpm install` and verify that test pass with `npm test`
- now update Stencil to latest, rerun test and verify that test fail due to `no such file or directory, open 'node:path'`
- now install `@stencil/core@4.18.2-dev.1716246842.b6713e1` (dev build of this branch) and rerun tests, verify that tests pass

## Other information

I was under the assumption that we are testing running tests in Jest v26, I will take a look if we could have caught this before release.
