### PR TITLE
fix(runtime): render component styles at the end of the head tag

### DIFF
--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -92,19 +92,17 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
           }
 
           /**
-           * only attach style tag to <head /> section if:
+           * attach styles at the end of the head tag if we render shadow components
            */
-          const injectStyle =
-            /**
-             * we render a scoped component
-             */
-            !(cmpMeta.$flags$ & CMP_FLAGS.shadowDomEncapsulation) ||
-            /**
-             * we are using shadow dom and render the style tag within the shadowRoot
-             */
-            (cmpMeta.$flags$ & CMP_FLAGS.shadowDomEncapsulation && styleContainerNode.nodeName !== 'HEAD');
-          if (injectStyle) {
-            styleContainerNode.insertBefore(styleElm, styleContainerNode.querySelector('link'));
+          if (!(cmpMeta.$flags$ & CMP_FLAGS.shadowDomEncapsulation)) {
+            styleContainerNode.append(styleElm);
+          }
+
+          /**
+           * attach styles at the beginning of a shadow root node if we render shadow components
+           */
+          if (cmpMeta.$flags$ & CMP_FLAGS.shadowDomEncapsulation && styleContainerNode.nodeName !== 'HEAD') {
+            styleContainerNode.insertBefore(styleElm);
           }
         }
 

--- a/test/end-to-end/src/miscellaneous/renderToString.e2e.ts
+++ b/test/end-to-end/src/miscellaneous/renderToString.e2e.ts
@@ -72,9 +72,13 @@ describe('renderToString', () => {
       { fullDocument: true, serializeShadowRoot: false },
     );
 
-    expect(html).toContain('<link rel="preconnect" href="https://some-url.com"> <style sty-id="sc-scoped-car-list">.sc-scoped-car-list-h{');
-    expect(html).toContain('.selected.sc-scoped-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style></head> <body> <div class=\"__next\"> <main> <scoped-car-list cars');
-  })
+    expect(html).toContain(
+      '<link rel="preconnect" href="https://some-url.com"> <style sty-id="sc-scoped-car-list">.sc-scoped-car-list-h{',
+    );
+    expect(html).toContain(
+      '.selected.sc-scoped-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style></head> <body> <div class="__next"> <main> <scoped-car-list cars',
+    );
+  });
 
   it('allows to hydrate whole HTML page with using a scoped component', async () => {
     const { html } = await renderToString(
@@ -106,7 +110,7 @@ describe('renderToString', () => {
      * renders hydration styles and custom link tag within the head tag
      */
     expect(html).toContain(
-      '<link rel=\"stylesheet\" href=\"whatever.css\"> <style sty-id=\"sc-scoped-car-list\">.sc-scoped-car-list-h{display:block;margin:10px;padding:10px;border:1px solid blue}ul.sc-scoped-car-list{display:block;margin:0;padding:0}li.sc-scoped-car-list{list-style:none;margin:0;padding:20px}.selected.sc-scoped-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style></head> <body> <div class=\"__next\"> <main> <scoped-car-list cars='
+      '<link rel="stylesheet" href="whatever.css"> <style sty-id="sc-scoped-car-list">.sc-scoped-car-list-h{display:block;margin:10px;padding:10px;border:1px solid blue}ul.sc-scoped-car-list{display:block;margin:0;padding:0}li.sc-scoped-car-list{list-style:none;margin:0;padding:20px}.selected.sc-scoped-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style></head> <body> <div class="__next"> <main> <scoped-car-list cars=',
     );
   });
 });

--- a/test/end-to-end/src/miscellaneous/renderToString.e2e.ts
+++ b/test/end-to-end/src/miscellaneous/renderToString.e2e.ts
@@ -49,6 +49,33 @@ describe('renderToString', () => {
     );
   });
 
+  it('puts style last in the head tag', async () => {
+    const { html } = await renderToString(
+      `<html>
+      <head>
+        <link rel="preconnect" href="https://some-url.com" />
+      </head>
+
+      <body>
+        <div class="__next">
+          <main>
+            <scoped-car-list cars=${JSON.stringify([vento, beetle])}></scoped-car-list>
+          </main>
+        </div>
+
+        <script type="module">
+            import { defineCustomElements } from "./static/loader/index.js";
+            defineCustomElements().catch(console.error);
+        </script>
+      </body>
+      </html>`,
+      { fullDocument: true, serializeShadowRoot: false },
+    );
+
+    expect(html).toContain('<link rel="preconnect" href="https://some-url.com"> <style sty-id="sc-scoped-car-list">.sc-scoped-car-list-h{');
+    expect(html).toContain('.selected.sc-scoped-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style></head> <body> <div class=\"__next\"> <main> <scoped-car-list cars');
+  })
+
   it('allows to hydrate whole HTML page with using a scoped component', async () => {
     const { html } = await renderToString(
       `<html>
@@ -79,7 +106,7 @@ describe('renderToString', () => {
      * renders hydration styles and custom link tag within the head tag
      */
     expect(html).toContain(
-      '.selected.sc-scoped-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style><link rel="stylesheet" href="whatever.css"> </head> <body> <div class="__next"> <main> <scoped-car-list cars=',
+      '<link rel=\"stylesheet\" href=\"whatever.css\"> <style sty-id=\"sc-scoped-car-list\">.sc-scoped-car-list-h{display:block;margin:10px;padding:10px;border:1px solid blue}ul.sc-scoped-car-list{display:block;margin:0;padding:0}li.sc-scoped-car-list{list-style:none;margin:0;padding:20px}.selected.sc-scoped-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style></head> <body> <div class=\"__next\"> <main> <scoped-car-list cars='
     );
   });
 });


### PR DESCRIPTION
## What is the current behavior?
The `<style />` tag for scoped components is added before any link tag. The behavior was implemented in https://github.com/ionic-team/stencil/commit/05d242d5d6ba558896495df3f7b923ca109c70d9 without any concrete description as to why. As reported in below linked issue it can cause links with `preconnect` attribute to be loaded later hence negatively impacting the performance of an application.

GitHub Issue Number: fixes #5915

## What is the new behavior?
Attach styles at the end of the `<head />` so that the browser can already load assets marked with `preconnect` before all styles are streamed over the wire.

An alternative would be to make this configurable but I don't think there is a viable reason why someone would want to have styles injected first. If someone reports the requirement for this we can add it to the backlog.

## Documentation

n/a

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Add an e2e test for this behavior.

## Other information

n/a
