### PR TITLE
fix(hydrate): Add missing alias to hydrate build to fix app globals

### DIFF
--- a/scripts/esbuild/internal-platform-hydrate.ts
+++ b/scripts/esbuild/internal-platform-hydrate.ts
@@ -54,6 +54,7 @@ export async function getInternalPlatformHydrateBundles(opts: BuildOptions): Pro
     plugins: [
       externalAlias('@utils/shadow-css', '../client/shadow-css.js'),
       externalAlias('@app-data', '@stencil/core/internal/app-data'),
+      externalAlias('@app-globals', '@stencil/core/internal/app-globals'),
     ],
   };
 


### PR DESCRIPTION
The hydrate platform esbuild is missing an alias for `@app-globals`, causing it to be resolved to the `noop` in `src/app-globals/index.ts`. This results in the globals not being correctly included in hydrate apps.

Adding the alias returns hydrate to it's previous behaviour.


## What is the current behavior?


GitHub Issue Number: #6002


## What is the new behavior?

Hydrate app now includes global script.

## Documentation

_none_

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Testing

See #6002

