### PR TITLE
fix(runtime): catch errors in async lifecycle methods

### DIFF
--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -137,7 +137,12 @@ const dispatchHooks = (hostRef: d.HostRef, isInitialLoad: boolean): Promise<void
  * @returns either a `Promise` or the return value of the provided function
  */
 const enqueue = (maybePromise: Promise<void> | undefined, fn: () => Promise<void>): Promise<void> | undefined =>
-  isPromisey(maybePromise) ? maybePromise.then(fn) : fn();
+  isPromisey(maybePromise)
+    ? maybePromise.then(fn).catch((err) => {
+        console.error(err);
+        fn();
+      })
+    : fn();
 
 /**
  * Check that a value is a `Promise`. To check, we first see if the value is an


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There is a discrepancy between how Stencil handles errors in synchronous vs asynchronous component lifecycle methods. In synchronous components, the error is thrown, but the component will still render. For async, the error block component rendering.

Fixes: #5824 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The runtime will now catch errors thrown from async lifecycle methods, log them, and then continue the render cycle.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Validated fix in the associated issue's reproduction case.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
