### PR TITLE
fix(internal): add cli sub package to export map

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,10 +55,6 @@
       "require": "./mock-doc/index.cjs",
       "types": "./mock-doc/index.d.ts"
     },
-    "./mock-doc": {
-      "import": "./mock-doc/index.js",
-      "require": "./mock-doc/index.cjs"
-    },
     "./compiler": {
       "import": "./compiler/stencil.js",
       "require": "./compiler/stencil.js",

--- a/package.json
+++ b/package.json
@@ -25,14 +25,16 @@
   "exports": {
     ".": {
       "import": "./internal/stencil-core/index.js",
-      "require": "./internal/stencil-core/index.cjs"
+      "require": "./internal/stencil-core/index.cjs",
+      "types": "./internal/stencil-core/index.d.ts"
     },
     "./cli": {
       "import": "./cli/index.js",
       "require": "./cli/index.cjs"
     },
     "./internal": {
-      "import": "./internal/index.js"
+      "import": "./internal/index.js",
+      "types": "./internal/index.d.ts"
     },
     "./internal/client": {
       "import": "./internal/client/index.js"
@@ -45,14 +47,22 @@
     },
     "./internal/app-data": {
       "import": "./internal/app-data/index.js",
-      "require": "./internal/app-data/index.cjs"
+      "require": "./internal/app-data/index.cjs",
+      "types": "./internal/app-data/index.d.ts"
+    },
+    "./mock-doc": {
+      "import": "./mock-doc/index.js",
+      "require": "./mock-doc/index.cjs",
+      "types": "./mock-doc/index.d.ts"
     },
     "./mock-doc": {
       "import": "./mock-doc/index.js",
       "require": "./mock-doc/index.cjs"
     },
     "./compiler": {
-      "import": "./compiler/stencil.js"
+      "import": "./compiler/stencil.js",
+      "require": "./compiler/stencil.js",
+      "types": "./compiler/stencil.d.ts"
     },
     "./compiler/*": {
       "import": "./compiler/*"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
       "import": "./internal/stencil-core/index.js",
       "require": "./internal/stencil-core/index.cjs"
     },
+    "./cli": {
+      "import": "./cli/index.js",
+      "require": "./cli/index.cjs"
+    },
     "./internal": {
       "import": "./internal/index.js"
     },

--- a/package.json
+++ b/package.json
@@ -62,6 +62,15 @@
     },
     "./compiler/*": {
       "import": "./compiler/*"
+    },
+    "./sys/node": {
+      "import": "./sys/node/index.js",
+      "require": "./sys/node/index.js",
+      "types": "./sys/node/index.d.ts"
+    },
+    "./sys/node/*": {
+      "import": "./sys/node/*",
+      "require": "./sys/node/*"
     }
   },
   "scripts": {

--- a/test/end-to-end/exportMap/index.js
+++ b/test/end-to-end/exportMap/index.js
@@ -5,7 +5,7 @@ const { run } = require('@stencil/core/cli');
 const { h } = require('@stencil/core');
 const { MockDocument } = require('@stencil/core/mock-doc');
 const appData = require('@stencil/core/internal/app-data');
-const { createNodeLogger } = require('@stencil/core/sys/node')
+const { createNodeLogger } = require('@stencil/core/sys/node');
 
 assert(typeof version === 'string');
 assert(typeof run, 'function');

--- a/test/end-to-end/exportMap/index.js
+++ b/test/end-to-end/exportMap/index.js
@@ -5,9 +5,11 @@ const { run } = require('@stencil/core/cli');
 const { h } = require('@stencil/core');
 const { MockDocument } = require('@stencil/core/mock-doc');
 const appData = require('@stencil/core/internal/app-data');
+const { createNodeLogger } = require('@stencil/core/sys/node')
 
 assert(typeof version === 'string');
 assert(typeof run, 'function');
 assert(typeof h === 'function');
 assert(typeof MockDocument === 'function');
 assert(Object.keys(appData).length === 3);
+assert(typeof createNodeLogger === 'function');

--- a/test/end-to-end/exportMap/index.js
+++ b/test/end-to-end/exportMap/index.js
@@ -1,0 +1,13 @@
+const assert = require('node:assert')
+
+const { version } = require('@stencil/core/compiler')
+const { run } = require('@stencil/core/cli')
+const { h } = require('@stencil/core')
+const { MockDocument } = require('@stencil/core/mock-doc')
+const appData = require('@stencil/core/internal/app-data')
+
+assert(typeof version === 'string')
+assert(typeof run, 'function')
+assert(typeof h === 'function')
+assert(typeof MockDocument === 'function')
+assert(Object.keys(appData).length === 3)

--- a/test/end-to-end/exportMap/index.js
+++ b/test/end-to-end/exportMap/index.js
@@ -1,13 +1,13 @@
-const assert = require('node:assert')
+const assert = require('node:assert');
 
-const { version } = require('@stencil/core/compiler')
-const { run } = require('@stencil/core/cli')
-const { h } = require('@stencil/core')
-const { MockDocument } = require('@stencil/core/mock-doc')
-const appData = require('@stencil/core/internal/app-data')
+const { version } = require('@stencil/core/compiler');
+const { run } = require('@stencil/core/cli');
+const { h } = require('@stencil/core');
+const { MockDocument } = require('@stencil/core/mock-doc');
+const appData = require('@stencil/core/internal/app-data');
 
-assert(typeof version === 'string')
-assert(typeof run, 'function')
-assert(typeof h === 'function')
-assert(typeof MockDocument === 'function')
-assert(Object.keys(appData).length === 3)
+assert(typeof version === 'string');
+assert(typeof run, 'function');
+assert(typeof h === 'function');
+assert(typeof MockDocument === 'function');
+assert(Object.keys(appData).length === 3);

--- a/test/end-to-end/exportMap/index.mts
+++ b/test/end-to-end/exportMap/index.mts
@@ -1,0 +1,18 @@
+import assert from 'node:assert'
+
+import { run } from '@stencil/core/cli'
+import { version } from '@stencil/core/compiler'
+import { MockDocument } from '@stencil/core/mock-doc';
+import type { BuildConditionals } from '@stencil/core/internal';
+import { BUILD } from '@stencil/core/internal/app-data'
+import * as foo from '@stencil/core/internal/client'
+
+assert(typeof version === 'string')
+version.slice()
+BUILD as BuildConditionals
+
+assert(typeof run, 'function')
+run.call
+
+assert(typeof MockDocument === 'function')
+assert(typeof BUILD !== 'undefined')

--- a/test/end-to-end/exportMap/index.mts
+++ b/test/end-to-end/exportMap/index.mts
@@ -5,7 +5,7 @@ import { version } from '@stencil/core/compiler'
 import { MockDocument } from '@stencil/core/mock-doc';
 import type { BuildConditionals } from '@stencil/core/internal';
 import { BUILD } from '@stencil/core/internal/app-data'
-import * as foo from '@stencil/core/internal/client'
+import { createNodeLogger } from '@stencil/core/sys/node'
 
 assert(typeof version === 'string')
 version.slice()
@@ -16,3 +16,4 @@ run.call
 
 assert(typeof MockDocument === 'function')
 assert(typeof BUILD !== 'undefined')
+assert(typeof createNodeLogger === 'function')

--- a/test/end-to-end/package-lock.json
+++ b/test/end-to-end/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "@stencil/end-to-end",
       "devDependencies": {
+        "@stencil/core": "file:../../",
         "@stencil/react-output-target": "^0.0.9",
         "@types/file-saver": "^2.0.1",
         "@types/lodash": "^4.14.165",
@@ -17,8 +18,89 @@
         "lodash-es": "^4.17.15",
         "rollup-plugin-css-only": "^2.1.0",
         "rollup-plugin-node-builtins": "^2.1.2",
+        "tsx": "^4.15.7",
         "video.js": "^7.10.2",
         "why-is-node-running": "^2.2.0"
+      }
+    },
+    "../..": {
+      "name": "@stencil/core",
+      "version": "4.19.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "stencil": "bin/stencil"
+      },
+      "devDependencies": {
+        "@ionic/prettier-config": "^4.0.0",
+        "@rollup/plugin-commonjs": "21.1.0",
+        "@rollup/plugin-json": "6.1.0",
+        "@rollup/plugin-node-resolve": "9.0.0",
+        "@rollup/plugin-replace": "5.0.7",
+        "@rollup/pluginutils": "5.1.0",
+        "@types/eslint": "^8.4.6",
+        "@types/exit": "^0.1.31",
+        "@types/fs-extra": "^11.0.0",
+        "@types/graceful-fs": "^4.1.5",
+        "@types/jest": "^27.0.3",
+        "@types/listr": "^0.14.4",
+        "@types/node": "^20.12.11",
+        "@types/pixelmatch": "^5.2.4",
+        "@types/pngjs": "^6.0.1",
+        "@types/prompts": "^2.0.9",
+        "@types/semver": "^7.3.12",
+        "@types/ws": "^8.5.4",
+        "@types/yarnpkg__lockfile": "^1.1.5",
+        "@typescript-eslint/eslint-plugin": "^7.0.0",
+        "@typescript-eslint/parser": "^7.0.0",
+        "@yarnpkg/lockfile": "^1.1.0",
+        "ansi-colors": "4.1.3",
+        "autoprefixer": "10.4.19",
+        "conventional-changelog-cli": "^5.0.0",
+        "cspell": "^8.0.0",
+        "dts-bundle-generator": "~9.5.0",
+        "esbuild": "^0.21.0",
+        "esbuild-plugin-replace": "^1.4.0",
+        "eslint": "^8.23.1",
+        "eslint-config-prettier": "^9.0.0",
+        "eslint-plugin-jest": "^28.0.0",
+        "eslint-plugin-jsdoc": "^48.0.0",
+        "eslint-plugin-simple-import-sort": "^12.0.0",
+        "eslint-plugin-wdio": "^8.24.12",
+        "execa": "8.0.1",
+        "exit": "^0.1.2",
+        "fs-extra": "^11.0.0",
+        "glob": "10.4.1",
+        "graceful-fs": "~4.2.6",
+        "jest": "^27.4.5",
+        "jest-cli": "^27.4.5",
+        "jest-environment-node": "^27.4.4",
+        "jquery": "https://github.com/jquery/jquery/tarball/c98597eaf5e144ee5e549cb41984687cd1033068",
+        "listr": "^0.14.3",
+        "magic-string": "^0.30.0",
+        "merge-source-map": "^1.1.0",
+        "mime-db": "^1.46.0",
+        "minimatch": "9.0.4",
+        "node-fetch": "3.3.2",
+        "open": "^9.0.0",
+        "open-in-editor": "2.2.0",
+        "parse5": "7.1.2",
+        "pixelmatch": "5.3.0",
+        "postcss": "^8.2.8",
+        "prettier": "3.3.1",
+        "prompts": "2.4.2",
+        "puppeteer": "^21.0.0",
+        "rollup": "2.56.3",
+        "semver": "^7.3.7",
+        "terser": "5.31.1",
+        "tsx": "^4.10.3",
+        "typescript": "~5.4.0",
+        "webpack": "^5.75.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.10.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -399,6 +481,374 @@
       "integrity": "sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg==",
       "dev": true
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
@@ -423,18 +873,8 @@
       "dev": true
     },
     "node_modules/@stencil/core": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.4.0.tgz",
