### PR TITLE
fix(runtime): place scoped component styles after preconnect links but before custom styles

### DIFF
--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -101,7 +101,8 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
                * after the last preconnect link to ensure the styles are preloaded
                */
               const preconnectLinks = styleContainerNode.querySelectorAll('link[rel=preconnect]');
-              const referenceNode = preconnectLinks.length > 0
+              const referenceNode =
+                preconnectLinks.length > 0
                   ? preconnectLinks[preconnectLinks.length - 1].nextSibling
                   : document.querySelector('style');
               styleContainerNode.insertBefore(styleElm, referenceNode);

--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -100,9 +100,8 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
              * after the last preconnect link to ensure the styles are preloaded
              */
             const preconnectLinks = styleContainerNode.querySelectorAll('link[rel=preconnect]');
-            const lastPreconnectLinkSibling = preconnectLinks.length > 0
-              ? preconnectLinks[preconnectLinks.length - 1].nextSibling
-              : null;
+            const lastPreconnectLinkSibling =
+              preconnectLinks.length > 0 ? preconnectLinks[preconnectLinks.length - 1].nextSibling : null;
             styleContainerNode.insertBefore(styleElm, lastPreconnectLinkSibling);
           }
 

--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -95,14 +95,23 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
            * attach styles at the end of the head tag if we render scoped components
            */
           if (!(cmpMeta.$flags$ & CMP_FLAGS.shadowDomEncapsulation)) {
-            /**
-             * if the page contains preconnect links, we want to insert the styles
-             * after the last preconnect link to ensure the styles are preloaded
-             */
-            const preconnectLinks = styleContainerNode.querySelectorAll('link[rel=preconnect]');
-            const lastPreconnectLinkSibling =
-              preconnectLinks.length > 0 ? preconnectLinks[preconnectLinks.length - 1].nextSibling : document.querySelector('style');
-            styleContainerNode.insertBefore(styleElm, lastPreconnectLinkSibling);
+            if (styleContainerNode.nodeName === 'HEAD') {
+              /**
+               * if the page contains preconnect links, we want to insert the styles
+               * after the last preconnect link to ensure the styles are preloaded
+               */
+              const preconnectLinks = styleContainerNode.querySelectorAll('link[rel=preconnect]');
+              const referenceNode = preconnectLinks.length > 0
+                  ? preconnectLinks[preconnectLinks.length - 1].nextSibling
+                  : document.querySelector('style');
+              styleContainerNode.insertBefore(styleElm, referenceNode);
+            } else if ('host' in styleContainerNode) {
+              /**
+               * if a scoped component is used within a shadow root, we want to insert the styles
+               * at the beginning of the shadow root node
+               */
+              styleContainerNode.prepend(styleElm, null);
+            }
           }
 
           /**

--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -92,10 +92,18 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
           }
 
           /**
-           * attach styles at the end of the head tag if we render shadow components
+           * attach styles at the end of the head tag if we render scoped components
            */
           if (!(cmpMeta.$flags$ & CMP_FLAGS.shadowDomEncapsulation)) {
-            styleContainerNode.append(styleElm);
+            /**
+             * if the page contains preconnect links, we want to insert the styles
+             * after the last preconnect link to ensure the styles are preloaded
+             */
+            const preconnectLinks = styleContainerNode.querySelectorAll('link[rel=preconnect]');
+            const lastPreconnectLinkSibling = preconnectLinks.length > 0
+              ? preconnectLinks[preconnectLinks.length - 1].nextSibling
+              : null;
+            styleContainerNode.insertBefore(styleElm, lastPreconnectLinkSibling);
           }
 
           /**

--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -101,7 +101,7 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
              */
             const preconnectLinks = styleContainerNode.querySelectorAll('link[rel=preconnect]');
             const lastPreconnectLinkSibling =
-              preconnectLinks.length > 0 ? preconnectLinks[preconnectLinks.length - 1].nextSibling : null;
+              preconnectLinks.length > 0 ? preconnectLinks[preconnectLinks.length - 1].nextSibling : document.querySelector('style');
             styleContainerNode.insertBefore(styleElm, lastPreconnectLinkSibling);
           }
 

