### PR TITLE
fix(types): expose missing `JSX.Element` on `h`

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -619,6 +619,8 @@ export declare namespace h {
   export function h(sel: any, data: VNodeData | null, children: VNode): VNode;
 
   export namespace JSX {
+    interface Element extends LocalJSX.Element {}
+
     interface IntrinsicElements extends LocalJSX.IntrinsicElements, JSXBase.IntrinsicElements {
       [tagName: string]: any;
     }


### PR DESCRIPTION
## What is the current behavior?

An accidental `any` can leak as that's what JSX returns when `JSX.Element` is missing ([TS playground](https://www.typescriptlang.org/play/?jsxFactory=h&ts=5.5.4#code/PTAEAECsGcA8C5QCcCmBDAxgFwLACgQIZYAxTLAeyQE9EALfASwFsAHKrUAb1DtAF9QAMyQVmoAOThoWFADsMjADbAMVFBNCEs1VimiIALADoATAAZj5-PjVyZoFEtABeUAB4AJowBuwAHz4hKAhAHoA-EA))
```ts
// @jsx: react
// @jsxFactory: h
import { h } from '@stencil/core' // types: 4.20.0

const el = <div/> // any
```

GitHub Issue Number: N/A


## What is the new behavior?

This PR reuses the already defined `LocalJSX.Element` as `JSX.Element`. The resulting type is still pretty permissive (it's an empty interface) but at least it's not `any`.

## Documentation

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Manual testing of how types are resolved with this.

## Other information

discovered here https://github.com/microsoft/TypeScript/pull/59584#issuecomment-2286943503
