### PR TITLE
fix(mock-doc): expose ShadowRoot and DocumentFragment globals

### DIFF
--- a/src/mock-doc/global.ts
+++ b/src/mock-doc/global.ts
@@ -1,3 +1,4 @@
+import { MockDocumentFragment } from './document-fragment';
 import {
   MockAnchorElement,
   MockBaseElement,
@@ -156,14 +157,16 @@ const WINDOW_PROPS = [
 
 const GLOBAL_CONSTRUCTORS: [string, any][] = [
   ['CustomEvent', MockCustomEvent],
+  ['DocumentFragment', MockDocumentFragment],
+  ['DOMParser', MockDOMParser],
   ['Event', MockEvent],
-  ['Headers', MockHeaders],
   ['FocusEvent', MockFocusEvent],
+  ['Headers', MockHeaders],
   ['KeyboardEvent', MockKeyboardEvent],
   ['MouseEvent', MockMouseEvent],
   ['Request', MockRequest],
   ['Response', MockResponse],
-  ['DOMParser', MockDOMParser],
+  ['ShadowRoot', MockDocumentFragment],
 
   ['HTMLAnchorElement', MockAnchorElement],
   ['HTMLBaseElement', MockBaseElement],


### PR DESCRIPTION
## What is the current behavior?

fixes #3260

## What is the new behavior?

This patch exposes `DocumentFragment` and `ShadowRoot` into the global scope.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
