### PR TITLE
fix(declarations): fix nightly build

### DIFF
--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -1137,7 +1137,7 @@ export interface HostElement extends HTMLElement {
 
   ['s-p']?: Promise<void>[];
 
-  componentOnReady?: () => Promise<this> | undefined;
+  componentOnReady?: () => Promise<this>;
 }
 
 export interface HydrateResults {


### PR DESCRIPTION
## What is the current behavior?
Stencils Nightly build is failing due to a type change made in #5792. The original intention was to reflect reality better because `getHostRef` may return `undefined`. However it seems easier to just revert this change for now to ensure we don't break Ionic when releasing the change.

## What is the new behavior?
Reverted particular change.

## Documentation

n/a

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

Stencil nightly build: https://github.com/ionic-team/ionic-framework/actions/runs/9640370566/job/26608094616
