### PR TITLE
fix(mock-doc): get native primitive from `globalThis`

### DIFF
--- a/src/mock-doc/window.ts
+++ b/src/mock-doc/window.ts
@@ -25,11 +25,11 @@ import { MockResizeObserver } from './resize-observer';
 import { MockShadowRoot } from './shadow-root';
 import { MockStorage } from './storage';
 
-const nativeClearInterval = clearInterval;
-const nativeClearTimeout = clearTimeout;
-const nativeSetInterval = setInterval;
-const nativeSetTimeout = setTimeout;
-const nativeURL = URL;
+const nativeClearInterval = globalThis.clearInterval;
+const nativeClearTimeout = globalThis.clearTimeout;
+const nativeSetInterval = globalThis.setInterval;
+const nativeSetTimeout = globalThis.setTimeout;
+const nativeURL = globalThis.URL;
 const nativeWindow = globalThis.window;
 
 export class MockWindow {


### PR DESCRIPTION
## What is the current behavior?

Using Stencil in a server side rendering context with Nuxt, causes issue due to the fact that Nuxt fails to do its auto importing feature with `Cannot find module '#app/compat/interval'`. It turns out it has to do with using `setTimeout` which probably is lazy loaded in Nuxt from a special polyfill.

## What is the new behavior?
While this is technically not an issue with Stencil , I found a workaround we can apply to make it work. I think this makes it generally safer to obtain the function from `globalThis`.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
