### PR TITLE
fix(compiler): don't allow shadowRoot getter to avoid hydration issues

### DIFF
--- a/src/compiler/transformers/static-to-meta/component.ts
+++ b/src/compiler/transformers/static-to-meta/component.ts
@@ -26,7 +26,7 @@ const BLACKLISTED_COMPONENT_METHODS = [
    * If someone would define a getter called "shadowRoot" on a component
    * this would cause issues when Stencil tries to hydrate the component.
    */
-  'shadowRoot'
+  'shadowRoot',
 ];
 
 /**

--- a/src/compiler/transformers/test/parse-component.spec.ts
+++ b/src/compiler/transformers/test/parse-component.spec.ts
@@ -23,4 +23,48 @@ describe('parse component', () => {
 
     expect(t.componentClassName).toBe('CmpA');
   });
+
+  it('can not have shadowRoot getter', () => {
+    let error: Error | undefined;
+    try {
+      transpileModule(`
+        @Component({
+          tag: 'cmp-a'
+        })
+        export class CmpA {
+          get shadowRoot() {
+            return this;
+          }
+        }
+      `);
+    } catch (err: unknown) {
+      error = err as Error;
+    }
+
+    expect(error.message).toContain(
+      `The component "CmpA" has a getter called "shadowRoot". This getter is reserved for use by Stencil components and should not be defined by the user.`,
+    );
+  });
+
+  it('ignores shadowRoot getter in unrelated class', () => {
+    const t = transpileModule(`
+      @Component({
+        tag: 'cmp-a'
+      })
+      export class CmpA {
+        // use a better name for the getter
+        get elementShadowRoot() {
+          return this;
+        }
+      }
+
+      export class Unrelated {
+        get shadowRoot() {
+          return this;
+        }
+      }
+    `);
+
+    expect(t.componentClassName).toBe('CmpA');
+  });
 });


### PR DESCRIPTION
## What is the current behavior?
We have discovered an issue where a user is running into hydration issues due to the fact that they have defined a component getter like so:

```ts
  /**
   * Gets shadow root of nearest host element if one exists
   */
  private get shadowRoot() {
    return this.host.getRootNode() as ShadowRoot;
  }
```

## What is the new behavior?
The compiler now detects this class member in a Stencil components and throws a nice error making users aware that this is not allowed.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

This can potentially break for people that do this but don't do any client side hydration.

## Testing

Added sufficient unit tests.

## Other information

n/a
