### PR TITLE
fix(compiler): run copy task after other output targets

### DIFF
--- a/src/compiler/output-targets/index.ts
+++ b/src/compiler/output-targets/index.ts
@@ -28,13 +28,16 @@ export const generateOutputTargets = async (
   invalidateRollupCaches(compilerCtx);
 
   await Promise.all([
-    outputCopy(config, compilerCtx, buildCtx),
     outputCollection(config, compilerCtx, buildCtx, changedModuleFiles),
     outputCustomElements(config, compilerCtx, buildCtx),
     outputHydrateScript(config, compilerCtx, buildCtx),
     outputLazyLoader(config, compilerCtx),
     outputLazy(config, compilerCtx, buildCtx),
   ]);
+
+  // the user may want to copy compiled assets which requires above tasks to
+  // have finished first
+  await outputCopy(config, compilerCtx, buildCtx),
 
   // the www output target depends on the output of the lazy output target
   // since it attempts to inline the lazy build entry point into `index.html`

--- a/src/compiler/output-targets/index.ts
+++ b/src/compiler/output-targets/index.ts
@@ -35,21 +35,23 @@ export const generateOutputTargets = async (
     outputLazy(config, compilerCtx, buildCtx),
   ]);
 
-  // the user may want to copy compiled assets which requires above tasks to
-  // have finished first
-  await outputCopy(config, compilerCtx, buildCtx),
+  await Promise.all([
+    // the user may want to copy compiled assets which requires above tasks to
+    // have finished first
+    outputCopy(config, compilerCtx, buildCtx),
 
-  // the www output target depends on the output of the lazy output target
-  // since it attempts to inline the lazy build entry point into `index.html`
-  // so we want to ensure that the lazy OT has already completed and written
-  // all of its files before the www OT runs.
-  await outputWww(config, compilerCtx, buildCtx);
+    // the www output target depends on the output of the lazy output target
+    // since it attempts to inline the lazy build entry point into `index.html`
+    // so we want to ensure that the lazy OT has already completed and written
+    // all of its files before the www OT runs.
+    outputWww(config, compilerCtx, buildCtx),
 
-  // must run after all the other outputs
-  // since it validates files were created
-  await outputDocs(config, compilerCtx, buildCtx);
-  await outputTypes(config, compilerCtx, buildCtx);
-  await outputCustom(config, compilerCtx, buildCtx);
+    // must run after all the other outputs
+    // since it validates files were created
+    outputDocs(config, compilerCtx, buildCtx),
+    outputTypes(config, compilerCtx, buildCtx),
+    outputCustom(config, compilerCtx, buildCtx),
+  ]);
 
   timeSpan.finish('generate outputs finished');
 };


### PR DESCRIPTION
## What is the current behavior?
The copy task is run at the same time as other output targets which doesn't allow users to include any of the build artifacts into the copy task.

GitHub Issue Number: fixes #5592

## What is the new behavior?
Run the copy task after all build artifacts are generated. Since `outputCopy`, `outputWww`, `outputDocs`, `outputTypes` and `outputCustom` are not dependent on each other I wrapped them into a `Promise.all` so we don't increase the build time due to more sequential calls.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Not sure how to properly test this, hence if current build passes I would feel confident moving forward.

## Other information

STENCIL-1327