### PR TITLE
fix(runtime): ensure event listener are not registered twice

### DIFF
--- a/src/runtime/bootstrap-custom-element.ts
+++ b/src/runtime/bootstrap-custom-element.ts
@@ -67,7 +67,7 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
 
   const originalConnectedCallback = Cstr.prototype.connectedCallback;
   const originalDisconnectedCallback = Cstr.prototype.disconnectedCallback;
-  let hasHostListenerAttached = false
+  let hasHostListenerAttached = false;
   Object.assign(Cstr.prototype, {
     __registerHost() {
       registerHost(this, cmpMeta);

--- a/src/runtime/bootstrap-custom-element.ts
+++ b/src/runtime/bootstrap-custom-element.ts
@@ -67,13 +67,17 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
 
   const originalConnectedCallback = Cstr.prototype.connectedCallback;
   const originalDisconnectedCallback = Cstr.prototype.disconnectedCallback;
+  let hasHostListenerAttached = false
   Object.assign(Cstr.prototype, {
     __registerHost() {
       registerHost(this, cmpMeta);
     },
     connectedCallback() {
-      const hostRef = getHostRef(this);
-      addHostEventListeners(this, hostRef, cmpMeta.$listeners$, false);
+      if (!hasHostListenerAttached) {
+        const hostRef = getHostRef(this);
+        addHostEventListeners(this, hostRef, cmpMeta.$listeners$, false);
+        hasHostListenerAttached = true;
+      }
 
       connectedCallback(this);
       if (BUILD.connectedCallback && originalConnectedCallback) {

--- a/test/wdio/event-listener-capture/event-re-register.css
+++ b/test/wdio/event-listener-capture/event-re-register.css
@@ -1,0 +1,10 @@
+:host {
+  display: block;
+  padding: 5px;
+  background: bisque;
+  cursor: pointer;
+  max-width: 300px;
+}
+:host(:focus) {
+  outline: 2px solid blue;
+}

--- a/test/wdio/event-listener-capture/event-re-register.test.tsx
+++ b/test/wdio/event-listener-capture/event-re-register.test.tsx
@@ -1,0 +1,49 @@
+// @ts-expect-error will be resolved by WDIO
+import { defineCustomElement } from '/test-components/event-re-register.js';
+
+defineCustomElement();
+
+describe('event-listener-capture using lazy load components', function () {
+  const eventListenerCaptureCmp = () => $('event-re-register');
+
+  afterEach(() => {
+    const elem = document.querySelector('event-re-register') as HTMLElement;
+    if (elem) {
+      elem.remove();
+    }
+  });
+
+  it('should only attach keydown event listener once', async () => {
+    const elem = document.createElement('event-re-register') as HTMLElement;
+    document.body.appendChild(elem);
+
+    const reattach = eventListenerCaptureCmp();
+    await expect(reattach).toBePresent();
+
+    // focus on element
+    await reattach.click();
+    await browser.action('key').down('a').pause(100).up('a').perform();
+    await browser.action('key').down('a').pause(100).up('a').perform();
+    await browser.action('key').down('a').pause(100).up('a').perform();
+
+    // check if event fired 3 times
+    await expect(reattach).toHaveText(
+      expect.stringContaining('Event fired times: 3'));
+
+    // remove node from DOM
+    elem.remove();
+
+    // reattach node to DOM
+    document.body.appendChild(elem);
+
+    // retrigger event
+    await reattach.click();
+    await browser.action('key').down('a').pause(100).up('a').perform();
+    await browser.action('key').down('a').pause(100).up('a').perform();
+    await browser.action('key').down('a').pause(100).up('a').perform();
+
+    // check if event fired 6 times
+    await expect(reattach).toHaveText(
+      expect.stringContaining('Event fired times: 6'));
+  });
+});

--- a/test/wdio/event-listener-capture/event-re-register.test.tsx
+++ b/test/wdio/event-listener-capture/event-re-register.test.tsx
@@ -27,8 +27,7 @@ describe('event-listener-capture using lazy load components', function () {
     await browser.action('key').down('a').pause(100).up('a').perform();
 
     // check if event fired 3 times
-    await expect(reattach).toHaveText(
-      expect.stringContaining('Event fired times: 3'));
+    await expect(reattach).toHaveText(expect.stringContaining('Event fired times: 3'));
 
     // remove node from DOM
     elem.remove();
@@ -43,7 +42,6 @@ describe('event-listener-capture using lazy load components', function () {
     await browser.action('key').down('a').pause(100).up('a').perform();
 
     // check if event fired 6 times
-    await expect(reattach).toHaveText(
-      expect.stringContaining('Event fired times: 6'));
+    await expect(reattach).toHaveText(expect.stringContaining('Event fired times: 6'));
   });
 });

--- a/test/wdio/event-listener-capture/event-re-register.tsx
+++ b/test/wdio/event-listener-capture/event-re-register.tsx
@@ -20,15 +20,17 @@ export class EventReRegister implements ComponentInterface {
     console.log('disconnected');
   }
   render() {
-    return <Host tabindex="1">
-      <ul id="reattach">
-        <li>Focus this component;</li>
-        <li>Press key;</li>
-        <li>See console output</li>
-        <li>Press 'Reconnect' button</li>
-        <li>Repeat steps 1-3</li>
-      </ul>
-      <p>Event fired times: {this.eventFiredTimes}</p>
-      </Host>;
+    return (
+      <Host tabindex="1">
+        <ul id="reattach">
+          <li>Focus this component;</li>
+          <li>Press key;</li>
+          <li>See console output</li>
+          <li>Press 'Reconnect' button</li>
+          <li>Repeat steps 1-3</li>
+        </ul>
+        <p>Event fired times: {this.eventFiredTimes}</p>
+      </Host>
+    );
   }
 }

--- a/test/wdio/event-listener-capture/event-re-register.tsx
+++ b/test/wdio/event-listener-capture/event-re-register.tsx
@@ -1,0 +1,34 @@
+import { Component, ComponentInterface, h, Host, Listen, State } from '@stencil/core';
+
+@Component({
+  tag: 'event-re-register',
+  styleUrl: 'event-re-register.css',
+  shadow: true,
+})
+export class EventReRegister implements ComponentInterface {
+  @State() eventFiredTimes: number = 0;
+  @Listen('keydown')
+  handleKeydown(event: KeyboardEvent) {
+    this.eventFiredTimes++;
+    console.log(event);
+  }
+
+  connectedCallback() {
+    console.log('connected');
+  }
+  disconnectedCallback() {
+    console.log('disconnected');
+  }
+  render() {
+    return <Host tabindex="1">
+      <ul id="reattach">
+        <li>Focus this component;</li>
+        <li>Press key;</li>
+        <li>See console output</li>
+        <li>Press 'Reconnect' button</li>
+        <li>Repeat steps 1-3</li>
+      </ul>
+      <p>Event fired times: {this.eventFiredTimes}</p>
+      </Host>;
+  }
+}

--- a/test/wdio/setup.ts
+++ b/test/wdio/setup.ts
@@ -15,10 +15,11 @@ const testRequiresManualSetup =
   window.__wdioSpec__.includes('custom-elements-output') ||
   window.__wdioSpec__.includes('global-script') ||
   window.__wdioSpec__.endsWith('custom-tag-name.test.tsx') ||
-  window.__wdioSpec__.endsWith('page-list.test.ts');
+  window.__wdioSpec__.endsWith('page-list.test.ts') ||
+  window.__wdioSpec__.endsWith('event-re-register.test.tsx');
 
 /**
- * setup all components defined in tests except for those where we want ot manually setup
+ * setup all components defined in tests except for those where we want to manually setup
  * the components in the test
  */
 if (!testRequiresManualSetup) {


### PR DESCRIPTION
## What is the current behavior?

For dist-custom-elements we didn't ensure that events are only registered once.

GitHub Issue Number: fixes #4135

## What is the new behavior?
Verify whether events were registered already.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
