### PR TITLE
feat(cli): support generation of sass and less files

### DIFF
--- a/src/cli/task-generate.ts
+++ b/src/cli/task-generate.ts
@@ -356,7 +356,7 @@ export type GeneratableExtension = 'tsx' | 'spec.tsx' | 'e2e.ts' | GeneratableSt
 /**
  * Extensions available to generate.
  */
-export type GeneratableStylingExtension = 'css' | 'sass' | 'less';
+export type GeneratableStylingExtension = 'css' | 'sass' | 'scss' | 'less';
 
 /**
  * A little interface to wrap up the info we need to pass around for generating

--- a/src/cli/task-generate.ts
+++ b/src/cli/task-generate.ts
@@ -44,11 +44,11 @@ export const taskGenerate = async (config: ValidatedConfig): Promise<void> => {
     return config.sys.exit(1);
   }
 
-  let cssExtension: GeneratableStylingExtension = "css";
-  if (!!config.plugins.find(plugin => plugin.name === "sass")) {
+  let cssExtension: GeneratableStylingExtension = 'css';
+  if (!!config.plugins.find((plugin) => plugin.name === 'sass')) {
     cssExtension = await chooseSassExtension();
-  } else if (!!config.plugins.find(plugin => plugin.name === "less")) {
-    cssExtension = "less";
+  } else if (!!config.plugins.find((plugin) => plugin.name === 'less')) {
+    cssExtension = 'less';
   }
   const filesToGenerateExt = await chooseFilesToGenerate(cssExtension);
   if (!filesToGenerateExt) {
@@ -120,14 +120,15 @@ const chooseSassExtension = async () => {
     await prompt({
       name: 'filesToGenerate',
       type: 'select',
-      message: 'Which Sass format would you like to use? (More info: https://sass-lang.com/documentation/syntax/#the-indented-syntax)',
+      message:
+        'Which Sass format would you like to use? (More info: https://sass-lang.com/documentation/syntax/#the-indented-syntax)',
       choices: [
         { value: 'sass', title: `*.sass Format`, selected: true },
         { value: 'scss', title: '*.scss Format' },
       ],
     })
   ).filesToGenerate;
-}
+};
 
 /**
  * Get a filepath for a file we want to generate!
@@ -220,7 +221,12 @@ const isTest = (extension: GeneratableExtension): boolean => {
  * @param styleExtension extension used for styles
  * @returns a string container the file boilerplate for the supplied extension
  */
