### PR TITLE
chore(runtime): add mock-doc export in client runtime package.json (#5860)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,10 @@
       "import": "./internal/app-data/index.js",
       "require": "./internal/app-data/index.cjs"
     },
+    "./mock-doc": {
+      "import": "./mock-doc/index.js",
+      "require": "./mock-doc/index.cjs"
+    },
     "./compiler": {
       "import": "./compiler/stencil.js"
     },


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #5860


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Set mock-doc export in the package.json for the client runtime so it can be imported by ESM.



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Testing

n/a

## Other information

n/a
