### PR TITLE
fix(types): add controlslist to html declarations

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1129,6 +1129,8 @@ export namespace JSXBase {
     autoPlay?: boolean;
     autoplay?: boolean | string;
     controls?: boolean;
+    controlslist?: 'nodownload' | 'nofullscreen' | 'noremoteplayback';
+    controlsList?: 'nodownload' | 'nofullscreen' | 'noremoteplayback';
     crossOrigin?: string;
     crossorigin?: string;
     loop?: boolean;


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

prior to this commit, using the `controlslist` attribute in a `video` or `audio` element would result in a type checking error. with this commit, we allow the attribute to take one of three values:
- nodownload
- nofullscreen
- noremoteplayback


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



note that at the time of this writing, only chromium browsers support this attribute. it is the responsibilty of end users to determine if using this attribute is appropraite for their projects.


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Adding a `video` or `audio` element to a stencil component like so no longer creates type errors:
```html
<>
  <video controlslist="noremoteplayback"></video>
  <video controlslist="nofullscreen"></video>
  <video controlslist="noremoteplayback"></video>
</>
```

## Other information

fixes: #6015

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
