### PR TITLE
fix(testing): allow to re-use pages across it blocks

### DIFF
--- a/src/testing/jest/jest-27-and-under/jest-environment.ts
+++ b/src/testing/jest/jest-27-and-under/jest-environment.ts
@@ -45,10 +45,7 @@ export function createJestPuppeteerEnvironment(): JestPuppeteerEnvironmentConstr
     }
 
     async closeOpenPages() {
-      await Promise.all(this.pages
-        .filter((page) => !page.isClosed())
-        .map((page) => page.close())
-      );
+      await Promise.all(this.pages.filter((page) => !page.isClosed()).map((page) => page.close()));
       this.pages.length = 0;
     }
 

--- a/src/testing/jest/jest-27-and-under/jest-environment.ts
+++ b/src/testing/jest/jest-27-and-under/jest-environment.ts
@@ -29,6 +29,11 @@ export function createJestPuppeteerEnvironment(): JestPuppeteerEnvironmentConstr
         this.browser = await connectBrowser();
       }
 
+      /**
+       * if the user had open pages before, close them all when creating a new one
+       */
+      await this.closeOpenPages();
+
       const page = await newBrowserPage(this.browser);
       this.pages.push(page);
       // during E2E tests, we can safely assume that the current environment is a `E2EProcessEnv`
@@ -40,7 +45,10 @@ export function createJestPuppeteerEnvironment(): JestPuppeteerEnvironmentConstr
     }
 
     async closeOpenPages() {
-      await Promise.all(this.pages.map((page) => page.close()));
+      await Promise.all(this.pages
+        .filter((page) => !page.isClosed())
+        .map((page) => page.close())
+      );
       this.pages.length = 0;
     }
 

--- a/src/testing/jest/jest-27-and-under/jest-setup-test-framework.ts
+++ b/src/testing/jest/jest-27-and-under/jest-setup-test-framework.ts
@@ -34,9 +34,6 @@ export function jestSetupTestFramework() {
   });
 
   afterEach(async () => {
-    if (global.__CLOSE_OPEN_PAGES__) {
-      await global.__CLOSE_OPEN_PAGES__();
-    }
     stopAutoApplyChanges();
 
     // Remove each node from the mocked DOM
@@ -59,6 +56,12 @@ export function jestSetupTestFramework() {
 
     teardownGlobal(global);
     global.resourcesUrl = '/build';
+  });
+
+  afterAll(async () => {
+    if (global.__CLOSE_OPEN_PAGES__) {
+      await global.__CLOSE_OPEN_PAGES__();
+    }
   });
 
   const jasmineEnv = (jasmine as any).getEnv();

--- a/src/testing/jest/jest-28/jest-environment.ts
+++ b/src/testing/jest/jest-28/jest-environment.ts
@@ -86,10 +86,7 @@ export function createJestPuppeteerEnvironment(): JestPuppeteerEnvironmentConstr
     }
 
     async closeOpenPages() {
-      await Promise.all(this.pages
-        .filter((page) => !page.isClosed())
-        .map((page) => page.close())
-      );
+      await Promise.all(this.pages.filter((page) => !page.isClosed()).map((page) => page.close()));
       this.pages.length = 0;
     }
 

--- a/src/testing/jest/jest-28/jest-environment.ts
+++ b/src/testing/jest/jest-28/jest-environment.ts
@@ -70,6 +70,11 @@ export function createJestPuppeteerEnvironment(): JestPuppeteerEnvironmentConstr
         this.browser = await connectBrowser();
       }
 
+      /**
+       * if the user had open pages before, close them all when creating a new one
+       */
+      await this.closeOpenPages();
+
       const page = await newBrowserPage(this.browser);
       this.pages.push(page);
       // during E2E tests, we can safely assume that the current environment is a `E2EProcessEnv`
@@ -81,7 +86,10 @@ export function createJestPuppeteerEnvironment(): JestPuppeteerEnvironmentConstr
     }
 
     async closeOpenPages() {
-      await Promise.all(this.pages.map((page) => page.close()));
+      await Promise.all(this.pages
+        .filter((page) => !page.isClosed())
+        .map((page) => page.close())
+      );
       this.pages.length = 0;
     }
 

--- a/src/testing/jest/jest-28/jest-setup-test-framework.ts
+++ b/src/testing/jest/jest-28/jest-setup-test-framework.ts
@@ -34,9 +34,6 @@ export function jestSetupTestFramework() {
   });
 
   afterEach(async () => {
-    if (global.__CLOSE_OPEN_PAGES__) {
-      await global.__CLOSE_OPEN_PAGES__();
-    }
     stopAutoApplyChanges();
 
     // Remove each node from the mocked DOM
@@ -59,6 +56,12 @@ export function jestSetupTestFramework() {
 
     teardownGlobal(global);
     global.resourcesUrl = '/build';
+  });
+
+  afterAll(async () => {
+    if (global.__CLOSE_OPEN_PAGES__) {
+      await global.__CLOSE_OPEN_PAGES__();
+    }
   });
 
   global.screenshotDescriptions = new Set();

--- a/src/testing/jest/jest-29/jest-environment.ts
+++ b/src/testing/jest/jest-29/jest-environment.ts
@@ -86,10 +86,7 @@ export function createJestPuppeteerEnvironment(): JestPuppeteerEnvironmentConstr
     }
 
     async closeOpenPages() {
-      await Promise.all(this.pages
-        .filter((page) => !page.isClosed())
-        .map((page) => page.close())
-      );
+      await Promise.all(this.pages.filter((page) => !page.isClosed()).map((page) => page.close()));
       this.pages.length = 0;
     }
 

