### PR TITLE
fix(runtime): ensure referenceNode is child node of styleContainerNode

### DIFF
--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -104,7 +104,7 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
               const referenceNode =
                 preconnectLinks.length > 0
                   ? preconnectLinks[preconnectLinks.length - 1].nextSibling
-                  : document.querySelector('style');
+                  : styleContainerNode.querySelector('style');
               (styleContainerNode as HTMLElement).insertBefore(styleElm, referenceNode);
             } else if ('host' in styleContainerNode) {
               /**


### PR DESCRIPTION
## What is the current behavior?

GitHub Issue Number: #5993

## What is the new behavior?

With this bugfix, only a style node within the styleContainerNode is searched for.

## Documentation

--

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Testing

--

## Other information

--
