### PR TITLE
feat(compiler): generate export maps on build

### DIFF
--- a/src/compiler/build/test/write-export-maps.spec.ts
+++ b/src/compiler/build/test/write-export-maps.spec.ts
@@ -1,0 +1,39 @@
+import { mockBuildCtx, mockValidatedConfig } from '@stencil/core/testing';
+
+import * as d from '../../../declarations';
+import { writeExportMaps } from '../write-export-maps';
+
+const execSyncMock = jest.fn();
+jest.mock('child_process', () => ({
+  execSync: execSyncMock,
+}));
+
+describe('writeExportMaps', () => {
+  let config: d.ValidatedConfig;
+  let buildCtx: d.BuildCtx;
+
+  beforeEach(() => {
+    config = mockValidatedConfig();
+    buildCtx = mockBuildCtx(config);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should always generate the default exports', () => {
+    writeExportMaps(config, buildCtx);
+
+    expect(execSyncMock).toHaveBeenCalledTimes(2);
+    expect(execSyncMock).toHaveBeenCalledWith(
+      `npm pkg set "exports[.][import]"="./dist/${config.fsNamespace}/${config.fsNamespace}.esm.js"`,
+    );
+    expect(execSyncMock).toHaveBeenCalledWith(
+      `npm pkg set "exports[.][require]"="./dist/${config.fsNamespace}/${config.fsNamespace}.cjs.js"`,
+    );
+  });
+
+  //   it('should generate the lazy loader exports if the output target is present', () => {});
+
+  //   it('should generate the custom elements exports if the output target is present', () => {});
+});

--- a/src/compiler/build/test/write-export-maps.spec.ts
+++ b/src/compiler/build/test/write-export-maps.spec.ts
@@ -21,16 +21,43 @@ describe('writeExportMaps', () => {
     jest.clearAllMocks();
   });
 
