### PR TITLE
fix(compiler): allow attribute & reflect values on props w/ non JS primitives

### DIFF
--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -100,13 +100,9 @@ const parsePropDecorator = (
     required: prop.exclamationToken !== undefined && propName !== 'mode',
     optional: prop.questionToken !== undefined,
     docs: serializeSymbol(typeChecker, symbol),
+    attribute: getAttributeName(propName, propOptions),
+    reflect: getReflect(diagnostics, propDecorator, propOptions),
   };
-
-  // prop can have an attribute if type is NOT "unknown"
-  if (typeStr !== 'unknown') {
-    propMeta.attribute = getAttributeName(propName, propOptions);
-    propMeta.reflect = getReflect(diagnostics, propDecorator, propOptions);
-  }
 
   // extract default value
   const initializer = prop.initializer;

--- a/src/compiler/transformers/test/parse-props.spec.ts
+++ b/src/compiler/transformers/test/parse-props.spec.ts
@@ -213,10 +213,12 @@ describe('parse props', () => {
         optional: false,
         required: false,
         type: 'unknown',
+        attribute: 'val',
+        reflect: false,
       },
     });
     expect(t.property?.type).toBe('unknown');
-    expect(t.property?.attribute).toBe(undefined);
+    expect(t.property?.attribute).toBe('val');
     expect(t.property?.reflect).toBe(false);
   });
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Stencil ignores setting the `attribute` and `reflect` values when transforming `@Prop()` decorators if their resolved types don't resolve to a JS primitive (string, number, etc.). 

GitHub Issue Number: #5618

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Stencil will now set the `attribute` and `reflect` values regardless of the resolved type. This was they are always present in the generated `docs-json`. 

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Verified the expected behavior with the reproduction case, and updated unit test cases where the previous behavior was checked

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

There may be some repercussions to this change beyond what we can foresee, so we'll keep an eye on feedback once this is released if there are unwanted consequences
