### PR TITLE
fix(runtime): update call to `prepend` to remove `null` node

### DIFF
--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -105,13 +105,13 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
                 preconnectLinks.length > 0
                   ? preconnectLinks[preconnectLinks.length - 1].nextSibling
                   : document.querySelector('style');
-              styleContainerNode.insertBefore(styleElm, referenceNode);
+              (styleContainerNode as HTMLElement).insertBefore(styleElm, referenceNode);
             } else if ('host' in styleContainerNode) {
               /**
                * if a scoped component is used within a shadow root, we want to insert the styles
                * at the beginning of the shadow root node
                */
-              styleContainerNode.prepend(styleElm, null);
+              (styleContainerNode as HTMLElement).prepend(styleElm);
             }
           }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Inserting styles inside shadow components calls to `prepend` with a `null` node (i.e. `prepend(styles, null)`). This causes a text node with "null" to be rendered.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Removes the `null` node from the call to `prepend`.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
