### PR TITLE
fix(docs): escape backticks in type or default value columns

### DIFF
--- a/src/compiler/docs/readme/markdown-props.ts
+++ b/src/compiler/docs/readme/markdown-props.ts
@@ -19,8 +19,8 @@ export const propsToMarkdown = (props: d.JsonDocsProp[]) => {
       getPropertyField(prop),
       getAttributeField(prop),
       getDocsField(prop),
-      `\`${prop.type}\``,
-      `\`${prop.default}\``,
+      getTypeField(prop),
+      getDefaultValueField(prop),
     ]);
   });
 
@@ -45,4 +45,12 @@ const getDocsField = (prop: d.JsonDocsProp) => {
       ? `<span style="color:red">**[DEPRECATED]**</span> ${prop.deprecation}<br/><br/>`
       : ''
   }${prop.docs}`;
+};
+
+const getTypeField = (prop: d.JsonDocsProp) => {
+  return prop.type.includes('`') ? `\`\` ${prop.type} \`\`` : `\`${prop.type}\``;
+};
+
+const getDefaultValueField = (prop: d.JsonDocsProp) => {
+  return prop.default?.includes('`') ? `\`\` ${prop.default} \`\`` : `\`${prop.default}\``;
 };

--- a/src/compiler/docs/test/markdown-props.spec.ts
+++ b/src/compiler/docs/test/markdown-props.spec.ts
@@ -39,4 +39,82 @@ describe('markdown props', () => {
 
 `);
   });
+
+  it('escapes template literal types', () => {
+    const markdown = propsToMarkdown([
+      {
+        name: 'width',
+        attr: 'width',
+        docs: 'Width of the button',
+        default: 'undefined',
+        type: '`${number}px` | `${number}%`',
+        mutable: false,
+        optional: false,
+        required: false,
+        reflectToAttr: false,
+        docsTags: [],
+        values: [],
+      },
+    ]).join('\n');
+
+    expect(markdown).toEqual(`## Properties
+
+| Property | Attribute | Description         | Type                                | Default     |
+| -------- | --------- | ------------------- | ----------------------------------- | ----------- |
+| \`width\`  | \`width\`   | Width of the button | \`\` \`\${number}px\` \\| \`\${number}%\` \`\` | \`undefined\` |
+
+`);
+  });
+
+  it('escapes backticks in default value', () => {
+    const markdown = propsToMarkdown([
+      {
+        name: 'quote',
+        attr: 'quote',
+        docs: 'Quote character',
+        default: "'`'",
+        type: 'string',
+        mutable: false,
+        optional: false,
+        required: false,
+        reflectToAttr: false,
+        docsTags: [],
+        values: [],
+      },
+    ]).join('\n');
+
+    expect(markdown).toEqual(`## Properties
+
+| Property | Attribute | Description     | Type     | Default   |
+| -------- | --------- | --------------- | -------- | --------- |
+| \`quote\`  | \`quote\`   | Quote character | \`string\` | \`\` '\`' \`\` |
+
+`);
+  });
+
+  it('outputs `undefined` in default column when `prop.default` is undefined', () => {
+    const markdown = propsToMarkdown([
+      {
+        name: 'first',
+        attr: 'first',
+        docs: 'First name',
+        default: undefined,
+        type: 'string',
+        mutable: false,
+        optional: false,
+        required: false,
+        reflectToAttr: false,
+        docsTags: [],
+        values: [],
+      },
+    ]).join('\n');
+
+    expect(markdown).toBe(`## Properties
+
+| Property | Attribute | Description | Type     | Default     |
+| -------- | --------- | ----------- | -------- | ----------- |
+| \`first\`  | \`first\`   | First name  | \`string\` | \`undefined\` |
+
+`);
+  });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

fixes #6024 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Types or default values that include a backtick are escaped with two backticks and a space.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

See the new unit tests in `markdown-props.spec.ts`. If you think the logic for this bug fix should exist somewhere else, let me know! 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
