### PR TITLE
feat(runtime): support already-existing shadow roots

### DIFF
--- a/src/runtime/bootstrap-custom-element.ts
+++ b/src/runtime/bootstrap-custom-element.ts
@@ -94,6 +94,15 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
           } else {
             this.attachShadow({ mode: 'open' });
           }
+        } else {
+          // we want to check to make sure that the mode for the shadow
+          // root already attached to the element (i.e. created via DSD)
+          // is set to 'open' since that's the only mode we support
+          if (this.shadowRoot.mode !== 'open') {
+            throw new Error(
+              `Unable to re-use existing shadow root for ${cmpMeta.$tagName$}! Mode is set to ${this.shadowRoot.mode} but Stencil only supports open shadow roots.`,
+            );
+          }
         }
       } else {
         (this as any).shadowRoot = this;

--- a/src/runtime/bootstrap-custom-element.ts
+++ b/src/runtime/bootstrap-custom-element.ts
@@ -85,13 +85,15 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
     },
     __attachShadow() {
       if (supportsShadow) {
-        if (BUILD.shadowDelegatesFocus) {
-          this.attachShadow({
-            mode: 'open',
-            delegatesFocus: !!(cmpMeta.$flags$ & CMP_FLAGS.shadowDelegatesFocus),
-          });
-        } else {
-          this.attachShadow({ mode: 'open' });
+        if (!this.shadowRoot) {
+          if (BUILD.shadowDelegatesFocus) {
+            this.attachShadow({
+              mode: 'open',
+              delegatesFocus: !!(cmpMeta.$flags$ & CMP_FLAGS.shadowDelegatesFocus),
+            });
+          } else {
+            this.attachShadow({ mode: 'open' });
+          }
         }
       } else {
         (this as any).shadowRoot = this;

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -111,6 +111,8 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
             // adding the shadow root build conditionals to minimize runtime
             if (supportsShadow) {
               if (!self.shadowRoot) {
+                // we don't want to call `attachShadow` if there's already a shadow root
+                // attached to the
                 if (BUILD.shadowDelegatesFocus) {
                   self.attachShadow({
                     mode: 'open',
@@ -118,6 +120,15 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
                   });
                 } else {
                   self.attachShadow({ mode: 'open' });
+                }
+              } else {
+                // we want to check to make sure that the mode for the shadow
+                // root already attached to the element (i.e. created via DSD)
+                // is set to 'open' since that's the only mode we support
+                if (self.shadowRoot.mode !== 'open') {
+                  throw new Error(
+                    `Unable to re-use existing shadow root for ${cmpMeta.$tagName$}! Mode is set to ${self.shadowRoot.mode} but Stencil only supports open shadow roots.`,
+                  );
                 }
               }
             } else if (!BUILD.hydrateServerSide && !('shadowRoot' in self)) {

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -110,13 +110,15 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
             // add the read-only property "shadowRoot" to the host element
             // adding the shadow root build conditionals to minimize runtime
             if (supportsShadow) {
-              if (BUILD.shadowDelegatesFocus) {
-                self.attachShadow({
-                  mode: 'open',
-                  delegatesFocus: !!(cmpMeta.$flags$ & CMP_FLAGS.shadowDelegatesFocus),
-                });
-              } else {
-                self.attachShadow({ mode: 'open' });
+              if (!self.shadowRoot) {
+                if (BUILD.shadowDelegatesFocus) {
+                  self.attachShadow({
+                    mode: 'open',
+                    delegatesFocus: !!(cmpMeta.$flags$ & CMP_FLAGS.shadowDelegatesFocus),
+                  });
+                } else {
+                  self.attachShadow({ mode: 'open' });
+                }
               }
             } else if (!BUILD.hydrateServerSide && !('shadowRoot' in self)) {
               (self as any).shadowRoot = self;

--- a/src/runtime/vdom/test/patch-svg.spec.ts
+++ b/src/runtime/vdom/test/patch-svg.spec.ts
@@ -2,8 +2,8 @@ import { SVG_NS } from '@utils';
 
 import type * as d from '../../../declarations';
 import { h, newVNode } from '../h';
+import { toVNode } from '../util';
 import { patch } from '../vdom-render';
-import { toVNode } from './to-vnode';
 
 describe('renderer', () => {
   let hostElm: d.HostElement;

--- a/src/runtime/vdom/test/patch.spec.ts
+++ b/src/runtime/vdom/test/patch.spec.ts
@@ -3,8 +3,8 @@ import { SVG_NS } from '@utils';
 
 import type * as d from '../../../declarations';
 import { h, newVNode } from '../h';
+import { toVNode } from '../util';
 import { patch } from '../vdom-render';
-import { toVNode } from './to-vnode';
 
 describe('renderer', () => {
   let hostElm: any;

--- a/src/runtime/vdom/test/to-vnode.spec.ts
+++ b/src/runtime/vdom/test/to-vnode.spec.ts
@@ -1,4 +1,4 @@
-import { toVNode } from './to-vnode';
+import { toVNode } from '../util';
 
 describe('toVNode()', () => {
   it('should create element w/ child elements and text nodes', () => {

--- a/src/runtime/vdom/util.ts
+++ b/src/runtime/vdom/util.ts
@@ -25,7 +25,7 @@ export function toVNode(node: Node): d.VNode {
     for (let i = 0, l = childNodes.length; i < l; i++) {
       childVnode = toVNode(childNodes[i]);
       if (childVnode) {
-        (vnode.$children$ ||= []).push(childVnode);
+        (vnode.$children$ = vnode.$children$ || []).push(childVnode);
       }
     }
     return vnode;

--- a/src/runtime/vdom/util.ts
+++ b/src/runtime/vdom/util.ts
@@ -1,7 +1,15 @@
-import type * as d from '../../../declarations';
-import { NODE_TYPE } from '../../runtime-constants';
-import { newVNode } from '../h';
+import type * as d from '@stencil/core/declarations';
 
+import { NODE_TYPE } from '../runtime-constants';
+import { newVNode } from './h';
+
+/**
+ * Derive a tree of virtual DOM nodes from a DOM node, handling the DOM node's
+ * children (if any)
+ *
+ * @param node a DOM node to use as a 'template'
+ * @returns a virtual DOM node based on the supplied DOM node
+ */
 export function toVNode(node: Node): d.VNode {
   if (node.nodeType === NODE_TYPE.TextNode) {
     const vnode: d.VNode = newVNode(null, node.textContent);
@@ -17,7 +25,7 @@ export function toVNode(node: Node): d.VNode {
     for (let i = 0, l = childNodes.length; i < l; i++) {
       childVnode = toVNode(childNodes[i]);
       if (childVnode) {
-        (vnode.$children$ = vnode.$children$ || []).push(childVnode);
+        (vnode.$children$ ||= []).push(childVnode);
       }
     }
     return vnode;

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -653,17 +653,18 @@ export const patch = (oldVNode: d.VNode, newVNode: d.VNode, isInitialRender = fa
   const text = newVNode.$text$;
   let defaultHolder: Comment;
 
-  if (BUILD.shadowDom && isInitialRender && oldVNode.$elm$.nodeType === NODE_TYPE.DocumentFragment) {
-    // TODO perhaps we should try to only do this when DSD has been used?
-    // although there may not be any harm in just doing it all the time.
-    //
-    // we need to create fake 'oldChildren' for any nodes that might be present
+  if (!BUILD.hydrateServerSide && BUILD.shadowDom && isInitialRender && oldVNode.$elm$.nodeType === NODE_TYPE.DocumentFragment) {
+    // We need to create fake 'oldChildren' for any nodes that might be present
     // in the shadow root because of DSD. We want to do this when:
     //
     // 1. this is the first render
     // 2. the `$elm$` for the current old vdom node is a document fragment,
     //    meaning the content node for a shadow root that was created by the
     //    browser based on a `<template>` tag in the HTML
+    //
+    // This will allow the component rendering lifecycle to boot up with vdom
+    // nodes for the DOM nodes already present in the shadow root, allowing the
+    // vdom to re-use these nodes (if they are suitable, of course).
     for (const child of oldVNode.$elm$.children) {
       // TODO be more fine-grained about this
       // 1. can I tell whether the style tag was added client-side or not?

--- a/test/hello-vdom/src/components/hello-vdom.tsx
+++ b/test/hello-vdom/src/components/hello-vdom.tsx
@@ -4,9 +4,10 @@ import styles from './styles.css';
 @Component({
   tag: 'hello-vdom',
   styles,
+  shadow: true,
 })
 export class HelloWorld {
   render() {
-    return <h1>Hello VDom!</h1>;
+    return <h1>Hello Client-side shadow DOM!</h1>;
   }
 }

--- a/test/hello-vdom/src/index.html
+++ b/test/hello-vdom/src/index.html
@@ -4,4 +4,9 @@
 <script type="module" src="build/hellovdom.esm.js"></script>
 <script nomodule src="build/hellovdom.js"></script>
 
-<hello-vdom></hello-vdom>
+<hello-vdom>
+  <template shadowrootmode="open">
+    <style>h1 { color: red }</style>
+    <h1>Hello, Declarative Shadow DOM!</h1>
+  </template>
+</hello-vdom>

--- a/test/wdio/dsd-template/cmp.test.tsx
+++ b/test/wdio/dsd-template/cmp.test.tsx
@@ -1,0 +1,20 @@
+import { h } from '@stencil/core';
+import { render } from '@wdio/browser-runner/stencil';
+
+describe('dsd-template', () => {
+  beforeEach(async () => {
+    render({
+      template: () => (
+        <dsd-template>
+          <template shadowrootmode="open">
+            <div>Hello, World! I'm rendered from the DSD!</div>
+          </template>
+        </dsd-template>
+      ),
+    });
+  });
+
+  it('should render', async () => {
+    await expect($('dsd-template')).toHaveText("Hello, World! I'm rendering!");
+  });
+});

--- a/test/wdio/dsd-template/cmp.test.tsx
+++ b/test/wdio/dsd-template/cmp.test.tsx
@@ -17,4 +17,6 @@ describe('dsd-template', () => {
   it('should render', async () => {
     await expect($('dsd-template')).toHaveText("Hello, World! I'm rendering!");
   });
+
+  // TODO add test that mismatched mode causes Stencil to throw
 });

--- a/test/wdio/dsd-template/cmp.tsx
+++ b/test/wdio/dsd-template/cmp.tsx
@@ -1,0 +1,11 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'dsd-template',
+  shadow: true,
+})
+export class DsdTemplate {
+  render() {
+    return <div>Hello, World! I'm rendering!</div>;
+  }
+}


### PR DESCRIPTION
This adds some checks when a Stencil component is booting up that will
re-use a shadow root if the host element already has one, instead of
just calling `this.attachShadow` in all cases.

Additionally, Stencil's virtual DOM will now cleanly take over any
elements which are already present in its root element when it first
runs. This will allow it to re-use elements that were already created in
the shadow root, as well as clean up any stray elements that shouldn't
be there.

Together these changes will allow the Stencil runtime to smoothly take
over a shadow root which was created via a `<template>` tag in the
page's HTML, i.e. via declarative shadow DOM (DSD).

**NOTE** this _only_ enables the Stencil runtime to re-use a shadow root
created via DSD, it does not add any support to Stencil for rendering
a suitable `<template>...` HTML string.

STENCIL-1316


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
