### PR TITLE
fix(mock-doc): add missing ShadowRoot window primitive

### DIFF
--- a/src/compiler/output-targets/dist-hydrate-script/hydrate-factory-closure.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/hydrate-factory-closure.ts
@@ -43,6 +43,7 @@ export function hydrateFactory($stencilWindow, $stencilHydrateOpts, $stencilHydr
   var CSS = $stencilWindow.CSS;
   var CustomEvent = $stencilWindow.CustomEvent;
   var Document = $stencilWindow.Document;
+  var ShadowRoot = $stencilWindow.ShadowRoot;
   var DocumentFragment = $stencilWindow.DocumentFragment;
   var DocumentType = $stencilWindow.DocumentType;
   var DOMTokenList = $stencilWindow.DOMTokenList;

--- a/src/mock-doc/shadow-root.ts
+++ b/src/mock-doc/shadow-root.ts
@@ -1,31 +1,31 @@
 import { MockDocumentFragment } from './document-fragment';
 
 export class MockShadowRoot extends MockDocumentFragment {
-  get activeElement() {
+  get activeElement(): HTMLElement | null {
     return null;
   }
 
-  set adoptedStyleSheets(adoptedStyleSheets: any) {
+  set adoptedStyleSheets(_adoptedStyleSheets: StyleSheet[]) {
     throw new Error('Unimplemented');
   }
 
-  get adoptedStyleSheets() {
+  get adoptedStyleSheets(): StyleSheet[] {
     return [];
   }
 
-  get cloneable() {
+  get cloneable(): boolean {
     return false;
   }
 
-  get delegatesFocus() {
+  get delegatesFocus(): boolean {
     return false;
   }
 
-  get fullscreenElement() {
-    return null
+  get fullscreenElement(): HTMLElement | null {
+    return null;
   }
 
-  get host() {
+  get host(): HTMLElement | null {
     let parent = this.parentElement();
     while (parent) {
       if (parent.nodeType === 11) {
@@ -36,27 +36,27 @@ export class MockShadowRoot extends MockDocumentFragment {
     return null;
   }
 
-  get mode() {
+  get mode(): 'open' | 'closed' {
     return 'open';
   }
 
-  get pictureInPictureElement() {
+  get pictureInPictureElement(): HTMLElement | null {
     return null;
   }
 
-  get pointerLockElement() {
+  get pointerLockElement(): HTMLElement | null {
     return null;
   }
 
-  get serializable() {
+  get serializable(): boolean {
     return false;
   }
 
-  get slotAssignment() {
-    return 'named'
+  get slotAssignment(): 'named' | 'manual' {
+    return 'named';
   }
 
-  get styleSheets() {
+  get styleSheets(): StyleSheet[] {
     return [];
   }
 }

--- a/src/mock-doc/shadow-root.ts
+++ b/src/mock-doc/shadow-root.ts
@@ -1,0 +1,62 @@
+import { MockDocumentFragment } from './document-fragment';
+
+export class MockShadowRoot extends MockDocumentFragment {
+  get activeElement() {
+    return null;
+  }
+
+  set adoptedStyleSheets(adoptedStyleSheets: any) {
+    throw new Error('Unimplemented');
+  }
+
+  get adoptedStyleSheets() {
+    return [];
+  }
+
+  get cloneable() {
+    return false;
+  }
+
+  get delegatesFocus() {
+    return false;
+  }
+
+  get fullscreenElement() {
+    return null
+  }
+
+  get host() {
+    let parent = this.parentElement();
+    while (parent) {
+      if (parent.nodeType === 11) {
+        return parent;
+      }
+      parent = parent.parentElement();
+    }
+    return null;
+  }
+
+  get mode() {
+    return 'open';
+  }
+
+  get pictureInPictureElement() {
+    return null;
+  }
+
+  get pointerLockElement() {
+    return null;
+  }
+
+  get serializable() {
+    return false;
+  }
+
+  get slotAssignment() {
+    return 'named'
+  }
+
+  get styleSheets() {
+    return [];
+  }
+}

--- a/src/mock-doc/window.ts
+++ b/src/mock-doc/window.ts
@@ -22,6 +22,7 @@ import { MockNavigator } from './navigator';
 import { MockElement, MockHTMLElement, MockNode, MockNodeList } from './node';
 import { MockPerformance, resetPerformance } from './performance';
 import { MockResizeObserver } from './resize-observer';
+import { MockShadowRoot } from './shadow-root';
 import { MockStorage } from './storage';
 
 const nativeClearInterval = clearInterval;
@@ -186,6 +187,10 @@ export class MockWindow {
   }
   set DocumentFragment(docFragCstr: any) {
     this.__docFragCstr = docFragCstr;
+  }
+
+  get ShadowRoot() {
+    return MockShadowRoot;
   }
 
   get DocumentType() {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
The [`ShadowRoot`](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/styleSheets) class is currently not defined in MockDoc.


## What is the new behavior?
Added a mocked implementation of it.

## Documentation

n/a

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
