### PR TITLE
fix(testing): add testing sub module to export map

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,10 +37,12 @@
       "types": "./internal/index.d.ts"
     },
     "./internal/client": {
-      "import": "./internal/client/index.js"
+      "import": "./internal/client/index.js",
+      "require": "./internal/client/index.js"
     },
     "./internal/testing": {
-      "import": "./internal/testing/index.js"
+      "import": "./internal/testing/index.js",
+      "require": "./internal/testing/index.js"
     },
     "./internal/testing/*": {
       "import": "./internal/testing/*"
@@ -61,7 +63,8 @@
       "types": "./compiler/stencil.d.ts"
     },
     "./compiler/*": {
-      "import": "./compiler/*"
+      "import": "./compiler/*",
+      "types": "./compiler/*"
     },
     "./sys/node": {
       "import": "./sys/node/index.js",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,15 @@
     "./sys/node/*": {
       "import": "./sys/node/*",
       "require": "./sys/node/*"
+    },
+    "./testing": {
+      "import": "./testing/index.js",
+      "types": "./testing/index.d.ts",
+      "require": "./testing/index.js"
+    },
+    "./testing/*": {
+      "import": "./testing/*",
+      "require": "./testing/*"
     }
   },
   "scripts": {

--- a/test/end-to-end/exportMap/index.js
+++ b/test/end-to-end/exportMap/index.js
@@ -6,6 +6,7 @@ const { h } = require('@stencil/core');
 const { MockDocument } = require('@stencil/core/mock-doc');
 const appData = require('@stencil/core/internal/app-data');
 const { createNodeLogger } = require('@stencil/core/sys/node');
+const { createTesting } = require('@stencil/core/testing');
 
 assert(typeof version === 'string');
 assert(typeof run, 'function');
@@ -13,3 +14,7 @@ assert(typeof h === 'function');
 assert(typeof MockDocument === 'function');
 assert(Object.keys(appData).length === 3);
 assert(typeof createNodeLogger === 'function');
+assert(typeof createTesting === 'function');
+
+console.log(`🎉 All CJS imports successfully resolved!`);
+console.log('✅ passed!\n');

--- a/test/end-to-end/exportMap/index.mts
+++ b/test/end-to-end/exportMap/index.mts
@@ -1,19 +1,24 @@
-import assert from 'node:assert'
+import assert from 'node:assert';
 
-import { run } from '@stencil/core/cli'
-import { version } from '@stencil/core/compiler'
+import { run } from '@stencil/core/cli';
+import { version } from '@stencil/core/compiler';
 import { MockDocument } from '@stencil/core/mock-doc';
 import type { BuildConditionals } from '@stencil/core/internal';
-import { BUILD } from '@stencil/core/internal/app-data'
-import { createNodeLogger } from '@stencil/core/sys/node'
+import { BUILD } from '@stencil/core/internal/app-data';
+import { createNodeLogger } from '@stencil/core/sys/node';
+import { createTesting } from '@stencil/core/testing';
 
-assert(typeof version === 'string')
-version.slice()
-BUILD as BuildConditionals
+assert(typeof version === 'string');
+version.slice();
+BUILD as BuildConditionals;
 
-assert(typeof run, 'function')
-run.call
+assert(typeof run, 'function');
+run.call;
 
-assert(typeof MockDocument === 'function')
-assert(typeof BUILD !== 'undefined')
-assert(typeof createNodeLogger === 'function')
+assert(typeof MockDocument === 'function');
+assert(typeof BUILD !== 'undefined');
+assert(typeof createNodeLogger === 'function');
+assert(typeof createTesting === 'function');
+
+console.log(`🎉 All ESM imports successfully resolved!`);
+console.log('✅ passed!\n');


### PR DESCRIPTION
## What is the current behavior?
There was an export target missing. Something that is no where documented that you can just use the Jest testrunner and test Stencil components by just passing in `preset: '@stencil/core/testing',`.

GitHub Issue Number:
fixes #5871
fixes #5868

## What is the new behavior?
Enable this use case again.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Added unit tests for this.

## Other information

n/a
