### PR TITLE
fix(compiler): verify parent node when validating component members

### DIFF
--- a/src/compiler/transformers/static-to-meta/component.ts
+++ b/src/compiler/transformers/static-to-meta/component.ts
@@ -201,6 +201,7 @@ const validateComponentMembers = (node: ts.Node) => {
     /**
      * the parent node is a class declaration
      */
+    node.parent &&
     ts.isClassDeclaration(node.parent)
   ) {
     const propName = node.name.escapedText;


### PR DESCRIPTION
## What is the current behavior?

GitHub Issue Number: fixes #5940

## What is the new behavior?
Check for the parent member before calling `ts.isClassDeclaration` on it.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