-export const getBoilerplateByExtension = (tagName: string, extension: GeneratableExtension, withCss: boolean, styleExtension: GeneratableStylingExtension,): string => {
+export const getBoilerplateByExtension = (
+  tagName: string,
+  extension: GeneratableExtension,
+  withCss: boolean,
+  styleExtension: GeneratableStylingExtension,
+): string => {
   switch (extension) {
     case 'tsx':
       return getComponentBoilerplate(tagName, withCss, styleExtension);
@@ -246,7 +252,11 @@ export const getBoilerplateByExtension = (tagName: string, extension: Generatabl
  * @param styleExtension extension used for styles
  * @returns the contents of a file that defines a component
  */
-const getComponentBoilerplate = (tagName: string, hasStyle: boolean, styleExtension: GeneratableStylingExtension): string => {
+const getComponentBoilerplate = (
+  tagName: string,
+  hasStyle: boolean,
+  styleExtension: GeneratableStylingExtension,
+): string => {
   const decorator = [`{`];
   decorator.push(`  tag: '${tagName}',`);
   if (hasStyle) {
@@ -275,14 +285,15 @@ export class ${toPascalCase(tagName)} {
  * @param ext extension used for styles
  * @returns a boilerplate CSS block
  */
-const getStyleUrlBoilerplate = (ext: GeneratableExtension): string => (
+const getStyleUrlBoilerplate = (ext: GeneratableExtension): string =>
   ext === 'sass'
     ? `:host
   display: block
-` : `:host {
+`
+    : `:host {
   display: block;
 }
-`);
+`;
 
 /**
  * Get the boilerplate for a file containing a spec (unit) test for a component

--- a/src/cli/task-generate.ts
+++ b/src/cli/task-generate.ts
@@ -73,14 +73,12 @@ export const taskGenerate = async (config: ValidatedConfig): Promise<void> => {
       getBoilerplateAndWriteFile(
         config,
         componentName,
-        (
-          extensionsToGenerate.includes('css') ||
+        extensionsToGenerate.includes('css') ||
           extensionsToGenerate.includes('sass') ||
           extensionsToGenerate.includes('scss') ||
-          extensionsToGenerate.includes('less')
-        ),
+          extensionsToGenerate.includes('less'),
         file,
-        cssExtension
+        cssExtension,
       ),
     ),
   ).catch((error) => config.logger.error(error));

--- a/src/cli/task-generate.ts
+++ b/src/cli/task-generate.ts
@@ -70,7 +70,18 @@ export const taskGenerate = async (config: ValidatedConfig): Promise<void> => {
 
   const writtenFiles = await Promise.all(
     filesToGenerate.map((file) =>
-      getBoilerplateAndWriteFile(config, componentName, extensionsToGenerate.includes('css'), file, cssExtension),
+      getBoilerplateAndWriteFile(
+        config,
+        componentName,
+        (
+          extensionsToGenerate.includes('css') ||
+          extensionsToGenerate.includes('sass') ||
+          extensionsToGenerate.includes('scss') ||
+          extensionsToGenerate.includes('less')
+        ),
+        file,
+        cssExtension
+      ),
     ),
   ).catch((error) => config.logger.error(error));
 
@@ -118,7 +129,7 @@ const chooseSassExtension = async () => {
   const { prompt } = await import('prompts');
   return (
     await prompt({
-      name: 'filesToGenerate',
+      name: 'sassFormat',
       type: 'select',
       message:
         'Which Sass format would you like to use? (More info: https://sass-lang.com/documentation/syntax/#the-indented-syntax)',
@@ -127,7 +138,7 @@ const chooseSassExtension = async () => {
         { value: 'scss', title: '*.scss Format' },
       ],
     })
-  ).filesToGenerate;
+  ).sassFormat;
 };
 
 /**
@@ -231,7 +242,10 @@ export const getBoilerplateByExtension = (
     case 'tsx':
       return getComponentBoilerplate(tagName, withCss, styleExtension);
 
-    case styleExtension:
+    case 'css':
+    case 'less':
+    case 'sass':
+    case 'scss':
       return getStyleUrlBoilerplate(styleExtension);
 
     case 'spec.tsx':

--- a/src/cli/test/task-generate.spec.ts
+++ b/src/cli/test/task-generate.spec.ts
@@ -11,13 +11,14 @@ jest.mock('prompts', () => ({
   prompt: promptMock,
 }));
 
-const setup = async () => {
+const setup = async (plugins: any[] = []) => {
   const sys = mockCompilerSystem();
   const config: d.ValidatedConfig = mockValidatedConfig({
     configPath: '/testing-path',
     flags: createConfigFlags({ task: 'generate' }),
     srcDir: '/src',
     sys,
+    plugins
   });
 
   // set up some mocks / spies

--- a/src/cli/test/task-generate.spec.ts
+++ b/src/cli/test/task-generate.spec.ts
@@ -20,7 +20,7 @@ const setup = async (plugins: any[] = []) => {
     flags: createConfigFlags({ task: 'generate' }),
     srcDir: '/src',
     sys,
-    plugins
+    plugins,
   });
 
   // set up some mocks / spies
@@ -40,7 +40,7 @@ const setup = async (plugins: any[] = []) => {
     return {
       tagName: 'my-component',
       filesToGenerate: [format, 'spec.tsx', 'e2e.ts'],
-    }
+    };
   });
 
   return { config, errorSpy, validateTagSpy };
@@ -164,10 +164,10 @@ describe('generate task', () => {
         getBoilerplateByExtension('my-component', file.extension, true, 'sass'),
       );
     });
-  })
+  });
 
   it('should generate files for less projects', async () => {
-    formatToPick = 'less'
+    formatToPick = 'less';
     const { config } = await setup([{ name: 'less' }]);
     const writeFileSpy = jest.spyOn(config.sys, 'writeFile');
     await silentGenerate(config);
@@ -184,5 +184,5 @@ describe('generate task', () => {
         getBoilerplateByExtension('my-component', file.extension, true, 'less'),
       );
     });
-  })
+  });
 });

--- a/src/cli/test/task-generate.spec.ts
+++ b/src/cli/test/task-generate.spec.ts
@@ -117,7 +117,7 @@ describe('generate task', () => {
     userChoices.forEach((file) => {
       expect(writeFileSpy).toHaveBeenCalledWith(
         file.path,
-        getBoilerplateByExtension('my-component', file.extension, true),
+        getBoilerplateByExtension('my-component', file.extension, true, 'css'),
       );
     });
   });

--- a/src/cli/test/task-generate.spec.ts
+++ b/src/cli/test/task-generate.spec.ts
@@ -11,6 +11,8 @@ jest.mock('prompts', () => ({
   prompt: promptMock,
 }));
 
+let formatToPick = 'css';
+
 const setup = async (plugins: any[] = []) => {
   const sys = mockCompilerSystem();
   const config: d.ValidatedConfig = mockValidatedConfig({
@@ -29,9 +31,16 @@ const setup = async (plugins: any[] = []) => {
   // mock prompt usage: tagName and filesToGenerate are the keys used for
   // different calls, so we can cheat here and just do a single
   // mockResolvedValue
-  promptMock.mockResolvedValue({
-    tagName: 'my-component',
-    filesToGenerate: ['css', 'spec.tsx', 'e2e.ts'],
+  let format = formatToPick;
+  promptMock.mockImplementation((params) => {
+    if (params.name === 'sassFormat') {
+      format = 'sass';
+      return { sassFormat: 'sass' };
+    }
+    return {
+      tagName: 'my-component',
+      filesToGenerate: [format, 'spec.tsx', 'e2e.ts'],
+    }
   });
 
   return { config, errorSpy, validateTagSpy };
@@ -54,6 +63,7 @@ describe('generate task', () => {
     jest.restoreAllMocks();
     jest.clearAllMocks();
     jest.resetModules();
+    formatToPick = 'css';
   });
 
   afterAll(() => {
@@ -136,4 +146,43 @@ describe('generate task', () => {
     );
     expect(config.sys.exit).toHaveBeenCalledWith(1);
   });
+
+  it('should generate files for sass projects', async () => {
+    const { config } = await setup([{ name: 'sass' }]);
+    const writeFileSpy = jest.spyOn(config.sys, 'writeFile');
+    await silentGenerate(config);
+    const userChoices: ReadonlyArray<BoilerplateFile> = [
+      { extension: 'tsx', path: '/src/components/my-component/my-component.tsx' },
+      { extension: 'sass', path: '/src/components/my-component/my-component.sass' },
+      { extension: 'spec.tsx', path: '/src/components/my-component/test/my-component.spec.tsx' },
+      { extension: 'e2e.ts', path: '/src/components/my-component/test/my-component.e2e.ts' },
+    ];
+
+    userChoices.forEach((file) => {
+      expect(writeFileSpy).toHaveBeenCalledWith(
+        file.path,
+        getBoilerplateByExtension('my-component', file.extension, true, 'sass'),
+      );
+    });
+  })
+
+  it('should generate files for less projects', async () => {
+    formatToPick = 'less'
+    const { config } = await setup([{ name: 'less' }]);
+    const writeFileSpy = jest.spyOn(config.sys, 'writeFile');
+    await silentGenerate(config);
+    const userChoices: ReadonlyArray<BoilerplateFile> = [
+      { extension: 'tsx', path: '/src/components/my-component/my-component.tsx' },
+      { extension: 'less', path: '/src/components/my-component/my-component.less' },
+      { extension: 'spec.tsx', path: '/src/components/my-component/test/my-component.spec.tsx' },
+      { extension: 'e2e.ts', path: '/src/components/my-component/test/my-component.e2e.ts' },
+    ];
+
+    userChoices.forEach((file) => {
+      expect(writeFileSpy).toHaveBeenCalledWith(
+        file.path,
+        getBoilerplateByExtension('my-component', file.extension, true, 'less'),
+      );
+    });
+  })
 });


### PR DESCRIPTION
## What is the current behavior?
This feature was requested in #2155 but the community PR (https://github.com/ionic-team/stencil/pull/2334) was never reviewed. Let's get this in as it seems generally useful.

## What is the new behavior?
We recognise the Less or Sass plugin now, if it exists and generate a proper style file. In case Sass is used, we also ask which format they want to use (`.sass` vs `scss` files).

## Documentation

n/a

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

@tanner-reits you made [this comment](https://github.com/ionic-team/stencil/issues/2155#issuecomment-1235827720) to enhance the `create-stencil` package, can you elaborate what you were thinking?
