### PR TITLE
fix(compiler): add `popover` reserved keyword

### DIFF
--- a/src/compiler/transformers/reserved-public-members.ts
+++ b/src/compiler/transformers/reserved-public-members.ts
@@ -34,6 +34,7 @@ export const validatePublicName = (
 };
 
 const HTML_ELEMENT_KEYS = [
+  'popover',
   'title',
   'lang',
   'translate',


### PR DESCRIPTION
add `popover` keyword

fixes: #6000

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6000


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Add `popover` has reserved keywork to avoid developer to name a property in a component with this name to do not have unexpected comportment outside stencil dev mode


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
Manual testting

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
