### PR TITLE
feat(complier): support type import aliasing

### DIFF
--- a/src/compiler/types/generate-app-types.ts
+++ b/src/compiler/types/generate-app-types.ts
@@ -108,10 +108,10 @@ const generateComponentTypesFile = (
     return `{ ${typeData
       .sort(sortImportNames)
       .map((td) => {
-        if (td.localName === td.importName) {
-          return `${td.importName}`;
+        if (td.originalName === td.importName) {
+          return `${td.originalName}`;
         } else {
-          return `${td.localName} as ${td.importName}`;
+          return `${td.originalName} as ${td.importName}`;
         }
       })
       .join(`, `)} } from "${importFilePath}";`;

--- a/src/compiler/types/tests/ComponentCompilerEvent.stub.ts
+++ b/src/compiler/types/tests/ComponentCompilerEvent.stub.ts
@@ -22,7 +22,7 @@ export const stubComponentCompilerEvent = (
       resolved: '"foo" | "bar"',
       references: {
         UserImplementedEventType: {
-          id: 'placeholder',
+          id: './resources.ts::UserImplementedEventType',
           location: 'import',
           path: './resources',
         },

--- a/src/compiler/types/tests/generate-app-types.spec.ts
+++ b/src/compiler/types/tests/generate-app-types.spec.ts
@@ -206,7 +206,7 @@ declare module "@stencil/core" {
               resolved: '"wee" | "woo"',
               references: {
                 SecondUserImplementedEventType: {
-                  id: 'placeholder',
+                  id: './resources.ts::SecondUserImplementedEventType',
                   location: 'import',
                   path: './resources',
                 },
@@ -310,7 +310,7 @@ declare module "@stencil/core" {
               references: {
                 UserImplementedEventType: {
                   location: 'import',
-                  id: 'placeholder',
+                  id: './resources.ts::UserImplementedEventType',
                   path: './resources',
                 },
               },
@@ -479,7 +479,7 @@ declare module "@stencil/core" {
                 UserImplementedEventType: {
                   location: 'import',
                   path: './resources',
-                  id: 'placeholder',
+                  id: './resources::UserImplementedEventType',
                 },
               },
             },
@@ -502,7 +502,7 @@ declare module "@stencil/core" {
                 UserImplementedEventType: {
                   location: 'import',
                   path: './resources',
-                  id: 'placeholder',
+                  id: './resources::UserImplementedEventType',
                 },
               },
             },
@@ -649,7 +649,7 @@ declare module "@stencil/core" {
                 UserImplementedEventType: {
                   location: 'local',
                   path: '/some/stubbed/path/a/my-component.tsx',
-                  id: 'placeholder',
+                  id: '/some/stubbed/path/a/my-component.tsx::UserImplementedEventType',
                 },
               },
             },
@@ -671,7 +671,7 @@ declare module "@stencil/core" {
               references: {
                 UserImplementedEventType: {
                   location: 'local',
-                  id: 'placeholder',
+                  id: '/some/stubbed/path/b/my-new-component.tsx::UserImplementedEventType',
                   path: '/some/stubbed/path/b/my-new-component.tsx',
                 },
               },
@@ -819,7 +819,7 @@ declare module "@stencil/core" {
                 UserImplementedPropType: {
                   location: 'import',
                   path: './resources',
-                  id: 'placeholder',
+                  id: './resources::UserImplementedPropType',
                 },
               },
             },
@@ -907,7 +907,7 @@ declare module "@stencil/core" {
                 UserImplementedPropType: {
                   location: 'import',
                   path: './resources',
-                  id: 'placeholder',
+                  id: './resources::UserImplementedPropType',
                 },
               },
             },
@@ -921,7 +921,7 @@ declare module "@stencil/core" {
                 SecondUserImplementedPropType: {
                   location: 'import',
                   path: './resources',
-                  id: 'placeholder',
+                  id: './resources::SecondUserImplementedPropType',
                 },
               },
             },
@@ -1011,7 +1011,7 @@ declare module "@stencil/core" {
                 UserImplementedPropType: {
                   location: 'import',
                   path: './resources',
-                  id: 'placeholder',
+                  id: './resources::UserImplementedPropType',
                 },
               },
             },
