### PR TITLE
fix(compiler): default `asyncLoading` build conditional to `true`

### DIFF
--- a/src/app-data/index.ts
+++ b/src/app-data/index.ts
@@ -105,7 +105,7 @@ export const BUILD: BuildConditionals = {
   devTools: false,
   shadowDelegatesFocus: true,
   initializeNextTick: false,
-  asyncLoading: false,
+  asyncLoading: true,
   asyncQueue: false,
   transformTagName: false,
   attachStyles: true,

--- a/test/wdio/custom-elements-hierarchy-lifecycle/cmp-child.tsx
+++ b/test/wdio/custom-elements-hierarchy-lifecycle/cmp-child.tsx
@@ -1,0 +1,18 @@
+import { Component, h } from '@stencil/core';
+
+import { createAndAppendElement } from './cmp-util.js';
+
+@Component({
+  tag: 'custom-elements-hierarchy-lifecycle-child',
+  shadow: true,
+})
+export class CustomElementsHierarchyLifecycleChild {
+  async componentDidLoad(): Promise<void> {
+    createAndAppendElement('DID LOAD CHILD');
+    return Promise.resolve();
+  }
+
+  render() {
+    return <p>CHILD CONTENT</p>;
+  }
+}

--- a/test/wdio/custom-elements-hierarchy-lifecycle/cmp-parent.tsx
+++ b/test/wdio/custom-elements-hierarchy-lifecycle/cmp-parent.tsx
@@ -1,0 +1,18 @@
+import { Component, h } from '@stencil/core';
+
+import { createAndAppendElement } from './cmp-util.js';
+
+@Component({
+  tag: 'custom-elements-hierarchy-lifecycle-parent',
+  shadow: true,
+})
+export class CustomElementsHierarchyLifecycleParent {
+  async componentDidLoad(): Promise<void> {
+    createAndAppendElement('DID LOAD PARENT');
+    return Promise.resolve();
+  }
+
+  render() {
+    return <custom-elements-hierarchy-lifecycle-child></custom-elements-hierarchy-lifecycle-child>;
+  }
+}

--- a/test/wdio/custom-elements-hierarchy-lifecycle/cmp-util.ts
+++ b/test/wdio/custom-elements-hierarchy-lifecycle/cmp-util.ts
@@ -1,0 +1,6 @@
+export const createAndAppendElement = (text: string) => {
+  const p = document.createElement('p');
+  p.textContent = text;
+
+  document.body.appendChild(p);
+};

--- a/test/wdio/custom-elements-hierarchy-lifecycle/cmp.test.tsx
+++ b/test/wdio/custom-elements-hierarchy-lifecycle/cmp.test.tsx
@@ -1,0 +1,35 @@
+import { Fragment, h } from '@stencil/core';
+import { render } from '@wdio/browser-runner/stencil';
+
+import { defineCustomElement as defineCustomElementChildCmp } from '../test-components/custom-elements-hierarchy-lifecycle-child.js';
+import { defineCustomElement as defineCustomElementParentCmp } from '../test-components/custom-elements-hierarchy-lifecycle-parent.js';
+
+describe('custom-elements-hierarchy-lifecycle', () => {
+  before(() => {
+    defineCustomElementChildCmp();
+    defineCustomElementParentCmp();
+  });
+
+  it('should call componentDidLoad in the child before the parent', async () => {
+    expect(customElements.get('custom-elements-hierarchy-lifecycle-child')).toBeDefined();
+    expect(customElements.get('custom-elements-hierarchy-lifecycle-parent')).toBeDefined();
+
+    render({
+      template: () => (
+        <>
+          <custom-elements-hierarchy-lifecycle-parent></custom-elements-hierarchy-lifecycle-parent>
+        </>
+      ),
+    });
+
+    const elm = document.querySelector('custom-elements-hierarchy-lifecycle-parent');
+    expect(elm.shadowRoot).toBeDefined();
+
+    await browser.waitUntil(() => Boolean(elm.shadowRoot.querySelector('custom-elements-hierarchy-lifecycle-child')));
+
+    expect(Array.from(document.querySelectorAll('p')).map((r) => r.textContent)).toEqual([
+      'DID LOAD CHILD',
+      'DID LOAD PARENT',
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, the `dist-custom-elements` build does not respect the behavior of certain lifecycle methods executing for child components, prior to parent components (as mentioned in the [Stencil documentation](https://stenciljs.com/docs/component-lifecycle#lifecycle-hierarchy)).

Fixes: #3580


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This commit updates the default behavior for `BUILD.asyncLoading` to `true`. This change is necessary because the custom elements build does not customize the build conditionals like the lazy build. So, this value was never being set to `true` even in applicable scenarios.

This does have a slight impact on treeshaking (since any `if` statement testing this condition will now always be `true`) and runtime performance. 

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Tested in the reproduction case from #3580 and added a e2e test to ensure the methods are called in the appropriate order.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
