### PR TITLE
fix(hydrate): ensure beforeHydrateFn and afterHydrateFn always return a function (#5884)

### DIFF
--- a/src/hydrate/runner/render.ts
+++ b/src/hydrate/runner/render.ts
@@ -130,7 +130,7 @@ async function render(win: MockWindow, opts: HydrateFactoryOptions, results: Hyd
   }
 
   initializeWindow(win, win.document, opts, results);
-  const beforeHydrateFn = typeof opts.beforeHydrate === 'function' ? opts.beforeHydrate(win.document) : NOOP;
+  const beforeHydrateFn = typeof opts.beforeHydrate === 'function' ? opts.beforeHydrate : NOOP;
   try {
     await Promise.resolve(beforeHydrateFn(win.document));
     return new Promise<HydrateResults>((resolve) => hydrateFactory(win, opts, results, afterHydrate, resolve));
@@ -162,7 +162,7 @@ async function afterHydrate(
   results: HydrateResults,
   resolve: (results: HydrateResults) => void,
 ) {
-  const afterHydrateFn = typeof opts.afterHydrate === 'function' ? opts.afterHydrate(win.document) : NOOP;
+  const afterHydrateFn = typeof opts.afterHydrate === 'function' ? opts.afterHydrate : NOOP;
   try {
     await Promise.resolve(afterHydrateFn(win.document));
     return resolve(finalizeHydrate(win, win.document, opts, results));


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #5884


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Ensure beforeHydrateFn and afterHydrateFn are always returning a function.


## Documentation

n/a

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

n/a

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

n/a
