### PR TITLE
fix(runtime): scope id fix for component children for typescript issue

### DIFF
--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -984,7 +984,7 @@ const updateElementScopeIds = (element: d.RenderNode, parent: d.RenderNode, iter
   if (element && parent && element.nodeType === NODE_TYPE.ElementNode) {
     const scopeIds = new Set(findScopeIds(parent).filter(Boolean));
     if (scopeIds.size) {
-      element.classList?.add(...(element['s-scs'] = [...scopeIds]));
+      element.classList?.add(...(element['s-scs'] = Array.from(scopeIds)));
 
       if (element['s-ol'] || iterateChildNodes) {
         /**


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

This fixes an issue we encountered in several of our projects: when using scoped components, scoped classes for child elements in the component is not set correctly, which causes style problems on the child elements. 

Apparently this is caused by usage of a spread operator on a Set of scope ids (it is a known issue on the typescript https://github.com/Microsoft/TypeScript/issues/8856), this small fix enables to set the scope ids on child element correctly. 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: [6042](https://github.com/ionic-team/stencil/issues/6042)


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
