### PR TITLE
fix: support modern package exports syntax

### DIFF
--- a/src/compiler/transpile/ts-config.ts
+++ b/src/compiler/transpile/ts-config.ts
@@ -27,7 +27,7 @@ export const getTsOptionsToExtend = (config: d.ValidatedConfig): ts.CompilerOpti
     // declaration files
     declaration: config.outputTargets.some(isOutputTargetDistTypes),
     module: ts.ModuleKind.ESNext,
-    moduleResolution: ts.ModuleResolutionKind.NodeJs,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
     noEmitOnError: false,
     outDir: config.cacheDir || config.sys.tmpDirSync(),
     sourceMap: config.sourceMap,


### PR DESCRIPTION
## What is the current behavior?
Currently, you cannot use packages that use modern module resolution based on subpath-exports in your Stencil Project[^1].
This is caused by the hard coding of Node10 for moduleResolution in Stencil.

GitHub Issue Number: #4229 (mitigation, not 💯 fix) 


## What is the new behavior?
Replace Node10 with Bundler. While it's not a "trivial" change, the impact for the end-user should be minimal (see Breaking change section)


## Documentation

N.A.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

I ran some 'health-check' (running stencil compiler with & without my changes on packages that use various ways of defining sub-packages), and all projects that worked without my changes worked with it as well, without changes.

Moreover, from the TypeScript reference documentation, I reckon it is safe to say that Bundler is akin to a "superset" of Node10:
https://www.typescriptlang.org/docs/handbook/modules/reference.html#bundler
https://www.typescriptlang.org/docs/handbook/modules/reference.html#node10-formerly-known-as-node

## Testing

In addition to the existing test (`npm test`), I ran some san-check. We have a package that we are migrating from 'hackish subpackages' (using subdirectory and package.json in them) to subpath exports in a major version, I used this package as an example and did the following tests:
 - [Stencil 4.21.0 'vanilla' + hackish subpackages](https://github.com/louis-bompart/stencil-bugfixes-exports-testing/tree/legacy-package): ✅ compiling, behavior nominal
 - [Stencil 4.21.0 'patched' (i.e with my changes) + hackish subpackages](https://github.com/louis-bompart/stencil-bugfixes-exports-testing/tree/legacy-package%2Bpatched-stencil): ✅  compiling, behavior nominal
 - [Stencil 4.21.0 'vanilla' + subpath exports](https://github.com/louis-bompart/stencil-bugfixes-exports-testing/tree/next-package): ❌ failing when importing a subpath, as expected.
 - [Stencil 4.21.0 'patched' + subpath exports](https://github.com/louis-bompart/stencil-bugfixes-exports-testing/tree/next-package%2Bstencil-patch): ✅ compiling, behavior nominal.

To validate, check the linked repo (pay attention to the branch), `npm i ; npm start`

I'm not necessarily expecting this to be an 'LGTM & merge' but more a base to discuss how to improve Stencil so that it's not a blocker for good practices adoption (pure incompatibility with modern package practice is quite a sore point tbh), which is paramount IMHO for developer-oriented products.

[^1]: https://nodejs.org/api/packages.html#subpath-exports