### PR TITLE
fix(runtime): properly assign style declarations

### DIFF
--- a/src/runtime/initialize-component.ts
+++ b/src/runtime/initialize-component.ts
@@ -116,7 +116,7 @@ export const initializeComponent = async (
       /**
        * this component has styles but we haven't registered them yet
        */
-      let style: string | undefined
+      let style: string | undefined;
 
       if (typeof Cstr.style === 'string') {
         /**
@@ -128,8 +128,8 @@ export const initializeComponent = async (
          * })
          * ```
          */
-        style = Cstr.style
-      } else if (BUILD.mode && typeof style !== 'string') {
+        style = Cstr.style;
+      } else if (BUILD.mode && typeof Cstr.style !== 'string') {
         /**
          * in case the component has a `styleUrl` object defined, e.g.
          * ```ts
@@ -144,7 +144,7 @@ export const initializeComponent = async (
          */
         hostRef.$modeName$ = computeMode(elm) as string | undefined;
         if (hostRef.$modeName$) {
-          style = style[hostRef.$modeName$];
+          style = Cstr.style[hostRef.$modeName$];
         }
 
         if (BUILD.hydrateServerSide && hostRef.$modeName$) {

--- a/src/runtime/initialize-component.ts
+++ b/src/runtime/initialize-component.ts
@@ -113,10 +113,35 @@ export const initializeComponent = async (
     }
 
     if (BUILD.style && Cstr && Cstr.style) {
-      // this component has styles but we haven't registered them yet
-      let style = Cstr.style;
+      /**
+       * this component has styles but we haven't registered them yet
+       */
+      let style: string | undefined
 
-      if (BUILD.mode && typeof style !== 'string') {
+      if (typeof Cstr.style === 'string') {
+        /**
+         * in case the component has a `styleUrl` defined, e.g.
+         * ```ts
+         * @Component({
+         *   tag: 'my-component',
+         *   styleUrl: 'my-component.css'
+         * })
+         * ```
+         */
+        style = Cstr.style
+      } else if (BUILD.mode && typeof style !== 'string') {
+        /**
+         * in case the component has a `styleUrl` object defined, e.g.
+         * ```ts
+         * @Component({
+         *   tag: 'my-component',
+         *   styleUrl: {
+         *     ios: 'my-component.ios.css',
+         *     md: 'my-component.md.css'
+         *   }
+         * })
+         * ```
+         */
         hostRef.$modeName$ = computeMode(elm) as string | undefined;
         if (hostRef.$modeName$) {
           style = style[hostRef.$modeName$];

--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -47,7 +47,11 @@ export const registerStyle = (scopeId: string, cssText: string, allowCS: boolean
  * @param mode an optional current mode
  * @returns the scope ID for the component of interest
  */
-export const addStyle = (styleContainerNode: Element | Document | ShadowRoot, cmpMeta: d.ComponentRuntimeMeta, mode?: string) => {
+export const addStyle = (
+  styleContainerNode: Element | Document | ShadowRoot,
+  cmpMeta: d.ComponentRuntimeMeta,
+  mode?: string,
+) => {
   const styleContainerDocument = styleContainerNode as Document;
   const styleContainerShadowRoot = styleContainerNode as ShadowRoot;
   const scopeId = getScopeId(cmpMeta, mode);
@@ -62,7 +66,7 @@ export const addStyle = (styleContainerNode: Element | Document | ShadowRoot, cm
 
   if (style) {
     if (typeof style === 'string') {
-      styleContainerNode = styleContainerDocument.head || styleContainerNode as HTMLElement;
+      styleContainerNode = styleContainerDocument.head || (styleContainerNode as HTMLElement);
       let appliedStyles = rootAppliedStyles.get(styleContainerNode);
       let styleElm;
       if (!appliedStyles) {
@@ -121,7 +125,7 @@ export const attachStyles = (hostRef: d.HostRef) => {
   const flags = cmpMeta.$flags$;
   const endAttachStyles = createTime('attachStyles', cmpMeta.$tagName$);
   const scopeId = addStyle(
-    BUILD.shadowDom && supportsShadow && elm.shadowRoot ? elm.shadowRoot : elm.getRootNode() as ShadowRoot,
+    BUILD.shadowDom && supportsShadow && elm.shadowRoot ? elm.shadowRoot : (elm.getRootNode() as ShadowRoot),
     cmpMeta,
     hostRef.$modeName$,
   );

--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -47,7 +47,9 @@ export const registerStyle = (scopeId: string, cssText: string, allowCS: boolean
  * @param mode an optional current mode
  * @returns the scope ID for the component of interest
  */
-export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMeta, mode?: string) => {
+export const addStyle = (styleContainerNode: Element | Document | ShadowRoot, cmpMeta: d.ComponentRuntimeMeta, mode?: string) => {
+  const styleContainerDocument = styleContainerNode as Document;
+  const styleContainerShadowRoot = styleContainerNode as ShadowRoot;
   const scopeId = getScopeId(cmpMeta, mode);
   const style = styles.get(scopeId);
 
@@ -60,7 +62,7 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
 
   if (style) {
     if (typeof style === 'string') {
-      styleContainerNode = styleContainerNode.head || styleContainerNode;
+      styleContainerNode = styleContainerDocument.head || styleContainerNode as HTMLElement;
       let appliedStyles = rootAppliedStyles.get(styleContainerNode);
       let styleElm;
       if (!appliedStyles) {
@@ -69,7 +71,7 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
       if (!appliedStyles.has(scopeId)) {
         if (
           BUILD.hydrateClientSide &&
-          styleContainerNode.host &&
+          styleContainerShadowRoot.host &&
           (styleElm = styleContainerNode.querySelector(`[${HYDRATED_STYLE_ID}="${scopeId}"]`))
         ) {
           // This is only happening on native shadow-dom, do not needs CSS var shim
@@ -100,8 +102,8 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
           appliedStyles.add(scopeId);
         }
       }
-    } else if (BUILD.constructableCSS && !styleContainerNode.adoptedStyleSheets.includes(style)) {
-      styleContainerNode.adoptedStyleSheets = [...styleContainerNode.adoptedStyleSheets, style];
+    } else if (BUILD.constructableCSS && !styleContainerDocument.adoptedStyleSheets.includes(style)) {
+      styleContainerDocument.adoptedStyleSheets = [...styleContainerDocument.adoptedStyleSheets, style];
     }
   }
   return scopeId;
@@ -119,7 +121,7 @@ export const attachStyles = (hostRef: d.HostRef) => {
   const flags = cmpMeta.$flags$;
   const endAttachStyles = createTime('attachStyles', cmpMeta.$tagName$);
   const scopeId = addStyle(
-    BUILD.shadowDom && supportsShadow && elm.shadowRoot ? elm.shadowRoot : elm.getRootNode(),
+    BUILD.shadowDom && supportsShadow && elm.shadowRoot ? elm.shadowRoot : elm.getRootNode() as ShadowRoot,
     cmpMeta,
     hostRef.$modeName$,
   );


### PR DESCRIPTION
## What is the current behavior?

Fixes ionic-team/ionic-framework#29593

## What is the new behavior?

The type fix I initially did suggested a different type ob the style object so this fix makes this more clear that `Cstr.style` can be either a `string` or a `Record<string, string>`.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
