### PR TITLE
fix(runtime): ensure Node is defined

### DIFF
--- a/src/runtime/dom-extras.ts
+++ b/src/runtime/dom-extras.ts
@@ -249,7 +249,7 @@ export const patchSlotInsertAdjacentElement = (HostElementPrototype: HTMLElement
  * @param hostElementPrototype the `Element` to be patched
  */
 export const patchTextContent = (hostElementPrototype: HTMLElement): void => {
-  let descriptor = Object.getOwnPropertyDescriptor(Node.prototype, 'textContent');
+  let descriptor = globalThis.Node && Object.getOwnPropertyDescriptor(Node.prototype, 'textContent');
 
   if (!descriptor) {
     // for mock-doc
@@ -282,7 +282,7 @@ export const patchChildSlotNodes = (elm: HTMLElement) => {
     }
   }
 
-  let childNodesFn = Object.getOwnPropertyDescriptor(Node.prototype, 'childNodes');
+  let childNodesFn = globalThis.Node && Object.getOwnPropertyDescriptor(Node.prototype, 'childNodes');
   if (!childNodesFn) {
     // for mock-doc
     childNodesFn = Object.getOwnPropertyDescriptor(elm, 'childNodes');


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
Stencils runtime tries to access `Node` which may not be defined when server side rendering components.

## What is the new behavior?
Have a check for `Node` before accessing it.

fixes https://github.com/ionic-team/stencil-ds-output-targets/issues/537

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

We will have to put some tests in place to ensure we can build the Output targets project. This should be a separate effort.

## Other information

n/a