@@ -1035,7 +1035,7 @@ declare module "@stencil/core" {
                 UserImplementedPropType: {
                   location: 'import',
                   path: '../resources',
-                  id: 'placeholder',
+                  id: '../resources::UserImplementedPropType',
                 },
               },
             },
@@ -1152,7 +1152,7 @@ declare module "@stencil/core" {
               references: {
                 UserImplementedPropType: {
                   location: 'import',
-                  id: 'placeholder',
+                  id: './resources.ts::UserImplementedPropType',
                   path: './resources',
                 },
               },
@@ -1177,7 +1177,7 @@ declare module "@stencil/core" {
                 UserImplementedPropType: {
                   location: 'import',
                   path: './resources',
-                  id: 'placeholder',
+                  id: './resources.ts::UserImplementedPropType',
                 },
               },
             },
@@ -1297,7 +1297,7 @@ declare module "@stencil/core" {
                 UserImplementedPropType: {
                   location: 'local',
                   path: '/some/stubbed/path/a/my-component.tsx',
-                  id: 'placeholder',
+                  id: '/some/stubbed/path/a/my-component.tsx::UserImplementedPropType',
                 },
               },
             },
@@ -1321,7 +1321,7 @@ declare module "@stencil/core" {
                 UserImplementedPropType: {
                   location: 'local',
                   path: '/some/stubbed/path/b/my-new-component.tsx',
-                  id: 'placeholder',
+                  id: '/some/stubbed/path/b/my-new-component.tsx::UserImplementedPropType',
                 },
               },
             },
@@ -1444,7 +1444,7 @@ declare module "@stencil/core" {
               UserImplementedPropType: {
                 location: 'import',
                 path: './resources',
-                id: 'placeholder',
+                id: './resources.ts::UserImplementedPropType',
               },
             },
           },
