### PR TITLE
fix(runtime): make isSameVnode return false on initial render in a hydration case

### DIFF
--- a/src/runtime/vdom/test/vdom-render.spec.tsx
+++ b/src/runtime/vdom/test/vdom-render.spec.tsx
@@ -1,0 +1,39 @@
+import { isSameVnode } from '../vdom-render';
+
+describe('isSameVnode', () => {
+  it('should detect objectively same nodes', () => {
+    const vnode1: any = {
+      $tag$: 'div',
+      $key$: '1',
+      $elm$: { nodeType: 9 },
+    };
+    const vnode2: any = {
+      $tag$: 'div',
+      $key$: '1',
+      $elm$: { nodeType: 9 },
+    };
+    expect(isSameVnode(vnode1, vnode2)).toBe(true);
+  });
+
+  it('should return false in case of hyration', () => {
+    const vnode1: any = {
+      $tag$: 'slot',
+      $key$: '1',
+      $elm$: { nodeType: 9 },
+      $nodeId$: 1,
+    };
+    const vnode2: any = {
+      $tag$: 'slot',
+      $key$: '1',
+      $elm$: { nodeType: 9 },
+    };
+    const vnode3: any = {
+      $tag$: 'slot',
+      $key$: '1',
+      $elm$: { nodeType: 8 },
+      $nodeId$: 2,
+    };
+    expect(isSameVnode(vnode1, vnode2, true)).toBe(false);
+    expect(isSameVnode(vnode3, vnode2, true)).toBe(true);
+  });
+});

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -614,7 +614,8 @@ export const isSameVnode = (leftVNode: d.VNode, rightVNode: d.VNode, isInitialRe
       if (
         // The component gets hydrated and no VDOM has been initialized.
         // Here the comparison can't happen as $name$ property is not set for `leftNode`.
-        '$nodeId$' in leftVNode && isInitialRender &&
+        '$nodeId$' in leftVNode &&
+        isInitialRender &&
         // `leftNode` is not from type HTMLComment which would cause many
         // hydration comments to be removed
         leftVNode.$elm$.nodeType !== 8

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -610,6 +610,18 @@ export const isSameVnode = (leftVNode: d.VNode, rightVNode: d.VNode, isInitialRe
   // need to have the same element tag, and same key to be the same
   if (leftVNode.$tag$ === rightVNode.$tag$) {
     if (BUILD.slotRelocation && leftVNode.$tag$ === 'slot') {
+      // We are not considering the same node if:
+      if (
+        // The component gets hydrated and no VDOM has been initialized.
+        // Here the comparison can't happen as $name$ property is not set for `leftNode`.
+        '$nodeId$' in leftVNode && isInitialRender &&
+        // `leftNode` is not from type HTMLComment which would cause many
+        // hydration comments to be removed
+        leftVNode.$elm$.nodeType !== 8
+      ) {
+        return false;
+      }
+
       return leftVNode.$name$ === rightVNode.$name$;
     }
     // this will be set if JSX tags in the build have `key` attrs set on them


### PR DESCRIPTION
## What is the current behavior?
Stencil believes two nodes are the same on initial render, in cases were are comparing slots with no name attached to them. This causes rendering issues and the slot node being removed.

## What is the new behavior?
Instead, Stencil should not re-order its VDOM and properly hydrate the VDOM first.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Added some unit test to check this case.

## Other information

Discovered this as part of my work on #5831
