### PR TITLE
fix(runtime): only use setter if existing

### DIFF
--- a/src/mock-doc/element.ts
+++ b/src/mock-doc/element.ts
@@ -129,7 +129,7 @@ patchPropAttributes(
 Object.defineProperty(MockButtonElement.prototype, 'form', {
   get(this: MockElement) {
     return this.hasAttribute('form') ? this.getAttribute('form') : null;
-  }
+  },
 });
 
 export class MockImageElement extends MockHTMLElement {

--- a/src/mock-doc/element.ts
+++ b/src/mock-doc/element.ts
@@ -126,6 +126,12 @@ patchPropAttributes(
   },
 );
 
+Object.defineProperty(MockButtonElement.prototype, 'form', {
+  get(this: MockElement) {
+    return this.hasAttribute('form') ? this.getAttribute('form') : null;
+  }
+});
+
 export class MockImageElement extends MockHTMLElement {
   constructor(ownerDocument: any) {
     super(ownerDocument, 'img');

--- a/src/runtime/vdom/set-accessor.ts
+++ b/src/runtime/vdom/set-accessor.ts
@@ -136,7 +136,11 @@ export const setAccessor = (
             if (memberName === 'list') {
               isProp = false;
             } else if (oldValue == null || (elm as any)[memberName] != n) {
-              (elm as any)[memberName] = n;
+              if (typeof (elm as any).__lookupSetter__(memberName) === 'function') {
+                (elm as any)[memberName] = n;
+              } else {
+                elm.setAttribute(memberName, n);
+              }
             }
           } else {
             (elm as any)[memberName] = newValue;

--- a/src/runtime/vdom/test/set-accessor.spec.ts
+++ b/src/runtime/vdom/test/set-accessor.spec.ts
@@ -897,5 +897,5 @@ describe('setAccessor for standard html elements', () => {
     const spy2 = jest.spyOn(elm2, 'setAttribute');
     setAccessor(elm2, 'textContent', undefined, 'some-content', false, 0);
     expect(spy2.mock.calls).toEqual([]);
-  })
+  });
 });

--- a/src/runtime/vdom/test/set-accessor.spec.ts
+++ b/src/runtime/vdom/test/set-accessor.spec.ts
@@ -886,4 +886,16 @@ describe('setAccessor for standard html elements', () => {
       expect(elm.style.cssText).toEqual('margin: 30px; color: orange;');
     });
   });
+
+  it('uses setAttribute if element has not setter', () => {
+    const elm = document.createElement('button');
+    const spy = jest.spyOn(elm, 'setAttribute');
+    setAccessor(elm, 'form', undefined, 'some-form', false, 0);
+    expect(spy.mock.calls).toEqual([['form', 'some-form']]);
+
+    const elm2 = document.createElement('button');
+    const spy2 = jest.spyOn(elm2, 'setAttribute');
+    setAccessor(elm2, 'textContent', undefined, 'some-content', false, 0);
+    expect(spy2.mock.calls).toEqual([]);
+  })
 });


### PR DESCRIPTION
## What is the current behavior?
Trying to set properties without a setter fails silently in Stencil.

GitHub Issue Number: #2703

## What is the new behavior?
Check if property has a setter and use `setAttribute` otherwise.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Added unit test.

## Other information

n/a
