### PR TITLE
fix(scripts): fix Esbuild scripts to allow to run on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,10 @@ on:
 jobs:
   build_core:
     name: Core
-    runs-on: 'ubuntu-22.04'
+    strategy:
+      matrix:
+        os: ['ubuntu-22.04', 'windows-latest']
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -29,6 +32,7 @@ jobs:
         shell: bash
 
       - name: Upload Build Artifacts
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
         uses: ./.github/workflows/actions/upload-archive
         with:
           name: stencil-core

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,3 +57,8 @@ jobs:
     name: Unit Tests
     needs: [build_core]
     uses: ./.github/workflows/test-unit.yml
+
+  wdio_tests:
+    name: WebdriverIO Tests
+    needs: [build_core]
+    uses: ./.github/workflows/test-wdio.yml

--- a/.github/workflows/test-wdio.yml
+++ b/.github/workflows/test-wdio.yml
@@ -1,21 +1,14 @@
 name: WebdriverIO Tests
 
 on:
-  merge_group:
-  pull_request:
-  push:
-    branches:
-      - 'main'
+  workflow_call:
+    # Make this a reusable workflow, no value needed
+    # https://docs.github.com/en/actions/using-workflows/reusing-workflows
 
 jobs:
-  build_core:
-    name: Build
-    uses: ./.github/workflows/build.yml
-
   run_wdio:
     name: Run WebdriverIO Component Tests (${{ matrix.browser }})
     runs-on: ubuntu-22.04
-    needs: [build_core]
     strategy:
       matrix:
         browser: [CHROME, FIREFOX, EDGE]
@@ -23,6 +16,9 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Get Core Dependencies
+        uses: ./.github/workflows/actions/get-core-dependencies
 
       - name: Use Node Version from Volta
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3

