### PR TITLE
fix(runtime): hydrate shadow dom first

### DIFF
--- a/src/runtime/client-hydrate.ts
+++ b/src/runtime/client-hydrate.ts
@@ -181,7 +181,6 @@ const clientHydrate = (
         hostId,
       );
     }
-
   } else if (node.nodeType === NODE_TYPE.CommentNode) {
     // `${COMMENT_TYPE}.${hostId}.${nodeId}.${depth}.${index}`
     childIdSplt = node.nodeValue.split('.');

--- a/src/runtime/client-hydrate.ts
+++ b/src/runtime/client-hydrate.ts
@@ -295,11 +295,11 @@ export const initializeDocumentHydrate = (node: d.RenderNode, orgLocNodes: d.Pla
     let i = 0;
     if (node.shadowRoot) {
       for (; i < node.shadowRoot.childNodes.length; i++) {
-        initializeDocumentHydrate(node.shadowRoot.childNodes[i] as any, orgLocNodes);
+        initializeDocumentHydrate(node.shadowRoot.childNodes[i] as d.RenderNode, orgLocNodes);
       }
     }
     for (i = 0; i < node.childNodes.length; i++) {
-      initializeDocumentHydrate(node.childNodes[i] as any, orgLocNodes);
+      initializeDocumentHydrate(node.childNodes[i] as d.RenderNode, orgLocNodes);
     }
   } else if (node.nodeType === NODE_TYPE.CommentNode) {
     const childIdSplt = node.nodeValue.split('.');

--- a/src/runtime/client-hydrate.ts
+++ b/src/runtime/client-hydrate.ts
@@ -293,13 +293,13 @@ const clientHydrate = (
 export const initializeDocumentHydrate = (node: d.RenderNode, orgLocNodes: d.PlatformRuntime['$orgLocNodes$']) => {
   if (node.nodeType === NODE_TYPE.ElementNode) {
     let i = 0;
-    for (; i < node.childNodes.length; i++) {
-      initializeDocumentHydrate(node.childNodes[i] as any, orgLocNodes);
-    }
     if (node.shadowRoot) {
-      for (i = 0; i < node.shadowRoot.childNodes.length; i++) {
+      for (; i < node.shadowRoot.childNodes.length; i++) {
         initializeDocumentHydrate(node.shadowRoot.childNodes[i] as any, orgLocNodes);
       }
+    }
+    for (i = 0; i < node.childNodes.length; i++) {
+      initializeDocumentHydrate(node.childNodes[i] as any, orgLocNodes);
     }
   } else if (node.nodeType === NODE_TYPE.CommentNode) {
     const childIdSplt = node.nodeValue.split('.');

--- a/src/runtime/client-hydrate.ts
+++ b/src/runtime/client-hydrate.ts
@@ -154,19 +154,6 @@ const clientHydrate = (
       }
     }
 
-    // recursively drill down, end to start so we can remove nodes
-    for (i = node.childNodes.length - 1; i >= 0; i--) {
-      clientHydrate(
-        parentVNode,
-        childRenderNodes,
-        slotNodes,
-        shadowRootNodes,
-        hostElm,
-        node.childNodes[i] as any,
-        hostId,
-      );
-    }
-
     if (node.shadowRoot) {
       // keep drilling down through the shadow root nodes
       for (i = node.shadowRoot.childNodes.length - 1; i >= 0; i--) {
@@ -181,6 +168,20 @@ const clientHydrate = (
         );
       }
     }
+
+    // recursively drill down, end to start so we can remove nodes
+    for (i = node.childNodes.length - 1; i >= 0; i--) {
+      clientHydrate(
+        parentVNode,
+        childRenderNodes,
+        slotNodes,
+        shadowRootNodes,
+        hostElm,
+        node.childNodes[i] as any,
+        hostId,
+      );
+    }
+
   } else if (node.nodeType === NODE_TYPE.CommentNode) {
     // `${COMMENT_TYPE}.${hostId}.${nodeId}.${depth}.${index}`
     childIdSplt = node.nodeValue.split('.');

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -707,7 +707,8 @@ export const patch = (oldVNode: d.VNode, newVNode: d.VNode, isInitialRender = fa
     } else if (
       // don't do this on initial render as it can cause non-hydrated content to be removed
       !isInitialRender &&
-      BUILD.updatable && oldChildren !== null
+      BUILD.updatable &&
+      oldChildren !== null
     ) {
       // no new child vnodes, but there are old child vnodes to remove
       removeVnodes(oldChildren, 0, oldChildren.length - 1);

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -704,7 +704,11 @@ export const patch = (oldVNode: d.VNode, newVNode: d.VNode, isInitialRender = fa
       }
       // add the new vnode children
       addVnodes(elm, null, newVNode, newChildren, 0, newChildren.length - 1);
-    } else if (BUILD.updatable && oldChildren !== null) {
+    } else if (
+      // don't do this on initial render as it can cause non-hydrated content to be removed
+      !isInitialRender &&
+      BUILD.updatable && oldChildren !== null
+    ) {
       // no new child vnodes, but there are old child vnodes to remove
       removeVnodes(oldChildren, 0, oldChildren.length - 1);
     }

--- a/test/end-to-end/src/declarative-shadow-dom/test.e2e.ts
+++ b/test/end-to-end/src/declarative-shadow-dom/test.e2e.ts
@@ -218,7 +218,7 @@ describe('renderToString', () => {
     `,
       {
         serializeShadowRoot: true,
-        fullDocument: false,
+        fullDocument: true,
       },
     );
 
@@ -255,6 +255,10 @@ describe('renderToString', () => {
     expect(html).toContain(
       `<car-detail custom-hydrate-flag=\"\" c-id=\"2.4.2.0\" s-id=\"4\"><!--r.4--><section c-id=\"4.0.0.0\"><!--t.4.1.1.0-->2023 VW Beetle</section></car-detail>`,
     );
+
+    const page = await newE2EPage({ html, url: 'https://stencil.com' });
+    const cars = await page.findAll('>>>car-detail');
+    expect(cars.map((car) => car.textContent)).toEqual(['2024 VW Vento', '2023 VW Beetle']);
   });
 
   it('calls beforeHydrate and afterHydrate function hooks', async () => {


### PR DESCRIPTION
## What is the current behavior?
In order to support Next.js we have to inject the hydration comment into the template tag to properly supported nested components. This requires us to hydrate the shadow root first before hydrating the light dom.

## What is the new behavior?
When hydrating the component, walk through the shadow root first before light dom.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I did some manual test and it all seems fine. Not sure how we should test this from end to end or if a unit test makes sense.

## Other information

n/a
