### PR TITLE
fix(compiler): prefer `localName` over `originalName` by running an empty check on `originalName`

### DIFF
--- a/src/compiler/types/generate-app-types.ts
+++ b/src/compiler/types/generate-app-types.ts
@@ -108,7 +108,9 @@ const generateComponentTypesFile = (
     return `{ ${typeData
       .sort(sortImportNames)
       .map((td) => {
-        if (td.originalName === td.importName) {
+        if (td.originalName === '') {
+          return `${td.localName}`;
+        } else if (td.originalName === td.importName) {
           return `${td.originalName}`;
         } else {
           return `${td.originalName} as ${td.importName}`;

--- a/src/compiler/types/tests/generate-app-types.spec.ts
+++ b/src/compiler/types/tests/generate-app-types.spec.ts
@@ -1747,6 +1747,11 @@ declare module "@stencil/core" {
                 location: 'import',
                 path: '@utils',
               },
+              Fragment: {
+                location: 'import',
+                path: '@stencil/core',
+                id: ''
+              },
             },
           },
         }),
@@ -1767,7 +1772,9 @@ declare module "@stencil/core" {
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { MyType as UserImplementedPropType } from "@utils";
+import { Fragment } from "@stencil/core";
 export { MyType as UserImplementedPropType } from "@utils";
+export { Fragment } from "@stencil/core";
 export namespace Components {
     /**
      * docs

--- a/src/compiler/types/tests/generate-app-types.spec.ts
+++ b/src/compiler/types/tests/generate-app-types.spec.ts
@@ -1750,7 +1750,7 @@ declare module "@stencil/core" {
               Fragment: {
                 location: 'import',
                 path: '@stencil/core',
-                id: ''
+                id: '',
               },
             },
           },


### PR DESCRIPTION
## What is the current behavior?
GitHub Issue Number: fixes #5882

## What is the new behavior?
We have missed a case where an import type can come with an empty id.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Enhanced existing unit test.

## Other information

n/a
