### PR TITLE
fix(compiler): account for package imports in aliasing

### DIFF
--- a/src/compiler/transformers/type-library.ts
+++ b/src/compiler/transformers/type-library.ts
@@ -31,9 +31,12 @@ export function addToLibrary(
 ): string {
   pathToTypeModule = relative(process.cwd(), pathToTypeModule);
 
-  // for now we don't make any attempt to include types in node_modules
+  // Create a stub path for types that are in node_modules,
+  // this allows us to have a unique ID for types that are from
+  // external packages so we can leverage the original type name when
+  // dealing with type aliases.
   if (pathToTypeModule.startsWith('node_modules')) {
-    return '';
+    return 'node_modules::' + typeName;
   }
 
   const id = getTypeId(pathToTypeModule, typeName);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

7ffb25d259de5b863e7dc3bc43270265cc786557 introduced a regression when generating the `components.d.ts` file. The logic for import aliasing did not account for external packages, resulting in broken import/export statements like `import { as MyType } from 'external-package';`

Fixes #5859 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The compiler will now generate a stub id for external packages so we can keep track of the original type name.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->
N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Verified fix on the reproduction case

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

This does technically change the output generated for the `docs-json` output target. Previously, the id for imports in these cases would be an empty string, now it will be a mocked id in the form of `node_modules::<type_name>'
