### PR TITLE
fix(emit): don't emit test files

### DIFF
--- a/src/compiler/transpile/run-program.ts
+++ b/src/compiler/transpile/run-program.ts
@@ -43,16 +43,18 @@ export const runTsProgram = async (
   const typesOutputTarget = config.outputTargets.filter(isOutputTargetDistTypes);
   const emittedDts: string[] = [];
   const emitCallback: ts.WriteFileCallback = (emitFilePath, data, _w, _e, tsSourceFiles) => {
-    if (emitFilePath.endsWith('.js') || emitFilePath.endsWith('js.map')) {
-      updateModule(config, compilerCtx, buildCtx, tsSourceFiles[0], data, emitFilePath, tsTypeChecker, null);
-    } else if (
-      emitFilePath.endsWith('.e2e.d.ts') ||
-      emitFilePath.endsWith('.spec.d.ts') ||
-      emitFilePath === 'e2e.d.ts' ||
-      emitFilePath === 'spec.d.ts'
+    if (
+      emitFilePath.includes('e2e.') ||
+      emitFilePath.includes('spec.') ||
+      emitFilePath.endsWith('e2e.d.ts') ||
+      emitFilePath.endsWith('spec.d.ts')
     ) {
       // we don't want to write these to disk!
       return;
+    }
+
+    if (emitFilePath.endsWith('.js') || emitFilePath.endsWith('js.map')) {
+      updateModule(config, compilerCtx, buildCtx, tsSourceFiles[0], data, emitFilePath, tsTypeChecker, null);
     } else if (emitFilePath.endsWith('.d.ts')) {
       const srcDtsPath = normalizePath(tsSourceFiles[0].fileName);
       const relativeEmitFilepath = getRelativeDts(config, srcDtsPath, emitFilePath);


### PR DESCRIPTION
This fixes a bug introduced in #4315, which upgraded to TypeScript 5. In that PR we had to change the way that we prevented certain files from being emitted by the typescript compiler because in the 5.0 release our previous approach stopped working.

However, in porting over to a new approach that worked with TS 5.0 there was an oversight. I misunderstood the intent of the old code as being to merely prevent writing `.d.ts` files in the output, when actually it was about preventing the compiled JavaScript from being written for `.e2e.ts` and `.spec.ts` files.

This change ensures that we no longer emit these files.

fixes #5788
STENCIL-1325

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
