### PR TITLE
feat(testing): allow to disable network error logging via 'logFailingNetworkRequests' option

### DIFF
--- a/src/testing/puppeteer/puppeteer-declarations.ts
+++ b/src/testing/puppeteer/puppeteer-declarations.ts
@@ -18,8 +18,18 @@ export type PageCloseOptions = {
 export interface NewE2EPageOptions extends WaitForOptions {
   url?: string;
   html?: string;
+  /**
+   * If set to `true`, Stencil will throw an error if a console error occurs
+   */
   failOnConsoleError?: boolean;
+  /**
+   * If set to `true`, Stencil will throw an error if a network request fails
+   */
   failOnNetworkError?: boolean;
+  /**
+   * If set to `true`, Stencil will log failing network requests
+   */
+  logFailingNetworkRequests?: boolean;
 }
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;

--- a/src/testing/puppeteer/puppeteer-declarations.ts
+++ b/src/testing/puppeteer/puppeteer-declarations.ts
@@ -28,6 +28,7 @@ export interface NewE2EPageOptions extends WaitForOptions {
   failOnNetworkError?: boolean;
   /**
    * If set to `true`, Stencil will log failing network requests
+   * @default true
    */
   logFailingNetworkRequests?: boolean;
 }

--- a/src/testing/puppeteer/puppeteer-page.ts
+++ b/src/testing/puppeteer/puppeteer-page.ts
@@ -115,7 +115,8 @@ export async function newE2EPage(opts: NewE2EPageOptions = {}): Promise<E2EPage>
 
     const failOnConsoleError = opts.failOnConsoleError === true;
     const failOnNetworkError = opts.failOnNetworkError === true;
-    const logFailingNetworkRequests = opts.logFailingNetworkRequests === true;
+    const logFailingNetworkRequests =
+      typeof opts.logFailingNetworkRequests === 'boolean' ? opts.logFailingNetworkRequests : true;
 
     page.on('console', (ev) => {
       if (ev.type() === 'error') {

--- a/src/testing/puppeteer/puppeteer-page.ts
+++ b/src/testing/puppeteer/puppeteer-page.ts
@@ -115,6 +115,7 @@ export async function newE2EPage(opts: NewE2EPageOptions = {}): Promise<E2EPage>
 
     const failOnConsoleError = opts.failOnConsoleError === true;
     const failOnNetworkError = opts.failOnNetworkError === true;
+    const logFailingNetworkRequests = opts.logFailingNetworkRequests === true;
 
     page.on('console', (ev) => {
       if (ev.type() === 'error') {
@@ -145,7 +146,7 @@ export async function newE2EPage(opts: NewE2EPageOptions = {}): Promise<E2EPage>
       });
       if (failOnNetworkError) {
         throw new Error(req.failure().errorText);
-      } else {
+      } else if (logFailingNetworkRequests) {
         console.error('requestfailed', req.url());
       }
     });


### PR DESCRIPTION
## What is the current behavior?

fixes #2572

## What is the new behavior?
This patch allows users to change the behavior to not log failing network requests.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a