### PR TITLE
chore(renovate): lower update frequency

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -151,18 +151,9 @@
   // Never rebase the branch or update it unless manually requested to avoid noisy PR emails
   rebaseWhen: 'never',
   /**
-   * Run every Monday and Thursday between midnight at 11 AM (in UTC)
-   *
-   * Monday and Thursday were chosen to:
-   * - Keep the `minimumReleaseAge` value in mind (three days)
-   * - Prevent spikes/bursts of PRs from Renovate on a single day of the week
-   *
-   * We use cron syntax here as it's more deterministic/easier to provide a value that we know that Renovate will
-   * accept, compared to the natural language syntax which is (subjectively) trickier to test without merging first.
-   *
-   * {@see https://crontab.guru} for debugging cron schedules
+   * Natural language syntax taken directly from renovate preset examples (with time adjusted).
    */
-  schedule: ['* 0-11 * * 1,4'],
+  schedule: ["before 8am on the first day of the month"],
   /**
    * Ensure semantic commits are enabled for commits + PR titles.
    *


### PR DESCRIPTION
## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Lowers the frequency at which Renovate runs from twice a week, to once a month. This will cut down on the noise of update PRs. Many of these updates tend to not be useful to Stencil and/or can cause unforseen breaking changes. Some dependencies may be manually updated on a case-by-case basis.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Merge and find out if it works. The schedule was taken directly from renovate's examples so should work 🤞 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