-      "integrity": "sha512-kEtPtV6QegME8YgMjWrhS7KktItbhqOpAuK9aXypDdI/7bLU9iM/4DtnQGWY/DARBophk+XRBfNXcE62Bmi0dw==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=14.10.0",
-        "npm": ">=6.0.0"
-      }
+      "resolved": "../..",
+      "link": true
     },
     "node_modules/@stencil/react-output-target": {
       "version": "0.0.9",
@@ -1462,6 +1902,44 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -1777,16 +2255,15 @@
       "dev": true
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -1846,6 +2323,18 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.5.tgz",
+      "integrity": "sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/get-value": {
@@ -3342,6 +3831,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -3931,6 +4429,25 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.15.7",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.15.7.tgz",
+      "integrity": "sha512-u3H0iSFDZM3za+VxkZ1kywdCeHCn+8/qHQS1MNoO2sONDgD95HlWtt8aB23OzeTmFP9IU4/8bZUdg58Uu5J4cg==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.21.4",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/typedarray": {

--- a/test/end-to-end/package.json
+++ b/test/end-to-end/package.json
@@ -9,8 +9,9 @@
     "build": "node ../../bin/stencil build --config ./stencil.build.config.ts --docs",
     "start": "node ../../bin/stencil build --debug --watch --dev --serve",
     "test": "node ../../bin/stencil test --ci --e2e --spec --screenshot --debug",
-    "test.dist": "npm run build && node test-end-to-end-dist.js && node test-end-to-end-hydrate.js",
+    "test.dist": "npm run build && node test-end-to-end-dist.js && node test-end-to-end-hydrate.js && npm run test.exportMap",
     "test.e2e": "node ../../bin/stencil test --e2e",
+    "test.exportMap": "node ./exportMap/index.js && tsx ./exportMap/index.mts",
     "test.hydrate": "node test-end-to-end-hydrate.js",
     "test.screenshot": "node ../../bin/stencil test --e2e --debug --screenshot",
     "test.spec": "node ../../bin/stencil test --spec --debug",
@@ -20,6 +21,7 @@
     "preset": "../../testing/jest-preset.js"
   },
   "devDependencies": {
+    "@stencil/core": "file:../../",
     "@stencil/react-output-target": "^0.0.9",
     "@types/file-saver": "^2.0.1",
     "@types/lodash": "^4.14.165",
@@ -31,6 +33,7 @@
     "lodash-es": "^4.17.15",
     "rollup-plugin-css-only": "^2.1.0",
     "rollup-plugin-node-builtins": "^2.1.2",
+    "tsx": "^4.15.7",
     "video.js": "^7.10.2",
     "why-is-node-running": "^2.2.0"
   },


### PR DESCRIPTION
## What is the current behavior?
We recently added an export map to Stencil and didn't include the `cli` sub modules which has been used by the community.

## What is the new behavior?
Add the `cli` sub module to the export map.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Will work on a test for this separately.

## Other information

n/a
