### PR TITLE
fix(compiler) restore old copy behaviour, with new ignore option

### DIFF
--- a/test/copy-task/stencil.config.ts
+++ b/test/copy-task/stencil.config.ts
@@ -7,7 +7,7 @@ export const config: Config = {
       type: 'dist-custom-elements',
       copy: [
         {
-          src: './utils',
+          src: './utils/**',
           dest: './dist/utilsExtra',
         },
       ],


### PR DESCRIPTION
## What is the current behavior?

#5899 introduced a lot of regressions:

A breaking change in copy behavior: #5983
file to file copying broken: #5956
EBUSY: resource busy: #5966
Directories from above the root dir are copied outside of the output dir. 

## What is the new behavior?

This PR restores the old copy behavior, but uses the passed filter list, rather than the hardcoded one.

This isn't an optimum fix, as it changes the copy back to `dir` to `dir` (or `file` to `file`), so ignore patterns aren't matched against child files. Only glob matches are ignored (as was the previous behavior). IMO it's better than the large number of regressions, especially as this can now be worked around (e.g. in the case of #5781) by the user moving to a glob copy, with the new ignore option.

## Documentation

none

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Testing

Tested on own repo.

## Other information

fixes: #5983
fixes: #5956
fixes: #5966