### PR TITLE
fix(compiler): handle file rename in watch mode

### DIFF
--- a/.github/workflows/test-wdio.yml
+++ b/.github/workflows/test-wdio.yml
@@ -6,7 +6,7 @@ on:
     # https://docs.github.com/en/actions/using-workflows/reusing-workflows
 
 jobs:
-  run_wdio:
+  wdio_test:
     name: Run WebdriverIO Component Tests (${{ matrix.browser }})
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/test-wdio.yml
+++ b/.github/workflows/test-wdio.yml
@@ -27,9 +27,6 @@ jobs:
           node-version-file: './test/wdio/package.json'
           cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
-
       - name: Download Build Archive
         uses: ./.github/workflows/actions/download-archive
         with:
@@ -39,6 +36,7 @@ jobs:
 
       - name: Run WebdriverIO Component Tests
         run: npm run test.wdio
+        shell: bash
         env:
           BROWSER: ${{ matrix.browser }}
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #3443

When renaming a file in watch mode, it is possible to run into two errors:

1. A build error resulting from the compiler believing that two components exist with the same tag name (one from the old file name, and one from the new)
2. An HMR issue where the new file name is not correctly registered with the file watcher. So, changes to the renamed file did not trigger an HMR reload

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Addresses both of the issues mentioned above by updating the watched files and compiler context whenever a change is detected that triggers the watch callback

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

This is a difficult issue to test (especially the HMR since that was not always consistent), so I was only able to perform manual tests

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
