### PR TITLE
fix: add @stencil/core/testing/jest-preset to export map

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,9 @@
       "types": "./testing/index.d.ts",
       "require": "./testing/index.js"
     },
+    "./testing/jest-preset": {
+      "require": "./testing/jest-preset.js"
+    },
     "./testing/*": {
       "import": "./testing/*",
       "require": "./testing/*"

--- a/test/end-to-end/exportMap/index.js
+++ b/test/end-to-end/exportMap/index.js
@@ -7,6 +7,7 @@ const { MockDocument } = require('@stencil/core/mock-doc');
 const appData = require('@stencil/core/internal/app-data');
 const { createNodeLogger } = require('@stencil/core/sys/node');
 const { createTesting } = require('@stencil/core/testing');
+const preset = require('@stencil/core/testing/jest-preset');
 
 assert(typeof version === 'string');
 assert(typeof run, 'function');
@@ -15,6 +16,7 @@ assert(typeof MockDocument === 'function');
 assert(Object.keys(appData).length === 3);
 assert(typeof createNodeLogger === 'function');
 assert(typeof createTesting === 'function');
+assert(preset.moduleFileExtensions);
 
 console.log(`🎉 All CJS imports successfully resolved!`);
 console.log('✅ passed!\n');


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
When requiring `@stencil/core/testing/jest-preset` your import will fail as the module is not exported.

GitHub Issue Number: fixes #5896


## What is the new behavior?
Adding this to the export map. It wasn't very clear before which files are being used by users. So this fixes a regression I introduced by adding these export maps.

## Documentation

n/a

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Added a test for this.

## Other information

n/a
