### PR TITLE
chore(deps): don't update `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` until we update Eslint

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -73,6 +73,12 @@
       allowedVersions: '<9.0.0',
     },
     {
+      // TODO(STENCIL-1274): Remove this block
+      // disable Eslint plugin updates until we have updated Eslint to v9
+      matchPackageNames: ['@typescript-eslint/eslint-plugin', '@typescript-eslint/parser'],
+      allowedVersions: '<8.0.0',
+    },
+    {
       matchPackagePrefixes: ['@typescript-eslint'],
       groupName: 'TypeScript-ESLint',
       // these packages can be released often, let's look at them every week


### PR DESCRIPTION
## What is the current behavior?
Renovate tries to update these packages but they require an update to Eslint v9 which we have planned to do but haven't gotten around just yet.

## What is the new behavior?
Ignore updates to these packages for now.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
