### PR TITLE
fix(compiler): removed support for tagNameTransform

### DIFF
--- a/src/app-data/index.ts
+++ b/src/app-data/index.ts
@@ -107,7 +107,6 @@ export const BUILD: BuildConditionals = {
   initializeNextTick: false,
   asyncLoading: false,
   asyncQueue: false,
-  transformTagName: false,
   attachStyles: true,
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior
   experimentalSlotFixes: false,

--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -391,7 +391,6 @@ describe('validation', () => {
     expect(config.extras.scriptDataOpts).toBe(false);
     expect(config.extras.slotChildNodesFix).toBe(false);
     expect(config.extras.initializeNextTick).toBe(false);
-    expect(config.extras.tagNameTransform).toBe(false);
     expect(config.extras.scopedSlotTextContentFix).toBe(false);
   });
 

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -147,7 +147,6 @@ export const validateConfig = (
   validatedConfig.extras.lifecycleDOMEvents = !!validatedConfig.extras.lifecycleDOMEvents;
   validatedConfig.extras.scriptDataOpts = !!validatedConfig.extras.scriptDataOpts;
   validatedConfig.extras.initializeNextTick = !!validatedConfig.extras.initializeNextTick;
-  validatedConfig.extras.tagNameTransform = !!validatedConfig.extras.tagNameTransform;
 
   // TODO(STENCIL-914): remove when `experimentalSlotFixes` is the default behavior
   // If the user set `experimentalSlotFixes` and any individual slot fix flags to `false`, we need to log a warning

--- a/src/compiler/output-targets/dist-custom-elements/custom-elements-types.ts
+++ b/src/compiler/output-targets/dist-custom-elements/custom-elements-types.ts
@@ -186,9 +186,11 @@ const generateCustomElementsTypesOutput = async (
  * @returns the contents of the type declaration file for the provided `cmp`
  */
 const generateCustomElementType = (componentsDtsRelPath: string, cmp: d.ComponentCompilerMeta): string => {
+  const stencilPublicRuntime = join(dirname(componentsDtsRelPath), 'stencil-public-runtime.d.ts')
   const tagNameAsPascal = dashToPascalCase(cmp.tagName);
   const o: string[] = [
     `import type { Components, JSX } from "${componentsDtsRelPath}";`,
+    `import type { CustomElementsDefineOptions } from "${stencilPublicRuntime}";`,
     ``,
     `interface ${tagNameAsPascal} extends Components.${tagNameAsPascal}, HTMLElement {}`,
     `export const ${tagNameAsPascal}: {`,
@@ -198,7 +200,7 @@ const generateCustomElementType = (componentsDtsRelPath: string, cmp: d.Componen
     `/**`,
     ` * Used to define this component and all nested components recursively.`,
     ` */`,
-    `export const defineCustomElement: () => void;`,
+    `export const defineCustomElement: (options?: CustomElementsDefineOptions) => void;`,
     ``,
   ];
 

--- a/src/compiler/output-targets/dist-custom-elements/custom-elements-types.ts
+++ b/src/compiler/output-targets/dist-custom-elements/custom-elements-types.ts
@@ -186,7 +186,7 @@ const generateCustomElementsTypesOutput = async (
  * @returns the contents of the type declaration file for the provided `cmp`
  */
 const generateCustomElementType = (componentsDtsRelPath: string, cmp: d.ComponentCompilerMeta): string => {
-  const stencilPublicRuntime = join(dirname(componentsDtsRelPath), 'stencil-public-runtime.d.ts')
+  const stencilPublicRuntime = join(dirname(componentsDtsRelPath), 'stencil-public-runtime.d.ts');
   const tagNameAsPascal = dashToPascalCase(cmp.tagName);
   const o: string[] = [
     `import type { Components, JSX } from "${componentsDtsRelPath}";`,

--- a/src/compiler/output-targets/dist-lazy/lazy-build-conditionals.ts
+++ b/src/compiler/output-targets/dist-lazy/lazy-build-conditionals.ts
@@ -11,7 +11,6 @@ export const getLazyBuildConditionals = (
 
   build.lazyLoad = true;
   build.hydrateServerSide = false;
-  build.transformTagName = config.extras.tagNameTransform;
   build.asyncQueue = config.taskQueue === 'congestionAsync';
   build.taskQueue = config.taskQueue !== 'immediate';
   build.initializeNextTick = config.extras.initializeNextTick;

--- a/src/compiler/output-targets/test/build-conditionals.spec.ts
+++ b/src/compiler/output-targets/test/build-conditionals.spec.ts
@@ -126,19 +126,6 @@ describe('build-conditionals', () => {
       expect(config.taskQueue).toBe('async');
     });
 
-    it('tagNameTransform default', () => {
-      const { config } = validateConfig(userConfig, mockLoadConfigInit());
-      const bc = getLazyBuildConditionals(config, cmps);
-      expect(bc.transformTagName).toBe(false);
-    });
-
-    it('tagNameTransform true', () => {
-      userConfig.extras = { tagNameTransform: true };
-      const { config } = validateConfig(userConfig, mockLoadConfigInit());
-      const bc = getLazyBuildConditionals(config, cmps);
-      expect(bc.transformTagName).toBe(true);
-    });
-
     it('hydrateClientSide default', () => {
       const { config } = validateConfig(userConfig, mockLoadConfigInit());
       const bc = getLazyBuildConditionals(config, cmps);

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -187,7 +187,6 @@ export interface BuildConditionals extends Partial<BuildFeatures> {
   // TODO(STENCIL-854): Remove code related to legacy shadowDomShim field
   shadowDomShim?: boolean;
   asyncQueue?: boolean;
-  transformTagName?: boolean;
   attachStyles?: boolean;
 
   // TODO(STENCIL-914): remove this option when `experimentalSlotFixes` is the default behavior

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -348,12 +348,6 @@ interface ConfigExtrasBase {
    */
   initializeNextTick?: boolean;
 
-  /**
-   * Enables the tagNameTransform option of `defineCustomElements()`, so the component tagName
-   * can be customized at runtime. Defaults to `false`.
-   */
-  tagNameTransform?: boolean;
-
   // TODO(STENCIL-1086): remove this option when it's the default behavior
   /**
    * Experimental flag.

--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1859,7 +1859,6 @@ export interface CustomElementsDefineOptions {
   exclude?: string[];
   resourcesUrl?: string;
   syncQueue?: boolean;
-  transformTagName?: (tagName: string) => string;
   jmp?: (c: Function) => any;
   raf?: (c: FrameRequestCallback) => number;
   ael?: (

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -82,10 +82,7 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
         // TODO(STENCIL-854): Remove code related to legacy shadowDomShim field
         cmpMeta.$flags$ |= CMP_FLAGS.needsShadowDomShim;
       }
-      const tagName =
-        BUILD.transformTagName && options.transformTagName
-          ? options.transformTagName(cmpMeta.$tagName$)
-          : cmpMeta.$tagName$;
+      const tagName = cmpMeta.$tagName$;
       const HostElement = class extends HTMLElement {
         ['s-p']: Promise<void>[];
         ['s-rc']: (() => void)[];


### PR DESCRIPTION
## What is the current behavior?
It seems like Stencil currently allows to transform the tag name at runtime. The feature was introduced in https://github.com/ionic-team/stencil/pull/2343/files but was never really introduced nor added to the docs.

## What is the new behavior?
I suggest to remove this entirely since we don't have any tests for this nor do we know how it suppose to behave.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Technically yes but since we never documented it, it was never actually been released as a feature.

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

n/a
