### PR TITLE
fix(runtime): provide second arg to `insertBefore`

### DIFF
--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -102,7 +102,7 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
            * attach styles at the beginning of a shadow root node if we render shadow components
            */
           if (cmpMeta.$flags$ & CMP_FLAGS.shadowDomEncapsulation && styleContainerNode.nodeName !== 'HEAD') {
-            styleContainerNode.insertBefore(styleElm);
+            styleContainerNode.insertBefore(styleElm, null);
           }
         }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A

The runtime will throw an error when trying to apply styles to a Shadow component


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Styles will be applied without throwing an error

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