--- a/test/end-to-end/src/miscellaneous/renderToString.e2e.ts
+++ b/test/end-to-end/src/miscellaneous/renderToString.e2e.ts
@@ -54,6 +54,11 @@ describe('renderToString', () => {
       `<html>
       <head>
         <link rel="preconnect" href="https://some-url.com" />
+        <style>
+          .myComponent {
+            display: none;
+          }
+        </style>
       </head>
 
       <body>
@@ -72,11 +77,17 @@ describe('renderToString', () => {
       { fullDocument: true, serializeShadowRoot: false },
     );
 
+    /**
+     * expect the scoped component styles to be injected after the preconnect link
+     */
     expect(html).toContain(
-      '<link rel="preconnect" href="https://some-url.com"> <style sty-id="sc-scoped-car-list">.sc-scoped-car-list-h{',
+      '<link rel=\"preconnect\" href=\"https://some-url.com\"><style sty-id=\"sc-scoped-car-list\">.sc-scoped-car-list-h',
     );
-    expect(html).toContain(
-      '.selected.sc-scoped-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style></head> <body> <div class="__next"> <main> <scoped-car-list cars',
+    /**
+     * expect the custom style tag to be last in the head tag
+     */
+    expect(html.replaceAll(/\n[ ]+/g, '')).toContain(
+      `.selected.sc-scoped-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style> <style>.myComponent {display: none;}</style> </head> <body>`,
     );
   });
 

--- a/test/end-to-end/src/miscellaneous/renderToString.e2e.ts
+++ b/test/end-to-end/src/miscellaneous/renderToString.e2e.ts
@@ -81,7 +81,7 @@ describe('renderToString', () => {
      * expect the scoped component styles to be injected after the preconnect link
      */
     expect(html).toContain(
-      '<link rel=\"preconnect\" href=\"https://some-url.com\"><style sty-id=\"sc-scoped-car-list\">.sc-scoped-car-list-h',
+      '<link rel="preconnect" href="https://some-url.com"><style sty-id="sc-scoped-car-list">.sc-scoped-car-list-h',
     );
     /**
      * expect the custom style tag to be last in the head tag

--- a/test/end-to-end/src/miscellaneous/renderToString.e2e.ts
+++ b/test/end-to-end/src/miscellaneous/renderToString.e2e.ts
@@ -122,9 +122,9 @@ describe('renderToString', () => {
      * expect the scoped component styles to be injected before custom styles
      */
     expect(html.replaceAll(/\n[ ]*/g, '')).toContain(
-      '.selected.sc-scoped-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style><style class=\"vjs-styles-defaults\">.video-js {width: 300px;height: 150px;}.vjs-fluid {padding-top: 56.25%}</style> <style>.myComponent {display: none;}</style> </head>',
+      '.selected.sc-scoped-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style><style class="vjs-styles-defaults">.video-js {width: 300px;height: 150px;}.vjs-fluid {padding-top: 56.25%}</style> <style>.myComponent {display: none;}</style> </head>',
     );
-  })
+  });
 
   it('allows to hydrate whole HTML page with using a scoped component', async () => {
     const { html } = await renderToString(
@@ -156,7 +156,7 @@ describe('renderToString', () => {
      * renders hydration styles and custom link tag within the head tag
      */
     expect(html.replaceAll(/\n[ ]*/g, '')).toContain(
-      '<head><meta charset=\"utf-8\"><style sty-id=\"sc-scoped-car-list\">.sc-scoped-car-list-h{display:block;margin:10px;padding:10px;border:1px solid blue}ul.sc-scoped-car-list{display:block;margin:0;padding:0}li.sc-scoped-car-list{list-style:none;margin:0;padding:20px}.selected.sc-scoped-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style><style class=\"vjs-styles-defaults\">.video-js {width: 300px;height: 150px;}.vjs-fluid {padding-top: 56.25%}</style> <link rel=\"stylesheet\" href=\"whatever.css\"> </head>',
+      '<head><meta charset="utf-8"><style sty-id="sc-scoped-car-list">.sc-scoped-car-list-h{display:block;margin:10px;padding:10px;border:1px solid blue}ul.sc-scoped-car-list{display:block;margin:0;padding:0}li.sc-scoped-car-list{list-style:none;margin:0;padding:20px}.selected.sc-scoped-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style><style class="vjs-styles-defaults">.video-js {width: 300px;height: 150px;}.vjs-fluid {padding-top: 56.25%}</style> <link rel="stylesheet" href="whatever.css"> </head>',
     );
   });
 });

--- a/test/end-to-end/tsconfig.json
+++ b/test/end-to-end/tsconfig.json
@@ -12,7 +12,7 @@
     "jsxFragmentFactory": "Fragment",
     "lib": [
       "dom",
-      "es2017"
+      "es2021"
     ],
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
## What is the current behavior?
This is an enhancement to a fix we made in in #5926 which caused our Nightly build to fail due to the inability to place custom styles in the HTML template as all component styles were injected last in the `<head />` tag.

STENCIL-1372

## What is the new behavior?
Place scoped component styles after existing preconnect links but allow custom styles to be set at the end of the `<head />` tag.

## Documentation

I will raise a separate PR to the docs page mentioning this behavior.

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Enhanced existing e2e test.

## Other information

n/a
