### PR TITLE
fix(mock-doc): provide mock for resize observer

### DIFF
--- a/src/compiler/output-targets/dist-hydrate-script/hydrate-factory-closure.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/hydrate-factory-closure.ts
@@ -63,6 +63,7 @@ export function hydrateFactory($stencilWindow, $stencilHydrateOpts, $stencilHydr
   var HTMLTemplateElement = $stencilWindow.HTMLTemplateElement;
   var HTMLTitleElement = $stencilWindow.HTMLTitleElement;
   var IntersectionObserver = $stencilWindow.IntersectionObserver;
+  var ResizeObserver = $stencilWindow.ResizeObserver;
   var KeyboardEvent = $stencilWindow.KeyboardEvent;
   var MouseEvent = $stencilWindow.MouseEvent;
   var Node = $stencilWindow.Node;

--- a/src/mock-doc/resize-observer.ts
+++ b/src/mock-doc/resize-observer.ts
@@ -1,0 +1,21 @@
+export class MockResizeObserver {
+  constructor() {
+    /**/
+  }
+
+  disconnect() {
+    /**/
+  }
+
+  observe() {
+    /**/
+  }
+
+  takeRecords(): any[] {
+    return [];
+  }
+
+  unobserve() {
+    /**/
+  }
+}

--- a/src/mock-doc/window.ts
+++ b/src/mock-doc/window.ts
@@ -21,6 +21,7 @@ import { MockLocation } from './location';
 import { MockNavigator } from './navigator';
 import { MockElement, MockHTMLElement, MockNode, MockNodeList } from './node';
 import { MockPerformance, resetPerformance } from './performance';
+import { MockResizeObserver } from './resize-observer';
 import { MockStorage } from './storage';
 
 const nativeClearInterval = clearInterval;
@@ -309,6 +310,10 @@ export class MockWindow {
 
   get IntersectionObserver() {
     return MockIntersectionObserver;
+  }
+
+  get ResizeObserver() {
+    return MockResizeObserver;
   }
 
   get localStorage() {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
Yet another Web API to mock out in MockDoc.

## What is the new behavior?
Make components using this primitive not fail when hydrating it.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
