### PR TITLE
chore(renovate): change to cron schedule

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -151,9 +151,11 @@
   // Never rebase the branch or update it unless manually requested to avoid noisy PR emails
   rebaseWhen: 'never',
   /**
-   * Natural language syntax taken directly from renovate preset examples (with time adjusted).
+   * Cron syntax to run at midnight (UTC) on the first day of every month
+   * 
+   * Note: Renovate does not support minute value granularity, so the wildcard value is necessary
    */
-  schedule: ["before 8am on the first day of the month"],
+  schedule: ["* 0 1 * *"],
   /**
    * Ensure semantic commits are enabled for commits + PR titles.
    *


### PR DESCRIPTION
Changes Renovate's schedule config to a cron job. Since changing to natural language syntax, Renovate has been running more frequently. After some quick online investigation, it appears that support for natural language syntax may not be as stable as Renovate's documentation can lead to believe.

We can give this a shot and update our other repositories once we're confident this is working as expected