--- a/scripts/esbuild/cli.ts
+++ b/scripts/esbuild/cli.ts
@@ -30,10 +30,7 @@ export async function buildCli(opts: BuildOptions) {
   // this isn't strictly necessary to alias - however, this minimizes cuts down the bundle size by ~70kb.
   cliAliases['prompts'] = 'prompts/lib/index.js';
 
-  const external = [
-    ...getEsbuildExternalModules(opts, opts.output.cliDir),
-    '../testing/*',
-  ];
+  const external = [...getEsbuildExternalModules(opts, opts.output.cliDir), '../testing/*'];
 
   const cliEsbuildOptions = {
     ...getBaseEsbuildOptions(),

--- a/scripts/esbuild/cli.ts
+++ b/scripts/esbuild/cli.ts
@@ -5,7 +5,7 @@ import { join } from 'path';
 import { getBanner } from '../utils/banner';
 import { BuildOptions } from '../utils/options';
 import { writePkgJson } from '../utils/write-pkg-json';
-import { getBaseEsbuildOptions, getEsbuildAliases, getEsbuildExternalModules, runBuilds } from './utils';
+import { externalNodeModules, getBaseEsbuildOptions, getEsbuildAliases, runBuilds } from './utils';
 
 /**
  * Runs esbuild to bundle the `cli` submodule
@@ -30,7 +30,7 @@ export async function buildCli(opts: BuildOptions) {
   // this isn't strictly necessary to alias - however, this minimizes cuts down the bundle size by ~70kb.
   cliAliases['prompts'] = 'prompts/lib/index.js';
 
-  const external = [...getEsbuildExternalModules(opts, opts.output.cliDir), '../testing/*'];
+  const external = [...externalNodeModules, '../testing/*'];
 
   const cliEsbuildOptions = {
     ...getBaseEsbuildOptions(),

--- a/scripts/esbuild/cli.ts
+++ b/scripts/esbuild/cli.ts
@@ -30,7 +30,10 @@ export async function buildCli(opts: BuildOptions) {
   // this isn't strictly necessary to alias - however, this minimizes cuts down the bundle size by ~70kb.
   cliAliases['prompts'] = 'prompts/lib/index.js';
 
-  const external = getEsbuildExternalModules(opts, opts.output.cliDir);
+  const external = [
+    ...getEsbuildExternalModules(opts, opts.output.cliDir),
+    '../testing/*',
+  ];
 
   const cliEsbuildOptions = {
     ...getBaseEsbuildOptions(),

--- a/scripts/esbuild/compiler.ts
+++ b/scripts/esbuild/compiler.ts
@@ -46,11 +46,13 @@ export async function buildCompiler(opts: BuildOptions) {
 
   const alias: Record<string, string> = {
     ...getEsbuildAliases(),
-    glob: '../sys/node/glob.js',
+    glob: './sys/node/glob.js',
+    '@stencil/core/mock-doc': './mock-doc/index.cjs',
   };
 
   const external = [
     ...getEsbuildExternalModules(opts, opts.output.compilerDir),
+    '../mock-doc/index.cjs',
     '../sys/node/autoprefixer.js',
     '../sys/node/index.js',
   ];

--- a/scripts/esbuild/compiler.ts
+++ b/scripts/esbuild/compiler.ts
@@ -44,7 +44,10 @@ export async function buildCompiler(opts: BuildOptions) {
   transpileDts = transpileDts.replace('@stencil/core/internal', '../internal/index');
   await fs.writeFile(join(opts.output.compilerDir, 'transpile.d.ts'), transpileDts);
 
-  const alias = getEsbuildAliases();
+  const alias: Record<string, string> = {
+    ...getEsbuildAliases(),
+    glob: '../sys/node/glob.js',
+  };
 
   const external = [
     ...getEsbuildExternalModules(opts, opts.output.compilerDir),

--- a/scripts/esbuild/compiler.ts
+++ b/scripts/esbuild/compiler.ts
@@ -48,6 +48,7 @@ export async function buildCompiler(opts: BuildOptions) {
     ...getEsbuildAliases(),
     glob: './sys/node/glob.js',
     '@stencil/core/mock-doc': './mock-doc/index.cjs',
+    '@sys-api-node': '../sys/node/index.js',
   };
 
   const external = [

--- a/scripts/esbuild/compiler.ts
+++ b/scripts/esbuild/compiler.ts
@@ -6,7 +6,7 @@ import { join } from 'path';
 import { getBanner } from '../utils/banner';
 import { BuildOptions, createReplaceData } from '../utils/options';
 import { writePkgJson } from '../utils/write-pkg-json';
-import { getBaseEsbuildOptions, getEsbuildAliases, getEsbuildExternalModules, runBuilds } from './utils';
+import { externalNodeModules, getBaseEsbuildOptions, getEsbuildAliases, runBuilds } from './utils';
 import { bundleParse5 } from './utils/parse5';
 import { bundleTerser } from './utils/terser';
 import { bundleTypeScriptSource, tsCacheFilePath } from './utils/typescript-source';
@@ -51,7 +51,7 @@ export async function buildCompiler(opts: BuildOptions) {
   };
 
   const external = [
-    ...getEsbuildExternalModules(opts, opts.output.compilerDir),
+    ...externalNodeModules,
     '../mock-doc/index.cjs',
     '../sys/node/autoprefixer.js',
     '../sys/node/index.js',

--- a/scripts/esbuild/compiler.ts
+++ b/scripts/esbuild/compiler.ts
@@ -47,7 +47,6 @@ export async function buildCompiler(opts: BuildOptions) {
   const alias: Record<string, string> = {
     ...getEsbuildAliases(),
     glob: './sys/node/glob.js',
-    '@stencil/core/mock-doc': './mock-doc/index.cjs',
     '@sys-api-node': '../sys/node/index.js',
   };
 

--- a/scripts/esbuild/dev-server.ts
+++ b/scripts/esbuild/dev-server.ts
@@ -78,7 +78,11 @@ export async function buildDevServer(opts: BuildOptions) {
     './open-in-editor-api',
   ];
 
-  const devServerAliases = getEsbuildAliases();
+  const devServerAliases = {
+    ...getEsbuildAliases(),
+    glob: '../../sys/node/glob.js',
+    '@stencil/core/mock-doc': '../../mock-doc/index.cjs',
+  };
   const devServerIndexEsbuildOptions = {
     ...getBaseEsbuildOptions(),
     alias: devServerAliases,
@@ -98,6 +102,8 @@ export async function buildDevServer(opts: BuildOptions) {
     ...getBaseEsbuildOptions(),
     alias: {
       ...devServerAliases,
+      glob: '../../sys/node/glob.js',
+      '@stencil/core/mock-doc': '../../mock-doc/index.cjs',
       '@sys-api-node': '../sys/node/index.js',
     },
     entryPoints: [join(inputDir, 'server-process.js')],
@@ -118,7 +124,9 @@ export async function buildDevServer(opts: BuildOptions) {
   } satisfies ESBuildOptions;
 
   const connectorAlias = {
+    glob: '../../sys/node/glob.js',
     '@stencil/core/dev-server/client': join(inputDir, 'client', 'index.js'),
+    '@stencil/core/mock-doc': '../../mock-doc/index.cjs',
   };
   const connectorEsbuildOptions = {
     ...getBaseEsbuildOptions(),

--- a/scripts/esbuild/internal-platform-client.ts
+++ b/scripts/esbuild/internal-platform-client.ts
@@ -7,7 +7,7 @@ import { join } from 'path';
 import { getBanner } from '../utils/banner';
 import { BuildOptions, createReplaceData } from '../utils/options';
 import { writePkgJson } from '../utils/write-pkg-json';
-import { externalAlias, getBaseEsbuildOptions, getEsbuildAliases, getEsbuildExternalModules } from './utils';
+import { externalAlias, externalNodeModules, getBaseEsbuildOptions, getEsbuildAliases } from './utils';
 
 /**
  * Create objects containing ESbuild options for the two bundles which need to
@@ -41,7 +41,7 @@ export async function getInternalClientBundles(opts: BuildOptions): Promise<ESBu
   const internalClientAliases = getEsbuildAliases();
   internalClientAliases['@platform'] = join(inputClientDir, 'index.ts');
 
-  const clientExternal = getEsbuildExternalModules(opts, opts.output.internalDir);
+  const clientExternal = externalNodeModules;
 
   const internalClientBundle: ESBuildOptions = {
     ...getBaseEsbuildOptions(),
@@ -73,7 +73,7 @@ export async function getInternalClientBundles(opts: BuildOptions): Promise<ESBu
   }
 
   const patchBrowserExternal = [
-    ...getEsbuildExternalModules(opts, opts.output.internalDir),
+    ...externalNodeModules,
     '@stencil/core',
     '@stencil/core/mock-doc',
   ];

--- a/scripts/esbuild/internal-platform-client.ts
+++ b/scripts/esbuild/internal-platform-client.ts
@@ -72,11 +72,7 @@ export async function getInternalClientBundles(opts: BuildOptions): Promise<ESBu
     patchBrowserAliases[`polyfills/${polyFillFile}`] = join(opts.srcDir, 'client', 'polyfills');
   }
 
-  const patchBrowserExternal = [
-    ...externalNodeModules,
-    '@stencil/core',
-    '@stencil/core/mock-doc',
-  ];
+  const patchBrowserExternal = [...externalNodeModules, '@stencil/core', '@stencil/core/mock-doc'];
 
   const internalClientPatchBrowserBundle: ESBuildOptions = {
     ...getBaseEsbuildOptions(),

--- a/scripts/esbuild/internal-platform-client.ts
+++ b/scripts/esbuild/internal-platform-client.ts
@@ -69,7 +69,7 @@ export async function getInternalClientBundles(opts: BuildOptions): Promise<ESBu
 
   const polyfills = await fs.readdir(join(opts.srcDir, 'client', 'polyfills'));
   for (const polyFillFile of polyfills) {
-    patchBrowserAliases[join('./polyfills', polyFillFile)] = join(opts.srcDir, 'client', 'polyfills');
+    patchBrowserAliases[`polyfills/${polyFillFile}`] = join(opts.srcDir, 'client', 'polyfills');
   }
 
   const patchBrowserExternal = [

--- a/scripts/esbuild/internal-platform-hydrate.ts
+++ b/scripts/esbuild/internal-platform-hydrate.ts
@@ -6,7 +6,7 @@ import { getBanner } from '../utils/banner';
 import { bundleDts } from '../utils/bundle-dts';
 import { BuildOptions } from '../utils/options';
 import { writePkgJson } from '../utils/write-pkg-json';
-import { externalAlias, getBaseEsbuildOptions, getEsbuildAliases, getEsbuildExternalModules } from './utils';
+import { externalAlias, externalNodeModules, getBaseEsbuildOptions, getEsbuildAliases } from './utils';
 
 /**
  * Create objects containing ESbuild options for the two bundles comprising
@@ -35,7 +35,7 @@ export async function getInternalPlatformHydrateBundles(opts: BuildOptions): Pro
 
   const hydratePlatformInput = join(hydrateSrcDir, 'platform', 'index.js');
 
-  const external = getEsbuildExternalModules(opts, outputInternalHydrateDir);
+  const external = externalNodeModules;
 
   const internalHydrateAliases = getEsbuildAliases();
   internalHydrateAliases['@platform'] = hydratePlatformInput;

--- a/scripts/esbuild/internal-platform-testing.ts
+++ b/scripts/esbuild/internal-platform-testing.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 
 import { BuildOptions } from '../utils/options';
 import { writePkgJson } from '../utils/write-pkg-json';
-import { externalAlias, getBaseEsbuildOptions, getEsbuildAliases, getEsbuildExternalModules } from './utils';
+import { externalAlias, externalNodeModules, getBaseEsbuildOptions, getEsbuildAliases } from './utils';
 
 /**
  * Get an ESBuild configuration object for the internal testing bundle. This
@@ -34,7 +34,7 @@ export async function getInternalTestingBundle(opts: BuildOptions): Promise<ESBu
     '@stencil/core/mock-doc': '../../mock-doc/index.cjs',
   };
 
-  const external: string[] = [...getEsbuildExternalModules(opts, opts.output.internalDir), '../../mock-doc/index.cjs'];
+  const external: string[] = [...externalNodeModules, '../../mock-doc/index.cjs'];
 
   const internalTestingBuildOptions: ESBuildOptions = {
     ...getBaseEsbuildOptions(),

--- a/scripts/esbuild/internal-platform-testing.ts
+++ b/scripts/esbuild/internal-platform-testing.ts
@@ -31,9 +31,10 @@ export async function getInternalTestingBundle(opts: BuildOptions): Promise<ESBu
   const internalTestingAliases = {
     ...getEsbuildAliases(),
     '@platform': inputTestingPlatform,
+    '@stencil/core/mock-doc': '../../mock-doc/index.cjs',
   };
 
-  const external = getEsbuildExternalModules(opts, opts.output.internalDir);
+  const external: string[] = [...getEsbuildExternalModules(opts, opts.output.internalDir), '../../mock-doc/index.cjs'];
 
   const internalTestingBuildOptions: ESBuildOptions = {
     ...getBaseEsbuildOptions(),

--- a/scripts/esbuild/screenshot.ts
+++ b/scripts/esbuild/screenshot.ts
@@ -5,7 +5,7 @@ import { join } from 'path';
 import { getBanner } from '../utils/banner';
 import { BuildOptions } from '../utils/options';
 import { writePkgJson } from '../utils/write-pkg-json';
-import { getBaseEsbuildOptions, getEsbuildAliases, getEsbuildExternalModules, runBuilds } from './utils';
+import { externalNodeModules, getBaseEsbuildOptions, getEsbuildAliases, runBuilds } from './utils';
 
 const screenshotBuilds = {
   'Stencil Screenshot': 'index',
@@ -39,9 +39,7 @@ export async function buildScreenshot(opts: BuildOptions) {
   });
 
   const aliases = getEsbuildAliases();
-
-  const external = getEsbuildExternalModules(opts, opts.output.screenshotDir);
-
+  const external = externalNodeModules;
   const baseScreenshotOptions = {
     ...getBaseEsbuildOptions(),
     alias: aliases,

--- a/scripts/esbuild/sys-node.ts
+++ b/scripts/esbuild/sys-node.ts
@@ -1,6 +1,6 @@
 import type { BuildOptions as ESBuildOptions } from 'esbuild';
 import fs from 'fs-extra';
-import { join } from 'path';
+import path from 'path';
 import resolve from 'resolve';
 import webpack, { Configuration } from 'webpack';
 
@@ -10,18 +10,18 @@ import { writePkgJson } from '../utils/write-pkg-json';
 import { externalAlias, getBaseEsbuildOptions, getEsbuildAliases, getEsbuildExternalModules, runBuilds } from './utils';
 
 export async function buildSysNode(opts: BuildOptions) {
-  const inputDir = join(opts.buildDir, 'sys', 'node');
-  const srcDir = join(opts.srcDir, 'sys', 'node');
-  const inputFile = join(srcDir, 'index.ts');
-  const outputFile = join(opts.output.sysNodeDir, 'index.js');
+  const inputDir = path.join(opts.buildDir, 'sys', 'node');
+  const srcDir = path.join(opts.srcDir, 'sys', 'node');
+  const inputFile = path.join(srcDir, 'index.ts');
+  const outputFile = path.join(opts.output.sysNodeDir, 'index.js');
 
   // clear out rollup stuff and ensure directory exists
   await fs.emptyDir(opts.output.sysNodeDir);
 
   // create public d.ts
-  let dts = await fs.readFile(join(inputDir, 'public.d.ts'), 'utf8');
+  let dts = await fs.readFile(path.join(inputDir, 'public.d.ts'), 'utf8');
   dts = dts.replace('@stencil/core/internal', '../../internal/index');
-  await fs.writeFile(join(opts.output.sysNodeDir, 'index.d.ts'), dts);
+  await fs.writeFile(path.join(opts.output.sysNodeDir, 'index.d.ts'), dts);
 
   // write @stencil/core/sys/node/package.json
   writePkgJson(opts, opts.output.sysNodeDir, {
@@ -36,10 +36,15 @@ export async function buildSysNode(opts: BuildOptions) {
     // normally you wouldn't externalize your "own" directory here, but since
     // we build multiple things within `opts.output.sysNodeDir` which should
     // externalize each other we need to do so
-    join(opts.output.sysNodeDir, '*'),
+    '../../compiler/stencil.js',
+    '../../sys/node/*',
   ];
 
-  const sysNodeAliases = getEsbuildAliases();
+  const sysNodeAliases = {
+    ...getEsbuildAliases(),
+    '@stencil/core/compiler': '../../compiler/stencil.js',
+    '@sys-api-node': '../../sys/node/index.js',
+  };
 
   const sysNodeOptions: ESBuildOptions = {
     ...getBaseEsbuildOptions(),
@@ -57,8 +62,8 @@ export async function buildSysNode(opts: BuildOptions) {
   };
 
   // sys/node/worker.js bundle
-  const inputWorkerFile = join(srcDir, 'worker.ts');
-  const outputWorkerFile = join(opts.output.sysNodeDir, 'worker.js');
+  const inputWorkerFile = path.join(srcDir, 'worker.ts');
+  const outputWorkerFile = path.join(opts.output.sysNodeDir, 'worker.js');
 
   const workerOptions: ESBuildOptions = {
     ...getBaseEsbuildOptions(),
@@ -81,7 +86,7 @@ export async function buildSysNode(opts: BuildOptions) {
 
 export const sysNodeBundleCacheDir = 'sys-node-bundle-cache';
 async function sysNodeExternalBundles(opts: BuildOptions) {
-  const cachedDir = join(opts.scriptsBuildDir, sysNodeBundleCacheDir);
+  const cachedDir = path.join(opts.scriptsBuildDir, sysNodeBundleCacheDir);
 
   await fs.ensureDir(cachedDir);
 
@@ -101,27 +106,27 @@ async function sysNodeExternalBundles(opts: BuildOptions) {
    * is not supported by Jest v26. This is a workaround to remove the `node:`.
    * TODO(STENCIL-1323): remove once we deprecated Jest v26 support
    */
-  const globOutputPath = join(opts.output.sysNodeDir, 'glob.js');
+  const globOutputPath = path.join(opts.output.sysNodeDir, 'glob.js');
   const glob = fs.readFileSync(globOutputPath, 'utf8');
   fs.writeFileSync(globOutputPath, glob.replace(/require\("node:/g, 'require("'));
 
   // open-in-editor's visualstudio.vbs file
   // TODO(STENCIL-1052): remove once Rollup -> esbuild migration is complete
-  const visualstudioVbsSrc = join(opts.nodeModulesDir, 'open-in-editor', 'lib', 'editors', 'visualstudio.vbs');
-  const visualstudioVbsDesc = join(opts.output.devServerDir, 'visualstudio.vbs');
+  const visualstudioVbsSrc = path.join(opts.nodeModulesDir, 'open-in-editor', 'lib', 'editors', 'visualstudio.vbs');
+  const visualstudioVbsDesc = path.join(opts.output.devServerDir, 'visualstudio.vbs');
   await fs.copy(visualstudioVbsSrc, visualstudioVbsDesc);
 
   // copy open's xdg-open file
   // TODO(STENCIL-1052): remove once Rollup -> esbuild migration is complete
-  const xdgOpenSrcPath = join(opts.nodeModulesDir, 'open', 'xdg-open');
-  const xdgOpenDestPath = join(opts.output.devServerDir, 'xdg-open');
+  const xdgOpenSrcPath = path.join(opts.nodeModulesDir, 'open', 'xdg-open');
+  const xdgOpenDestPath = path.join(opts.output.devServerDir, 'xdg-open');
   await fs.copy(xdgOpenSrcPath, xdgOpenDestPath);
 }
 
 export function bundleExternal(opts: BuildOptions, outputDir: string, cachedDir: string, entryFileName: string) {
   return new Promise<void>(async (resolveBundle, rejectBundle) => {
-    const outputFile = join(outputDir, entryFileName);
-    const cachedFile = join(cachedDir, entryFileName) + (opts.isProd ? '.min.js' : '');
+    const outputFile = path.join(outputDir, entryFileName);
+    const cachedFile = path.join(cachedDir, entryFileName) + (opts.isProd ? '.min.js' : '');
 
     const cachedExists = fs.existsSync(cachedFile);
     if (cachedExists) {
@@ -132,7 +137,7 @@ export function bundleExternal(opts: BuildOptions, outputDir: string, cachedDir:
 
     const whitelist = new Set(['child_process', 'os', 'typescript']);
     const webpackConfig: Configuration = {
-      entry: join(opts.srcDir, 'sys', 'node', 'bundles', entryFileName),
+      entry: path.join(opts.srcDir, 'sys', 'node', 'bundles', entryFileName),
       output: {
         path: outputDir,
         filename: entryFileName,
@@ -166,10 +171,10 @@ export function bundleExternal(opts: BuildOptions, outputDir: string, cachedDir:
       },
       resolve: {
         alias: {
-          '@utils': join(opts.buildDir, 'utils', 'index.js'),
-          postcss: join(opts.nodeModulesDir, 'postcss'),
-          'source-map': join(opts.nodeModulesDir, 'source-map'),
-          chalk: join(opts.bundleHelpersDir, 'empty.js'),
+          '@utils': path.join(opts.buildDir, 'utils', 'index.js'),
+          postcss: path.join(opts.nodeModulesDir, 'postcss'),
+          'source-map': path.join(opts.nodeModulesDir, 'source-map'),
+          chalk: path.join(opts.bundleHelpersDir, 'empty.js'),
         },
       },
       optimization: {

--- a/scripts/esbuild/sys-node.ts
+++ b/scripts/esbuild/sys-node.ts
@@ -37,7 +37,7 @@ export async function buildSysNode(opts: BuildOptions) {
     // we build multiple things within `opts.output.sysNodeDir` which should
     // externalize each other we need to do so
     '../../compiler/stencil.js',
-    '../../sys/node/*',
+    '../../sys/node/index.js',
     './glob.js',
   ];
 

--- a/scripts/esbuild/sys-node.ts
+++ b/scripts/esbuild/sys-node.ts
@@ -7,7 +7,7 @@ import webpack, { Configuration } from 'webpack';
 import { getBanner } from '../utils/banner';
 import type { BuildOptions } from '../utils/options';
 import { writePkgJson } from '../utils/write-pkg-json';
-import { externalAlias, getBaseEsbuildOptions, getEsbuildAliases, getEsbuildExternalModules, runBuilds } from './utils';
+import { externalAlias, externalNodeModules, getBaseEsbuildOptions, getEsbuildAliases, runBuilds } from './utils';
 
 export async function buildSysNode(opts: BuildOptions) {
   const inputDir = path.join(opts.buildDir, 'sys', 'node');
@@ -32,7 +32,7 @@ export async function buildSysNode(opts: BuildOptions) {
   });
 
   const external = [
-    ...getEsbuildExternalModules(opts, opts.output.sysNodeDir),
+    ...externalNodeModules,
     // normally you wouldn't externalize your "own" directory here, but since
     // we build multiple things within `opts.output.sysNodeDir` which should
     // externalize each other we need to do so

--- a/scripts/esbuild/sys-node.ts
+++ b/scripts/esbuild/sys-node.ts
@@ -38,6 +38,7 @@ export async function buildSysNode(opts: BuildOptions) {
     // externalize each other we need to do so
     '../../compiler/stencil.js',
     '../../sys/node/*',
+    './glob.js',
   ];
 
   const sysNodeAliases = {

--- a/scripts/esbuild/testing.ts
+++ b/scripts/esbuild/testing.ts
@@ -1,6 +1,6 @@
 import type { BuildOptions as ESBuildOptions, Plugin } from 'esbuild';
 import fs from 'fs-extra';
-import { join } from 'path';
+import path from 'path';
 
 import { getBanner } from '../utils/banner';
 import type { BuildOptions } from '../utils/options';
@@ -24,13 +24,13 @@ const EXTERNAL_TESTING_MODULES = [
 ];
 
 export async function buildTesting(opts: BuildOptions) {
-  const inputDir = join(opts.buildDir, 'testing');
-  const sourceDir = join(opts.srcDir, 'testing');
+  const inputDir = path.join(opts.buildDir, 'testing');
+  const sourceDir = path.join(opts.srcDir, 'testing');
   await fs.emptyDir(opts.output.testingDir);
 
   await Promise.all([
     // copy jest testing entry files
-    fs.copy(join(opts.scriptsBundlesDir, 'helpers', 'jest'), opts.output.testingDir),
+    fs.copy(path.join(opts.scriptsBundlesDir, 'helpers', 'jest'), opts.output.testingDir),
     copyTestingInternalDts(opts, inputDir),
   ]);
 
@@ -46,6 +46,7 @@ export async function buildTesting(opts: BuildOptions) {
     ...EXTERNAL_TESTING_MODULES,
     ...getEsbuildExternalModules(opts, opts.output.testingDir),
     '../compiler/stencil.js',
+    '../internal/testing/*',
   ];
 
   const aliases = getEsbuildAliases();
@@ -54,10 +55,10 @@ export async function buildTesting(opts: BuildOptions) {
 
   const testingEsbuildOptions: ESBuildOptions = {
     ...getBaseEsbuildOptions(),
-    entryPoints: [join(sourceDir, 'index.ts')],
+    entryPoints: [path.join(sourceDir, 'index.ts')],
     bundle: true,
     format: 'cjs',
-    outfile: join(opts.output.testingDir, 'index.js'),
+    outfile: path.join(opts.output.testingDir, 'index.js'),
     platform: 'node',
     logLevel: 'info',
     external,
@@ -89,7 +90,7 @@ export async function buildTesting(opts: BuildOptions) {
 }
 
 function getLazyRequireFn(opts: BuildOptions) {
-  return fs.readFileSync(join(opts.bundleHelpersDir, 'lazy-require.js'), 'utf8').trim();
+  return fs.readFileSync(path.join(opts.bundleHelpersDir, 'lazy-require.js'), 'utf8').trim();
 }
 
 function lazyRequirePlugin(opts: BuildOptions, moduleIds: string[]): Plugin {
@@ -136,7 +137,7 @@ function ignorePuppeteerDependency(opts: BuildOptions): Plugin {
 export async function copyTestingInternalDts(opts: BuildOptions, inputDir: string) {
   // copy testing d.ts files
 
-  await fs.copy(join(inputDir), join(opts.output.testingDir), {
+  await fs.copy(path.join(inputDir), path.join(opts.output.testingDir), {
     filter: (f) => {
       if (f.endsWith('.d.ts')) {
         return true;
@@ -158,7 +159,7 @@ export async function copyTestingInternalDts(opts: BuildOptions, inputDir: strin
  * @param opts build options
  */
 export async function writePatchedPuppeteerDts(opts: BuildOptions) {
-  const typeFilePath = join(opts.output.testingDir, 'puppeteer', 'puppeteer-declarations.d.ts');
+  const typeFilePath = path.join(opts.output.testingDir, 'puppeteer', 'puppeteer-declarations.d.ts');
   const updatedFileContent = (await fs.readFile(typeFilePath, 'utf8'))
     .split('\n')
     .reduce((lines, line) => {

--- a/scripts/esbuild/testing.ts
+++ b/scripts/esbuild/testing.ts
@@ -45,8 +45,9 @@ export async function buildTesting(opts: BuildOptions) {
   const external = [
     ...EXTERNAL_TESTING_MODULES,
     ...getEsbuildExternalModules(opts, opts.output.testingDir),
-    '../compiler/stencil.js',
     '../internal/testing/*',
+    '../src/cli/*',
+    '../compiler/*',
   ];
 
   const aliases = getEsbuildAliases();

--- a/scripts/esbuild/testing.ts
+++ b/scripts/esbuild/testing.ts
@@ -48,7 +48,7 @@ export async function buildTesting(opts: BuildOptions) {
     '../internal/testing/*',
     '../cli/index.cjs',
     '../sys/node/index.js',
-    '../compiler/stencil.js'
+    '../compiler/stencil.js',
   ];
 
   const aliases = getEsbuildAliases();

--- a/scripts/esbuild/testing.ts
+++ b/scripts/esbuild/testing.ts
@@ -46,14 +46,12 @@ export async function buildTesting(opts: BuildOptions) {
     ...EXTERNAL_TESTING_MODULES,
     ...getEsbuildExternalModules(opts, opts.output.testingDir),
     '../internal/testing/*',
-    '../src/cli/*',
-    '../compiler/*',
+    '../cli/index.cjs',
+    '../sys/node/index.js',
+    '../compiler/stencil.js'
   ];
 
   const aliases = getEsbuildAliases();
-  // we want to point at the cjs module here because we're building cjs
-  aliases['@stencil/core/cli'] = './cli/index.cjs';
-
   const testingEsbuildOptions: ESBuildOptions = {
     ...getBaseEsbuildOptions(),
     entryPoints: [path.join(sourceDir, 'index.ts')],

--- a/scripts/esbuild/testing.ts
+++ b/scripts/esbuild/testing.ts
@@ -7,9 +7,9 @@ import type { BuildOptions } from '../utils/options';
 import { writePkgJson } from '../utils/write-pkg-json';
 import {
   externalAlias,
+  externalNodeModules,
   getBaseEsbuildOptions,
   getEsbuildAliases,
-  getEsbuildExternalModules,
   getFirstOutputFile,
   runBuilds,
 } from './utils';
@@ -44,7 +44,7 @@ export async function buildTesting(opts: BuildOptions) {
 
   const external = [
     ...EXTERNAL_TESTING_MODULES,
-    ...getEsbuildExternalModules(opts, opts.output.testingDir),
+    ...externalNodeModules,
     '../internal/testing/*',
     '../cli/index.cjs',
     '../sys/node/index.js',

--- a/scripts/esbuild/utils/index.ts
+++ b/scripts/esbuild/utils/index.ts
@@ -74,8 +74,8 @@ export function getEsbuildExternalModules(opts: BuildOptions, ownEntryPoint: str
      * transform the absolute path to a relative one
      */
     .map((p) => [
-      '..' + path.sep + 'src'  + path.sep + path.relative(root, path.join(p, '*')),
-      '.' + path.sep + 'src'  + path.sep + path.relative(root, path.join(p, '*'))
+      '..' + path.sep + 'src' + path.sep + path.relative(root, path.join(p, '*')),
+      '.' + path.sep + 'src' + path.sep + path.relative(root, path.join(p, '*')),
     ])
     .flat()
     /**

--- a/scripts/esbuild/utils/index.ts
+++ b/scripts/esbuild/utils/index.ts
@@ -37,7 +37,7 @@ export function getEsbuildAliases(): Record<string, string> {
  * as side-effect-free, which allows imports from them to be properly
  * tree-shaken.
  */
-const externalNodeModules = [
+export const externalNodeModules = [
   '@jest/core',
   '@jest/reporters',
   '@microsoft/typescript-etw',
@@ -54,39 +54,6 @@ const externalNodeModules = [
   'puppeteer-core',
   'yargs',
 ];
-
-/**
- * Get a manifest of modules which should be marked as external for a given
- * esbuild bundle
- *
- * @param opts options for the current build
- * @param ownEntryPoint the entry point alias of the current module
- * @returns a list of modules which should be marked as external
- */
-export function getEsbuildExternalModules(opts: BuildOptions, ownEntryPoint: string): string[] {
-  const root = path.resolve(__dirname, '..', '..', '..');
-  const bundles = Object.values(opts.output)
-    /**
-     * Filter out the `internal`, `cli`, and `compiler` directories, as they we intend to import
-     * these primitives directly from these packages.
-     */
-    .filter((bundle) => !bundle.endsWith('internal') && !bundle.endsWith('cli') && !bundle.endsWith('compiler') && !bundle.endsWith('screenshot') && !bundle.endsWith('mock-doc'))
-    .filter((outdir) => outdir !== ownEntryPoint)
-    /**
-     * transform the absolute path to a relative one
-     */
-    .map((p) => [
-      '..' + path.sep + 'src' + path.sep + path.relative(root, path.join(p, '*')),
-      '.' + path.sep + 'src' + path.sep + path.relative(root, path.join(p, '*')),
-    ])
-    .flat()
-    /**
-     * replace path separators with forward slashes
-     */
-    .map((p) => p.replaceAll(path.sep, '/'));
-
-  return [...externalNodeModules, ...bundles];
-}
 
 /**
  * A helper which runs an array of esbuild, uh, _builds_

--- a/scripts/esbuild/utils/index.ts
+++ b/scripts/esbuild/utils/index.ts
@@ -21,6 +21,8 @@ export function getEsbuildAliases(): Record<string, string> {
     '@stencil/core/dev-server': '../dev-server/index.js',
     '@stencil/core/mock-doc': '../mock-doc/index.cjs',
     '@stencil/core/internal/testing': '../internal/testing/index.js',
+    '@stencil/core/cli': '../cli/index.cjs',
+    '@sys-api-node': '../sys/node/index.js',
 
     // dev server related aliases
     ws: './ws.js',
@@ -68,7 +70,7 @@ export function getEsbuildExternalModules(opts: BuildOptions, ownEntryPoint: str
      * Filter out the `internal`, `cli`, and `compiler` directories, as they we intend to import
      * these primitives directly from these packages.
      */
-    .filter((bundle) => !bundle.endsWith('internal') && !bundle.endsWith('cli') && !bundle.endsWith('compiler'))
+    .filter((bundle) => !bundle.endsWith('internal') && !bundle.endsWith('cli') && !bundle.endsWith('compiler') && !bundle.endsWith('screenshot') && !bundle.endsWith('mock-doc'))
     .filter((outdir) => outdir !== ownEntryPoint)
     /**
      * transform the absolute path to a relative one

--- a/scripts/esbuild/utils/index.ts
+++ b/scripts/esbuild/utils/index.ts
@@ -1,6 +1,5 @@
 import type { BuildOptions as ESBuildOptions, BuildResult as ESBuildResult, OutputFile, Plugin } from 'esbuild';
-import * as esbuild from 'esbuild';
-import path from 'path';
+import { build, context } from 'esbuild';
 
 import { BuildOptions } from '../../utils/options';
 
@@ -70,12 +69,12 @@ export function runBuilds(builds: ESBuildOptions[], opts: BuildOptions): Promise
   if (opts.isWatch) {
     return Promise.all(
       builds.map(async (buildConfig) => {
-        const context = await esbuild.context(buildConfig);
-        return context.watch();
+        const ctx = await context(buildConfig);
+        return ctx.watch();
       }),
     );
   } else {
-    return Promise.all(builds.map(esbuild.build));
+    return Promise.all(builds.map(build));
   }
 }
 

--- a/scripts/esbuild/utils/index.ts
+++ b/scripts/esbuild/utils/index.ts
@@ -73,7 +73,11 @@ export function getEsbuildExternalModules(opts: BuildOptions, ownEntryPoint: str
     /**
      * transform the absolute path to a relative one
      */
-    .map((p) => '..' + path.sep + path.relative(root, path.join(p, '*')))
+    .map((p) => [
+      '..' + path.sep + 'src'  + path.sep + path.relative(root, path.join(p, '*')),
+      '.' + path.sep + 'src'  + path.sep + path.relative(root, path.join(p, '*'))
+    ])
+    .flat()
     /**
      * replace path separators with forward slashes
      */

--- a/scripts/test/validate-build.ts
+++ b/scripts/test/validate-build.ts
@@ -2,6 +2,7 @@ import fs from 'fs-extra';
 import { dirname, join, relative } from 'path';
 import { rollup } from 'rollup';
 import ts, { ModuleResolutionKind, ScriptTarget } from 'typescript';
+import url from 'url';
 
 import { NODE_BUILTINS } from '../utils/constants';
 import { BuildOptions, getOptions } from '../utils/options';
@@ -260,9 +261,9 @@ function validateDts(opts: BuildOptions, dtsEntries: string[]): void {
  * @param opts build options to be used to validate the compiler
  */
 async function validateCompiler(opts: BuildOptions): Promise<void> {
-  const compilerPath = join(opts.output.compilerDir, 'stencil.js');
-  const cliPath = join(opts.output.cliDir, 'index.cjs');
-  const sysNodePath = join(opts.output.sysNodeDir, 'index.js');
+  const compilerPath = url.pathToFileURL(join(opts.output.compilerDir, 'stencil.js')).pathname;
+  const cliPath = url.pathToFileURL(join(opts.output.cliDir, 'index.cjs')).pathname;
+  const sysNodePath = url.pathToFileURL(join(opts.output.sysNodeDir, 'index.js')).pathname;
 
   const compiler = await import(compilerPath);
   const cli = await import(cliPath);

--- a/scripts/test/validate-testing.js
+++ b/scripts/test/validate-testing.js
@@ -1,6 +1,6 @@
-var testing = require('../../testing/index.js');
+const testing = require('../../testing/index.js');
 
-var input = `
+const input = `
 import { Component, Prop } from '@stencil/core';
 @Component({
   tag: 'my-cmp'
@@ -10,10 +10,10 @@ export class MyCmp {
 }
 `;
 
-var output = testing.transpile(input);
+const output = testing.transpile(input);
 
 if (output.diagnostics.length > 0) {
-  var msg = output.diagnostics.map((d) => d.messageText).join('\n');
+  const msg = output.diagnostics.map((d) => d.messageText).join('\n');
   throw new Error('Testing transpile error: \n' + msg);
 }
 

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -7,7 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "lib": [
       "dom",
-      "es2020"
+      "es2021"
     ],
     "module": "NodeNext",
     "moduleResolution": "nodenext",


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
Stencil fails when trying to build it on a Windows machine.

STENCIL-1369

## What is the new behavior?
It turns out that the alias path needed to get normalized allowing Esbuild to pick up the right file and acknowledge it as external dependency.

This patch will also make some tweaks to the pipeline to run the `build` and `linter` tasks first and then run everything else. Before we were running WebdriverIO immediately.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Updated our pipeline to have the project being build on Windows so we ensure we don't introduce regressions.

## Other information

n/a