@@ -1676,6 +1676,98 @@ declare module "@stencil/core" {
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { UserImplementedPropType } from "@utils";
 export { UserImplementedPropType } from "@utils";
+export namespace Components {
+    /**
+     * docs
+     */
+    interface MyComponent {
+        "name": UserImplementedPropType;
+    }
+}
+declare global {
+    /**
+     * docs
+     */
+    interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
+    }
+    var HTMLMyComponentElement: {
+        prototype: HTMLMyComponentElement;
+        new (): HTMLMyComponentElement;
+    };
+    interface HTMLElementTagNameMap {
+        "my-component": HTMLMyComponentElement;
+    }
+}
+declare namespace LocalJSX {
+    /**
+     * docs
+     */
+    interface MyComponent {
+        "name"?: UserImplementedPropType;
+    }
+    interface IntrinsicElements {
+        "my-component": MyComponent;
+    }
+}
+export { LocalJSX as JSX };
+declare module "@stencil/core" {
+    export namespace JSX {
+        interface IntrinsicElements {
+            /**
+             * docs
+             */
+            "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
+        }
+    }
+}
+`,
+      {
+        immediateWrite: true,
+      },
+    );
+  });
+
+  it('should handle type import aliases', async () => {
+    const compilerComponentMeta = stubComponentCompilerMeta({
+      tagName: 'my-component',
+      componentClassName: 'MyComponent',
+      jsFilePath: '/some/stubbed/path/a/my-component.js',
+      sourceFilePath: '/some/stubbed/path/a/my-component.tsx',
+      sourceMapPath: '/some/stubbed/path/a/my-component.js.map',
+      hasProp: true,
+      properties: [
+        stubComponentCompilerProperty({
+          name: 'name',
+          complexType: {
+            original: 'UserImplementedPropType',
+            resolved: '"foo" | "bar"',
+            references: {
+              UserImplementedPropType: {
+                id: 'some-file.ts::MyType',
+                location: 'import',
+                path: '@utils',
+              },
+            },
+          },
+        }),
+      ],
+    });
+    buildCtx.components = [compilerComponentMeta];
+    config.tsCompilerOptions = {};
+
+    await generateAppTypes(config, compilerCtx, buildCtx, 'src');
+
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      '/components.d.ts',
+      `/* eslint-disable */
+/* tslint:disable */
+/**
+ * This is an autogenerated file created by the Stencil compiler.
+ * It contains typing information for all components that exist in this project.
+ */
+import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
+import { MyType as UserImplementedPropType } from "@utils";
+export { MyType as UserImplementedPropType } from "@utils";
 export namespace Components {
     /**
      * docs

--- a/src/compiler/types/tests/stencil-types.spec.ts
+++ b/src/compiler/types/tests/stencil-types.spec.ts
@@ -111,6 +111,7 @@ describe('stencil-types', () => {
           [typePath]: [
             {
               localName: 'SomeOtherType',
+              originalName: 'SomeOtherType',
             },
           ],
         });
@@ -176,6 +177,7 @@ describe('stencil-types', () => {
           [typePath]: [
             {
               localName: initialType,
+              originalName: initialType,
               importName: expectedType,
             },
           ],
@@ -198,6 +200,7 @@ describe('stencil-types', () => {
       const typeMemberNames = [
         {
           localName: 'SomeType',
+          originalName: 'SomeType',
           importName: 'SomeOtherType',
         },
       ];
@@ -211,6 +214,7 @@ describe('stencil-types', () => {
       const typeMemberNames = [
         {
           localName: 'Ar',
+          originalName: 'Ar',
           importName: 'Ar1',
         },
       ];
@@ -224,6 +228,7 @@ describe('stencil-types', () => {
       const typeMemberNames = [
         {
           localName: 'Ar',
+          originalName: 'Ar',
           importName: 'Ar1',
         },
       ];
@@ -237,10 +242,12 @@ describe('stencil-types', () => {
       const typeMemberNames = [
         {
           localName: 'SomeType',
+          originalName: 'SomeType',
           importName: 'SomeType1',
         },
         {
           localName: 'AnotherType',
+          originalName: 'AnotherType',
           importName: 'AnotherType1',
         },
       ];
@@ -254,6 +261,7 @@ describe('stencil-types', () => {
       const typeMemberNames = [
         {
           localName: 'SomeType',
+          originalName: 'SomeType',
           importName: 'SomeType1',
         },
       ];
@@ -279,6 +287,7 @@ describe('stencil-types', () => {
       const typeMemberNames = [
         {
           localName: 'SomeType',
+          originalName: 'SomeType',
           importName: 'SomeType1',
         },
       ];

--- a/src/compiler/types/update-import-refs.ts
+++ b/src/compiler/types/update-import-refs.ts
@@ -124,6 +124,9 @@ const updateImportReferenceFactory = (
 
         const newTypeName = getIncrementTypeName(typeName);
         existingTypeImportData[importResolvedFile].push({
+          // Since we create a unique ID for each type for documentation generation purposes, we can parse
+          // that ID to get the original name for the export
+          originalName: typeReference.id.split('::').pop(),
           localName: typeName,
           importName: newTypeName,
         });

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -2361,6 +2361,15 @@ export interface TypesImportData {
  */
 export interface TypesMemberNameData {
   /**
+   * The original name of the import before any aliasing was applied.
+   *
+   * i.e. if a component imports a type as follows:
+   * `import { MyType as MyCoolType } from './my-type';`
+   *
+   * the `originalName` would be 'MyType'. If the import is not aliased, then `originalName` and `localName` will be the same.
+   */
+  originalName: string;
+  /**
    * The name of the type as it's used within a file.
    */
   localName: string;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Stencil does not correctly handle aliased types when generating the `components.d.ts` file. If a type import is aliased, the generated file will try to import _only_ the aliased name, which cannot be resolved.

Closes: #2335 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Stencil will now import and cast (`as`) from the original type name to the aliased name in the generated `components.d.ts` file.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Tested the behavior in a component starter example.

Added a unit test for the new behavior.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
