### PR TITLE
fix: `patchChildSlotNodes` & `scopedSlotTextContentFix` not being applied

### DIFF
--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -150,6 +150,8 @@ export const validateConfig = (
   validatedConfig.extras.scriptDataOpts = !!validatedConfig.extras.scriptDataOpts;
   validatedConfig.extras.initializeNextTick = !!validatedConfig.extras.initializeNextTick;
   validatedConfig.extras.tagNameTransform = !!validatedConfig.extras.tagNameTransform;
+  // TODO(STENCIL-1086): remove this option when it's the default behavior
+  validatedConfig.extras.experimentalScopedSlotChanges = !!validatedConfig.extras.experimentalScopedSlotChanges;
 
   // TODO(STENCIL-914): remove when `experimentalSlotFixes` is the default behavior
   // If the user set `experimentalSlotFixes` and any individual slot fix flags to `false`, we need to log a warning
@@ -160,6 +162,7 @@ export const validateConfig = (
       'slotChildNodesFix',
       'cloneNodeFix',
       'scopedSlotTextContentFix',
+      'experimentalScopedSlotChanges',
     ];
     const conflictingFlags = possibleFlags.filter((flag) => validatedConfig.extras[flag] === false);
     if (conflictingFlags.length > 0) {
@@ -184,9 +187,6 @@ export const validateConfig = (
     validatedConfig.extras.slotChildNodesFix = !!validatedConfig.extras.slotChildNodesFix;
     validatedConfig.extras.scopedSlotTextContentFix = !!validatedConfig.extras.scopedSlotTextContentFix;
   }
-
-  // TODO(STENCIL-1086): remove this option when it's the default behavior
-  validatedConfig.extras.experimentalScopedSlotChanges = !!validatedConfig.extras.experimentalScopedSlotChanges;
 
   setBooleanConfig(
     validatedConfig,

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -1453,6 +1453,13 @@ export interface RenderNode extends HostElement {
    * empty "" for shadow, "c" from scoped
    */
   ['s-en']?: '' | /*shadow*/ 'c' /*scoped*/;
+
+  /**
+   * On a `scoped: true` component
+   * with `experimentalSlotFixes` flag enabled,
+   * returns the internal `childNodes` of the scoped element
+   */
+  readonly __childNodes?: NodeListOf<ChildNode>;
 }
 
 export type LazyBundlesRuntimeData = LazyBundleRuntimeData[];

--- a/src/runtime/bootstrap-custom-element.ts
+++ b/src/runtime/bootstrap-custom-element.ts
@@ -48,11 +48,11 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
     if (BUILD.scoped && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
       // This check is intentionally not combined with the surrounding `experimentalSlotFixes` check
       // since, moving forward, we only want to patch the pseudo shadow DOM when the component is scoped
-      patchPseudoShadowDom(Cstr.prototype, cmpMeta);
+      patchPseudoShadowDom(Cstr.prototype);
     }
   } else {
     if (BUILD.slotChildNodesFix) {
-      patchChildSlotNodes(Cstr.prototype, cmpMeta);
+      patchChildSlotNodes(Cstr.prototype);
     }
     if (BUILD.cloneNodeFix) {
       patchCloneNode(Cstr.prototype);

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -171,11 +171,11 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
         // This check is intentionally not combined with the surrounding `experimentalSlotFixes` check
         // since, moving forward, we only want to patch the pseudo shadow DOM when the component is scoped
         if (BUILD.scoped && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
-          patchPseudoShadowDom(HostElement.prototype, cmpMeta);
+          patchPseudoShadowDom(HostElement.prototype);
         }
       } else {
         if (BUILD.slotChildNodesFix) {
-          patchChildSlotNodes(HostElement.prototype, cmpMeta);
+          patchChildSlotNodes(HostElement.prototype);
         }
         if (BUILD.cloneNodeFix) {
           patchCloneNode(HostElement.prototype);

--- a/src/runtime/dom-extras.ts
+++ b/src/runtime/dom-extras.ts
@@ -250,15 +250,12 @@ export const patchSlotInsertAdjacentElement = (HostElementPrototype: HTMLElement
  */
 export const patchTextContent = (hostElementPrototype: HTMLElement): void => {
   let descriptor = Object.getOwnPropertyDescriptor(Node.prototype, 'textContent');
-  let toOverride = Node.prototype;
 
   if (!descriptor) {
     // for mock-doc
     descriptor = Object.getOwnPropertyDescriptor(hostElementPrototype, 'textContent');
-    toOverride = hostElementPrototype;
   }
-
-  if (descriptor) Object.defineProperty(toOverride, '__textContent', descriptor);
+  if (descriptor) Object.defineProperty(hostElementPrototype, '__textContent', descriptor);
 
   Object.defineProperty(hostElementPrototype, 'textContent', {
     get: function () {
@@ -279,22 +276,19 @@ export const patchTextContent = (hostElementPrototype: HTMLElement): void => {
 };
 
 export const patchChildSlotNodes = (elm: HTMLElement) => {
-  let childNodesFn = Object.getOwnPropertyDescriptor(Node.prototype, 'childNodes');
-  let toOverride = Node.prototype;
-
   class FakeNodeList extends Array {
     item(n: number) {
       return this[n];
     }
   }
 
+  let childNodesFn = Object.getOwnPropertyDescriptor(Node.prototype, 'childNodes');
   if (!childNodesFn) {
     // for mock-doc
     childNodesFn = Object.getOwnPropertyDescriptor(elm, 'childNodes');
-    toOverride = elm;
   }
 
-  if (childNodesFn) Object.defineProperty(toOverride, '__childNodes', childNodesFn);
+  if (childNodesFn) Object.defineProperty(elm, '__childNodes', childNodesFn);
 
   Object.defineProperty(elm, 'children', {
     get() {

--- a/src/runtime/test/dom-extras.spec.tsx
+++ b/src/runtime/test/dom-extras.spec.tsx
@@ -1,0 +1,93 @@
+import { Component, h, Host } from '@stencil/core';
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
+
+import { patchPseudoShadowDom } from '../../runtime/dom-extras';
+
+describe('dom-extras - patches for non-shadow dom methods and accessors', () => {
+  let specPage: SpecPage;
+
+  const nodeOrEleContent = (node: Node | Element) => {
+    return (node as Element)?.outerHTML || node?.nodeValue.trim();
+  };
+
+  beforeAll(async () => {
+    @Component({
+      tag: 'cmp-a',
+      scoped: true,
+    })
+    class CmpA {
+      render() {
+        return (
+          <Host>
+            'Shadow' first text node
+            <article>
+              <div>
+                <slot name="second-slot">Second slot fallback text</slot>
+              </div>
+              <div>
+                <slot>Default slot fallback text</slot>
+              </div>
+            </article>
+            'Shadow' last text node
+          </Host>
+        );
+      }
+    }
+
+    specPage = await newSpecPage({
+      components: [CmpA],
+      html: `
+        <cmp-a>
+          Some default slot, slotted text
+          <span>a default slot, slotted element</span>
+          <div slot="second-slot">
+            a second slot, slotted element
+            <span>nested element in the second slot<span>
+          </div></cmp-a>
+      `,
+      hydrateClientSide: true,
+    });
+
+    patchPseudoShadowDom(specPage.root);
+  });
+
+  it('patches `childNodes` to return only nodes that have been slotted', async () => {
+    const childNodes = specPage.root.childNodes;
+
+    expect(nodeOrEleContent(childNodes[0])).toBe(`Some default slot, slotted text`);
+    expect(nodeOrEleContent(childNodes[1])).toBe(`<span>a default slot, slotted element</span>`);
+    expect(nodeOrEleContent(childNodes[2])).toBe(``);
+    expect(nodeOrEleContent(childNodes[3])).toBe(
+      `<div slot="second-slot"> a second slot, slotted element <span>nested element in the second slot<span></span></span></div>`,
+    );
+
+    const innerChildNodes = specPage.root.__childNodes;
+
+    expect(nodeOrEleContent(innerChildNodes[0])).toBe(``);
+    expect(nodeOrEleContent(innerChildNodes[1])).toBe(``);
+    expect(nodeOrEleContent(innerChildNodes[2])).toBe(``);
+    expect(nodeOrEleContent(innerChildNodes[3])).toBe(``);
+    expect(nodeOrEleContent(innerChildNodes[4])).toBe(``);
+    expect(nodeOrEleContent(innerChildNodes[5])).toBe(`'Shadow' first text node`);
+  });
+
+  it('patches `children` to return only elements that have been slotted', async () => {
+    const children = specPage.root.children;
+
+    expect(nodeOrEleContent(children[0])).toBe(`<span>a default slot, slotted element</span>`);
+    expect(nodeOrEleContent(children[1])).toBe(
+      `<div slot="second-slot"> a second slot, slotted element <span>nested element in the second slot<span></span></span></div>`,
+    );
+    expect(nodeOrEleContent(children[2])).toBe(undefined);
+  });
+
+  it('patches `childElementCount` to only count elements that have been slotted', async () => {
+    expect(specPage.root.childElementCount).toBe(2);
+  });
+
+  it('patches `textContent` to only return slotted node text', async () => {
+    expect(specPage.root.textContent.replace(/\s+/g, ' ').trim()).toBe(
+      `Some default slot, slotted text a default slot, slotted element a second slot, slotted element nested element in the second slot`,
+    );
+  });
+});

--- a/src/runtime/test/dom-extras.spec.tsx
+++ b/src/runtime/test/dom-extras.spec.tsx
@@ -10,7 +10,7 @@ describe('dom-extras - patches for non-shadow dom methods and accessors', () => 
     return (node as Element)?.outerHTML || node?.nodeValue.trim();
   };
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     @Component({
       tag: 'cmp-a',
       scoped: true,

--- a/test/wdio/attribute-basic/cmp.test.tsx
+++ b/test/wdio/attribute-basic/cmp.test.tsx
@@ -10,6 +10,7 @@ describe('attribute-basic', () => {
   });
 
   it('button click rerenders', async () => {
+    await $('attribute-basic.hydrated').waitForExist();
     await expect($('.single')).toHaveText('single');
     await expect($('.multiWord')).toHaveText('multiWord');
     await expect($('.customAttr')).toHaveText('my-custom-attr');

--- a/test/wdio/attribute-boolean/cmp.test.tsx
+++ b/test/wdio/attribute-boolean/cmp.test.tsx
@@ -10,6 +10,7 @@ describe('attribute-boolean', () => {
   });
 
   it('button click rerenders', async () => {
+    await $('attribute-boolean-root.hydrated').waitForExist();
     const root: any = document.body.querySelector('attribute-boolean-root')!;
     await expect($(root)).toHaveAttribute('aria-hidden', 'false');
     await expect(root).toHaveAttribute('aria-hidden', 'false');

--- a/test/wdio/delegates-focus/cmp.test.tsx
+++ b/test/wdio/delegates-focus/cmp.test.tsx
@@ -25,8 +25,8 @@ describe('delegates-focus', function () {
   });
 
   it('should delegate focus', async () => {
-    await $('delegates-focus').waitForExist();
-    await $('no-delegates-focus').waitForExist();
+    await $('delegates-focus.hydrated').waitForExist();
+    await $('no-delegates-focus.hydrated').waitForExist();
 
     const delegatesFocus = document.querySelector('delegates-focus');
     const noDelegatesFocus = document.querySelector('no-delegates-focus');

--- a/test/wdio/text-content-patch/cmp.test.tsx
+++ b/test/wdio/text-content-patch/cmp.test.tsx
@@ -23,19 +23,13 @@ describe('textContent patch', () => {
     it('should return the content of all slots', async () => {
       const elm = $('text-content-patch-scoped-with-slot');
       await expect(elm.getText()).toMatchInlineSnapshot(`
-        "Top content
-        Slot content
-        Bottom content
-        Suffix content"
-      `);
+        "Slot content
+Suffix content"`);
     });
 
     it('should return an empty string if there is no slotted content', async () => {
       const elm = $('text-content-patch-scoped');
-      await expect(elm.getText()).toMatchInlineSnapshot(`
-        "Top content
-        Bottom content"
-      `);
+      await expect(await elm.getText()).toBe(``);
     });
 
     it('should overwrite the default slot content', async () => {
@@ -47,11 +41,7 @@ describe('textContent patch', () => {
         elm as any as HTMLElement,
       );
 
-      await expect(elm.getText()).toMatchInlineSnapshot(`
-        "Top content
-        New slot content
-        Bottom content"
-      `);
+      await expect(elm.getText()).toMatchInlineSnapshot(`"New slot content"`);
     });
 
     it('should not insert the text node if there is no default slot', async () => {
@@ -63,10 +53,7 @@ describe('textContent patch', () => {
         elm as any as HTMLElement,
       );
 
-      await expect(elm.getText()).toMatchInlineSnapshot(`
-        "Top content
-        Bottom content"
-      `);
+      await expect(await elm.getText()).toBe(``);
     });
   });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: Fixes https://github.com/ionic-team/stencil/issues/6054

TLDR ... `customElement.childNodes`, `customElement.children` monkey-patches are never actually switched-on in Stencil atm. `scopedSlotTextContentFix` doesn't fully patch the `textContent`.

...

Contrary to documentation, the `experimentalSlotFixes` or `slotChildNodesFix` flags have no effect on the `childNodes` or `children` accessors. The patches are only applied if the deprecated `needsShadowDomShim` flag is fulfilled. 

This must be a mistake / a hangover from supporting legacy browsers.

Additionally `scopedSlotTextContentFix` alone doesn't fully patch the `host.textContent` accessor. It adds a half-way patch - which I believe to be more confusing than useful. 

To get the full `textContent` patch users much add both `experimentalScopedSlotChanges` AND `scopedSlotTextContentFix` (`experimentalScopedSlotChanges` alone won't add ANY patch). 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Adding `experimentalSlotFixes` or `slotChildNodesFix` now patches `childNodes`, `children` and `childElementCount` - they only return the nodes / elements that have been slotted - not the items within the component internals. This more closely mimics shadowRoot enabled components.

I have removed the `experimentalScopedSlotChanges` for the `textContent` patch. 
Users need only apply `scopedSlotTextContentFix` or the unified `experimentalSlotFixes`. 

Additionally, I have rolled-in the `experimentalScopedSlotChanges` flag within the unified `experimentalSlotFixes` flag - I believe this makes sense as `experimentalScopedSlotChanges` will eventually be 'on' by default.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

- Added some spec tests for `dom-extras`. 
- Amended wdio tests (e.g. the `text-content-patch` test now only tests for the slotted text and doesn't return internal text)
- I made some flaky wdio tests slightly more reliable on my local machine. Happy to remove these as out-of-scope.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

Making these changes did open a slight a can of worms because the codebase has never actually dealt with `host.childNodes` being monkey patched; everything assumes it will return a full list of component internals...

- Within non-shadow vdom slot handling 
- Within other monkey-patched methods 

To fix this, using the precedent of `appendChild` (and similar methods) within `dom-extras.ts`, I have added a `__childNodes` accessor to return a component's 'internal' nodes. 