### PR TITLE
fix(compiler): match full type name when doing type name replacement

### DIFF
--- a/src/compiler/types/stencil-types.ts
+++ b/src/compiler/types/stencil-types.ts
@@ -106,7 +106,7 @@ const updateTypeName = (currentTypeName: string, typeAlias: d.TypesMemberNameDat
    * those in string literals. We do not check for a starting quote (" | ' | `) here as some browsers do not support
    * negative lookbehind. This works "well enough" until STENCIL-419 is completed.
    */
-  const typeNameRegex = new RegExp(`${typeAlias.localName}\\b${endingStrChar}`, 'g');
+  const typeNameRegex = new RegExp(`\\b${typeAlias.localName}\\b${endingStrChar}`, 'g');
   return currentTypeName.replace(typeNameRegex, typeAlias.importName);
 };
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When updating type names for component type imports, Stencil will match based on the original type name string. This can result in string partials getting replaced if they match the replacement string. For instance, having a type `Setting` that gets aliased to `Setting1` to avoid type collisions, can result in another type, like `TextSetting` getting changed to `TextSetting1` since the compiler will replace all instances of `Setting` with `Setting1`

Fixes #3975 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The compiler will only replace full matches of the string. So, `Setting` will still become `Setting1`, but `TextSetting` wouldn't change.


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
