### PR TITLE
fix(mock-doc): return empty string if anchor has no href attribute

### DIFF
--- a/src/mock-doc/element.ts
+++ b/src/mock-doc/element.ts
@@ -107,6 +107,9 @@ export class MockAnchorElement extends MockHTMLElement {
     this.setAttribute('href', value);
   }
   get pathname() {
+    if (!this.href) {
+      return '';
+    }
     return new URL(this.href).pathname;
   }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
If an anchor element in mock-doc has to `href` property, getting the `pathname` will fail. 

## What is the new behavior?
Instead it should return an empty string.

fixes #6047

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