--- a/src/testing/jest/jest-29/jest-environment.ts
+++ b/src/testing/jest/jest-29/jest-environment.ts
@@ -70,6 +70,11 @@ export function createJestPuppeteerEnvironment(): JestPuppeteerEnvironmentConstr
         this.browser = await connectBrowser();
       }
 
+      /**
+       * if the user had open pages before, close them all when creating a new one
+       */
+      await this.closeOpenPages();
+
       const page = await newBrowserPage(this.browser);
       this.pages.push(page);
       // during E2E tests, we can safely assume that the current environment is a `E2EProcessEnv`
@@ -81,7 +86,10 @@ export function createJestPuppeteerEnvironment(): JestPuppeteerEnvironmentConstr
     }
 
     async closeOpenPages() {
-      await Promise.all(this.pages.map((page) => page.close()));
+      await Promise.all(this.pages
+        .filter((page) => !page.isClosed())
+        .map((page) => page.close())
+      );
       this.pages.length = 0;
     }
 

--- a/src/testing/jest/jest-29/jest-setup-test-framework.ts
+++ b/src/testing/jest/jest-29/jest-setup-test-framework.ts
@@ -34,9 +34,6 @@ export function jestSetupTestFramework() {
   });
 
   afterEach(async () => {
-    if (global.__CLOSE_OPEN_PAGES__) {
-      await global.__CLOSE_OPEN_PAGES__();
-    }
     stopAutoApplyChanges();
 
     // Remove each node from the mocked DOM
@@ -59,6 +56,12 @@ export function jestSetupTestFramework() {
 
     teardownGlobal(global);
     global.resourcesUrl = '/build';
+  });
+
+  afterAll(async () => {
+    if (global.__CLOSE_OPEN_PAGES__) {
+      await global.__CLOSE_OPEN_PAGES__();
+    }
   });
 
   global.screenshotDescriptions = new Set();

--- a/src/testing/puppeteer/puppeteer-element.ts
+++ b/src/testing/puppeteer/puppeteer-element.ts
@@ -527,6 +527,14 @@ export class E2EElement extends MockHTMLElement implements pd.E2EElementInternal
 
     const rootElm = frag.firstElementChild;
 
+    /**
+     * in case the user called `newE2EPage` without any content `rootElm` will be undefined
+     * and further operations will fail. We need to check for this case and return early.
+     */
+    if (!rootElm) {
+      return;
+    }
+
     this.nodeName = rootElm.nodeName;
     this.attributes = cloneAttributes(rootElm.attributes);
 

--- a/test/end-to-end/src/miscellaneous/test.e2e.ts
+++ b/test/end-to-end/src/miscellaneous/test.e2e.ts
@@ -1,19 +1,19 @@
 import { type E2EPage, newE2EPage } from '@stencil/core/testing';
 
 describe('do not throw page already closed if page was defined in before(All) hook', () => {
-  let page: E2EPage
+  let page: E2EPage;
 
   beforeAll(async () => {
-    page = await newE2EPage()
-  })
+    page = await newE2EPage();
+  });
 
-  it("first test", async () => {
-    const p = await page.find('html')
-    expect(p).not.toBeNull()
-  })
+  it('first test', async () => {
+    const p = await page.find('html');
+    expect(p).not.toBeNull();
+  });
 
-  it("second test", async () => {
-    const p = await page.find('html')
-    expect(p).not.toBeNull()
-  })
-})
+  it('second test', async () => {
+    const p = await page.find('html');
+    expect(p).not.toBeNull();
+  });
+});

--- a/test/end-to-end/src/miscellaneous/test.e2e.ts
+++ b/test/end-to-end/src/miscellaneous/test.e2e.ts
@@ -1,0 +1,19 @@
+import { type E2EPage, newE2EPage } from '@stencil/core/testing';
+
+describe('do not throw page already closed if page was defined in before(All) hook', () => {
+  let page: E2EPage
+
+  beforeAll(async () => {
+    page = await newE2EPage()
+  })
+
+  it("first test", async () => {
+    const p = await page.find('html')
+    expect(p).not.toBeNull()
+  })
+
+  it("second test", async () => {
+    const p = await page.find('html')
+    expect(p).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## What is the current behavior?
Currently Stencil tears down all pages in an `afterEach` hook which causes issues when you re-use a page object across multiple it blocks, e.g.:

```tsx
import { type E2EPage, newE2EPage } from '@stencil/core/testing';

describe('do not throw page already closed if page was defined in before(All) hook', () => {
  let page: E2EPage

  beforeAll(async () => {
    page = await newE2EPage()
  })

  it("first test", async () => {
    const p = await page.find('html')
    expect(p).not.toBeNull()
  })

  it("second test", async () => {
    const p = await page.find('html')
    expect(p).not.toBeNull()
  })
})
```

fixes #3720

## What is the new behavior?

Let's not remove all pages after each `it` block and instead do it after all it blocks or when the user is creating a `newE2EPage` object.

## Documentation

n/a

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Added an e2e test to verify this expected behavior works.

## Other information

n/a
