### PR TITLE
fix(compiler): no need for commenting selectors anymore

### DIFF
--- a/src/compiler/bundle/bundle-output.ts
+++ b/src/compiler/bundle/bundle-output.ts
@@ -121,7 +121,7 @@ export const getRollupOptions = (
       userIndexPlugin(config, compilerCtx),
       typescriptPlugin(compilerCtx, bundleOpts, config),
       extFormatPlugin(config),
-      extTransformsPlugin(config, compilerCtx, buildCtx, bundleOpts),
+      extTransformsPlugin(config, compilerCtx, buildCtx),
       workerPlugin(config, compilerCtx, buildCtx, bundleOpts.platform, !!bundleOpts.inlineWorkers),
       serverPlugin(config, bundleOpts.platform),
       ...beforePlugins,

--- a/src/compiler/bundle/ext-transforms-plugin.ts
+++ b/src/compiler/bundle/ext-transforms-plugin.ts
@@ -35,7 +35,6 @@ const allCmpStyles = new Map<string, ComponentStyleMap>();
  * @param bundleOpts bundle options for Rollup
  * @returns a Rollup plugin which carries out the necessary work
  */
-let i = 0
 export const extTransformsPlugin = (
   config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
@@ -57,7 +56,6 @@ export const extTransformsPlugin = (
      * @returns metadata for Rollup or null if no transformation should be done
      */
     async transform(_, id) {
-      const ok = ++i
       if (/\0/.test(id)) {
         return null;
       }
@@ -123,10 +121,6 @@ export const extTransformsPlugin = (
           cmpStyles = allCmpStyles.get(scopeId);
         }
 
-        console.log(ok, '---------------------------------------------');
-        
-        console.log(ok, 'code', data.encapsulation, pluginTransforms.code);
-        
         const cssTransformResults = await compilerCtx.worker.transformCssToEsm({
           file: pluginTransforms.id,
           input: pluginTransforms.code,
@@ -200,13 +194,11 @@ export const extTransformsPlugin = (
                */
               cssTransformResults.styleText;
 
-          console.log(ok, 11, styleText);
           if (styleText.startsWith('/*!@:host')) {
             const a = new Error('styleText');
             console.log(a.stack);
-            
           }
-          
+
           buildCtx.stylesUpdated.push({
             styleTag: data.tag,
             styleMode: data.mode,

--- a/src/compiler/bundle/ext-transforms-plugin.ts
+++ b/src/compiler/bundle/ext-transforms-plugin.ts
@@ -32,7 +32,6 @@ const allCmpStyles = new Map<string, ComponentStyleMap>();
  * @param config a user-supplied configuration
  * @param compilerCtx the current compiler context
  * @param buildCtx the current build context
- * @param bundleOpts bundle options for Rollup
  * @returns a Rollup plugin which carries out the necessary work
  */
 export const extTransformsPlugin = (

--- a/src/compiler/bundle/ext-transforms-plugin.ts
+++ b/src/compiler/bundle/ext-transforms-plugin.ts
@@ -194,11 +194,6 @@ export const extTransformsPlugin = (
                */
               cssTransformResults.styleText;
 
-          if (styleText.startsWith('/*!@:host')) {
-            const a = new Error('styleText');
-            console.log(a.stack);
-          }
-
           buildCtx.stylesUpdated.push({
             styleTag: data.tag,
             styleMode: data.mode,

--- a/src/compiler/bundle/test/ext-transforms-plugin.spec.ts
+++ b/src/compiler/bundle/test/ext-transforms-plugin.spec.ts
@@ -63,7 +63,7 @@ describe('extTransformsPlugin', () => {
 
     const writeFileSpy = jest.spyOn(compilerCtx.fs, 'writeFile');
     return {
-      plugin: extTransformsPlugin(config, compilerCtx, buildCtx, bundleOpts),
+      plugin: extTransformsPlugin(config, compilerCtx, buildCtx),
       config,
       compilerCtx,
       buildCtx,
@@ -100,42 +100,6 @@ describe('extTransformsPlugin', () => {
       expect(normalizePath(path)).toBe('./dist/collectionDir/foo.css');
 
       expect(css).toBe(':host { text: pink; }');
-    });
-
-    describe('passing `commentOriginalSelector` to `transformCssToEsm`', () => {
-      it.each([
-        [false, 'tag=my-component&encapsulation=scoped'],
-        [true, 'tag=my-component&encapsulation=shadow'],
-        [false, 'tag=my-component'],
-      ])('should pass true if %p and hydrate', async (expectation, queryParams) => {
-        const { plugin, transformCssToEsmSpy } = setup({ platform: 'hydrate' });
-        // @ts-ignore the Rollup plugins expect to be called in a Rollup context
-        await plugin.transform('asdf', `/some/stubbed/path/foo.css?${queryParams}`);
-        expect(transformCssToEsmSpy.mock.calls[0][0].commentOriginalSelector).toBe(expectation);
-      });
-
-      it('should pass false if shadow, hydrate, but using HMR in dev watch mode', async () => {
-        const { plugin, transformCssToEsmSpy, config } = setup({ platform: 'hydrate' });
-
-        config.flags.watch = true;
-        config.flags.dev = true;
-        config.flags.serve = true;
-        config.devServer = { reloadStrategy: 'hmr' };
-
-        // @ts-ignore the Rollup plugins expect to be called in a Rollup context
-        await plugin.transform('asdf', '/some/stubbed/path/foo.css?tag=my-component&encapsulation=shadow');
-        expect(transformCssToEsmSpy.mock.calls[0][0].commentOriginalSelector).toBe(false);
-      });
-
-      it.each(['tag=my-component&encapsulation=scoped', 'tag=my-component&encapsulation=shadow', 'tag=my-component'])(
-        'should pass false if %p without hydrate',
-        async (queryParams) => {
-          const { plugin, transformCssToEsmSpy } = setup();
-          // @ts-ignore the Rollup plugins expect to be called in a Rollup context
-          await plugin.transform('asdf', `/some/stubbed/path/foo.css?${queryParams}`);
-          expect(transformCssToEsmSpy.mock.calls[0][0].commentOriginalSelector).toBe(false);
-        },
-      );
     });
   });
 });

--- a/src/compiler/config/transpile-options.ts
+++ b/src/compiler/config/transpile-options.ts
@@ -166,7 +166,6 @@ export const getTranspileCssConfig = (
     encapsulation: importData && importData.encapsulation,
     mode: importData && importData.mode,
     sourceMap: compileOpts.sourceMap !== false,
-    commentOriginalSelector: false,
     minify: false,
     autoprefixer: false,
     module: compileOpts.module,

--- a/src/compiler/style/css-to-esm.ts
+++ b/src/compiler/style/css-to-esm.ts
@@ -113,11 +113,9 @@ const transformCssToEsmModule = (input: d.TransformCssToEsmInput): d.TransformCs
   try {
     const varNames = new Set([results.defaultVarName]);
 
-    if (isString(input.tag)) {
-      if (input.encapsulation === 'scoped' || (input.encapsulation === 'shadow' && input.commentOriginalSelector)) {
-        const scopeId = getScopeId(input.tag, input.mode);
-        results.styleText = scopeCss(results.styleText, scopeId, !!input.commentOriginalSelector);
-      }
+    if (isString(input.tag) && input.encapsulation === 'scoped') {
+      const scopeId = getScopeId(input.tag, input.mode);
+      results.styleText = scopeCss(results.styleText, scopeId);
     }
 
     const cssImports = getCssToEsmImports(varNames, results.styleText, input.file, input.mode);

--- a/src/compiler/transformers/add-static-style.ts
+++ b/src/compiler/transformers/add-static-style.ts
@@ -64,10 +64,7 @@ const getStyleLiteral = (cmp: d.ComponentCompilerMeta) => {
   return null;
 };
 
-const getMultipleModeStyle = (
-  cmp: d.ComponentCompilerMeta,
-  styles: d.StyleCompiler[],
-) => {
+const getMultipleModeStyle = (cmp: d.ComponentCompilerMeta, styles: d.StyleCompiler[]) => {
   const styleModes: ts.ObjectLiteralElementLike[] = [];
 
   styles.forEach((style) => {

--- a/src/compiler/transformers/add-static-style.ts
+++ b/src/compiler/transformers/add-static-style.ts
@@ -16,14 +16,12 @@ import { createStaticGetter, getExternalStyles } from './transform-utils';
  * @param classMembers a class to existing members of a class. **this parameter will be mutated** rather than returning
  * a cloned version
  * @param cmp the metadata associated with the component being evaluated
- * @param commentOriginalSelector if `true`, add a comment with the original CSS selector to the style.
  */
 export const addStaticStyleGetterWithinClass = (
   classMembers: ts.ClassElement[],
   cmp: d.ComponentCompilerMeta,
-  commentOriginalSelector: boolean,
 ): void => {
-  const styleLiteral = getStyleLiteral(cmp, commentOriginalSelector);
+  const styleLiteral = getStyleLiteral(cmp);
   if (styleLiteral) {
     classMembers.push(createStaticGetter('style', styleLiteral));
   }
@@ -41,7 +39,7 @@ export const addStaticStyleGetterWithinClass = (
  * @param cmp the metadata associated with the component being evaluated
  */
 export const addStaticStylePropertyToClass = (styleStatements: ts.Statement[], cmp: d.ComponentCompilerMeta): void => {
-  const styleLiteral = getStyleLiteral(cmp, false);
+  const styleLiteral = getStyleLiteral(cmp);
   if (styleLiteral) {
     const statement = ts.factory.createExpressionStatement(
       ts.factory.createAssignment(
@@ -53,14 +51,14 @@ export const addStaticStylePropertyToClass = (styleStatements: ts.Statement[], c
   }
 };
 
-const getStyleLiteral = (cmp: d.ComponentCompilerMeta, commentOriginalSelector: boolean) => {
+const getStyleLiteral = (cmp: d.ComponentCompilerMeta) => {
   if (Array.isArray(cmp.styles) && cmp.styles.length > 0) {
     if (cmp.styles.length > 1 || (cmp.styles.length === 1 && cmp.styles[0].modeName !== DEFAULT_STYLE_MODE)) {
       // multiple style modes
-      return getMultipleModeStyle(cmp, cmp.styles, commentOriginalSelector);
+      return getMultipleModeStyle(cmp, cmp.styles);
     } else {
       // single style
-      return getSingleStyle(cmp, cmp.styles[0], commentOriginalSelector);
+      return getSingleStyle(cmp, cmp.styles[0]);
     }
   }
   return null;
@@ -69,7 +67,6 @@ const getStyleLiteral = (cmp: d.ComponentCompilerMeta, commentOriginalSelector: 
 const getMultipleModeStyle = (
   cmp: d.ComponentCompilerMeta,
   styles: d.StyleCompiler[],
-  commentOriginalSelector: boolean,
 ) => {
   const styleModes: ts.ObjectLiteralElementLike[] = [];
 
@@ -83,7 +80,7 @@ const getMultipleModeStyle = (
     if (typeof style.styleStr === 'string') {
       // inline the style string
       // static get style() { return { ios: "string" }; }
-      const styleLiteral = createStyleLiteral(cmp, style, commentOriginalSelector);
+      const styleLiteral = createStyleLiteral(cmp, style);
       const propStr = ts.factory.createPropertyAssignment(style.modeName, styleLiteral);
       styleModes.push(propStr);
     } else if (Array.isArray(style.externalStyles) && style.externalStyles.length > 0) {
@@ -106,7 +103,7 @@ const getMultipleModeStyle = (
   return ts.factory.createObjectLiteralExpression(styleModes, true);
 };
 
-const getSingleStyle = (cmp: d.ComponentCompilerMeta, style: d.StyleCompiler, commentOriginalSelector: boolean) => {
+const getSingleStyle = (cmp: d.ComponentCompilerMeta, style: d.StyleCompiler) => {
   /**
    * the order of these if statements must match with
    * - {@link src/compiler/transformers/component-native/native-static-style.ts#addSingleStyleGetter}
@@ -116,7 +113,7 @@ const getSingleStyle = (cmp: d.ComponentCompilerMeta, style: d.StyleCompiler, co
   if (typeof style.styleStr === 'string') {
     // inline the style string
     // static get style() { return "string"; }
-    return createStyleLiteral(cmp, style, commentOriginalSelector);
+    return createStyleLiteral(cmp, style);
   }
 
   if (Array.isArray(style.externalStyles) && style.externalStyles.length > 0) {
@@ -136,11 +133,11 @@ const getSingleStyle = (cmp: d.ComponentCompilerMeta, style: d.StyleCompiler, co
   return null;
 };
 
-const createStyleLiteral = (cmp: d.ComponentCompilerMeta, style: d.StyleCompiler, commentOriginalSelector: boolean) => {
-  if (cmp.encapsulation === 'scoped' || (commentOriginalSelector && cmp.encapsulation === 'shadow')) {
+const createStyleLiteral = (cmp: d.ComponentCompilerMeta, style: d.StyleCompiler) => {
+  if (cmp.encapsulation === 'scoped') {
     // scope the css first
     const scopeId = getScopeId(cmp.tagName, style.modeName);
-    return ts.factory.createStringLiteral(scopeCss(style.styleStr, scopeId, commentOriginalSelector));
+    return ts.factory.createStringLiteral(scopeCss(style.styleStr, scopeId));
   }
 
   return ts.factory.createStringLiteral(style.styleStr);

--- a/src/compiler/transformers/component-hydrate/hydrate-runtime-cmp-meta.ts
+++ b/src/compiler/transformers/component-hydrate/hydrate-runtime-cmp-meta.ts
@@ -21,8 +21,7 @@ export const addHydrateRuntimeCmpMeta = (classMembers: ts.ClassElement[], cmp: d
     cmpMeta.$flags$ |= CMP_FLAGS.needsShadowDomShim;
   }
   const staticMember = createStaticGetter('cmpMeta', convertValueToLiteral(cmpMeta));
-  const commentOriginalSelector = cmp.encapsulation === 'shadow';
-  addStaticStyleGetterWithinClass(classMembers, cmp, commentOriginalSelector);
+  addStaticStyleGetterWithinClass(classMembers, cmp);
 
   classMembers.push(staticMember);
 };

--- a/src/compiler/transformers/component-native/native-static-style.ts
+++ b/src/compiler/transformers/component-native/native-static-style.ts
@@ -96,7 +96,7 @@ const createStyleLiteral = (cmp: d.ComponentCompilerMeta, style: d.StyleCompiler
   if (cmp.encapsulation === 'scoped') {
     // scope the css first
     const scopeId = getScopeId(cmp.tagName, style.modeName);
-    return ts.factory.createStringLiteral(scopeCss(style.styleStr, scopeId, false));
+    return ts.factory.createStringLiteral(scopeCss(style.styleStr, scopeId));
   }
 
   return ts.factory.createStringLiteral(style.styleStr);

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -1938,7 +1938,6 @@ export interface TransformCssToEsmInput {
    * is not shared by multiple fields, nor is it a composite of multiple modes).
    */
   mode?: string;
-  commentOriginalSelector?: boolean;
   sourceMap?: boolean;
   minify?: boolean;
   docs?: boolean;

--- a/src/hydrate/platform/hydrate-app.ts
+++ b/src/hydrate/platform/hydrate-app.ts
@@ -91,7 +91,7 @@ export function hydrateApp(
             registerHost(elm, Cstr.cmpMeta);
 
             // proxy the host element with the component's metadata
-            proxyHostElement(elm, Cstr.cmpMeta, opts);
+            proxyHostElement(elm, Cstr.cmpMeta);
           }
         }
       }

--- a/src/hydrate/platform/proxy-host-element.ts
+++ b/src/hydrate/platform/proxy-host-element.ts
@@ -5,10 +5,7 @@ import { CMP_FLAGS, MEMBER_FLAGS } from '@utils';
 
 import type * as d from '../../declarations';
 
-export function proxyHostElement(
-  elm: d.HostElement,
-  cmpMeta: d.ComponentRuntimeMeta,
-): void {
+export function proxyHostElement(elm: d.HostElement, cmpMeta: d.ComponentRuntimeMeta): void {
   if (typeof elm.componentOnReady !== 'function') {
     elm.componentOnReady = componentOnReady;
   }

--- a/src/hydrate/platform/proxy-host-element.ts
+++ b/src/hydrate/platform/proxy-host-element.ts
@@ -8,7 +8,6 @@ import type * as d from '../../declarations';
 export function proxyHostElement(
   elm: d.HostElement,
   cmpMeta: d.ComponentRuntimeMeta,
-  opts: d.HydrateFactoryOptions,
 ): void {
   if (typeof elm.componentOnReady !== 'function') {
     elm.componentOnReady = componentOnReady;
@@ -26,14 +25,8 @@ export function proxyHostElement(
         mode: 'open',
         delegatesFocus: !!(cmpMeta.$flags$ & CMP_FLAGS.shadowDelegatesFocus),
       });
-    } else if (opts.serializeShadowRoot) {
-      elm.attachShadow({ mode: 'open' });
     } else {
-      /**
-       * For hydration users may want to render the shadow component as scoped
-       * component, so we need to assign the element as shadowRoot.
-       */
-      (elm as any).shadowRoot = elm;
+      elm.attachShadow({ mode: 'open' });
     }
   }
 

--- a/src/hydrate/runner/inspect-element.ts
+++ b/src/hydrate/runner/inspect-element.ts
@@ -1,10 +1,7 @@
 import type * as d from '../../declarations';
 
 export function inspectElement(results: d.HydrateResults, elm: Element, depth: number) {
-  const children = [
-    ...Array.from(elm.children),
-    ...Array.from(elm.shadowRoot ? elm.shadowRoot.children : [])
-  ];
+  const children = [...Array.from(elm.children), ...Array.from(elm.shadowRoot ? elm.shadowRoot.children : [])];
 
   for (let i = 0, ii = children.length; i < ii; i++) {
     const childElm = children[i];

--- a/src/hydrate/runner/inspect-element.ts
+++ b/src/hydrate/runner/inspect-element.ts
@@ -1,7 +1,10 @@
 import type * as d from '../../declarations';
 
 export function inspectElement(results: d.HydrateResults, elm: Element, depth: number) {
-  const children = elm.children;
+  const children = [
+    ...Array.from(elm.children),
+    ...Array.from(elm.shadowRoot ? elm.shadowRoot.children : [])
+  ];
 
   for (let i = 0, ii = children.length; i < ii; i++) {
     const childElm = children[i];

--- a/src/hydrate/runner/render.ts
+++ b/src/hydrate/runner/render.ts
@@ -47,7 +47,7 @@ export function renderToString(
   /**
    * Defines whether we render the shadow root as a declarative shadow root or as scoped shadow root.
    */
-  opts.serializeShadowRoot = typeof opts.serializeShadowRoot === 'boolean' ? opts.serializeShadowRoot : true
+  opts.serializeShadowRoot = typeof opts.serializeShadowRoot === 'boolean' ? opts.serializeShadowRoot : true;
   /**
    * Make sure we wait for components to be hydrated.
    */

--- a/src/hydrate/runner/render.ts
+++ b/src/hydrate/runner/render.ts
@@ -47,7 +47,7 @@ export function renderToString(
   /**
    * Defines whether we render the shadow root as a declarative shadow root or as scoped shadow root.
    */
-  opts.serializeShadowRoot = Boolean(opts.serializeShadowRoot);
+  opts.serializeShadowRoot = typeof opts.serializeShadowRoot === 'boolean' ? opts.serializeShadowRoot : true
   /**
    * Make sure we wait for components to be hydrated.
    */

--- a/src/mock-doc/serialize-node.ts
+++ b/src/mock-doc/serialize-node.ts
@@ -29,7 +29,7 @@ function normalizeSerializationOptions(opts: Partial<SerializeNodeToHtmlOptions>
     removeBooleanAttributeQuotes:
       typeof opts.removeBooleanAttributeQuotes !== 'boolean' ? false : opts.removeBooleanAttributeQuotes,
     removeHtmlComments: typeof opts.removeHtmlComments !== 'boolean' ? false : opts.removeHtmlComments,
-    serializeShadowRoot: typeof opts.serializeShadowRoot !== 'boolean' ? false : opts.serializeShadowRoot,
+    serializeShadowRoot: typeof opts.serializeShadowRoot !== 'boolean' ? true : opts.serializeShadowRoot,
     fullDocument: typeof opts.fullDocument !== 'boolean' ? true : opts.fullDocument,
   } as const;
 }
@@ -229,14 +229,7 @@ function* streamToHtml(
 
     if (EMPTY_ELEMENTS.has(tagName) === false) {
       const shadowRoot = (node as HTMLElement).shadowRoot;
-      if (shadowRoot != null) {
-        /**
-         * if user doesn't desire to serialize shadow root, skip over it
-         */
-        if (!opts.serializeShadowRoot) {
-          return;
-        }
-
+      if (shadowRoot != null && opts.serializeShadowRoot) {
         output.indent = output.indent + (opts.indentSpaces ?? 0);
 
         yield* streamToHtml(shadowRoot, opts, output);

--- a/src/mock-doc/serialize-node.ts
+++ b/src/mock-doc/serialize-node.ts
@@ -229,7 +229,14 @@ function* streamToHtml(
 
     if (EMPTY_ELEMENTS.has(tagName) === false) {
       const shadowRoot = (node as HTMLElement).shadowRoot;
-      if (opts.serializeShadowRoot && shadowRoot != null) {
+      if (shadowRoot != null) {
+        /**
+         * if user doesn't desire to serialize shadow root, skip over it
+         */
+        if (!opts.serializeShadowRoot) {
+          return;
+        }
+
         output.indent = output.indent + (opts.indentSpaces ?? 0);
 
         yield* streamToHtml(shadowRoot, opts, output);

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -16,8 +16,7 @@ import {
 import { hmrStart } from './hmr-component';
 import { createTime, installDevTools } from './profile';
 import { proxyComponent } from './proxy-component';
-import { HYDRATED_CSS, HYDRATED_STYLE_ID, PLATFORM_FLAGS, PROXY_FLAGS, SLOT_FB_CSS } from './runtime-constants';
-import { convertScopedToShadow, registerStyle } from './styles';
+import { HYDRATED_CSS, PLATFORM_FLAGS, PROXY_FLAGS, SLOT_FB_CSS } from './runtime-constants';
 import { appDidLoad } from './update-component';
 export { setNonce } from '@platform';
 
@@ -35,10 +34,8 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
   const metaCharset = /*@__PURE__*/ head.querySelector('meta[charset]');
   const dataStyles = /*@__PURE__*/ doc.createElement('style');
   const deferredConnectedCallbacks: { connectedCallback: () => void }[] = [];
-  const styles = /*@__PURE__*/ doc.querySelectorAll(`[${HYDRATED_STYLE_ID}]`);
   let appLoadFallback: any;
   let isBootstrapping = true;
-  let i = 0;
 
   Object.assign(plt, options);
   plt.$resourcesUrl$ = new URL(options.resourcesUrl || './', doc.baseURI).href;
@@ -51,11 +48,6 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
     // If the app is already hydrated there is not point to disable the
     // async queue. This will improve the first input delay
     plt.$flags$ |= PLATFORM_FLAGS.appLoaded;
-  }
-  if (BUILD.hydrateClientSide && BUILD.shadowDom) {
-    for (; i < styles.length; i++) {
-      registerStyle(styles[i].getAttribute(HYDRATED_STYLE_ID), convertScopedToShadow(styles[i].innerHTML), true);
-    }
   }
 
   let hasSlotRelocation = false;

--- a/src/runtime/initialize-component.ts
+++ b/src/runtime/initialize-component.ts
@@ -162,7 +162,7 @@ export const initializeComponent = async (
           BUILD.shadowDomShim &&
           cmpMeta.$flags$ & CMP_FLAGS.needsShadowDomShim
         ) {
-          style = await import('@utils/shadow-css').then((m) => m.scopeCss(style, scopeId, false));
+          style = await import('@utils/shadow-css').then((m) => m.scopeCss(style, scopeId));
         }
 
         registerStyle(scopeId, style, !!(cmpMeta.$flags$ & CMP_FLAGS.shadowDomEncapsulation));

--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -84,11 +84,26 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
             styleElm.setAttribute('nonce', nonce);
           }
 
-          if (BUILD.hydrateServerSide || BUILD.hotModuleReplacement) {
+          if ((BUILD.hydrateServerSide || BUILD.hotModuleReplacement) && (cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation)) {
             styleElm.setAttribute(HYDRATED_STYLE_ID, scopeId);
           }
 
-          styleContainerNode.insertBefore(styleElm, styleContainerNode.querySelector('link'));
+          /**
+           * only attach style tag to <head /> section if:
+           */
+          const injectStyle = (
+            /**
+             * we render a scoped component
+             */
+            (cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) ||
+            /**
+             * we are using shadow dom and render the style tag within the shadowRoot
+             */
+            ((cmpMeta.$flags$ & CMP_FLAGS.shadowDomEncapsulation) && styleContainerNode.nodeName !== 'HEAD')
+          );
+          if (injectStyle) {
+            styleContainerNode.insertBefore(styleElm, styleContainerNode.querySelector('link'));
+          }
         }
 
         // Add styles for `slot-fb` elements if we're using slots outside the Shadow DOM

--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -84,14 +84,17 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
             styleElm.setAttribute('nonce', nonce);
           }
 
-          if ((BUILD.hydrateServerSide || BUILD.hotModuleReplacement) && (cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation)) {
+          if (
+            (BUILD.hydrateServerSide || BUILD.hotModuleReplacement) &&
+            cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation
+          ) {
             styleElm.setAttribute(HYDRATED_STYLE_ID, scopeId);
           }
 
           /**
            * only attach style tag to <head /> section if:
            */
-          const injectStyle = (
+          const injectStyle =
             /**
              * we render a scoped component
              */
@@ -99,8 +102,7 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
             /**
              * we are using shadow dom and render the style tag within the shadowRoot
              */
-            ((cmpMeta.$flags$ & CMP_FLAGS.shadowDomEncapsulation) && styleContainerNode.nodeName !== 'HEAD')
-          );
+            (cmpMeta.$flags$ & CMP_FLAGS.shadowDomEncapsulation && styleContainerNode.nodeName !== 'HEAD');
           if (injectStyle) {
             styleContainerNode.insertBefore(styleElm, styleContainerNode.querySelector('link'));
           }
@@ -139,7 +141,12 @@ export const attachStyles = (hostRef: d.HostRef) => {
     hostRef.$modeName$,
   );
 
-  if ((BUILD.shadowDom || BUILD.scoped) && BUILD.cssAnnotations && flags & CMP_FLAGS.needsScopedEncapsulation && (flags & CMP_FLAGS.scopedCssEncapsulation)) {
+  if (
+    (BUILD.shadowDom || BUILD.scoped) &&
+    BUILD.cssAnnotations &&
+    flags & CMP_FLAGS.needsScopedEncapsulation &&
+    flags & CMP_FLAGS.scopedCssEncapsulation
+  ) {
     // only required when we're NOT using native shadow dom (slot)
     // or this browser doesn't support native shadow dom
     // and this host element was NOT created with SSR

--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -95,14 +95,13 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
             /**
              * we render a scoped component
              */
-            (cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) ||
+            !(cmpMeta.$flags$ & CMP_FLAGS.shadowDomEncapsulation) ||
             /**
              * we are using shadow dom and render the style tag within the shadowRoot
              */
             ((cmpMeta.$flags$ & CMP_FLAGS.shadowDomEncapsulation) && styleContainerNode.nodeName !== 'HEAD')
           );
           if (injectStyle) {
-            console.log
             styleContainerNode.insertBefore(styleElm, styleContainerNode.querySelector('link'));
           }
         }
@@ -167,34 +166,6 @@ export const attachStyles = (hostRef: d.HostRef) => {
  */
 export const getScopeId = (cmp: d.ComponentRuntimeMeta, mode?: string) =>
   'sc-' + (BUILD.mode && mode && cmp.$flags$ & CMP_FLAGS.hasMode ? cmp.$tagName$ + '-' + mode : cmp.$tagName$);
-
-/**
- * Convert a 'scoped' CSS string to one appropriate for use in the shadow DOM.
- *
- * Given a 'scoped' CSS string that looks like this:
- *
- * ```
- * /*!@div*\/div.class-name { display: flex };
- * ```
- *
- * Convert it to a 'shadow' appropriate string, like so:
- *
- * ```
- *  /*!@div*\/div.class-name { display: flex }
- *      ─┬─                  ────────┬────────
- *       │                           │
- *       │         ┌─────────────────┘
- *       ▼         ▼
- *      div{ display: flex }
- * ```
- *
- * Note that forward-slashes in the above are escaped so they don't end the
- * comment.
- *
- * @param css a CSS string to convert
- * @returns the converted string
- */
-export const convertScopedToShadow = (css: string) => css.replace(/\/\*!@([^\/]+)\*\/[^\{]+\{/g, '$1{');
 
 declare global {
   export interface CSSStyleSheet {

--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -102,6 +102,7 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
             ((cmpMeta.$flags$ & CMP_FLAGS.shadowDomEncapsulation) && styleContainerNode.nodeName !== 'HEAD')
           );
           if (injectStyle) {
+            console.log
             styleContainerNode.insertBefore(styleElm, styleContainerNode.querySelector('link'));
           }
         }
@@ -139,7 +140,7 @@ export const attachStyles = (hostRef: d.HostRef) => {
     hostRef.$modeName$,
   );
 
-  if ((BUILD.shadowDom || BUILD.scoped) && BUILD.cssAnnotations && flags & CMP_FLAGS.needsScopedEncapsulation) {
+  if ((BUILD.shadowDom || BUILD.scoped) && BUILD.cssAnnotations && flags & CMP_FLAGS.needsScopedEncapsulation && (flags & CMP_FLAGS.scopedCssEncapsulation)) {
     // only required when we're NOT using native shadow dom (slot)
     // or this browser doesn't support native shadow dom
     // and this host element was NOT created with SSR

--- a/src/runtime/test/shadow.spec.tsx
+++ b/src/runtime/test/shadow.spec.tsx
@@ -84,17 +84,17 @@ describe('shadow', () => {
     });
 
     const expected = `
-    <cmp-a class="hydrated sc-cmp-a-h">
+    <cmp-a class="hydrated">
       <!---->
-      <div class="sc-cmp-a sc-cmp-a-s">
-        <span class="sc-cmp-a" slot=\"start\">
+      <div>
+        <span slot=\"start\">
           Start
         </span>
-        <span class='sc-cmp-a sc-cmp-a-s'>
+        <span>
           Text
         </span>
-        <div class='end sc-cmp-a sc-cmp-a-s'>
-          <span class="sc-cmp-a" slot=\"end\">
+        <div class="end">
+          <span slot=\"end\">
             End
           </span>
         </div>

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -105,7 +105,13 @@ const createElm = (oldParentVNode: d.VNode, newParentVNode: d.VNode, childIndex:
       updateElement(null, newVNode, isSvgMode);
     }
 
-    if ((BUILD.shadowDom || BUILD.scoped) && isDef(scopeId) && elm['s-si'] !== scopeId) {
+    /**
+     * walk up the DOM tree and check if we are in a shadow root because if we are within
+     * a shadow root DOM we don't need to attach scoped class names to the element
+     */
+    const rootNode = elm.getRootNode() as HTMLElement;
+    const isElementWithinShadowRoot = !rootNode.querySelector('body');
+    if (!isElementWithinShadowRoot && BUILD.scoped && isDef(scopeId) && elm['s-si'] !== scopeId) {
       // if there is a scopeId and this is the initial render
       // then let's add the scopeId as a css class
       elm.classList.add((elm['s-si'] = scopeId));

--- a/src/utils/shadow-css.ts
+++ b/src/utils/shadow-css.ts
@@ -425,12 +425,7 @@ const scopeSelector = (selector: string, scopeSelectorText: string, hostSelector
     .join(', ');
 };
 
-const scopeSelectors = (
-  cssText: string,
-  scopeSelectorText: string,
-  hostSelector: string,
-  slotSelector: string,
-) => {
+const scopeSelectors = (cssText: string, scopeSelectorText: string, hostSelector: string, slotSelector: string) => {
   return processRules(cssText, (rule: CssRule) => {
     let selector = rule.selector;
     let content = rule.content;
@@ -453,12 +448,7 @@ const scopeSelectors = (
   });
 };
 
-const scopeCssText = (
-  cssText: string,
-  scopeId: string,
-  hostScopeId: string,
-  slotScopeId: string,
-) => {
+const scopeCssText = (cssText: string, scopeId: string, hostScopeId: string, slotScopeId: string) => {
   cssText = insertPolyfillHostInCssText(cssText);
   cssText = convertColonHost(cssText);
   cssText = convertColonHostContext(cssText);

--- a/src/utils/test/scope-css.spec.ts
+++ b/src/utils/test/scope-css.spec.ts
@@ -15,8 +15,8 @@ import { convertScopedToShadow } from '../../runtime/styles';
 import { scopeCss } from '../shadow-css';
 
 describe('ShadowCss', function () {
-  function s(cssText: string, scopeId: string, commentOriginalSelector = false) {
-    const shim = scopeCss(cssText, scopeId, commentOriginalSelector);
+  function s(cssText: string, scopeId: string) {
+    const shim = scopeCss(cssText, scopeId);
 
     const nlRegexp = /\n/g;
     return normalizeCSS(shim.replace(nlRegexp, ''));
@@ -24,21 +24,6 @@ describe('ShadowCss', function () {
 
   it('should handle empty string', () => {
     expect(s('', 'a')).toEqual('');
-  });
-
-  it('should handle empty string, commented org selector', () => {
-    expect(s('', 'a', true)).toEqual('');
-  });
-
-  it('div', () => {
-    const r = s('div {}', 'sc-ion-tag', true);
-    expect(r).toEqual('/*!@div*/div.sc-ion-tag {}');
-  });
-
-  it('should add an attribute to every rule, commented org selector', () => {
-    const css = 'one {color: red;}two {color: red;}';
-    const expected = '/*!@one*/one.a {color:red;}/*!@two*/two.a {color:red;}';
-    expect(s(css, 'a', true)).toEqual(expected);
   });
 
   it('should add an attribute to every rule', () => {
@@ -71,22 +56,10 @@ describe('ShadowCss', function () {
     expect(s(css, 'a')).toEqual(expected);
   });
 
-  it('should handle media rules, commentOriginalSelector', () => {
-    const css = '@media screen and (max-width:800px, max-height:100%) {div {font-size:50px;}}';
-    const expected = '@media screen and (max-width:800px, max-height:100%) {/*!@div*/div.a {font-size:50px;}}';
-    expect(s(css, 'a', true)).toEqual(expected);
-  });
-
   it('should handle page rules', () => {
     const css = '@page {div {font-size:50px;}}';
     const expected = '@page {div.a {font-size:50px;}}';
     expect(s(css, 'a')).toEqual(expected);
-  });
-
-  it('should handle page rules, commentOriginalSelector', () => {
-    const css = '@page {div {font-size:50px;}}';
-    const expected = '@page {/*!@div*/div.a {font-size:50px;}}';
-    expect(s(css, 'a', true)).toEqual(expected);
   });
 
   it('should handle document rules', () => {
@@ -111,11 +84,6 @@ describe('ShadowCss', function () {
   it('should handle keyframes rules', () => {
     const css = '@keyframes foo {0% {transform:translate(-50%) scaleX(0);}}';
     expect(s(css, 'a')).toEqual(css);
-  });
-
-  it('should handle keyframes rules, commentOriginalSelector', () => {
-    const css = '@keyframes foo {0% {transform:translate(-50%) scaleX(0);}}';
-    expect(s(css, 'a', true)).toEqual(css);
   });
 
   it('should handle -webkit-keyframes rules', () => {
@@ -153,9 +121,6 @@ describe('ShadowCss', function () {
   });
 
   describe(':host', () => {
-    it('should handle no context, commentOriginalSelector', () => {
-      expect(s(':host {}', 'a', true)).toEqual('/*!@:host*/.a-h {}');
-    });
 
     it('should handle no context', () => {
       expect(s(':host {}', 'a')).toEqual('.a-h {}');
@@ -174,11 +139,6 @@ describe('ShadowCss', function () {
       expect(s(':host([a=b]) {}', 'a')).toEqual('[a="b"].a-h {}');
     });
 
-    it('should handle multiple tag selectors, commenting the original selector', () => {
-      expect(s(':host(ul,li) {}', 'a', true)).toEqual('/*!@:host(ul,li)*/ul.a-h, li.a-h {}');
-      expect(s(':host(ul,li) > .z {}', 'a', true)).toEqual('/*!@:host(ul,li) > .z*/ul.a-h > .z.a, li.a-h > .z.a {}');
-    });
-
     it('should handle multiple tag selectors', () => {
       expect(s(':host(ul,li) {}', 'a')).toEqual('ul.a-h, li.a-h {}');
       expect(s(':host(ul,li) > .z {}', 'a')).toEqual('ul.a-h > .z.a, li.a-h > .z.a {}');
@@ -191,10 +151,6 @@ describe('ShadowCss', function () {
 
     it('should handle multiple attribute selectors', () => {
       expect(s(':host([a="b"],[c=d]) {}', 'a')).toEqual('[a="b"].a-h, [c="d"].a-h {}');
-    });
-
-    it('should handle multiple attribute selectors, commentOriginalSelector', () => {
-      expect(s(':host([a="b"],[c=d]) {}', 'a', true)).toEqual('/*!@:host([a="b"],[c=d])*/[a="b"].a-h, [c="d"].a-h {}');
     });
 
     it('should handle pseudo selectors', () => {
@@ -215,13 +171,6 @@ describe('ShadowCss', function () {
   });
 
   describe(':host-context', () => {
-    it('should handle tag selector, commentOriginalSelector', () => {
-      expect(s(':host-context(div) {}', 'a', true)).toEqual('/*!@:host-context(div)*/div.a-h, div .a-h {}');
-      expect(s(':host-context(ul) > .y {}', 'a', true)).toEqual(
-        '/*!@:host-context(ul) > .y*/ul.a-h > .y.a, ul .a-h > .y.a {}',
-      );
-    });
-
     it('should handle tag selector', () => {
       expect(s(':host-context(div) {}', 'a')).toEqual('div.a-h, div .a-h {}');
       expect(s(':host-context(ul) > .y {}', 'a')).toEqual('ul.a-h > .y.a, ul .a-h > .y.a {}');
@@ -247,11 +196,6 @@ describe('ShadowCss', function () {
   });
 
   describe('::slotted', () => {
-    it('should handle *, commentOriginalSelector', () => {
-      const r = s('::slotted(*) {}', 'sc-ion-tag', true);
-      expect(r).toEqual('/*!@::slotted(*)*/.sc-ion-tag-s > * {}');
-    });
-
     it('should handle *', () => {
       const r = s('::slotted(*) {}', 'sc-ion-tag');
       expect(r).toEqual('.sc-ion-tag-s > * {}');
@@ -306,21 +250,9 @@ describe('ShadowCss', function () {
       expect(r).toEqual('.sc-ion-tag-s > * {}, .sc-ion-tag-s > * {}, .sc-ion-tag-s > * {}');
     });
 
-    it('same selectors, commentOriginalSelector', () => {
-      const r = s('::slotted(*) {}, ::slotted(*) {}, ::slotted(*) {}', 'sc-ion-tag', true);
-      expect(r).toEqual(
-        '/*!@::slotted(*)*/.sc-ion-tag-s > * {}/*!@, ::slotted(*)*/.sc-ion-tag, .sc-ion-tag-s > * {}/*!@, ::slotted(*)*/.sc-ion-tag, .sc-ion-tag-s > * {}',
-      );
-    });
-
     it('should combine parent selector when comma', () => {
       const r = s('.a .b, .c ::slotted(*) {}', 'sc-ion-tag');
       expect(r).toEqual('.a.sc-ion-tag .b.sc-ion-tag, .c.sc-ion-tag-s > *, .c .sc-ion-tag-s > * {}');
-    });
-
-    it('should handle multiple selector, commentOriginalSelector', () => {
-      const r = s('::slotted(ul), ::slotted(li) {}', 'sc-ion-tag', true);
-      expect(r).toEqual('/*!@::slotted(ul), ::slotted(li)*/.sc-ion-tag-s > ul, .sc-ion-tag-s > li {}');
     });
 
     it('should not replace the selector in a `@supports` rule', () => {

--- a/src/utils/test/scope-css.spec.ts
+++ b/src/utils/test/scope-css.spec.ts
@@ -121,7 +121,6 @@ describe('ShadowCss', function () {
   });
 
   describe(':host', () => {
-
     it('should handle no context', () => {
       expect(s(':host {}', 'a')).toEqual('.a-h {}');
     });

--- a/src/utils/test/scope-css.spec.ts
+++ b/src/utils/test/scope-css.spec.ts
@@ -11,7 +11,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { convertScopedToShadow } from '../../runtime/styles';
 import { scopeCss } from '../shadow-css';
 
 describe('ShadowCss', function () {
@@ -258,38 +257,6 @@ describe('ShadowCss', function () {
       expect(s('@supports selector(::slotted(*)) {::slotted(*) {color: red; }}', 'sc-cmp')).toEqual(
         '@supports selector(::slotted(*)) {.sc-cmp-s > * {color:red;}}',
       );
-    });
-  });
-
-  describe('convertScopedToShadow', () => {
-    it('media query', () => {
-      const input = `@media screen and (max-width:800px, max-height:100%) {/*!@div*/div.a {font-size:50px;}}`;
-      const expected = `@media screen and (max-width:800px, max-height:100%) {div{font-size:50px;}}`;
-      expect(convertScopedToShadow(input)).toBe(expected);
-    });
-
-    it('div', () => {
-      const input = `/*!@div*/div.sc-ion-tag {}`;
-      const expected = `div{}`;
-      expect(convertScopedToShadow(input)).toBe(expected);
-    });
-
-    it('new lines', () => {
-      const input = `/*!@div*/div.sc-ion-tag \n\n\n     \t{}`;
-      const expected = `div{}`;
-      expect(convertScopedToShadow(input)).toBe(expected);
-    });
-
-    it(':host', () => {
-      const input = `/*!@:host*/.a-h {}`;
-      const expected = `:host{}`;
-      expect(convertScopedToShadow(input)).toBe(expected);
-    });
-
-    it('::slotted', () => {
-      const input = `/*!@::slotted(ul), ::slotted(li)*/.sc-ion-tag-s > ul, .sc-ion-tag-s > li {}`;
-      const expected = `::slotted(ul), ::slotted(li){}`;
-      expect(convertScopedToShadow(input)).toBe(expected);
     });
   });
 

--- a/test/end-to-end/src/components.d.ts
+++ b/test/end-to-end/src/components.d.ts
@@ -43,6 +43,8 @@ export namespace Components {
     }
     interface CmpServerVsClient {
     }
+    interface CmpWithSlot {
+    }
     interface DomApi {
     }
     interface DomInteraction {
@@ -241,6 +243,12 @@ declare global {
         prototype: HTMLCmpServerVsClientElement;
         new (): HTMLCmpServerVsClientElement;
     };
+    interface HTMLCmpWithSlotElement extends Components.CmpWithSlot, HTMLStencilElement {
+    }
+    var HTMLCmpWithSlotElement: {
+        prototype: HTMLCmpWithSlotElement;
+        new (): HTMLCmpWithSlotElement;
+    };
     interface HTMLDomApiElement extends Components.DomApi, HTMLStencilElement {
     }
     var HTMLDomApiElement: {
@@ -406,6 +414,7 @@ declare global {
         "cmp-c": HTMLCmpCElement;
         "cmp-dsd": HTMLCmpDsdElement;
         "cmp-server-vs-client": HTMLCmpServerVsClientElement;
+        "cmp-with-slot": HTMLCmpWithSlotElement;
         "dom-api": HTMLDomApiElement;
         "dom-interaction": HTMLDomInteractionElement;
         "dom-visible": HTMLDomVisibleElement;
@@ -466,6 +475,8 @@ declare namespace LocalJSX {
         "initialCounter"?: number;
     }
     interface CmpServerVsClient {
+    }
+    interface CmpWithSlot {
     }
     interface DomApi {
     }
@@ -540,6 +551,7 @@ declare namespace LocalJSX {
         "cmp-c": CmpC;
         "cmp-dsd": CmpDsd;
         "cmp-server-vs-client": CmpServerVsClient;
+        "cmp-with-slot": CmpWithSlot;
         "dom-api": DomApi;
         "dom-interaction": DomInteraction;
         "dom-visible": DomVisible;
@@ -584,6 +596,7 @@ declare module "@stencil/core" {
             "cmp-c": LocalJSX.CmpC & JSXBase.HTMLAttributes<HTMLCmpCElement>;
             "cmp-dsd": LocalJSX.CmpDsd & JSXBase.HTMLAttributes<HTMLCmpDsdElement>;
             "cmp-server-vs-client": LocalJSX.CmpServerVsClient & JSXBase.HTMLAttributes<HTMLCmpServerVsClientElement>;
+            "cmp-with-slot": LocalJSX.CmpWithSlot & JSXBase.HTMLAttributes<HTMLCmpWithSlotElement>;
             "dom-api": LocalJSX.DomApi & JSXBase.HTMLAttributes<HTMLDomApiElement>;
             "dom-interaction": LocalJSX.DomInteraction & JSXBase.HTMLAttributes<HTMLDomInteractionElement>;
             "dom-visible": LocalJSX.DomVisible & JSXBase.HTMLAttributes<HTMLDomVisibleElement>;

--- a/test/end-to-end/src/declarative-shadow-dom/__snapshots__/test.e2e.ts.snap
+++ b/test/end-to-end/src/declarative-shadow-dom/__snapshots__/test.e2e.ts.snap
@@ -1,11 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renderToString can render a scoped component within a shadow component 1`] = `"<car-list cars=\\"[{&quot;make&quot;:&quot;VW&quot;,&quot;model&quot;:&quot;Vento&quot;,&quot;year&quot;:2024},{&quot;make&quot;:&quot;VW&quot;,&quot;model&quot;:&quot;Beetle&quot;,&quot;year&quot;:2023}]\\" class=\\"sc-car-list-h\\" custom-hydrate-flag=\\"\\" s-id=\\"1\\"><template shadowrootmode=\\"open\\"><style sty-id=\\"sc-car-list\\">/*!@:host*/.sc-car-list-h{display:block;margin:10px;padding:10px;border:1px solid blue}/*!@ul*/ul.sc-car-list{display:block;margin:0;padding:0}/*!@li*/li.sc-car-list{list-style:none;margin:0;padding:20px}/*!@.selected*/.selected.sc-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style><ul class=\\"sc-car-list\\" c-id=\\"1.0.0.0\\"><li class=\\"sc-car-list\\" c-id=\\"1.1.1.0\\"><car-detail class=\\"sc-car-list\\" custom-hydrate-flag=\\"\\" c-id=\\"1.2.2.0\\" s-id=\\"2\\"><!--r.2--><section class=\\"sc-car-list\\" c-id=\\"2.0.0.0\\"><!--t.2.1.1.0-->2024 VW Vento</section></car-detail></li><li class=\\"sc-car-list\\" c-id=\\"1.3.1.1\\"><car-detail class=\\"sc-car-list\\" custom-hydrate-flag=\\"\\" c-id=\\"1.4.2.0\\" s-id=\\"3\\"><!--r.3--><section class=\\"sc-car-list\\" c-id=\\"3.0.0.0\\"><!--t.3.1.1.0-->2023 VW Beetle</section></car-detail></li></ul></template><!--r.1--></car-list>"`;
+exports[`renderToString can render a scoped component within a shadow component 1`] = `"<car-list cars=\\"[{&quot;make&quot;:&quot;VW&quot;,&quot;model&quot;:&quot;Vento&quot;,&quot;year&quot;:2024},{&quot;make&quot;:&quot;VW&quot;,&quot;model&quot;:&quot;Beetle&quot;,&quot;year&quot;:2023}]\\" custom-hydrate-flag=\\"\\" s-id=\\"1\\"><template shadowrootmode=\\"open\\"><style>:host{display:block;margin:10px;padding:10px;border:1px solid blue}ul{display:block;margin:0;padding:0}li{list-style:none;margin:0;padding:20px}.selected{font-weight:bold;background:rgb(255, 255, 210)}</style><ul c-id=\\"1.0.0.0\\"><li c-id=\\"1.1.1.0\\"><car-detail custom-hydrate-flag=\\"\\" c-id=\\"1.2.2.0\\" s-id=\\"2\\"><!--r.2--><section c-id=\\"2.0.0.0\\"><!--t.2.1.1.0-->2024 VW Vento</section></car-detail></li><li c-id=\\"1.3.1.1\\"><car-detail custom-hydrate-flag=\\"\\" c-id=\\"1.4.2.0\\" s-id=\\"3\\"><!--r.3--><section c-id=\\"3.0.0.0\\"><!--t.3.1.1.0-->2023 VW Beetle</section></car-detail></li></ul></template><!--r.1--></car-list>"`;
 
-exports[`renderToString can render nested components 1`] = `"<another-car-list cars=\\"[{&quot;make&quot;:&quot;VW&quot;,&quot;model&quot;:&quot;Vento&quot;,&quot;year&quot;:2024},{&quot;make&quot;:&quot;VW&quot;,&quot;model&quot;:&quot;Beetle&quot;,&quot;year&quot;:2023}]\\" class=\\"sc-another-car-list-h\\" custom-hydrate-flag=\\"\\" s-id=\\"1\\"><template shadowrootmode=\\"open\\"><style sty-id=\\"sc-another-car-list\\">/*!@:host*/.sc-another-car-list-h{display:block;margin:10px;padding:10px;border:1px solid blue}/*!@ul*/ul.sc-another-car-list{display:block;margin:0;padding:0}/*!@li*/li.sc-another-car-list{list-style:none;margin:0;padding:20px}/*!@.selected*/.selected.sc-another-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style><ul class=\\"sc-another-car-list\\" c-id=\\"1.0.0.0\\"><li class=\\"sc-another-car-list\\" c-id=\\"1.1.1.0\\"><another-car-detail class=\\"sc-another-car-list sc-another-car-detail-h\\" custom-hydrate-flag=\\"\\" c-id=\\"1.2.2.0\\" s-id=\\"2\\"><template shadowrootmode=\\"open\\"><style sty-id=\\"sc-another-car-detail\\">/*!@section*/section.sc-another-car-detail{color:green}</style><section class=\\"sc-another-car-detail\\" c-id=\\"2.0.0.0\\"><!--t.2.1.1.0-->2024 VW Vento</section></template><!--r.2--></another-car-detail></li><li class=\\"sc-another-car-list\\" c-id=\\"1.3.1.1\\"><another-car-detail class=\\"sc-another-car-list sc-another-car-detail-h\\" custom-hydrate-flag=\\"\\" c-id=\\"1.4.2.0\\" s-id=\\"3\\"><template shadowrootmode=\\"open\\"><style sty-id=\\"sc-another-car-detail\\">/*!@section*/section.sc-another-car-detail{color:green}</style><section class=\\"sc-another-car-detail\\" c-id=\\"3.0.0.0\\"><!--t.3.1.1.0-->2023 VW Beetle</section></template><!--r.3--></another-car-detail></li></ul></template><!--r.1--></another-car-list>"`;
+exports[`renderToString can render a simple shadow component 1`] = `
+"<another-car-detail custom-hydrate-flag=\\"\\" s-id=\\"1\\">
+  <template shadowrootmode=\\"open\\">
+    <style>
+      section{color:green}
+    </style>
+  </template>
+  <!--r.1-->
+</another-car-detail>"
+`;
 
-exports[`renderToString renders scoped component 1`] = `"<another-car-detail class=\\"sc-another-car-detail-h\\" custom-hydrate-flag=\\"\\" s-id=\\"1\\"><template shadowrootmode=\\"open\\"><style sty-id=\\"sc-another-car-detail\\">/*!@section*/section.sc-another-car-detail{color:green}</style></template><!--r.1--></another-car-detail>"`;
+exports[`renderToString can render nested components 1`] = `
+"<another-car-list cars=\\"[{&quot;make&quot;:&quot;VW&quot;,&quot;model&quot;:&quot;Vento&quot;,&quot;year&quot;:2024},{&quot;make&quot;:&quot;VW&quot;,&quot;model&quot;:&quot;Beetle&quot;,&quot;year&quot;:2023}]\\" custom-hydrate-flag=\\"\\" s-id=\\"1\\">
+  <template shadowrootmode=\\"open\\">
+    <style>
+      :host{display:block;margin:10px;padding:10px;border:1px solid blue}ul{display:block;margin:0;padding:0}li{list-style:none;margin:0;padding:20px}.selected{font-weight:bold;background:rgb(255, 255, 210)}
+    </style>
+    <ul c-id=\\"1.0.0.0\\">
+      <li c-id=\\"1.1.1.0\\">
+        <another-car-detail c-id=\\"1.2.2.0\\" custom-hydrate-flag=\\"\\" s-id=\\"2\\">
+          <template shadowrootmode=\\"open\\">
+            <style>
+              section{color:green}
+            </style>
+            <section c-id=\\"2.0.0.0\\">
+              <!--t.2.1.1.0-->
+              2024 VW Vento
+            </section>
+          </template>
+          <!--r.2-->
+        </another-car-detail>
+      </li>
+      <li c-id=\\"1.3.1.1\\">
+        <another-car-detail c-id=\\"1.4.2.0\\" custom-hydrate-flag=\\"\\" s-id=\\"3\\">
+          <template shadowrootmode=\\"open\\">
+            <style>
+              section{color:green}
+            </style>
+            <section c-id=\\"3.0.0.0\\">
+              <!--t.3.1.1.0-->
+              2023 VW Beetle
+            </section>
+          </template>
+          <!--r.3-->
+        </another-car-detail>
+      </li>
+    </ul>
+  </template>
+  <!--r.1-->
+</another-car-list>"
+`;
 
-exports[`renderToString supports passing props to components 1`] = `"<another-car-detail car=\\"{&quot;year&quot;:2024, &quot;make&quot;: &quot;VW&quot;, &quot;model&quot;: &quot;Vento&quot;}\\" class=\\"sc-another-car-detail-h\\" custom-hydrate-flag=\\"\\" s-id=\\"1\\"><template shadowrootmode=\\"open\\"><style sty-id=\\"sc-another-car-detail\\">/*!@section*/section.sc-another-car-detail{color:green}</style><section class=\\"sc-another-car-detail\\" c-id=\\"1.0.0.0\\"><!--t.1.1.1.0-->2024 VW Vento</section></template><!--r.1--></another-car-detail>"`;
+exports[`renderToString supports passing props to components 1`] = `
+"<another-car-detail car=\\"{&quot;year&quot;:2024, &quot;make&quot;: &quot;VW&quot;, &quot;model&quot;: &quot;Vento&quot;}\\" custom-hydrate-flag=\\"\\" s-id=\\"1\\">
+  <template shadowrootmode=\\"open\\">
+    <style>
+      section{color:green}
+    </style>
+    <section c-id=\\"1.0.0.0\\">
+      <!--t.1.1.1.0-->
+      2024 VW Vento
+    </section>
+  </template>
+  <!--r.1-->
+</another-car-detail>"
+`;
 
-exports[`renderToString supports passing props to components with a simple object 1`] = `"<another-car-detail car=\\"{&quot;make&quot;:&quot;VW&quot;,&quot;model&quot;:&quot;Vento&quot;,&quot;year&quot;:2024}\\" class=\\"sc-another-car-detail-h\\" custom-hydrate-flag=\\"\\" s-id=\\"1\\"><template shadowrootmode=\\"open\\"><style sty-id=\\"sc-another-car-detail\\">/*!@section*/section.sc-another-car-detail{color:green}</style><section class=\\"sc-another-car-detail\\" c-id=\\"1.0.0.0\\"><!--t.1.1.1.0-->2024 VW Vento</section></template><!--r.1--></another-car-detail>"`;
+exports[`renderToString supports passing props to components with a simple object 1`] = `
+"<another-car-detail car=\\"{&quot;make&quot;:&quot;VW&quot;,&quot;model&quot;:&quot;Vento&quot;,&quot;year&quot;:2024}\\" custom-hydrate-flag=\\"\\" s-id=\\"1\\">
+  <template shadowrootmode=\\"open\\">
+    <style>
+      section{color:green}
+    </style>
+    <section c-id=\\"1.0.0.0\\">
+      <!--t.1.1.1.0-->
+      2024 VW Vento
+    </section>
+  </template>
+  <!--r.1-->
+</another-car-detail>"
+`;

--- a/test/end-to-end/src/declarative-shadow-dom/cmp-dsd.css
+++ b/test/end-to-end/src/declarative-shadow-dom/cmp-dsd.css
@@ -1,0 +1,11 @@
+:host {
+  display: block;
+  border: 1px solid black;
+  padding: 10px;
+}
+
+:host button {
+  background-color: lightblue;
+  border: 1px solid blue;
+  padding: 5px;
+}

--- a/test/end-to-end/src/declarative-shadow-dom/cmp-dsd.tsx
+++ b/test/end-to-end/src/declarative-shadow-dom/cmp-dsd.tsx
@@ -2,6 +2,7 @@ import { Component, h, Prop, State } from '@stencil/core';
 
 @Component({
   tag: 'cmp-dsd',
+  styleUrl: 'cmp-dsd.css',
   shadow: true,
 })
 export class ComponentDSD {

--- a/test/end-to-end/src/declarative-shadow-dom/cmp-with-slot.tsx
+++ b/test/end-to-end/src/declarative-shadow-dom/cmp-with-slot.tsx
@@ -1,0 +1,17 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'cmp-with-slot',
+  shadow: true,
+})
+export class ServerVSClientCmp {
+  render() {
+    return <div>
+      <div>
+        <div>
+          <slot></slot>
+        </div>
+      </div>
+    </div>;
+  }
+}

--- a/test/end-to-end/src/declarative-shadow-dom/cmp-with-slot.tsx
+++ b/test/end-to-end/src/declarative-shadow-dom/cmp-with-slot.tsx
@@ -6,12 +6,14 @@ import { Component, h } from '@stencil/core';
 })
 export class ServerVSClientCmp {
   render() {
-    return <div>
+    return (
       <div>
         <div>
-          <slot></slot>
+          <div>
+            <slot></slot>
+          </div>
         </div>
       </div>
-    </div>;
+    );
   }
 }

--- a/test/end-to-end/src/declarative-shadow-dom/test.e2e.ts
+++ b/test/end-to-end/src/declarative-shadow-dom/test.e2e.ts
@@ -113,7 +113,7 @@ describe('renderToString', () => {
       serializeShadowRoot: true,
       fullDocument: false,
     });
-    expect(html).toContain('<template shadowrootmode=\"open\"><style>section{color:green}</style>');
+    expect(html).toContain('<template shadowrootmode="open"><style>section{color:green}</style>');
   });
 
   it('only returns the element if we render to DSD', async () => {
@@ -148,7 +148,7 @@ describe('renderToString', () => {
       `<car-detail custom-hydrate-flag=\"\" c-id=\"1.2.2.0\" s-id=\"2\"><!--r.2--><section c-id=\"2.0.0.0\"><!--t.2.1.1.0-->2024 VW Vento</section></car-detail>`,
     );
     expect(html).toContain(
-      `<car-detail custom-hydrate-flag=\"\" c-id=\"1.4.2.0\" s-id=\"3\"><!--r.3--><section c-id=\"3.0.0.0\"><!--t.3.1.1.0-->2023 VW Beetle</section></car-detail>`
+      `<car-detail custom-hydrate-flag=\"\" c-id=\"1.4.2.0\" s-id=\"3\"><!--r.3--><section c-id=\"3.0.0.0\"><!--t.3.1.1.0-->2023 VW Beetle</section></car-detail>`,
     );
   });
 
@@ -276,7 +276,7 @@ describe('renderToString', () => {
       serializeShadowRoot: false,
       fullDocument: false,
     });
-    expect(html).toBe('<another-car-detail custom-hydrate-flag=\"\" s-id=\"1\"><!--r.1--></another-car-detail>');
+    expect(html).toBe('<another-car-detail custom-hydrate-flag="" s-id="1"><!--r.1--></another-car-detail>');
   });
 
   it('does not render a shadow component but its light dom', async () => {

--- a/test/end-to-end/src/declarative-shadow-dom/test.e2e.ts
+++ b/test/end-to-end/src/declarative-shadow-dom/test.e2e.ts
@@ -65,10 +65,11 @@ describe('renderToString', () => {
     expect(await readableToString(streamToString(input))).toContain(renderedHTML);
   });
 
-  it('renders scoped component', async () => {
+  it('can render a simple shadow component', async () => {
     const { html } = await renderToString('<another-car-detail></another-car-detail>', {
       serializeShadowRoot: true,
       fullDocument: false,
+      prettyHtml: true,
     });
     expect(html).toMatchSnapshot();
   });
@@ -79,6 +80,7 @@ describe('renderToString', () => {
       {
         serializeShadowRoot: true,
         fullDocument: false,
+        prettyHtml: true,
       },
     );
     expect(html).toMatchSnapshot();
@@ -89,6 +91,7 @@ describe('renderToString', () => {
     const { html } = await renderToString(`<another-car-detail car=${JSON.stringify(vento)}></another-car-detail>`, {
       serializeShadowRoot: true,
       fullDocument: false,
+      prettyHtml: true,
     });
     expect(html).toMatchSnapshot();
     expect(html).toContain('2024 VW Vento');
@@ -102,7 +105,7 @@ describe('renderToString', () => {
         fullDocument: false,
       },
     );
-    expect(html).toContain('<section class="sc-another-car-detail" c-id="1.0.0.0"><!--t.1.1.1.0--> </section>');
+    expect(html).toContain('<section c-id="1.0.0.0"><!--t.1.1.1.0--> </section>');
   });
 
   it('supports styles for DSD', async () => {
@@ -110,7 +113,7 @@ describe('renderToString', () => {
       serializeShadowRoot: true,
       fullDocument: false,
     });
-    expect(html).toContain('section.sc-another-car-detail{color:green}');
+    expect(html).toContain('<template shadowrootmode=\"open\"><style>section{color:green}</style>');
   });
 
   it('only returns the element if we render to DSD', async () => {
@@ -127,6 +130,7 @@ describe('renderToString', () => {
       {
         serializeShadowRoot: true,
         fullDocument: false,
+        prettyHtml: true,
       },
     );
     expect(html).toMatchSnapshot();
@@ -141,18 +145,18 @@ describe('renderToString', () => {
     });
     expect(html).toMatchSnapshot();
     expect(html).toContain(
-      '<car-detail class="sc-car-list" custom-hydrate-flag="" c-id="1.2.2.0" s-id="2"><!--r.2--><section class="sc-car-list" c-id="2.0.0.0"><!--t.2.1.1.0-->2024 VW Vento</section></car-detail>',
+      `<car-detail custom-hydrate-flag=\"\" c-id=\"1.2.2.0\" s-id=\"2\"><!--r.2--><section c-id=\"2.0.0.0\"><!--t.2.1.1.0-->2024 VW Vento</section></car-detail>`,
     );
     expect(html).toContain(
-      '<car-detail class="sc-car-list" custom-hydrate-flag="" c-id="1.4.2.0" s-id="3"><!--r.3--><section class="sc-car-list" c-id="3.0.0.0"><!--t.3.1.1.0-->2023 VW Beetle</section></car-detail>',
+      `<car-detail custom-hydrate-flag=\"\" c-id=\"1.4.2.0\" s-id=\"3\"><!--r.3--><section c-id=\"3.0.0.0\"><!--t.3.1.1.0-->2023 VW Beetle</section></car-detail>`
     );
   });
 
   it('can render a scoped component within a shadow component (sync)', async () => {
     const input = `<car-list cars=${JSON.stringify([vento, beetle])}></car-list>`;
     const expectedResults = [
-      '<car-detail class="sc-car-list" custom-hydrate-flag="" c-id="1.2.2.0" s-id="2"><!--r.2--><section class="sc-car-list" c-id="2.0.0.0"><!--t.2.1.1.0-->2024 VW Vento</section></car-detail>',
-      '<car-detail class="sc-car-list" custom-hydrate-flag="" c-id="1.4.2.0" s-id="3"><!--r.3--><section class="sc-car-list" c-id="3.0.0.0"><!--t.3.1.1.0-->2023 VW Beetle</section></car-detail>',
+      '<car-detail custom-hydrate-flag="" c-id="1.2.2.0" s-id="2"><!--r.2--><section c-id="2.0.0.0"><!--t.2.1.1.0-->2024 VW Vento</section></car-detail>',
+      '<car-detail custom-hydrate-flag="" c-id="1.4.2.0" s-id="3"><!--r.3--><section c-id="3.0.0.0"><!--t.3.1.1.0-->2023 VW Beetle</section></car-detail>',
     ] as const;
     const opts = {
       serializeShadowRoot: true,
@@ -221,21 +225,20 @@ describe('renderToString', () => {
     /**
      * renders the component with listener with proper vdom annotation, e.g.
      * ```html
-     * <dsd-listen-cmp class="sc-dsd-listen-cmp-h" custom-hydrate-flag="" s-id="1">
+     * <dsd-listen-cmp custom-hydrate-flag="" s-id="1">
      *   <template shadowrootmode="open">
      *     <style sty-id="sc-dsd-listen-cmp">
      *       .sc-dsd-listen-cmp-h{display:block}
      *     </style>
-     *     <slot c-id="1.0.0.0" class="sc-dsd-listen-cmp"></slot>
+     *     <slot c-id="1.0.0.0"></slot>
      *   </template>
      *   <!--r.1-->
      *   Hello World
      * </dsd-listen-cmp>
      * ```
      */
-
     expect(html).toContain(
-      `<dsd-listen-cmp class=\"sc-dsd-listen-cmp-h\" custom-hydrate-flag=\"\" s-id=\"1\"><template shadowrootmode=\"open\"><style sty-id=\"sc-dsd-listen-cmp\">/*!@:host*/.sc-dsd-listen-cmp-h{display:block}</style><slot class=\"sc-dsd-listen-cmp\" c-id=\"1.0.0.0\"></slot></template><!--r.1-->Hello World</dsd-listen-cmp>`,
+      `<dsd-listen-cmp custom-hydrate-flag=\"\" s-id=\"1\"><template shadowrootmode=\"open\"><style>:host{display:block}</style><slot c-id=\"1.0.0.0\"></slot></template><!--r.1-->Hello World</dsd-listen-cmp>`,
     );
 
     /**
@@ -250,7 +253,7 @@ describe('renderToString', () => {
      * </car-detail>
      */
     expect(html).toContain(
-      `<car-detail class=\"sc-car-list\" custom-hydrate-flag=\"\" c-id=\"2.4.2.0\" s-id=\"4\"><!--r.4--><section class=\"sc-car-list\" c-id=\"4.0.0.0\"><!--t.4.1.1.0-->2023 VW Beetle</section></car-detail>`,
+      `<car-detail custom-hydrate-flag=\"\" c-id=\"2.4.2.0\" s-id=\"4\"><!--r.4--><section c-id=\"4.0.0.0\"><!--t.4.1.1.0-->2023 VW Beetle</section></car-detail>`,
     );
   });
 
@@ -266,5 +269,21 @@ describe('renderToString', () => {
     expect(beforeHydrate).toHaveBeenCalledTimes(1);
     expect(afterHydrate).toHaveBeenCalledTimes(1);
     expect(html).toContain('<body><div>Hello Universe</div></body>');
+  });
+
+  it('does not render a shadow component if serializeShadowRoot is false', async () => {
+    const { html } = await renderToString('<another-car-detail></another-car-detail>', {
+      serializeShadowRoot: false,
+      fullDocument: false,
+    });
+    expect(html).toBe('<another-car-detail custom-hydrate-flag=\"\" s-id=\"1\"><!--r.1--></another-car-detail>');
+  });
+
+  it('does not render a shadow component but its light dom', async () => {
+    const { html } = await renderToString('<cmp-with-slot>Hello World</cmp-with-slot>', {
+      serializeShadowRoot: false,
+      fullDocument: false,
+    });
+    expect(html).toBe('<cmp-with-slot custom-hydrate-flag="" s-id="1"><!--r.1-->Hello World</cmp-with-slot>');
   });
 });

--- a/test/end-to-end/src/miscellaneous/renderToString.e2e.ts
+++ b/test/end-to-end/src/miscellaneous/renderToString.e2e.ts
@@ -45,7 +45,7 @@ describe('renderToString', () => {
      * renders hydration styles and custom link tag within the head tag
      */
     expect(html).toContain(
-      '}</style> <link rel=\"stylesheet\" href=\"whatever.css\"> </head> <body> <div class=\"__next\"> <main> <car-list',
+      '}</style> <link rel="stylesheet" href="whatever.css"> </head> <body> <div class="__next"> <main> <car-list',
     );
   });
 
@@ -79,7 +79,7 @@ describe('renderToString', () => {
      * renders hydration styles and custom link tag within the head tag
      */
     expect(html).toContain(
-      '.selected.sc-scoped-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style><link rel=\"stylesheet\" href=\"whatever.css\"> </head> <body> <div class=\"__next\"> <main> <scoped-car-list cars=',
+      '.selected.sc-scoped-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style><link rel="stylesheet" href="whatever.css"> </head> <body> <div class="__next"> <main> <scoped-car-list cars=',
     );
   });
 });

--- a/test/end-to-end/src/miscellaneous/renderToString.e2e.ts
+++ b/test/end-to-end/src/miscellaneous/renderToString.e2e.ts
@@ -36,6 +36,7 @@ describe('renderToString', () => {
       </html>`,
       { fullDocument: true, serializeShadowRoot: false },
     );
+
     /**
      * starts with a DocType and HTML tag
      */
@@ -44,7 +45,7 @@ describe('renderToString', () => {
      * renders hydration styles and custom link tag within the head tag
      */
     expect(html).toContain(
-      'selected.sc-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style><link rel="stylesheet" href="whatever.css"> </head> <body>',
+      '}</style> <link rel=\"stylesheet\" href=\"whatever.css\"> </head> <body> <div class=\"__next\"> <main> <car-list',
     );
   });
 
@@ -78,7 +79,7 @@ describe('renderToString', () => {
      * renders hydration styles and custom link tag within the head tag
      */
     expect(html).toContain(
-      '.selected.sc-scoped-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style><style sty-id="sc-another-car-detail">/*!@section*/section.sc-another-car-detail{color:green}</style><link rel="stylesheet" href="whatever.css"> </head> <body> <div class="__next"> <main> <scoped-car-list',
+      '.selected.sc-scoped-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style><link rel=\"stylesheet\" href=\"whatever.css\"> </head> <body> <div class=\"__next\"> <main> <scoped-car-list cars=',
     );
   });
 });

--- a/test/end-to-end/test-end-to-end-hydrate.js
+++ b/test/end-to-end/test-end-to-end-hydrate.js
@@ -8,6 +8,7 @@ async function main() {
     <head><title>End To End</title></head>
     <body>
       <prerender-cmp></prerender-cmp>
+      <slot-cmp>Hello World</slot-cmp>
     </body>
     </html>
   `;
@@ -26,10 +27,10 @@ async function main() {
     throw new Error(`validated test/end-to-end/hydrate errors!!`);
   }
 
-  if (results.hydratedCount !== 1) {
+  if (results.hydratedCount !== 2) {
     throw new Error(`invalid hydratedCount: ${results.hydratedCount}`);
   }
-  if (results.components.length !== 1 || results.components[0].tag !== 'prerender-cmp') {
+  if (results.components.length !== 2 || results.components[0].tag !== 'prerender-cmp' || results.components[1].tag !== 'slot-cmp') {
     throw new Error(`invalid components: ${results.components}`);
   }
   if (results.httpStatus !== 200) {

--- a/test/end-to-end/test-end-to-end-hydrate.js
+++ b/test/end-to-end/test-end-to-end-hydrate.js
@@ -30,7 +30,11 @@ async function main() {
   if (results.hydratedCount !== 2) {
     throw new Error(`invalid hydratedCount: ${results.hydratedCount}`);
   }
-  if (results.components.length !== 2 || results.components[0].tag !== 'prerender-cmp' || results.components[1].tag !== 'slot-cmp') {
+  if (
+    results.components.length !== 2 ||
+    results.components[0].tag !== 'prerender-cmp' ||
+    results.components[1].tag !== 'slot-cmp'
+  ) {
     throw new Error(`invalid components: ${results.components}`);
   }
   if (results.httpStatus !== 200) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
With previous versions of Stencil where we didn't not had support for DSD, we used to comment selectors and transform them so that shadow components can by hydrated as scoped components. To have the styles applied properly, we would transform them and keep the original selector commented, e.g.:

```diff
- div {font-size:50px;}}';
+ /*!@div*/div.a {font-size:50px;}}';
```

GitHub Issue Number: fixes #5880

Since component styles are handled at compile time there is no easy way for us to just render define this behavior when calling `renderToString`. Hence this PR will change the behavior of how shadow components are being serialized. It now __doesn't__ render the shadow DOM anymore if the `serializeShadowRoot` is set to false. Before Stencil would transform a shadow component into a scoped component. This behavior will be removed with this patch.

To keep Stencil somewhat backwards compatible, I switched the default value for `serializeShadowRoot` to `true`.

## What is the new behavior?
CSS style text is not transformed into scoped styles anymore, nor there is any selector commenting.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Updated tests and added new ones.

## Other information

n/a