-  it('should always generate the default exports', () => {
+  it('should not generate any exports if there are no output targets', () => {
+    writeExportMaps(config, buildCtx);
+
+    expect(execSyncSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('should generate the default exports for the lazy build if present', () => {
+    config.outputTargets = [
+      {
+        type: 'dist',
+        dir: '/dist',
+        typesDir: '/dist/types',
+      },
+    ];
+
+    writeExportMaps(config, buildCtx);
+
+    expect(execSyncSpy).toHaveBeenCalledTimes(3);
+    expect(execSyncSpy).toHaveBeenCalledWith(`npm pkg set "exports[.][import]"="./dist/index.js"`);
+    expect(execSyncSpy).toHaveBeenCalledWith(`npm pkg set "exports[.][require]"="./dist/index.cjs.js"`);
+    expect(execSyncSpy).toHaveBeenCalledWith(`npm pkg set "exports[.][types]"="./dist/types/index.d.ts"`);
+  });
+
+  it('should generate the default exports for the custom elements build if present', () => {
+    config.outputTargets = [
+      {
+        type: 'dist-custom-elements',
+        dir: '/dist/components',
+        generateTypeDeclarations: true,
+      },
+    ];
+
     writeExportMaps(config, buildCtx);
 
     expect(execSyncSpy).toHaveBeenCalledTimes(2);
-    expect(execSyncSpy).toHaveBeenCalledWith(
-      `npm pkg set "exports[.][import]"="./dist/${config.fsNamespace}/${config.fsNamespace}.esm.js"`,
-    );
-    expect(execSyncSpy).toHaveBeenCalledWith(
-      `npm pkg set "exports[.][require]"="./dist/${config.fsNamespace}/${config.fsNamespace}.cjs.js"`,
-    );
+    expect(execSyncSpy).toHaveBeenCalledWith(`npm pkg set "exports[.][import]"="./dist/components/index.js"`);
+    expect(execSyncSpy).toHaveBeenCalledWith(`npm pkg set "exports[.][types]"="./dist/components/index.d.ts"`);
   });
 
   it('should generate the lazy loader exports if the output target is present', () => {
@@ -46,13 +73,7 @@ describe('writeExportMaps', () => {
 
     writeExportMaps(config, buildCtx);
 
-    expect(execSyncSpy).toHaveBeenCalledTimes(5);
-    expect(execSyncSpy).toHaveBeenCalledWith(
-      `npm pkg set "exports[.][import]"="./dist/${config.fsNamespace}/${config.fsNamespace}.esm.js"`,
-    );
-    expect(execSyncSpy).toHaveBeenCalledWith(
-      `npm pkg set "exports[.][require]"="./dist/${config.fsNamespace}/${config.fsNamespace}.cjs.js"`,
-    );
+    expect(execSyncSpy).toHaveBeenCalledTimes(3);
     expect(execSyncSpy).toHaveBeenCalledWith(`npm pkg set "exports[./loader][import]"="./dist/lazy-loader/index.js"`);
     expect(execSyncSpy).toHaveBeenCalledWith(`npm pkg set "exports[./loader][require]"="./dist/lazy-loader/index.cjs"`);
     expect(execSyncSpy).toHaveBeenCalledWith(`npm pkg set "exports[./loader][types]"="./dist/lazy-loader/index.d.ts"`);
@@ -76,12 +97,6 @@ describe('writeExportMaps', () => {
     writeExportMaps(config, buildCtx);
 
     expect(execSyncSpy).toHaveBeenCalledTimes(4);
-    expect(execSyncSpy).toHaveBeenCalledWith(
-      `npm pkg set "exports[.][import]"="./dist/${config.fsNamespace}/${config.fsNamespace}.esm.js"`,
-    );
-    expect(execSyncSpy).toHaveBeenCalledWith(
-      `npm pkg set "exports[.][require]"="./dist/${config.fsNamespace}/${config.fsNamespace}.cjs.js"`,
-    );
     expect(execSyncSpy).toHaveBeenCalledWith(
       `npm pkg set "exports[./my-component][import]"="./dist/components/my-component.js"`,
     );
@@ -112,12 +127,6 @@ describe('writeExportMaps', () => {
     writeExportMaps(config, buildCtx);
 
     expect(execSyncSpy).toHaveBeenCalledTimes(6);
-    expect(execSyncSpy).toHaveBeenCalledWith(
-      `npm pkg set "exports[.][import]"="./dist/${config.fsNamespace}/${config.fsNamespace}.esm.js"`,
-    );
-    expect(execSyncSpy).toHaveBeenCalledWith(
-      `npm pkg set "exports[.][require]"="./dist/${config.fsNamespace}/${config.fsNamespace}.cjs.js"`,
-    );
     expect(execSyncSpy).toHaveBeenCalledWith(
       `npm pkg set "exports[./my-component][import]"="./dist/components/my-component.js"`,
     );

--- a/src/compiler/build/test/write-export-maps.spec.ts
+++ b/src/compiler/build/test/write-export-maps.spec.ts
@@ -1,39 +1,134 @@
 import { mockBuildCtx, mockValidatedConfig } from '@stencil/core/testing';
+import childProcess from 'child_process';
 
 import * as d from '../../../declarations';
+import { stubComponentCompilerMeta } from '../../types/tests/ComponentCompilerMeta.stub';
 import { writeExportMaps } from '../write-export-maps';
-
-const execSyncMock = jest.fn();
-jest.mock('child_process', () => ({
-  execSync: execSyncMock,
-}));
 
 describe('writeExportMaps', () => {
   let config: d.ValidatedConfig;
   let buildCtx: d.BuildCtx;
+  let execSyncSpy: jest.SpyInstance;
 
   beforeEach(() => {
     config = mockValidatedConfig();
     buildCtx = mockBuildCtx(config);
+
+    execSyncSpy = jest.spyOn(childProcess, 'execSync').mockImplementation(() => '');
   });
 
-  afterAll(() => {
-    jest.restoreAllMocks();
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should always generate the default exports', () => {
     writeExportMaps(config, buildCtx);
 
-    expect(execSyncMock).toHaveBeenCalledTimes(2);
-    expect(execSyncMock).toHaveBeenCalledWith(
+    expect(execSyncSpy).toHaveBeenCalledTimes(2);
+    expect(execSyncSpy).toHaveBeenCalledWith(
       `npm pkg set "exports[.][import]"="./dist/${config.fsNamespace}/${config.fsNamespace}.esm.js"`,
     );
-    expect(execSyncMock).toHaveBeenCalledWith(
+    expect(execSyncSpy).toHaveBeenCalledWith(
       `npm pkg set "exports[.][require]"="./dist/${config.fsNamespace}/${config.fsNamespace}.cjs.js"`,
     );
   });
 
-  //   it('should generate the lazy loader exports if the output target is present', () => {});
+  it('should generate the lazy loader exports if the output target is present', () => {
+    config.rootDir = '/';
+    config.outputTargets.push({
+      type: 'dist-lazy-loader',
+      dir: '/dist/lazy-loader',
+      empty: true,
+      esmDir: '/dist/esm',
+      cjsDir: '/dist/cjs',
+      componentDts: '/dist/components.d.ts',
+    });
 
-  //   it('should generate the custom elements exports if the output target is present', () => {});
+    writeExportMaps(config, buildCtx);
+
+    expect(execSyncSpy).toHaveBeenCalledTimes(5);
+    expect(execSyncSpy).toHaveBeenCalledWith(
+      `npm pkg set "exports[.][import]"="./dist/${config.fsNamespace}/${config.fsNamespace}.esm.js"`,
+    );
+    expect(execSyncSpy).toHaveBeenCalledWith(
+      `npm pkg set "exports[.][require]"="./dist/${config.fsNamespace}/${config.fsNamespace}.cjs.js"`,
+    );
+    expect(execSyncSpy).toHaveBeenCalledWith(`npm pkg set "exports[./loader][import]"="./dist/lazy-loader/index.js"`);
+    expect(execSyncSpy).toHaveBeenCalledWith(`npm pkg set "exports[./loader][require]"="./dist/lazy-loader/index.cjs"`);
+    expect(execSyncSpy).toHaveBeenCalledWith(`npm pkg set "exports[./loader][types]"="./dist/lazy-loader/index.d.ts"`);
+  });
+
+  it('should generate the custom elements exports if the output target is present', () => {
+    config.rootDir = '/';
+    config.outputTargets.push({
+      type: 'dist-custom-elements',
+      dir: '/dist/components',
+      generateTypeDeclarations: true,
+    });
+
+    buildCtx.components = [
+      stubComponentCompilerMeta({
+        tagName: 'my-component',
+        componentClassName: 'MyComponent',
+      }),
+    ];
+
+    writeExportMaps(config, buildCtx);
+
+    expect(execSyncSpy).toHaveBeenCalledTimes(4);
+    expect(execSyncSpy).toHaveBeenCalledWith(
+      `npm pkg set "exports[.][import]"="./dist/${config.fsNamespace}/${config.fsNamespace}.esm.js"`,
+    );
+    expect(execSyncSpy).toHaveBeenCalledWith(
+      `npm pkg set "exports[.][require]"="./dist/${config.fsNamespace}/${config.fsNamespace}.cjs.js"`,
+    );
+    expect(execSyncSpy).toHaveBeenCalledWith(
+      `npm pkg set "exports[./my-component][import]"="./dist/components/my-component.js"`,
+    );
+    expect(execSyncSpy).toHaveBeenCalledWith(
+      `npm pkg set "exports[./my-component][types]"="./dist/components/my-component.d.ts"`,
+    );
+  });
+
+  it('should generate the custom elements exports for multiple components', () => {
+    config.rootDir = '/';
+    config.outputTargets.push({
+      type: 'dist-custom-elements',
+      dir: '/dist/components',
+      generateTypeDeclarations: true,
+    });
+
+    buildCtx.components = [
+      stubComponentCompilerMeta({
+        tagName: 'my-component',
+        componentClassName: 'MyComponent',
+      }),
+      stubComponentCompilerMeta({
+        tagName: 'my-other-component',
+        componentClassName: 'MyOtherComponent',
+      }),
+    ];
+
+    writeExportMaps(config, buildCtx);
+
+    expect(execSyncSpy).toHaveBeenCalledTimes(6);
+    expect(execSyncSpy).toHaveBeenCalledWith(
+      `npm pkg set "exports[.][import]"="./dist/${config.fsNamespace}/${config.fsNamespace}.esm.js"`,
+    );
+    expect(execSyncSpy).toHaveBeenCalledWith(
+      `npm pkg set "exports[.][require]"="./dist/${config.fsNamespace}/${config.fsNamespace}.cjs.js"`,
+    );
+    expect(execSyncSpy).toHaveBeenCalledWith(
+      `npm pkg set "exports[./my-component][import]"="./dist/components/my-component.js"`,
+    );
+    expect(execSyncSpy).toHaveBeenCalledWith(
+      `npm pkg set "exports[./my-component][types]"="./dist/components/my-component.d.ts"`,
+    );
+    expect(execSyncSpy).toHaveBeenCalledWith(
+      `npm pkg set "exports[./my-other-component][import]"="./dist/components/my-other-component.js"`,
+    );
+    expect(execSyncSpy).toHaveBeenCalledWith(
+      `npm pkg set "exports[./my-other-component][types]"="./dist/components/my-other-component.d.ts"`,
+    );
+  });
 });

--- a/src/compiler/build/write-build.ts
+++ b/src/compiler/build/write-build.ts
@@ -1,10 +1,9 @@
-import { catchError, isOutputTargetDistCustomElements, isOutputTargetDistLazyLoader } from '@utils';
-import { relative } from '@utils';
-import { execSync } from 'child_process';
+import { catchError } from '@utils';
 
 import * as d from '../../declarations';
 import { outputServiceWorkers } from '../output-targets/output-service-workers';
 import { validateBuildFiles } from './validate-files';
+import { writeExportMaps } from './write-export-maps';
 
 /**
  * Writes files to disk as a result of compilation
@@ -49,50 +48,4 @@ export const writeBuild = async (
   }
 
   timeSpan.finish(`writeBuildFiles finished, files wrote: ${totalFilesWrote}`);
-};
-
-/**
- * Create export map entry point definitions for the `package.json` file using the npm CLI.
- * This will generate a root entry point for the package, as well as entry points for each component and
- * the lazy loader (if applicable).
- *
- * @param config The validated Stencil config
- * @param buildCtx The build context containing the components to generate export maps for
- */
-const writeExportMaps = (config: d.ValidatedConfig, buildCtx: d.BuildCtx) => {
-  const namespace = buildCtx.config.fsNamespace;
-
-  execSync(`npm pkg set "exports[.][import]"="./dist/${namespace}/${namespace}.esm.js"`);
-  execSync(`npm pkg set "exports[.][require]"="./dist/${namespace}/${namespace}.cjs.js"`);
-
-  const distLazyLoader = config.outputTargets.find(isOutputTargetDistLazyLoader);
-  if (distLazyLoader != null) {
-    // Calculate relative path from project root to lazy-loader output directory
-    let outDir = relative(config.rootDir, distLazyLoader.dir);
-    if (!outDir.startsWith('.')) {
-      outDir = './' + outDir;
-    }
-
-    execSync(`npm pkg set "exports[./loader][import]"="${outDir}/index.js"`);
-    execSync(`npm pkg set "exports[./loader][require]"="${outDir}/index.cjs"`);
-    execSync(`npm pkg set "exports[./loader][types]"="${outDir}/index.d.ts"`);
-  }
-
-  const distCustomElements = config.outputTargets.find(isOutputTargetDistCustomElements);
-  if (distCustomElements != null) {
-    // Calculate relative path from project root to custom elements output directory
-    let outDir = relative(config.rootDir, distCustomElements.dir);
-    if (!outDir.startsWith('.')) {
-      outDir = './' + outDir;
-    }
-
-    buildCtx.components.forEach((cmp) => {
-      console.log('path', cmp.jsFilePath);
-      execSync(`npm pkg set "exports[./${cmp.tagName}][import]"="${outDir}/${cmp.tagName}.js"`);
-
-      if (distCustomElements.generateTypeDeclarations) {
-        execSync(`npm pkg set "exports[./${cmp.tagName}][types]"="${outDir}/${cmp.tagName}.d.ts"`);
-      }
-    });
-  }
 };

--- a/src/compiler/build/write-export-maps.ts
+++ b/src/compiler/build/write-export-maps.ts
@@ -18,8 +18,6 @@ export const writeExportMaps = (config: d.ValidatedConfig, buildCtx: d.BuildCtx)
   execSync(`npm pkg set "exports[.][import]"="./dist/${namespace}/${namespace}.esm.js"`);
   execSync(`npm pkg set "exports[.][require]"="./dist/${namespace}/${namespace}.cjs.js"`);
 
-  console.log('HERE');
-
   const distLazyLoader = config.outputTargets.find(isOutputTargetDistLazyLoader);
   if (distLazyLoader != null) {
     // Calculate relative path from project root to lazy-loader output directory

--- a/src/compiler/build/write-export-maps.ts
+++ b/src/compiler/build/write-export-maps.ts
@@ -25,7 +25,7 @@ export const writeExportMaps = (config: d.ValidatedConfig, buildCtx: d.BuildCtx)
     const outputTargetConfig = PRIMARY_PACKAGE_TARGET_CONFIGS[primaryTarget.type];
 
     if (outputTargetConfig.getModulePath) {
-      const importPath = outputTargetConfig.getModulePath(config.rootDir, primaryTarget.dir);
+      const importPath = outputTargetConfig.getModulePath(config.rootDir, primaryTarget.dir!);
 
       if (importPath) {
         execSync(`npm pkg set "exports[.][import]"="${importPath}"`);
@@ -33,7 +33,7 @@ export const writeExportMaps = (config: d.ValidatedConfig, buildCtx: d.BuildCtx)
     }
 
     if (outputTargetConfig.getMainPath) {
-      const requirePath = outputTargetConfig.getMainPath(config.rootDir, primaryTarget.dir);
+      const requirePath = outputTargetConfig.getMainPath(config.rootDir, primaryTarget.dir!);
 
       if (requirePath) {
         execSync(`npm pkg set "exports[.][require]"="${requirePath}"`);
@@ -65,7 +65,7 @@ export const writeExportMaps = (config: d.ValidatedConfig, buildCtx: d.BuildCtx)
   const distCustomElements = config.outputTargets.find(isOutputTargetDistCustomElements);
   if (distCustomElements != null) {
     // Calculate relative path from project root to custom elements output directory
-    let outDir = relative(config.rootDir, distCustomElements.dir);
+    let outDir = relative(config.rootDir, distCustomElements.dir!);
     if (!outDir.startsWith('.')) {
       outDir = './' + outDir;
     }

--- a/src/compiler/build/write-export-maps.ts
+++ b/src/compiler/build/write-export-maps.ts
@@ -40,7 +40,6 @@ export const writeExportMaps = (config: d.ValidatedConfig, buildCtx: d.BuildCtx)
     }
 
     buildCtx.components.forEach((cmp) => {
-      console.log('path', cmp.jsFilePath);
       execSync(`npm pkg set "exports[./${cmp.tagName}][import]"="${outDir}/${cmp.tagName}.js"`);
 
       if (distCustomElements.generateTypeDeclarations) {

--- a/src/compiler/build/write-export-maps.ts
+++ b/src/compiler/build/write-export-maps.ts
@@ -1,0 +1,53 @@
+import { isOutputTargetDistCustomElements, isOutputTargetDistLazyLoader } from '@utils';
+import { relative } from '@utils';
+import { execSync } from 'child_process';
+
+import * as d from '../../declarations';
+
+/**
+ * Create export map entry point definitions for the `package.json` file using the npm CLI.
+ * This will generate a root entry point for the package, as well as entry points for each component and
+ * the lazy loader (if applicable).
+ *
+ * @param config The validated Stencil config
+ * @param buildCtx The build context containing the components to generate export maps for
+ */
+export const writeExportMaps = (config: d.ValidatedConfig, buildCtx: d.BuildCtx) => {
+  const namespace = buildCtx.config.fsNamespace;
+
+  execSync(`npm pkg set "exports[.][import]"="./dist/${namespace}/${namespace}.esm.js"`);
+  execSync(`npm pkg set "exports[.][require]"="./dist/${namespace}/${namespace}.cjs.js"`);
+
+  console.log('HERE');
+
+  const distLazyLoader = config.outputTargets.find(isOutputTargetDistLazyLoader);
+  if (distLazyLoader != null) {
+    // Calculate relative path from project root to lazy-loader output directory
+    let outDir = relative(config.rootDir, distLazyLoader.dir);
+    if (!outDir.startsWith('.')) {
+      outDir = './' + outDir;
+    }
+
+    execSync(`npm pkg set "exports[./loader][import]"="${outDir}/index.js"`);
+    execSync(`npm pkg set "exports[./loader][require]"="${outDir}/index.cjs"`);
+    execSync(`npm pkg set "exports[./loader][types]"="${outDir}/index.d.ts"`);
+  }
+
+  const distCustomElements = config.outputTargets.find(isOutputTargetDistCustomElements);
+  if (distCustomElements != null) {
+    // Calculate relative path from project root to custom elements output directory
+    let outDir = relative(config.rootDir, distCustomElements.dir);
+    if (!outDir.startsWith('.')) {
+      outDir = './' + outDir;
+    }
+
+    buildCtx.components.forEach((cmp) => {
+      console.log('path', cmp.jsFilePath);
+      execSync(`npm pkg set "exports[./${cmp.tagName}][import]"="${outDir}/${cmp.tagName}.js"`);
+
+      if (distCustomElements.generateTypeDeclarations) {
+        execSync(`npm pkg set "exports[./${cmp.tagName}][types]"="${outDir}/${cmp.tagName}.d.ts"`);
+      }
+    });
+  }
+};

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -124,6 +124,7 @@ export const validateConfig = (
     devMode,
     extras: config.extras || {},
     flags,
+    generateExportMaps: isBoolean(config.generateExportMaps) ? config.generateExportMaps : false,
     hashFileNames,
     hashedFileNameLength: config.hashedFileNameLength ?? DEFAULT_HASHED_FILENAME_LENGTH,
     hydratedFlag: validateHydrated(config),

--- a/src/compiler/types/validate-primary-package-output-target.ts
+++ b/src/compiler/types/validate-primary-package-output-target.ts
@@ -17,7 +17,7 @@ export type PrimaryPackageOutputTargetRecommendedConfig = {
    * @param outputTargetDir The output directory for the output target's compiled code.
    * @returns The recommended path for the `module` property in a project's `package.json`
    */
-  getModulePath?: (rootDir: string, outputTargetDir: string) => string | null;
+  getModulePath: (rootDir: string, outputTargetDir: string) => string | null;
   /**
    * Generates the recommended path for the `types` property based on the output target type,
    * the project's root directory, and the output target's configuration.
@@ -26,7 +26,18 @@ export type PrimaryPackageOutputTargetRecommendedConfig = {
    * @param outputTargetConfig The output target's config.
    * @returns The recommended path for the `types` property in a project's `package.json`
    */
-  getTypesPath?: (rootDir: string, outputTargetConfig: any) => string | null;
+  getTypesPath: (rootDir: string, outputTargetConfig: any) => string | null;
+  /**
+   * Generates the recommended path for the `main` property based on the output target type,
+   * the project's root directory, and the output target's designated output location.
+   *
+   * Only used for generate export maps.
+   *
+   * @param rootDir The Stencil project's root directory pulled from the validated config.
+   * @param outputTargetDir The output directory for the output target's compiled code.
+   * @returns The recommended path for the `main` property in a project's `package.json`
+   */
+  getMainPath: (rootDir: string, outputTargetDir: string) => string | null;
 };
 
 /**
@@ -38,25 +49,32 @@ export const PRIMARY_PACKAGE_TARGET_CONFIGS = {
   dist: {
     getModulePath: (rootDir: string, outputTargetDir: string) =>
       normalizePath(relative(rootDir, join(outputTargetDir, 'index.js'))),
-    getTypesPath: (rootDir: string, outputTargetConfig: d.OutputTargetDist) =>
+    getTypesPath: (rootDir: string, outputTargetConfig: any) =>
       normalizePath(relative(rootDir, join(outputTargetConfig.typesDir!, 'index.d.ts'))),
+    getMainPath: (rootDir: string, outputTargetDir: string) =>
+      normalizePath(relative(rootDir, join(outputTargetDir, 'index.cjs.js'))),
   },
   'dist-collection': {
     getModulePath: (rootDir: string, outputTargetDir: string) =>
       normalizePath(relative(rootDir, join(outputTargetDir, 'index.js'))),
+    getTypesPath: () => null,
+    getMainPath: () => null,
   },
   'dist-custom-elements': {
     getModulePath: (rootDir: string, outputTargetDir: string) =>
       normalizePath(relative(rootDir, join(outputTargetDir, 'index.js'))),
-    getTypesPath: (rootDir: string, outputTargetConfig: d.OutputTargetDistCustomElements) => {
+    getTypesPath: (rootDir: string, outputTargetConfig: any) => {
       return outputTargetConfig.generateTypeDeclarations
         ? normalizePath(relative(rootDir, join(outputTargetConfig.dir!, 'index.d.ts')))
         : null;
     },
+    getMainPath: () => null,
   },
   'dist-types': {
-    getTypesPath: (rootDir: string, outputTargetConfig: d.OutputTargetDistTypes) =>
+    getModulePath: () => null,
+    getTypesPath: (rootDir: string, outputTargetConfig: any) =>
       normalizePath(relative(rootDir, join(outputTargetConfig.typesDir, 'index.d.ts'))),
+    getMainPath: () => null,
   },
 } satisfies Record<d.EligiblePrimaryPackageOutputTarget['type'], PrimaryPackageOutputTargetRecommendedConfig>;
 

--- a/src/compiler/types/validate-primary-package-output-target.ts
+++ b/src/compiler/types/validate-primary-package-output-target.ts
@@ -22,6 +22,9 @@ export type PrimaryPackageOutputTargetRecommendedConfig = {
    * Generates the recommended path for the `types` property based on the output target type,
    * the project's root directory, and the output target's configuration.
    *
+   * `outputTargetConfig` is typed as `any` because downstream consumers may run into type conflicts
+   * with the `type` property of all the different "eligible" output targets.
+   *
    * @param rootDir The Stencil project's root directory pulled from the validated config.
    * @param outputTargetConfig The output target's config.
    * @returns The recommended path for the `types` property in a project's `package.json`

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -85,6 +85,14 @@ export interface StencilConfig {
   globalStyle?: string;
 
   /**
+   * Will generate {@link https://nodejs.org/api/packages.html#packages_exports export map} entry points
+   * for each component in the build when `true`.
+   *
+   * @default false
+   */
+  generateExportMaps?: boolean;
+
+  /**
    * When the hashFileNames config is set to true, and it is a production build,
    * the hashedFileNameLength config is used to determine how many characters the file name's hash should be.
    */


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Stencil does not generate export maps for any entry points.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Stencil will generate export maps at build time. This include the default entry point, entry points for the lazy-loader (if applicable), and each custom element (if applicable).

This behavior is gated behind a new config flag.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

https://github.com/ionic-team/stencil-site/pull/1443

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Unit tests were added for the new behavior.

This feature can be manually tested by installing a build of this branch into the component starter and enabling the `generateExportMaps` config flag.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
