### PR TITLE
fix(runtime): allow watchers to fire w/ no Stencil members

### DIFF
--- a/src/compiler/app-core/app-data.ts
+++ b/src/compiler/app-core/app-data.ts
@@ -50,7 +50,7 @@ export const getBuildFeatures = (cmps: ComponentCompilerMeta[]): BuildFeatures =
     member: cmps.some((c) => c.hasMember),
     method: cmps.some((c) => c.hasMethod),
     mode: cmps.some((c) => c.hasMode),
-    observeAttribute: cmps.some((c) => c.hasWatchCallback),
+    observeAttribute: cmps.some((c) => c.hasAttribute || c.hasWatchCallback),
     prop: cmps.some((c) => c.hasProp),
     propBoolean: cmps.some((c) => c.hasPropBoolean),
     propNumber: cmps.some((c) => c.hasPropNumber),

--- a/src/compiler/app-core/app-data.ts
+++ b/src/compiler/app-core/app-data.ts
@@ -50,7 +50,7 @@ export const getBuildFeatures = (cmps: ComponentCompilerMeta[]): BuildFeatures =
     member: cmps.some((c) => c.hasMember),
     method: cmps.some((c) => c.hasMethod),
     mode: cmps.some((c) => c.hasMode),
-    observeAttribute: cmps.some((c) => c.hasAttribute),
+    observeAttribute: cmps.some((c) => c.hasWatchCallback),
     prop: cmps.some((c) => c.hasProp),
     propBoolean: cmps.some((c) => c.hasPropBoolean),
     propNumber: cmps.some((c) => c.hasPropNumber),

--- a/src/runtime/proxy-component.ts
+++ b/src/runtime/proxy-component.ts
@@ -49,12 +49,12 @@ export const proxyComponent = (
     );
   }
 
-  if (BUILD.member && cmpMeta.$members$) {
-    if (BUILD.watchCallback && Cstr.watchers) {
+  if ((BUILD.member && cmpMeta.$members$) || (BUILD.watchCallback && (cmpMeta.$watchers$ || Cstr.watchers))) {
+    if (BUILD.watchCallback && Cstr.watchers && !cmpMeta.$watchers$) {
       cmpMeta.$watchers$ = Cstr.watchers;
     }
     // It's better to have a const than two Object.entries()
-    const members = Object.entries(cmpMeta.$members$);
+    const members = Object.entries(cmpMeta.$members$ ?? {});
     members.map(([memberName, [memberFlags]]) => {
       if (
         (BUILD.prop || BUILD.state) &&

--- a/test/wdio/watch-native-attributes/cmp-no-members.test.tsx
+++ b/test/wdio/watch-native-attributes/cmp-no-members.test.tsx
@@ -1,0 +1,24 @@
+import { h } from '@stencil/core';
+import { render } from '@wdio/browser-runner/stencil';
+
+describe('watch native attributes w/ no Stencil members', () => {
+  beforeEach(() => {
+    render({
+      template: () => (
+        <watch-native-attributes-no-members aria-label="myStartingLabel"></watch-native-attributes-no-members>
+      ),
+    });
+  });
+
+  it('triggers the callback for the watched attribute', async () => {
+    const $cmp = $('watch-native-attributes-no-members');
+    await $cmp.waitForExist();
+
+    await expect($cmp).toHaveText('Label: myStartingLabel\nCallback triggered: false');
+
+    const cmp = document.querySelector('watch-native-attributes-no-members');
+    cmp.setAttribute('aria-label', 'myNewLabel');
+
+    await expect($cmp).toHaveText('Label: myNewLabel\nCallback triggered: true');
+  });
+});

--- a/test/wdio/watch-native-attributes/cmp-no-members.tsx
+++ b/test/wdio/watch-native-attributes/cmp-no-members.tsx
@@ -1,0 +1,23 @@
+import { Component, Element, forceUpdate, h, Watch } from '@stencil/core';
+
+@Component({
+  tag: 'watch-native-attributes-no-members',
+})
+export class WatchNativeAttributesNoMembers {
+  @Element() el!: HTMLElement;
+
+  private callbackTriggered = false;
+
+  @Watch('aria-label')
+  onAriaLabelChange() {
+    this.callbackTriggered = true;
+    forceUpdate(this);
+  }
+
+  render() {
+    return [
+      <p>Label: {this.el.getAttribute('aria-label')}</p>,
+      <p>Callback triggered: {`${this.callbackTriggered}`}</p>,
+    ];
+  }
+}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`@Watch()` callbacks will not fire for native HTML attributes if there is not at least one Stencil member (`@State` or `@Prop`) within the component. 

Fixes #5854

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Watch callbacks will no correctly fire even if no Stencil members are present

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

New e2e test added for use case and verified fix in reproduction

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
