### PR TITLE
fix(runtime): have fallback for style setting

### DIFF
--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -112,6 +112,8 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
                * at the beginning of the shadow root node
                */
               (styleContainerNode as HTMLElement).prepend(styleElm);
+            } else {
+              styleContainerNode.append(styleElm);
             }
           }
 


### PR DESCRIPTION
## What is the current behavior?
The Ionic Framework nightly build is failing. After some investigations it seems that the page had a missing style tag in the header which caused the component to be rendered without padding:

<img width="3024" alt="Screenshot 2024-08-16 at 3 11 10 PM" src="https://github.com/user-attachments/assets/23b5eff5-12ec-44ed-97bf-b0d234182482">

_> Left side is the working version, right side is the Playwright trace_

I don't know why the style tag with the styles for `ion-list` isn't rendered only in CI. I have to assume that it has to do with Playwright behaving funky here. I can't reproduce it locally at all.

## What is the new behavior?
Added an `else` statement in cases none of the previous if statement match which should never happen but may have happened here. Worth a try.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
