### PR TITLE
fix(hydrate): change type resolve order

### DIFF
--- a/src/hydrate/runner/render.ts
+++ b/src/hydrate/runner/render.ts
@@ -24,12 +24,12 @@ export function streamToString(html: string | any, option?: SerializeDocumentOpt
   return renderToString(html, option, true);
 }
 
+export function renderToString(html: string | any, options?: SerializeDocumentOptions): Promise<HydrateResults>;
 export function renderToString(
   html: string | any,
   options: SerializeDocumentOptions | undefined,
   asStream: true,
 ): Readable;
-export function renderToString(html: string | any, options?: SerializeDocumentOptions): Promise<HydrateResults>;
 export function renderToString(
   html: string | any,
   options?: SerializeDocumentOptions,
@@ -56,12 +56,12 @@ export function renderToString(
   return hydrateDocument(html, opts, asStream);
 }
 
+export function hydrateDocument(doc: any | string, options?: HydrateDocumentOptions): Promise<HydrateResults>;
 export function hydrateDocument(
   doc: any | string,
   options: HydrateDocumentOptions | undefined,
   asStream?: boolean,
 ): Readable;
-export function hydrateDocument(doc: any | string, options?: HydrateDocumentOptions): Promise<HydrateResults>;
 export function hydrateDocument(
   doc: any | string,
   options?: HydrateDocumentOptions,

--- a/test/end-to-end/package.json
+++ b/test/end-to-end/package.json
@@ -6,7 +6,7 @@
   "types": "dist/types/components.d.ts",
   "collection": " dist/collection/collection-manifest.json",
   "scripts": {
-    "build": "node ../../bin/stencil build --docs",
+    "build": "node ../../bin/stencil build --config ./stencil.build.config.ts --docs",
     "start": "node ../../bin/stencil build --debug --watch --dev --serve",
     "test": "node ../../bin/stencil test --ci --e2e --spec --screenshot --debug",
     "test.dist": "npm run build && node test-end-to-end-dist.js && node test-end-to-end-hydrate.js",

--- a/test/end-to-end/src/declarative-shadow-dom/test.e2e.ts
+++ b/test/end-to-end/src/declarative-shadow-dom/test.e2e.ts
@@ -44,13 +44,13 @@ describe('renderToString', () => {
     const renderedString = renderToString('<div>Hello World</div>');
     expect(typeof renderedString.then).toBe('function');
     // this is a type assertion to verify that the promise resolves to a HydrateResults object
-    renderedString.then((result) => result.html)
+    renderedString.then((result) => result.html);
 
     const renderedDocument = hydrateDocument('<div>Hello World</div>');
     expect(typeof renderedDocument.then).toBe('function');
     // this is a type assertion to verify that the promise resolves to a HydrateResults object
-    renderedDocument.then((result) => result.html)
-  })
+    renderedDocument.then((result) => result.html);
+  });
 
   it('can render a simple dom node', async () => {
     const { html } = await renderToString('<div>Hello World</div>');

--- a/test/end-to-end/src/declarative-shadow-dom/test.e2e.ts
+++ b/test/end-to-end/src/declarative-shadow-dom/test.e2e.ts
@@ -29,6 +29,7 @@ async function readableToString(readable: Readable) {
 type HydrateModule = typeof import('../../hydrate');
 let renderToString: HydrateModule['renderToString'];
 let streamToString: HydrateModule['streamToString'];
+let hydrateDocument: HydrateModule['hydrateDocument'];
 
 describe('renderToString', () => {
   beforeAll(async () => {
@@ -36,7 +37,20 @@ describe('renderToString', () => {
     const mod = await import('../../hydrate');
     renderToString = mod.renderToString;
     streamToString = mod.streamToString;
+    hydrateDocument = mod.hydrateDocument;
   });
+
+  it('resolves to a Promise<HydrateResults> by default', async () => {
+    const renderedString = renderToString('<div>Hello World</div>');
+    expect(typeof renderedString.then).toBe('function');
+    // this is a type assertion to verify that the promise resolves to a HydrateResults object
+    renderedString.then((result) => result.html)
+
+    const renderedDocument = hydrateDocument('<div>Hello World</div>');
+    expect(typeof renderedDocument.then).toBe('function');
+    // this is a type assertion to verify that the promise resolves to a HydrateResults object
+    renderedDocument.then((result) => result.html)
+  })
 
   it('can render a simple dom node', async () => {
     const { html } = await renderToString('<div>Hello World</div>');

--- a/test/end-to-end/stencil.build.config.ts
+++ b/test/end-to-end/stencil.build.config.ts
@@ -1,0 +1,9 @@
+import { config as baseConfig } from './stencil.config';
+
+/**
+ * We are using a slightly different tsconfig to build the end-to-end tests
+ * as we are doing type assertions on the hydrate module which is not available
+ * when the project hasn't been built.
+ */
+baseConfig.tsconfig = './tsconfig.build.json';
+export const config = baseConfig

--- a/test/end-to-end/stencil.build.config.ts
+++ b/test/end-to-end/stencil.build.config.ts
@@ -6,4 +6,4 @@ import { config as baseConfig } from './stencil.config';
  * when the project hasn't been built.
  */
 baseConfig.tsconfig = './tsconfig.build.json';
-export const config = baseConfig
+export const config = baseConfig;

--- a/test/end-to-end/tsconfig.build.json
+++ b/test/end-to-end/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  /**
+    * Exclude the test where we do type assertions using the hydrate module
+    * which doesn't exist at build time.
+    */
+  "exclude": ["src/declarative-shadow-dom/test.e2e.ts"]
+}


### PR DESCRIPTION
## What is the current behavior?
We have received feedback that people were running into type issues with the `hydrateDocument` function resolving in returning a `Readable` by default. This goes against our objective of supporting DSD without a breaking change.

## What is the new behavior?
Change the order of function overwrites to have TS resolve into a Promise first.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Added an e2e test for this.

## Other information

Thanks @sean-perkins for the hint!
