### PR TITLE
feat(testing): expose captureBeyondViewport in pageCompareScreenshot

### DIFF
--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -1848,6 +1848,12 @@ export interface ScreenshotOptions {
    * more sensitive. Defaults to the testing config `pixelmatchThreshold` value;
    */
   pixelmatchThreshold?: number;
+  /**
+   * Capture the screenshot beyond the viewport.
+   *
+   * @defaultValue `false` if there is no `clip`. `true` otherwise.
+   */
+  captureBeyondViewport?: boolean;
 }
 
 export interface ScreenshotBoundingBox {

--- a/src/testing/puppeteer/puppeteer-screenshot.ts
+++ b/src/testing/puppeteer/puppeteer-screenshot.ts
@@ -159,6 +159,8 @@ export function createPuppeteerScreenshotOptions(
   };
 
   if (opts.clip) {
+    puppeteerOpts.captureBeyondViewport =
+      typeof opts.captureBeyondViewport === 'boolean' ? opts.captureBeyondViewport : true;
     puppeteerOpts.clip = {
       x: opts.clip.x,
       y: opts.clip.y,
@@ -166,6 +168,8 @@ export function createPuppeteerScreenshotOptions(
       height: opts.clip.height,
     };
   } else {
+    puppeteerOpts.captureBeyondViewport =
+      typeof opts.captureBeyondViewport === 'boolean' ? opts.captureBeyondViewport : false;
     puppeteerOpts.clip = {
       x: 0,
       y: 0,

--- a/src/testing/puppeteer/test/puppeteer-screenshot.spec.ts
+++ b/src/testing/puppeteer/test/puppeteer-screenshot.spec.ts
@@ -11,6 +11,7 @@ describe('Puppeteer Screenshot', () => {
         width: 800,
         height: 600,
       });
+      expect(options.captureBeyondViewport).toBe(false);
     });
 
     it('should use clip options if provided', () => {
@@ -32,6 +33,7 @@ describe('Puppeteer Screenshot', () => {
         width: 100,
         height: 200,
       });
+      expect(options.captureBeyondViewport).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## What is the current behavior?

fixes #3188

## What is the new behavior?
This patch exposes the `captureBeyondViewport` option to the `pageCompareScreenshot` as requested in given issue.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Added a unit test for this.

## Other information

n/a
