### PR TITLE
fix: rewrite SSR client-side hydration

### DIFF
--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -1436,6 +1436,12 @@ export interface RenderNode extends HostElement {
   ['s-nr']?: RenderNode;
 
   /**
+   * Original Order:
+   * During SSR; a number representing the order of a slotted node
+   */
+  ['s-oo']?: number;
+
+  /**
    * Scope Id
    */
   ['s-si']?: string;

--- a/src/runtime/client-hydrate.ts
+++ b/src/runtime/client-hydrate.ts
@@ -1,5 +1,5 @@
 import { BUILD } from '@app-data';
-import { doc, plt, supportsShadow } from '@platform';
+import { doc, plt } from '@platform';
 
 import type * as d from '../declarations';
 import { createTime } from './profile';
@@ -11,14 +11,17 @@ import {
   ORG_LOCATION_ID,
   SLOT_NODE_ID,
   TEXT_NODE_ID,
+  COMMENT_NODE_ID,
 } from './runtime-constants';
 import { newVNode } from './vdom/h';
+import { addSlotRelocateNode } from './dom-extras';
 
 /**
- * Entrypoint of the client-side hydration process. Facilitates calls to hydrate the
- * document and all its nodes.
- *
- * This process will also reconstruct the shadow root and slot DOM nodes for components using shadow DOM.
+ * Takes an SSR rendered document, as annotated by 'vdom-annotations.ts' and:
+ * 1) Recreate an accurate VDOM tree to reconcile with during 'vdom-render.ts' (a failure to do so will result in DOM nodes being duplicated when rendering)
+ * 2) Add `shadow: true` DOM trees to their document-fragment
+ * 3) Move slotted nodes out of shadowDOMs
+ * 4) Add meta nodes to non-shadow DOMs and their 'slotted' nodes
  *
  * @param hostElm The element to hydrate.
  * @param tagName The element's tag name.
@@ -35,58 +38,159 @@ export const initializeClientHydrate = (
   const shadowRoot = hostElm.shadowRoot;
   const childRenderNodes: RenderNodeData[] = [];
   const slotNodes: RenderNodeData[] = [];
+  const slottedNodes: SlottedNodes[] = [];
   const shadowRootNodes: d.RenderNode[] = BUILD.shadowDom && shadowRoot ? [] : null;
-  const vnode: d.VNode = (hostRef.$vnode$ = newVNode(tagName, null));
+  const vnode: d.VNode = newVNode(tagName, null);
+  vnode.$elm$ = hostElm;
 
   if (!plt.$orgLocNodes$) {
+    // This is the first pass over of this whole document;
+    // does a scrape to construct a 'bare-bones' tree of what elements we have and where content has been moved from
     initializeDocumentHydrate(doc.body, (plt.$orgLocNodes$ = new Map()));
   }
 
   hostElm[HYDRATE_ID] = hostId;
   hostElm.removeAttribute(HYDRATE_ID);
 
-  clientHydrate(vnode, childRenderNodes, slotNodes, shadowRootNodes, hostElm, hostElm, hostId);
+  hostRef.$vnode$ = clientHydrate(
+    vnode,
+    childRenderNodes,
+    slotNodes,
+    shadowRootNodes,
+    hostElm,
+    hostElm,
+    hostId,
+    slottedNodes
+  );
 
-  childRenderNodes.map((c) => {
-    const orgLocationId = c.$hostId$ + '.' + c.$nodeId$;
+  let crIndex = 0;
+  const crLength = childRenderNodes.length;
+  let childRenderNode: RenderNodeData;
+
+  // Steps through childNodes we found.
+  // If moved from an original location (by nature of being rendered in SSR markup) we might be able to move it back there now,
+  // so slotted nodes don't get added to internal shadowDOMs
+  for (crIndex; crIndex < crLength; crIndex++) {
+    childRenderNode = childRenderNodes[crIndex];
+    const orgLocationId = childRenderNode.$hostId$ + '.' + childRenderNode.$nodeId$;
     const orgLocationNode = plt.$orgLocNodes$.get(orgLocationId);
-    const node = c.$elm$ as d.RenderNode;
-
-    // Put the node back in its original location since the native Shadow DOM
-    // can handle rendering it its correct location now
-    if (orgLocationNode && supportsShadow && orgLocationNode['s-en'] === '') {
-      orgLocationNode.parentNode.insertBefore(node, orgLocationNode.nextSibling);
-    }
-
+    const node = childRenderNode.$elm$ as d.RenderNode;
+    
     if (!shadowRoot) {
-      node['s-hn'] = tagName;
+      node['s-hn'] = tagName.toUpperCase();
 
-      if (orgLocationNode) {
-        node['s-ol'] = orgLocationNode;
-        node['s-ol']['s-nr'] = node;
+      if (childRenderNode.$tag$ === 'slot') {
+        // If this is a virtual 'slot', add it's Content-position Reference now.
+        // If we don't, `vdom-render.ts` will try to add nodes to it (and because it may be a comment node, it will error)
+        node['s-cr'] = hostElm['s-cr'];
       }
     }
+  
+    if (orgLocationNode && orgLocationNode.isConnected) {
+      if (shadowRoot && orgLocationNode['s-en'] === '') {
+        // if this node is within a shadowDOM, with an original location home
+        // we're safe to move it now
+        orgLocationNode.parentNode.insertBefore(node, orgLocationNode.nextSibling);
+      }
+      // Remove original location / slot reference comment now regardless:
+      // 1) Stops SSR frameworks complaining about mismatches
+      // 2) is un-required for non-shadow, slotted nodes as we'll add all the meta nodes we need when we deal with *all* slotted nodes ↓↓↓
+      orgLocationNode.parentNode.removeChild(orgLocationNode);
 
+      if (!shadowRoot) {
+        // Add the Original Order of this node.
+        // We'll use it later to make sure slotted nodes get added in the correct order
+        node['s-oo'] = parseInt(childRenderNode.$nodeId$);
+      }
+    }
+    // Remove the original location from the map
     plt.$orgLocNodes$.delete(orgLocationId);
-  });
+  }
+    
+  const hosts: d.HostElement[] = [];
+  let snIndex = 0;
+  const snLen = slottedNodes.length;
+  let slotGroup: SlottedNodes;
+  let snGroupIdx: number;
+  let snGroupLen: number;
+  let slottedItem: SlottedNodes[0];
+
+  // Loops through all the slotted nodes we found while stepping through this component
+  for (snIndex; snIndex < snLen; snIndex++) {
+    slotGroup = slottedNodes[snIndex];
+
+    if (!slotGroup || !slotGroup.length) continue;
+
+    snGroupLen = slotGroup.length;
+    snGroupIdx = 0;
+
+    for (snGroupIdx; snGroupIdx < snGroupLen; snGroupIdx++) {
+      slottedItem = slotGroup[snGroupIdx];
+
+      if (!hosts[slottedItem.hostId as any]) {
+        // Vache this host for other grouped slotted nodes
+        hosts[slottedItem.hostId as any] = plt.$orgLocNodes$.get(slottedItem.hostId);
+      }
+      // This *shouldn't* happen as we collect all the custom elements first in `initializeDocumentHydrate`
+      if (!hosts[slottedItem.hostId as any]) continue;
+
+      const hostEle = hosts[slottedItem.hostId as any];
+
+      // This node is either slotted in a non-shadow host, OR *that* host is nested in a non-shadow host
+      if (!hostEle.shadowRoot || !shadowRoot) {
+        // Try to set an appropriate Content-position Reference (CR) node for this host element
+
+        // Is a CR already set on the host?
+        slottedItem.slot['s-cr'] = hostEle['s-cr'];
+
+        if (!slottedItem.slot['s-cr'] && hostEle.shadowRoot) {
+          // Host has shadowDOM - just use the host itself as the CR for native slotting
+          slottedItem.slot['s-cr'] = hostEle;
+        } else {
+          // If all else fails - just set the CR as the first child
+          // (9/10 if node['s-cr'] hasn't been set, the node will be at the element root)
+          const hostChildren = (hostEle as any).__childNodes || hostEle.childNodes;
+          slottedItem.slot['s-cr'] = hostChildren[0] as d.RenderNode;
+        }
+        // Create our 'Original Location' node
+        addSlotRelocateNode(slottedItem.node, slottedItem.slot, false, slottedItem.node['s-oo']);
+      }
+
+      if (hostEle.shadowRoot && slottedItem.node.parentElement !== hostEle) {
+        // shadowDOM - move the item to the element root for native slotting
+        hostEle.appendChild(slottedItem.node);
+      }
+    }
+  }
 
   if (BUILD.shadowDom && shadowRoot) {
-    shadowRootNodes.map((shadowRootNode) => {
-      if (shadowRootNode) {
-        shadowRoot.appendChild(shadowRootNode as any);
+    // Add all the root nodes in the shadowDOM (a root node can have a whole nested DOM tree)
+    let rnIdex = 0;
+    const rnLen = shadowRootNodes.length;
+    for (rnIdex; rnIdex < rnLen; rnIdex++) {
+      shadowRoot.appendChild(shadowRootNodes[rnIdex] as any);
+    }
+
+    // Tidy up left-over / unnecessary comments to stop frameworks complaining about DOM mismatches
+    Array.from(hostElm.childNodes).forEach((node) => {
+      if (node.nodeType === NODE_TYPE.CommentNode && typeof (node as d.RenderNode)['s-sn'] !== 'string') {
+        node.parentNode.removeChild(node);
       }
     });
   }
+  
+  hostRef.$hostElement$ = hostElm;
   endHydrate();
 };
 
 /**
  * Recursively constructs the virtual node tree for a host element and its children.
- * The tree is constructed by parsing the annotations set on the nodes by the server.
+ * The tree is constructed by parsing the annotations set on the nodes by the server (`vdom-annotations.ts`).
  *
- * In addition to constructing the vNode tree, we also track information about the node's
- * descendants like which are slots, which should exist in the shadow root, and which
- * are nodes that should be rendered as children of the parent node.
+ * In addition to constructing the VNode tree, we also track information about the node's descendants:
+ * - which are slots
+ * - which should exist in the shadow root 
+ * - which are nodes that should be rendered as children of the parent node
  *
  * @param parentVNode The vNode representing the parent node.
  * @param childRenderNodes An array of all child nodes in the parent's node tree.
@@ -95,6 +199,8 @@ export const initializeClientHydrate = (
  * @param hostElm The parent element.
  * @param node The node to construct the vNode tree for.
  * @param hostId The host ID assigned to the element by the server.
+ * @param slottedNodes - nodes that have been slotted
+ * @returns - the constructed VNode
  */
 const clientHydrate = (
   parentVNode: d.VNode,
@@ -104,21 +210,23 @@ const clientHydrate = (
   hostElm: d.HostElement,
   node: d.RenderNode,
   hostId: string,
+  slottedNodes: SlottedNodes[] = [],
 ) => {
   let childNodeType: string;
   let childIdSplt: string[];
   let childVNode: RenderNodeData;
   let i: number;
+  const scopeId = hostElm['s-sc'];
 
   if (node.nodeType === NODE_TYPE.ElementNode) {
     childNodeType = (node as HTMLElement).getAttribute(HYDRATE_CHILD_ID);
     if (childNodeType) {
-      // got the node data from the element's attribute
+      // Node data from the element's attribute:
       // `${hostId}.${nodeId}.${depth}.${index}`
       childIdSplt = childNodeType.split('.');
 
       if (childIdSplt[0] === hostId || childIdSplt[0] === '0') {
-        childVNode = {
+        childVNode = createSimpleVNode({
           $flags$: 0,
           $hostId$: childIdSplt[0],
           $nodeId$: childIdSplt[1],
@@ -126,26 +234,35 @@ const clientHydrate = (
           $index$: childIdSplt[3],
           $tag$: node.tagName.toLowerCase(),
           $elm$: node,
-          $attrs$: null,
-          $children$: null,
-          $key$: null,
-          $name$: null,
-          $text$: null,
-        };
+          // If we don't add the initial classes to the VNode, the first `vdom-render.ts` reconciliation will fail:
+          // client side changes before componentDidLoad will be ignored, `set-accessor.ts` will just take the element's initial classes
+          $attrs$: { class: node.className },
+        });
 
         childRenderNodes.push(childVNode);
         node.removeAttribute(HYDRATE_CHILD_ID);
 
-        // this is a new child vnode
-        // so ensure its parent vnode has the vchildren array
+        // This is a new child VNode so ensure its parent VNode has the VChildren array
         if (!parentVNode.$children$) {
           parentVNode.$children$ = [];
         }
 
-        // add our child vnode to a specific index of the vnode's children
-        parentVNode.$children$[childVNode.$index$ as any] = childVNode;
+        // Test if this element was 'slotted'. Recreate node attributes
+        const slotName = childVNode.$elm$.getAttribute('s-sn');
+        if (typeof slotName === 'string') {
+          childVNode.$elm$['s-sn'] = slotName;
+          childVNode.$elm$.removeAttribute('s-sn');
+        }
+        if (childVNode.$index$ !== undefined) {
+          // add our child VNode to a specific index of the VNode's children
+          parentVNode.$children$[childVNode.$index$ as any] = childVNode;
+        }
 
-        // this is now the new parent vnode for all the next child checks
+        // Host is `scoped: true` - add that flag to the child.
+        // It's used in 'set-accessor.ts' to make sure our scoped class is present
+        if (scopeId) node['s-si'] = scopeId;
+
+        // This is now the new parent VNode for all the next child checks
         parentVNode = childVNode;
 
         if (shadowRootNodes && childVNode.$depth$ === '0') {
@@ -155,7 +272,7 @@ const clientHydrate = (
     }
 
     if (node.shadowRoot) {
-      // keep drilling down through the shadow root nodes
+      // Keep drilling down through the shadow root nodes
       for (i = node.shadowRoot.childNodes.length - 1; i >= 0; i--) {
         clientHydrate(
           parentVNode,
@@ -165,20 +282,23 @@ const clientHydrate = (
           hostElm,
           node.shadowRoot.childNodes[i] as any,
           hostId,
+          slottedNodes,
         );
       }
     }
 
-    // recursively drill down, end to start so we can remove nodes
-    for (i = node.childNodes.length - 1; i >= 0; i--) {
+    // Recursively drill down, end to start so we can remove nodes
+    const nonShadowNodes = node.__childNodes || node.childNodes;
+    for (i = nonShadowNodes.length - 1; i >= 0; i--) {
       clientHydrate(
         parentVNode,
         childRenderNodes,
         slotNodes,
         shadowRootNodes,
         hostElm,
-        node.childNodes[i] as any,
+        nonShadowNodes[i] as any,
         hostId,
+        slottedNodes,
       );
     }
   } else if (node.nodeType === NODE_TYPE.CommentNode) {
@@ -186,15 +306,14 @@ const clientHydrate = (
     childIdSplt = node.nodeValue.split('.');
 
     if (childIdSplt[1] === hostId || childIdSplt[1] === '0') {
-      // comment node for either the host id or a 0 host id
+      // This comment node for either the host id or a 0 host id (a root component)
       childNodeType = childIdSplt[0];
 
-      childVNode = {
-        $flags$: 0,
+      childVNode = createSimpleVNode({
         $hostId$: childIdSplt[1],
         $nodeId$: childIdSplt[2],
         $depth$: childIdSplt[3],
-        $index$: childIdSplt[4],
+        $index$: childIdSplt[4] || '0',
         $elm$: node,
         $attrs$: null,
         $children$: null,
@@ -202,59 +321,109 @@ const clientHydrate = (
         $name$: null,
         $tag$: null,
         $text$: null,
-      };
+      });
 
       if (childNodeType === TEXT_NODE_ID) {
         childVNode.$elm$ = node.nextSibling as any;
+        
         if (childVNode.$elm$ && childVNode.$elm$.nodeType === NODE_TYPE.TextNode) {
           childVNode.$text$ = childVNode.$elm$.textContent;
           childRenderNodes.push(childVNode);
 
-          // remove the text comment since it's no longer needed
+          // Remove the text comment since it's no longer needed
           node.remove();
-
-          if (!parentVNode.$children$) {
-            parentVNode.$children$ = [];
+          
+          // Checks to make sure this node actually belongs to this host.
+          // If it was slotted from another component, we don't want to add it to this host's VDOM; it can be removed on render reconciliation.
+          // We *want* slotting logic to take care of it
+          if (hostId === childVNode.$hostId$) {
+            if (!parentVNode.$children$) {
+              parentVNode.$children$ = [];
+            }
+            parentVNode.$children$[childVNode.$index$ as any] = childVNode;
           }
-          parentVNode.$children$[childVNode.$index$ as any] = childVNode;
 
           if (shadowRootNodes && childVNode.$depth$ === '0') {
             shadowRootNodes[childVNode.$index$ as any] = childVNode.$elm$;
           }
         }
+      } else if (childNodeType === COMMENT_NODE_ID) {
+        // A non-Stencil comment node
+        childVNode.$elm$ = node.nextSibling as any;
+
+        if (childVNode.$elm$ && childVNode.$elm$.nodeType === NODE_TYPE.CommentNode) {
+          childRenderNodes.push(childVNode);
+
+          // Remove the comment comment since it's no longer needed
+          node.remove();
+        }
       } else if (childVNode.$hostId$ === hostId) {
-        // this comment node is specifically for this host id
+        // This comment node is specifically for this host id
 
         if (childNodeType === SLOT_NODE_ID) {
+          // Comment refers to a slot node: 
           // `${SLOT_NODE_ID}.${hostId}.${nodeId}.${depth}.${index}.${slotName}`;
           childVNode.$tag$ = 'slot';
 
-          if (childIdSplt[5]) {
-            node['s-sn'] = childVNode.$name$ = childIdSplt[5];
-          } else {
-            node['s-sn'] = '';
-          }
+          // Add the slot name
+          const slotName = (node['s-sn'] = childVNode.$name$ = childIdSplt[5] || '');
           node['s-sr'] = true;
 
+          // Find this slots' current host parent (as dictated by the VDOM tree).
+          // Important because where it is now in the constructed SSR markup might be different to where to *should* be
+          const parentNodeId = parentVNode?.$elm$
+            ? parentVNode.$elm$['s-id'] || parentVNode.$elm$.getAttribute('s-id')
+            : '';
+
           if (BUILD.shadowDom && shadowRootNodes) {
-            // browser support shadowRoot and this is a shadow dom component
-            // create an actual slot element
-            childVNode.$elm$ = doc.createElement(childVNode.$tag$);
+            /* SHADOW */
+
+            // Browser supports shadowRoot and this is a shadow dom component; create an actual slot element
+            const slot = (childVNode.$elm$ = doc.createElement(childVNode.$tag$) as d.RenderNode);
 
             if (childVNode.$name$) {
-              // add the slot name attribute
-              childVNode.$elm$.setAttribute('name', childVNode.$name$);
+              // Add the slot name attribute
+              childVNode.$elm$.setAttribute('name', slotName);
             }
 
-            // insert the new slot element before the slot comment
-            node.parentNode.insertBefore(childVNode.$elm$, node);
+            if (parentNodeId && parentNodeId !== childVNode.$hostId$) {
+              // Shadow component's slot is placed inside a nested component's shadowDOM; it doesn't belong to this host - it was forwarded by the SSR markup.
+              // Insert it in the root of this host; it's lightDOM. It doesn't really matter where in the host root; the component will take care of it.
+              parentVNode.$elm$.insertBefore(slot, parentVNode.$elm$.children[0]);
+            } else {
+              // Insert the new slot element before the slot comment
+              node.parentNode.insertBefore(childVNode.$elm$, node);
+            }
+            addSlottedNodes(slottedNodes, childIdSplt[2], slotName, node, childVNode.$hostId$);
 
-            // remove the slot comment since it's not needed for shadow
+            // Remove the slot comment since it's not needed for shadow
             node.remove();
 
             if (childVNode.$depth$ === '0') {
               shadowRootNodes[childVNode.$index$ as any] = childVNode.$elm$;
             }
+          } else {
+            /* NON-SHADOW */
+            const slot = childVNode.$elm$ as d.RenderNode;
+
+            // Test to see if this non-shadow component's mock 'slot' is placed inside a nested component's shadowDOM. If so, it doesn't belong here;
+            // it was forwarded by the SSR markup. So we'll insert it into the root of this host; it's lightDOM with accompanying 'slotted' nodes
+            const shouldMove = parentNodeId && parentNodeId !== childVNode.$hostId$ && parentVNode.$elm$.shadowRoot;
+
+            // attempt to find any mock slotted nodes which we'll move later
+            addSlottedNodes(
+              slottedNodes,
+              childIdSplt[2],
+              slotName,
+              node,
+              shouldMove ? parentNodeId : childVNode.$hostId$
+            );
+
+            if (shouldMove) {
+              // Move slot comment node (to after any other comment nodes)
+              parentVNode.$elm$.insertBefore(slot, parentVNode.$elm$.children[0]);
+            }
+            childRenderNodes.push(childVNode);
           }
 
           slotNodes.push(childVNode);
@@ -266,7 +435,7 @@ const clientHydrate = (
         } else if (childNodeType === CONTENT_REF_ID) {
           // `${CONTENT_REF_ID}.${hostId}`;
           if (BUILD.shadowDom && shadowRootNodes) {
-            // remove the content ref comment since it's not needed for shadow
+            // Remove the content ref comment since it's not needed for shadow
             node.remove();
           } else if (BUILD.slotRelocation) {
             hostElm['s-cr'] = node;
@@ -281,25 +450,35 @@ const clientHydrate = (
     vnode.$index$ = '0';
     parentVNode.$children$ = [vnode];
   }
+
+  return parentVNode;
 };
 
 /**
- * Recursively locate any comments representing an original location for a node in a node's
- * children or shadowRoot children.
- *
+ * Recursively locate any comments representing a original location for a node in a node's children or shadowRoot children. 
+ * Creates a map of component IDs and "Original Location ID's" which are derived from comment nodes placed by 'vdom-annotations.ts'
+ * They relate to lightDOM nodes that were moved deeper into the SSR markup. e.g. `<!--o.1-->` maps to `<div c-id="0.1">`
+ * 
  * @param node The node to search.
- * @param orgLocNodes A map of the original location annotation and the current node being searched.
+ * @param orgLocNodes A map of the original location annotations and the current node being searched.
  */
 export const initializeDocumentHydrate = (node: d.RenderNode, orgLocNodes: d.PlatformRuntime['$orgLocNodes$']) => {
   if (node.nodeType === NODE_TYPE.ElementNode) {
+    // Add all the loaded component IDs in this document; required to find nodes later when deciding where slotted nodes should live
+    const componentId = node[HYDRATE_ID] || node.getAttribute(HYDRATE_ID);
+    if (componentId) {
+      orgLocNodes.set(componentId, node);
+    }
+
     let i = 0;
     if (node.shadowRoot) {
       for (; i < node.shadowRoot.childNodes.length; i++) {
         initializeDocumentHydrate(node.shadowRoot.childNodes[i] as d.RenderNode, orgLocNodes);
       }
     }
-    for (i = 0; i < node.childNodes.length; i++) {
-      initializeDocumentHydrate(node.childNodes[i] as d.RenderNode, orgLocNodes);
+    const nonShadowNodes = node.__childNodes || node.childNodes;
+    for (i = 0; i < nonShadowNodes.length; i++) {
+      initializeDocumentHydrate(nonShadowNodes[i] as d.RenderNode, orgLocNodes);
     }
   } else if (node.nodeType === NODE_TYPE.CommentNode) {
     const childIdSplt = node.nodeValue.split('.');
@@ -307,12 +486,74 @@ export const initializeDocumentHydrate = (node: d.RenderNode, orgLocNodes: d.Pla
       orgLocNodes.set(childIdSplt[1] + '.' + childIdSplt[2], node);
       node.nodeValue = '';
 
-      // useful to know if the original location is
-      // the root light-dom of a shadow dom component
+      // Useful to know if the original location is The root light-dom of a shadow dom component
       node['s-en'] = childIdSplt[3] as any;
     }
   }
 };
+
+/**
+ * Creates a VNode to add to a hydrated component VDOM
+ * 
+ * @param vnode - a vnode partial which will be augmented
+ * @returns an complete vnode
+ */
+const createSimpleVNode = (vnode: Partial<RenderNodeData>): RenderNodeData => {
+  const defaultVNode: RenderNodeData = {
+    $flags$: 0,
+    $hostId$: null,
+    $nodeId$: null,
+    $depth$: null,
+    $index$: '0',
+    $elm$: null,
+    $attrs$: null,
+    $children$: null,
+    $key$: null,
+    $name$: null,
+    $tag$: null,
+    $text$: null,
+  };
+  return { ...defaultVNode, ...vnode };
+};
+
+/**
+ * Adds groups of slotted nodes (grouped by slot ID) to this host element's 'master' array. 
+ * We'll use this after the host element's VDOM is completely constructed to finally position and add meta required by non-shadow slotted nodes
+ * 
+ * @param slottedNodes - the main host element 'master' array to add to
+ * @param slotNodeId - the slot node unique ID
+ * @param slotName - the slot node name (can be '')
+ * @param slotNode - the slot node
+ * @param hostId - the host element id where this node should be slotted
+ */
+const addSlottedNodes = (
+  slottedNodes: SlottedNodes[],
+  slotNodeId: string,
+  slotName: string,
+  slotNode: d.RenderNode,
+  hostId: string
+) => {
+  let slottedNode = slotNode.nextSibling as d.RenderNode;
+  slottedNodes[slotNodeId as any] = slottedNodes[slotNodeId as any] || [];
+
+  // Looking for nodes that match this slot's name,
+  // OR are text / comment nodes and the slot is a default slot (no name) - text / comments cannot be direct descendants of *named* slots.
+  // Also ignore slot fallback nodes - they're not part of the lightDOM
+  while (
+    slottedNode &&
+    (slottedNode['s-sn'] === slotName ||
+      (slotName === '' &&
+        !slottedNode['s-sn'] &&
+        ((slottedNode.nodeType === NODE_TYPE.CommentNode && slottedNode.nodeValue.indexOf('.') !== 1) ||
+          slottedNode.nodeType === NODE_TYPE.TextNode)))
+  ) {
+    slottedNode['s-sn'] = slotName;
+    slottedNodes[slotNodeId as any].push({ slot: slotNode, node: slottedNode, hostId });
+    slottedNode = slottedNode.nextSibling as d.RenderNode;
+  }
+};
+
+type SlottedNodes = Array<{ slot: d.RenderNode; node: d.RenderNode; hostId: string }>;
 
 interface RenderNodeData extends d.VNode {
   $hostId$: string;

--- a/src/runtime/connected-callback.ts
+++ b/src/runtime/connected-callback.ts
@@ -7,7 +7,7 @@ import { initializeClientHydrate } from './client-hydrate';
 import { fireConnectedCallback, initializeComponent } from './initialize-component';
 import { createTime } from './profile';
 import { HYDRATE_ID, NODE_TYPE, PLATFORM_FLAGS } from './runtime-constants';
-import { addStyle } from './styles';
+import { addStyle, getScopeId } from './styles';
 import { attachToAncestor } from './update-component';
 import { insertBefore } from './vdom/vdom-render';
 
@@ -35,6 +35,11 @@ export const connectedCallback = (elm: d.HostElement) => {
               ? addStyle(elm.shadowRoot, cmpMeta, elm.getAttribute('s-mode'))
               : addStyle(elm.shadowRoot, cmpMeta);
             elm.classList.remove(scopeId + '-h', scopeId + '-s');
+          } else if (BUILD.scoped && cmpMeta.$flags$ & CMP_FLAGS.scopedCssEncapsulation) {
+            // set the scope id on the element now. Useful when hydrating,
+            // to more quickly set the initial scoped classes for scoped css
+            const scopeId = getScopeId(cmpMeta, BUILD.mode ? elm.getAttribute('s-mode') : undefined);
+            elm['s-sc'] = scopeId;
           }
           initializeClientHydrate(elm, cmpMeta.$tagName$, hostId, hostRef);
         }

--- a/src/runtime/dom-extras.ts
+++ b/src/runtime/dom-extras.ts
@@ -287,8 +287,14 @@ export const patchChildSlotNodes = (elm: HTMLElement) => {
     // for mock-doc
     childNodesFn = Object.getOwnPropertyDescriptor(elm, 'childNodes');
   }
-
   if (childNodesFn) Object.defineProperty(elm, '__childNodes', childNodesFn);
+
+  let childrenFn = Object.getOwnPropertyDescriptor(Element.prototype, 'children');
+  if (!childrenFn) {
+    // for mock-doc
+    childrenFn = Object.getOwnPropertyDescriptor(elm, 'children');
+  }
+  if (childrenFn) Object.defineProperty(elm, '__children', childrenFn);
 
   Object.defineProperty(elm, 'children', {
     get() {

--- a/src/runtime/dom-extras.ts
+++ b/src/runtime/dom-extras.ts
@@ -330,9 +330,15 @@ export const patchChildSlotNodes = (elm: HTMLElement) => {
  * @param newChild a node that's going to be added to the component
  * @param slotNode the slot node that the node will be added to
  * @param prepend move the slotted location node to the beginning of the host
+ * @param position an ordered position to add the ref node which mirrors the lightDom nodes' order. Used during SSR hydration
  *  (the order of the slot location nodes determines the order of the slotted nodes in our patched accessors)
  */
-export const addSlotRelocateNode = (newChild: d.RenderNode, slotNode: d.RenderNode, prepend?: boolean) => {
+export const addSlotRelocateNode = (
+  newChild: d.RenderNode, 
+  slotNode: d.RenderNode, 
+  prepend?: boolean, 
+  position?: number
+) => {
   let slottedNodeLocation: d.RenderNode;
   // does newChild already have a slot location node?
   if (newChild['s-ol'] && newChild['s-ol'].isConnected) {
@@ -342,13 +348,33 @@ export const addSlotRelocateNode = (newChild: d.RenderNode, slotNode: d.RenderNo
     slottedNodeLocation['s-nr'] = newChild;
   }
 
+  if (!slotNode['s-cr'] || !slotNode['s-cr'].parentNode) return;
+
   const parent = slotNode['s-cr'].parentNode as any;
   const appendMethod = prepend ? parent.__prepend : parent.__appendChild;
 
+  if (typeof position !== 'undefined') {
+    if (BUILD.hydrateClientSide) {
+      slottedNodeLocation['s-oo'] = position;
+      const childNodes = (parent.__childNodes || parent.childNodes) as NodeListOf<d.RenderNode>;
+      const slotRelocateNodes: d.RenderNode[] = [slottedNodeLocation];
+      childNodes.forEach((n) => {
+        if (n['s-nr']) slotRelocateNodes.push(n);
+      });
+
+      slotRelocateNodes.sort((a, b) => {
+        if (!a['s-oo'] || a['s-oo'] < b['s-oo']) return -1;
+        else if (!b['s-oo'] || b['s-oo'] < a['s-oo']) return 1;
+        return 0;
+      });
+      slotRelocateNodes.forEach((n) => appendMethod.call(parent, n));
+    }
+  } else {
+    appendMethod.call(parent, slottedNodeLocation);
+  }
+
   newChild['s-ol'] = slottedNodeLocation;
   newChild['s-sh'] = slotNode['s-hn'];
-
-  appendMethod.call(parent, slottedNodeLocation);
 };
 
 /**

--- a/src/runtime/dom-extras.ts
+++ b/src/runtime/dom-extras.ts
@@ -334,10 +334,10 @@ export const patchChildSlotNodes = (elm: HTMLElement) => {
  *  (the order of the slot location nodes determines the order of the slotted nodes in our patched accessors)
  */
 export const addSlotRelocateNode = (
-  newChild: d.RenderNode, 
-  slotNode: d.RenderNode, 
-  prepend?: boolean, 
-  position?: number
+  newChild: d.RenderNode,
+  slotNode: d.RenderNode,
+  prepend?: boolean,
+  position?: number,
 ) => {
   let slottedNodeLocation: d.RenderNode;
   // does newChild already have a slot location node?
@@ -351,7 +351,7 @@ export const addSlotRelocateNode = (
   if (!slotNode['s-cr'] || !slotNode['s-cr'].parentNode) return;
 
   const parent = slotNode['s-cr'].parentNode as any;
-  const appendMethod = prepend ? parent.__prepend : parent.__appendChild;
+  const appendMethod = prepend ? parent.__prepend || parent.prepend : parent.__appendChild || parent.appendChild;
 
   if (typeof position !== 'undefined') {
     if (BUILD.hydrateClientSide) {

--- a/src/runtime/runtime-constants.ts
+++ b/src/runtime/runtime-constants.ts
@@ -54,6 +54,7 @@ export const CONTENT_REF_ID = 'r';
 export const ORG_LOCATION_ID = 'o';
 export const SLOT_NODE_ID = 's';
 export const TEXT_NODE_ID = 't';
+export const COMMENT_NODE_ID = 'c';
 
 export const HYDRATE_ID = 's-id';
 export const HYDRATED_STYLE_ID = 'sty-id';

--- a/src/runtime/test/hydrate-no-encapsulation.spec.tsx
+++ b/src/runtime/test/hydrate-no-encapsulation.spec.tsx
@@ -211,8 +211,6 @@ describe('hydrate no encapsulation', () => {
         <!--r.1-->
         <cmp-b class="hydrated">
           <!--r.2-->
-          <!---->
-          <!--s.2.0.0.0.-->
           light-dom
           <footer></footer>
         </cmp-b>
@@ -272,8 +270,6 @@ describe('hydrate no encapsulation', () => {
         <!--r.1-->
         <cmp-b class="hydrated">
           <!--r.2-->
-          <!---->
-          <!--s.2.0.0.0.-->
           light-dom
           <footer></footer>
         </cmp-b>
@@ -334,9 +330,7 @@ describe('hydrate no encapsulation', () => {
         <!--r.1-->
         <cmp-b class="hydrated">
           <!--r.2-->
-          <!---->
           <header></header>
-          <!--s.2.1.0.1.-->
           light-dom
         </cmp-b>
       </cmp-a>
@@ -397,9 +391,7 @@ describe('hydrate no encapsulation', () => {
         <!--r.1-->
         <cmp-b class="hydrated">
           <!--r.2-->
-          <!---->
           <header></header>
-          <!--s.2.1.0.1.-->
           light-dom
           <footer></footer>
         </cmp-b>
@@ -479,15 +471,11 @@ describe('hydrate no encapsulation', () => {
         <!--r.1-->
         <cmp-b class="hydrated">
           <!--r.2-->
-          <!---->
-          <!---->
-          <!---->
           <header></header>
           <!--s.2.1.0.1.top-->
           <div slot="top">
             top light-dom
           </div>
-          <!--s.2.2.0.2.-->
           middle light-dom
           <!--s.2.3.0.3.bottom-->
           <div slot="bottom">

--- a/src/runtime/test/hydrate-scoped.spec.tsx
+++ b/src/runtime/test/hydrate-scoped.spec.tsx
@@ -44,9 +44,7 @@ describe('hydrate scoped', () => {
     expect(clientHydrated.root).toEqualHtml(`
       <cmp-a class="hydrated">
         <!--r.1-->
-        <!---->
         <article>
-          <!--s.1.1.1.0.-->
           88mph
         </article>
       </cmp-a>
@@ -97,9 +95,7 @@ describe('hydrate scoped', () => {
     expect(clientHydrated.root).toEqualHtml(`
       <cmp-a class="hydrated">
         <!--r.1-->
-        <!---->
         <article>
-          <!--s.1.1.1.0.-->
           88mph
         </article>
       </cmp-a>
@@ -133,7 +129,6 @@ describe('hydrate scoped', () => {
       </cmp-a>
     `);
 
-    // @ts-ignore
     const clientHydrated = await newSpecPage({
       components: [CmpA],
       html: serverHydrated.root.outerHTML,

--- a/src/runtime/test/hydrate-scoped.spec.tsx
+++ b/src/runtime/test/hydrate-scoped.spec.tsx
@@ -95,7 +95,7 @@ describe('hydrate scoped', () => {
     expect(clientHydrated.root).toEqualHtml(`
       <cmp-a class="hydrated">
         <!--r.1-->
-        <article>
+        <article class="sc-cmp-a sc-cmp-a-s">
           88mph
         </article>
       </cmp-a>

--- a/src/runtime/test/hydrate-shadow-child.spec.tsx
+++ b/src/runtime/test/hydrate-shadow-child.spec.tsx
@@ -102,7 +102,6 @@ describe('hydrate, shadow child', () => {
           <mock:shadow-root>
             <slot></slot>
           </mock:shadow-root>
-          <!---->
           light-dom
         </cmp-b>
       </cmp-a>
@@ -285,7 +284,6 @@ describe('hydrate, shadow child', () => {
             <header></header>
             <slot></slot>
           </mock:shadow-root>
-          <!---->
           light-dom
         </cmp-b>
       </cmp-a>
@@ -417,7 +415,6 @@ describe('hydrate, shadow child', () => {
             <slot></slot>
             <footer></footer>
           </mock:shadow-root>
-          <!---->
           light-dom
         </cmp-b>
       </cmp-a>
@@ -428,7 +425,11 @@ describe('hydrate, shadow child', () => {
     @Component({ tag: 'cmp-a' })
     class CmpA {
       render() {
-        return <Host></Host>;
+        return (
+          <Host>
+            <slot />
+          </Host>
+        );
       }
     }
     @Component({ tag: 'cmp-b', shadow: true })
@@ -469,15 +470,17 @@ describe('hydrate, shadow child', () => {
     expect(serverHydrated.root).toEqualHtml(`
       <cmp-a class="hydrated" s-id="1">
         <!--r.1-->
-        <cmp-b class="hydrated" s-id="2">
+        <!--o.0.2-->
+        <!--s.1.0.0.0.-->
+        <cmp-b c-id="0.2" class="hydrated" s-id="2" s-sn="">
           <!--r.2-->
-          <!--o.0.1.-->
-          <!--o.0.2.-->
+          <!--o.0.4.-->
+          <!--o.0.5.-->
           <section c-id="2.0.0.0">
             <!--s.2.1.1.0.-->
-            <!--t.0.1-->
+            <!--t.0.4-->
             cmp-b-top-text
-            <cmp-c class="hydrated" c-id="0.2" s-id="3">
+            <cmp-c c-id="0.5" class="hydrated" s-id="3" s-sn="">
               <!--r.3-->
               <article c-id="3.0.0.0">
                 <!--t.3.1.1.0-->
@@ -497,18 +500,16 @@ describe('hydrate, shadow child', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class="hydrated">
+      <cmp-a class=\"hydrated\">
         <!--r.1-->
-        <cmp-b class="hydrated">
+        <cmp-b class=\"hydrated\">
           <mock:shadow-root>
             <section>
               <slot></slot>
             </section>
           </mock:shadow-root>
-          <!---->
           cmp-b-top-text
-          <!---->
-          <cmp-c class="hydrated">
+          <cmp-c class=\"hydrated\">
             <mock:shadow-root>
               <article>
                 cmp-c

--- a/src/runtime/test/hydrate-shadow-in-shadow.spec.tsx
+++ b/src/runtime/test/hydrate-shadow-in-shadow.spec.tsx
@@ -60,17 +60,14 @@ describe('hydrate, shadow in shadow', () => {
             <mock:shadow-root>
               <slot></slot>
             </mock:shadow-root>
-            <!---->
             <slot></slot>
           </cmp-b>
         </mock:shadow-root>
-        <!---->
         light-dom
       </cmp-a>
     `);
     expect(clientHydrated.root).toEqualLightHtml(`
       <cmp-a class="hydrated">
-        <!---->
         light-dom
       </cmp-a>
     `);
@@ -130,7 +127,6 @@ describe('hydrate, shadow in shadow', () => {
             <mock:shadow-root>
               <slot></slot>
             </mock:shadow-root>
-            <!---->
             light-dom
           </cmp-b>
         </mock:shadow-root>
@@ -314,7 +310,6 @@ describe('hydrate, shadow in shadow', () => {
             <header></header>
             <slot></slot>
           </mock:shadow-root>
-          <!---->
           light-dom
         </cmp-b>
       </cmp-a>
@@ -443,7 +438,7 @@ describe('hydrate, shadow in shadow', () => {
             <slot></slot>
             <footer></footer>
           </mock:shadow-root>
-          <!---->light-dom
+          light-dom
         </cmp-b>
       </cmp-a>
     `);

--- a/src/runtime/test/hydrate-shadow-parent.spec.tsx
+++ b/src/runtime/test/hydrate-shadow-parent.spec.tsx
@@ -54,7 +54,6 @@ describe('hydrate, shadow parent', () => {
             <slot></slot>
           </div>
         </mock:shadow-root>
-        <!---->
         middle
       </cmp-a>
     `);
@@ -114,7 +113,6 @@ describe('hydrate, shadow parent', () => {
           <slot></slot>
           bottom
         </mock:shadow-root>
-        <!---->
         middle
       </cmp-a>
     `);
@@ -272,8 +270,6 @@ describe('hydrate, shadow parent', () => {
         <mock:shadow-root>
           <cmp-b class="hydrated">
             <!--r.2-->
-            <!---->
-            <!--s.2.0.0.0.-->
             cmp-a-light-dom
           </cmp-b>
         </mock:shadow-root>
@@ -351,13 +347,11 @@ describe('hydrate, shadow parent', () => {
             <slot name="end"></slot>
           </section>
         </mock:shadow-root>
-        <!---->
         Title
       </cmp-a>
     `);
     expect(clientHydrated.root).toEqualLightHtml(`
     <cmp-a class="hydrated">
-      <!---->
       Title
     </cmp-a>
   `);
@@ -409,7 +403,7 @@ describe('hydrate, shadow parent', () => {
         <!--o.0.2.-->
         <a c-id="1.0.0.0">
           <!--s.1.1.1.0.-->
-          <ion-badge class="hydrated" c-id="0.2" s-id="2">
+          <ion-badge class="hydrated" c-id="0.2" s-id="2" s-sn="">
             <!--r.2-->
             <!--o.0.4.-->
             <!--s.2.0.0.0.-->
@@ -441,12 +435,10 @@ describe('hydrate, shadow parent', () => {
             </ion-ripple-effect>
           </a>
         </mock:shadow-root>
-        <!---->
         <ion-badge class="hydrated">
           <mock:shadow-root>
             <slot></slot>
           </mock:shadow-root>
-          <!---->
           root-text
         </ion-badge>
       </ion-tab-button>
@@ -482,7 +474,7 @@ describe('hydrate, shadow parent', () => {
         <!--r.1-->
         <!--o.0.1.-->
         <!--s.1.0.0.0.-->
-        <cmp-b class="hydrated" c-id="0.1" s-id="2">
+        <cmp-b class="hydrated" c-id="0.1" s-id="2" s-sn="">
           <!--r.2-->
           <!--o.0.2-->
           <!--s.2.0.0.0.-->
@@ -504,11 +496,8 @@ describe('hydrate, shadow parent', () => {
         <mock:shadow-root>
             <slot></slot>
         </mock:shadow-root>
-        <!---->
         <cmp-b class="hydrated">
           <!--r.2-->
-          <!---->
-          <!--s.2.0.0.0.-->
           cmp-a-light-dom
         </cmp-b>
       </cmp-a>
@@ -516,11 +505,8 @@ describe('hydrate, shadow parent', () => {
 
     expect(clientHydrated.root).toEqualLightHtml(`
       <cmp-a class="hydrated">
-        <!---->
         <cmp-b class="hydrated">
             <!--r.2-->
-            <!---->
-            <!--s.2.0.0.0.-->
             cmp-a-light-dom
         </cmp-b>
       </cmp-a>

--- a/src/runtime/test/hydrate-shadow.spec.tsx
+++ b/src/runtime/test/hydrate-shadow.spec.tsx
@@ -61,7 +61,6 @@ describe('hydrate, shadow', () => {
               <slot></slot>
             </article>
           </mock:shadow-root>
-          <!---->
           CmpALightDom
         </cmp-b>
       </cmp-a>
@@ -119,7 +118,7 @@ describe('hydrate, shadow', () => {
             </header>
             <div c-id="1.5.2.1">
               <!--s.1.6.3.0.-->
-              <div c-id="0.2">
+              <div c-id="0.2" s-sn="">
                 <img>
                 <p>
                   LightDom1
@@ -157,7 +156,6 @@ describe('hydrate, shadow', () => {
             </section>
           </article>
         </mock:shadow-root>
-        <!---->
         <div>
           <img>
           <p>

--- a/src/runtime/test/hydrate-slot-fallback.spec.tsx
+++ b/src/runtime/test/hydrate-slot-fallback.spec.tsx
@@ -1,0 +1,435 @@
+import { Component, h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+describe('hydrate, slot fallback', () => {
+  it('shows slot fallback content in a `scoped: true` parent', async () => {
+    @Component({
+      tag: 'cmp-a',
+      scoped: true,
+    })
+    class CmpA {
+      render() {
+        return (
+          <article>
+            <slot>
+              Fallback text - should not be hidden
+              <strong>Fallback element</strong>
+            </slot>
+          </article>
+        );
+      }
+    }
+
+    const serverHydrated = await newSpecPage({
+      components: [CmpA],
+      html: `<cmp-a></cmp-a>`,
+      hydrateServerSide: true,
+    });
+    expect(serverHydrated.root).toEqualHtml(`
+      <cmp-a class=\"hydrated\" s-id=\"1\">
+        <!--r.1-->
+        <article c-id=\"1.0.0.0\">
+          <slot-fb c-id=\"1.1.1.0\" s-sn=\"\">
+            <!--t.1.2.2.0-->
+            Fallback text - should not be hidden
+            <strong c-id=\"1.3.2.1\">
+              <!--t.1.4.3.0-->
+              Fallback element
+            </strong>
+          </slot-fb>
+        </article>
+      </cmp-a>
+    `);
+
+    const clientHydrated = await newSpecPage({
+      components: [CmpA],
+      html: serverHydrated.root.outerHTML,
+      hydrateClientSide: true,
+    });
+
+    expect(clientHydrated.root).toEqualHtml(`
+      <cmp-a class=\"hydrated\">
+        <!--r.1-->
+        <article>
+          <slot-fb>
+            Fallback text - should not be hidden
+            <strong>
+              Fallback element
+            </strong>
+          </slot-fb>
+        </article>
+      </cmp-a>
+    `);
+  });
+
+  it('shows slot fallback content in a `shadow: true` component`', async () => {
+    @Component({
+      tag: 'cmp-a',
+      shadow: true,
+    })
+    class CmpA {
+      render() {
+        return (
+          <article>
+            <slot>
+              Fallback text - should not be hidden
+              <strong>Fallback element</strong>
+            </slot>
+          </article>
+        );
+      }
+    }
+
+    const serverHydrated = await newSpecPage({
+      components: [CmpA],
+      html: `<cmp-a></cmp-a>`,
+      hydrateServerSide: true,
+    });
+    expect(serverHydrated.root).toEqualHtml(`
+      <cmp-a class=\"hydrated\" s-id=\"1\">
+        <!--r.1-->
+        <article c-id=\"1.0.0.0\">
+          <slot-fb c-id=\"1.1.1.0\" s-sn=\"\">
+            <!--t.1.2.2.0-->
+            Fallback text - should not be hidden
+            <strong c-id=\"1.3.2.1\">
+              <!--t.1.4.3.0-->
+              Fallback element
+            </strong>
+          </slot-fb>
+        </article>
+      </cmp-a>  
+    `);
+
+    const clientHydrated = await newSpecPage({
+      components: [CmpA],
+      html: serverHydrated.root.outerHTML,
+      hydrateClientSide: true,
+    });
+
+    expect(clientHydrated.root).toEqualHtml(`
+      <cmp-a class=\"hydrated\">
+        <mock:shadow-root>
+          <article>
+            <slot>
+              Fallback text - should not be hidden
+              <strong>
+                Fallback element
+              </strong>
+            </slot>
+          </article>
+        </mock:shadow-root>
+      </cmp-a>  
+    `);
+  });
+
+  it('shows slot fallback text in a nested `scoped: true` component (hides the fallback in the `scoped: true` parent component)', async () => {
+    @Component({
+      tag: 'cmp-a',
+      scoped: true,
+    })
+    class CmpA {
+      render() {
+        return (
+          <article>
+            <slot>Fallback content parent - should be hidden</slot>
+            <p>Non slot based content</p>
+          </article>
+        );
+      }
+    }
+
+    @Component({
+      tag: 'cmp-b',
+      scoped: true,
+    })
+    class CmpB {
+      render() {
+        return (
+          <section>
+            <slot>Fallback content child - should not be hidden</slot>
+            <p>Non slot based content</p>
+          </section>
+        );
+      }
+    }
+
+    const serverHydrated = await newSpecPage({
+      components: [CmpA, CmpB],
+      html: `<cmp-a><cmp-b></cmp-b></cmp-a>`,
+      hydrateServerSide: true,
+    });
+    expect(serverHydrated.root).toEqualHtml(`
+      <cmp-a class=\"hydrated\" s-id=\"1\">
+        <!--r.1-->
+        <!--o.0.1.c-->
+        <article c-id=\"1.0.0.0\">
+          <cmp-b c-id=\"0.1\" class=\"hydrated\" s-id=\"2\" s-sn=\"\">
+            <!--r.2-->
+            <section c-id=\"2.0.0.0\">
+              <slot-fb c-id=\"2.1.1.0\" s-sn=\"\">
+                <!--t.2.2.2.0-->
+                Fallback content child - should not be hidden
+              </slot-fb>
+              <p c-id=\"2.3.1.1\">
+                <!--t.2.4.2.0-->
+                Non slot based content
+              </p>
+            </section>
+          </cmp-b>
+          <slot-fb c-id=\"1.1.1.0\" hidden=\"\" s-sn=\"\">
+            <!--t.1.2.2.0-->
+            Fallback content parent - should be hidden
+          </slot-fb>
+          <p c-id=\"1.3.1.1\">
+            <!--t.1.4.2.0-->
+            Non slot based content
+          </p>
+        </article>
+      </cmp-a>  
+    `);
+
+    const clientHydrated = await newSpecPage({
+      components: [CmpA, CmpB],
+      html: serverHydrated.root.outerHTML,
+      hydrateClientSide: true,
+    });
+
+    expect(clientHydrated.root.outerHTML).toEqualHtml(`
+      <cmp-a class=\"hydrated\">
+        <!--r.1-->
+        <article>
+          <cmp-b class=\"hydrated\">
+            <!--r.2-->
+            <section>
+              <slot-fb>
+                Fallback content child - should not be hidden
+              </slot-fb>
+              <p>
+                Non slot based content
+              </p>
+            </section>
+          </cmp-b>
+          <slot-fb hidden=\"\">
+            Fallback content parent - should be hidden
+          </slot-fb>
+          <p>
+            Non slot based content
+          </p>
+        </article>
+      </cmp-a>
+    `);
+  });
+
+  it('renders slot fallback text in a nested `shadow: true` component (`shadow: true` parent component)', async () => {
+    @Component({
+      tag: 'cmp-a',
+      shadow: true,
+    })
+    class CmpA {
+      render() {
+        return (
+          <article>
+            <slot>Fallback content parent - should be hidden</slot>
+            <p>Non slot based content</p>
+          </article>
+        );
+      }
+    }
+
+    @Component({
+      tag: 'cmp-b',
+      shadow: true,
+    })
+    class CmpB {
+      render() {
+        return (
+          <section>
+            <slot>Fallback content child - should not be hidden</slot>
+            <p>Non slot based content</p>
+          </section>
+        );
+      }
+    }
+
+    const serverHydrated = await newSpecPage({
+      components: [CmpA, CmpB],
+      html: `<cmp-a><cmp-b></cmp-b></cmp-a>`,
+      hydrateServerSide: true,
+    });
+    expect(serverHydrated.root).toEqualHtml(`
+      <cmp-a class=\"hydrated\" s-id=\"1\">
+        <!--r.1-->
+        <!--o.0.1.-->
+        <article c-id=\"1.0.0.0\">
+          <cmp-b c-id=\"0.1\" class=\"hydrated\" s-id=\"2\" s-sn=\"\">
+            <!--r.2-->
+            <section c-id=\"2.0.0.0\">
+              <slot-fb c-id=\"2.1.1.0\" s-sn=\"\">
+                <!--t.2.2.2.0-->
+                Fallback content child - should not be hidden
+              </slot-fb>
+              <p c-id=\"2.3.1.1\">
+                <!--t.2.4.2.0-->
+                Non slot based content
+              </p>
+            </section>
+          </cmp-b>
+          <slot-fb c-id=\"1.1.1.0\" hidden=\"\" s-sn=\"\">
+            <!--t.1.2.2.0-->
+            Fallback content parent - should be hidden
+          </slot-fb>
+          <p c-id=\"1.3.1.1\">
+            <!--t.1.4.2.0-->
+            Non slot based content 
+          </p>
+        </article>
+      </cmp-a>
+    `);
+
+    const clientHydrated = await newSpecPage({
+      components: [CmpA, CmpB],
+      html: serverHydrated.root.outerHTML,
+      hydrateClientSide: true,
+    });
+
+    expect(clientHydrated.root).toEqualHtml(`
+      <cmp-a class=\"hydrated\">
+        <mock:shadow-root>
+          <article>
+            <slot>
+              Fallback content parent - should be hidden
+            </slot>
+            <p>
+              Non slot based content
+            </p>
+          </article>
+        </mock:shadow-root>
+        <cmp-b class=\"hydrated\">
+          <mock:shadow-root>
+            <section>
+              <slot>
+                Fallback content child - should not be hidden
+              </slot>
+              <p>
+                Non slot based content
+              </p>
+            </section>
+          </mock:shadow-root>
+        </cmp-b>
+      </cmp-a>  
+    `);
+  });
+
+  it('does not show slot fallback text when a `scoped: true` component forwards the slot to nested `shadow: true`', async () => {
+    @Component({
+      tag: 'cmp-a',
+      scoped: true,
+    })
+    class CmpA {
+      render() {
+        return (
+          <article>
+            <cmp-b>
+              <slot>Fallback content parent - should be hidden</slot>
+            </cmp-b>
+          </article>
+        );
+      }
+    }
+
+    @Component({
+      tag: 'cmp-b',
+      shadow: true,
+    })
+    class CmpB {
+      render() {
+        return (
+          <section>
+            <slot>Fallback content child - should be hidden</slot>
+          </section>
+        );
+      }
+    }
+
+    const serverHydrated = await newSpecPage({
+      components: [CmpA, CmpB],
+      html: `
+      <cmp-a>
+        <p>slotted item 1</p>
+        <p>slotted item 2</p>
+        <p>slotted item 3</p>
+      </cmp-a>
+      `,
+      hydrateServerSide: true,
+    });
+    expect(serverHydrated.root).toEqualHtml(`
+      <cmp-a class=\"hydrated\" s-id=\"1\">
+        <!--r.1-->
+        <!--o.0.2.c-->
+        <!--o.0.4.c-->
+        <!--o.0.6.c-->
+        <article c-id=\"1.0.0.0\">
+          <cmp-b c-id=\"1.1.1.0\" class=\"hydrated\" s-id=\"2\">
+            <!--r.2-->
+            <!--o.1.2.-->
+            <section c-id=\"2.0.0.0\">
+              <p c-id=\"0.2\" s-sn=\"\">
+                slotted item 1
+              </p>
+              <p c-id=\"0.4\" s-sn=\"\">
+                slotted item 2
+              </p>
+              <p c-id=\"0.6\" s-sn=\"\">
+                slotted item 3
+              </p>
+              <slot-fb c-id=\"1.2.2.0\" hidden=\"\" s-sn=\"\">
+                <!--t.1.3.3.0-->
+                Fallback content parent - should be hidden
+              </slot-fb>
+              <slot-fb c-id=\"2.1.1.0\" hidden=\"\" s-sn=\"\">
+                <!--t.2.2.2.0-->
+                Fallback content child - should be hidden
+              </slot-fb>
+            </section>
+          </cmp-b>
+        </article>
+      </cmp-a>  
+    `);
+
+    const clientHydrated = await newSpecPage({
+      components: [CmpA, CmpB],
+      html: serverHydrated.root.outerHTML,
+      hydrateClientSide: true,
+    });
+
+    expect(clientHydrated.root).toEqualHtml(`
+      <cmp-a class=\"hydrated\">
+        <!--r.1-->
+        <article>
+          <cmp-b class=\"hydrated\">
+            <mock:shadow-root>
+              <section>
+                <slot>
+                  Fallback content child - should be hidden
+                </slot>
+              </section>
+            </mock:shadow-root>
+            <slot-fb hidden=\"\">
+              Fallback content parent - should be hidden
+            </slot-fb>
+            <p>
+              slotted item 1
+            </p>
+            <p>
+              slotted item 2
+            </p>
+            <p>
+              slotted item 3
+            </p>
+          </cmp-b>
+        </article>
+      </cmp-a>  
+    `);
+  });
+});

--- a/src/runtime/test/hydrate-slot-fallback.spec.tsx
+++ b/src/runtime/test/hydrate-slot-fallback.spec.tsx
@@ -26,13 +26,13 @@ describe('hydrate, slot fallback', () => {
       hydrateServerSide: true,
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class=\"hydrated\" s-id=\"1\">
+      <cmp-a class="hydrated" s-id="1">
         <!--r.1-->
-        <article c-id=\"1.0.0.0\">
-          <slot-fb c-id=\"1.1.1.0\" s-sn=\"\">
+        <article c-id="1.0.0.0">
+          <slot-fb c-id="1.1.1.0" s-sn="">
             <!--t.1.2.2.0-->
             Fallback text - should not be hidden
-            <strong c-id=\"1.3.2.1\">
+            <strong c-id="1.3.2.1">
               <!--t.1.4.3.0-->
               Fallback element
             </strong>
@@ -48,12 +48,12 @@ describe('hydrate, slot fallback', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class=\"hydrated\">
+      <cmp-a class="hydrated">
         <!--r.1-->
-        <article>
-          <slot-fb>
+        <article class="sc-cmp-a sc-cmp-a-s">
+          <slot-fb class="sc-cmp-a">
             Fallback text - should not be hidden
-            <strong>
+            <strong class="sc-cmp-a">
               Fallback element
             </strong>
           </slot-fb>
@@ -86,13 +86,13 @@ describe('hydrate, slot fallback', () => {
       hydrateServerSide: true,
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class=\"hydrated\" s-id=\"1\">
+      <cmp-a class="hydrated" s-id="1">
         <!--r.1-->
-        <article c-id=\"1.0.0.0\">
-          <slot-fb c-id=\"1.1.1.0\" s-sn=\"\">
+        <article c-id="1.0.0.0">
+          <slot-fb c-id="1.1.1.0" s-sn="">
             <!--t.1.2.2.0-->
             Fallback text - should not be hidden
-            <strong c-id=\"1.3.2.1\">
+            <strong c-id="1.3.2.1">
               <!--t.1.4.3.0-->
               Fallback element
             </strong>
@@ -108,7 +108,7 @@ describe('hydrate, slot fallback', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class=\"hydrated\">
+      <cmp-a class="hydrated">
         <mock:shadow-root>
           <article>
             <slot>
@@ -160,28 +160,28 @@ describe('hydrate, slot fallback', () => {
       hydrateServerSide: true,
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class=\"hydrated\" s-id=\"1\">
+      <cmp-a class="hydrated" s-id="1">
         <!--r.1-->
         <!--o.0.1.c-->
-        <article c-id=\"1.0.0.0\">
-          <cmp-b c-id=\"0.1\" class=\"hydrated\" s-id=\"2\" s-sn=\"\">
+        <article c-id="1.0.0.0">
+          <cmp-b c-id="0.1" class="hydrated" s-id="2" s-sn="">
             <!--r.2-->
-            <section c-id=\"2.0.0.0\">
-              <slot-fb c-id=\"2.1.1.0\" s-sn=\"\">
+            <section c-id="2.0.0.0">
+              <slot-fb c-id="2.1.1.0" s-sn="">
                 <!--t.2.2.2.0-->
                 Fallback content child - should not be hidden
               </slot-fb>
-              <p c-id=\"2.3.1.1\">
+              <p c-id="2.3.1.1">
                 <!--t.2.4.2.0-->
                 Non slot based content
               </p>
             </section>
           </cmp-b>
-          <slot-fb c-id=\"1.1.1.0\" hidden=\"\" s-sn=\"\">
+          <slot-fb c-id="1.1.1.0" hidden="" s-sn="">
             <!--t.1.2.2.0-->
             Fallback content parent - should be hidden
           </slot-fb>
-          <p c-id=\"1.3.1.1\">
+          <p c-id="1.3.1.1">
             <!--t.1.4.2.0-->
             Non slot based content
           </p>
@@ -196,24 +196,24 @@ describe('hydrate, slot fallback', () => {
     });
 
     expect(clientHydrated.root.outerHTML).toEqualHtml(`
-      <cmp-a class=\"hydrated\">
+      <cmp-a class="hydrated">
         <!--r.1-->
-        <article>
-          <cmp-b class=\"hydrated\">
+        <article class="sc-cmp-a sc-cmp-a-s">
+          <cmp-b class="hydrated">
             <!--r.2-->
-            <section>
-              <slot-fb>
+            <section class="sc-cmp-b sc-cmp-b-s">
+              <slot-fb class="sc-cmp-a sc-cmp-b">
                 Fallback content child - should not be hidden
               </slot-fb>
-              <p>
+              <p class="sc-cmp-b">
                 Non slot based content
               </p>
             </section>
           </cmp-b>
-          <slot-fb hidden=\"\">
+          <slot-fb class="sc-cmp-a" hidden="">
             Fallback content parent - should be hidden
           </slot-fb>
-          <p>
+          <p class="sc-cmp-a">
             Non slot based content
           </p>
         </article>
@@ -258,28 +258,28 @@ describe('hydrate, slot fallback', () => {
       hydrateServerSide: true,
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class=\"hydrated\" s-id=\"1\">
+      <cmp-a class="hydrated" s-id="1">
         <!--r.1-->
         <!--o.0.1.-->
-        <article c-id=\"1.0.0.0\">
-          <cmp-b c-id=\"0.1\" class=\"hydrated\" s-id=\"2\" s-sn=\"\">
+        <article c-id="1.0.0.0">
+          <cmp-b c-id="0.1" class="hydrated" s-id="2" s-sn="">
             <!--r.2-->
-            <section c-id=\"2.0.0.0\">
-              <slot-fb c-id=\"2.1.1.0\" s-sn=\"\">
+            <section c-id="2.0.0.0">
+              <slot-fb c-id="2.1.1.0" s-sn="">
                 <!--t.2.2.2.0-->
                 Fallback content child - should not be hidden
               </slot-fb>
-              <p c-id=\"2.3.1.1\">
+              <p c-id="2.3.1.1">
                 <!--t.2.4.2.0-->
                 Non slot based content
               </p>
             </section>
           </cmp-b>
-          <slot-fb c-id=\"1.1.1.0\" hidden=\"\" s-sn=\"\">
+          <slot-fb c-id="1.1.1.0" hidden="" s-sn="">
             <!--t.1.2.2.0-->
             Fallback content parent - should be hidden
           </slot-fb>
-          <p c-id=\"1.3.1.1\">
+          <p c-id="1.3.1.1">
             <!--t.1.4.2.0-->
             Non slot based content 
           </p>
@@ -294,7 +294,7 @@ describe('hydrate, slot fallback', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class=\"hydrated\">
+      <cmp-a class="hydrated">
         <mock:shadow-root>
           <article>
             <slot>
@@ -305,7 +305,7 @@ describe('hydrate, slot fallback', () => {
             </p>
           </article>
         </mock:shadow-root>
-        <cmp-b class=\"hydrated\">
+        <cmp-b class="hydrated">
           <mock:shadow-root>
             <section>
               <slot>
@@ -364,30 +364,30 @@ describe('hydrate, slot fallback', () => {
       hydrateServerSide: true,
     });
     expect(serverHydrated.root).toEqualHtml(`
-      <cmp-a class=\"hydrated\" s-id=\"1\">
+      <cmp-a class="hydrated" s-id="1">
         <!--r.1-->
         <!--o.0.2.c-->
         <!--o.0.4.c-->
         <!--o.0.6.c-->
-        <article c-id=\"1.0.0.0\">
-          <cmp-b c-id=\"1.1.1.0\" class=\"hydrated\" s-id=\"2\">
+        <article c-id="1.0.0.0">
+          <cmp-b c-id="1.1.1.0" class="hydrated" s-id="2">
             <!--r.2-->
             <!--o.1.2.-->
-            <section c-id=\"2.0.0.0\">
-              <p c-id=\"0.2\" s-sn=\"\">
+            <section c-id="2.0.0.0">
+              <p c-id="0.2" s-sn="">
                 slotted item 1
               </p>
-              <p c-id=\"0.4\" s-sn=\"\">
+              <p c-id="0.4" s-sn="">
                 slotted item 2
               </p>
-              <p c-id=\"0.6\" s-sn=\"\">
+              <p c-id="0.6" s-sn="">
                 slotted item 3
               </p>
-              <slot-fb c-id=\"1.2.2.0\" hidden=\"\" s-sn=\"\">
+              <slot-fb c-id="1.2.2.0" hidden="" s-sn="">
                 <!--t.1.3.3.0-->
                 Fallback content parent - should be hidden
               </slot-fb>
-              <slot-fb c-id=\"2.1.1.0\" hidden=\"\" s-sn=\"\">
+              <slot-fb c-id="2.1.1.0" hidden="" s-sn="">
                 <!--t.2.2.2.0-->
                 Fallback content child - should be hidden
               </slot-fb>
@@ -404,10 +404,10 @@ describe('hydrate, slot fallback', () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class=\"hydrated\">
+      <cmp-a class="hydrated">
         <!--r.1-->
-        <article>
-          <cmp-b class=\"hydrated\">
+        <article class="sc-cmp-a">
+          <cmp-b class="hydrated sc-cmp-a sc-cmp-a-s">
             <mock:shadow-root>
               <section>
                 <slot>
@@ -415,7 +415,7 @@ describe('hydrate, slot fallback', () => {
                 </slot>
               </section>
             </mock:shadow-root>
-            <slot-fb hidden=\"\">
+            <slot-fb class="sc-cmp-a" hidden="">
               Fallback content parent - should be hidden
             </slot-fb>
             <p>

--- a/src/runtime/test/hydrate-slotted-content-order.spec.tsx
+++ b/src/runtime/test/hydrate-slotted-content-order.spec.tsx
@@ -1,0 +1,541 @@
+import { Component, h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+import { patchPseudoShadowDom } from '../../runtime/dom-extras';
+
+describe("hydrated components' slotted node order", () => {
+  const nodeOrEle = (node: Node | Element) => {
+    if (!node) return '';
+    return (node as Element).outerHTML || node.nodeValue;
+  };
+
+  it('should retain original order of slotted nodes within a `shadow: true` component', async () => {
+    @Component({
+      tag: 'cmp-a',
+      shadow: true,
+    })
+    class CmpA {
+      render() {
+        return (
+          <main>
+            <slot />
+          </main>
+        );
+      }
+    }
+
+    const serverHydrated = await newSpecPage({
+      components: [CmpA],
+      html: `
+      <cmp-a><p>slotted item 1</p><!-- a comment --!><p>slotted item 2</p>A text node<p>slotted item 3</p><!-- another comment --!></cmp-a>
+      `,
+      hydrateServerSide: true,
+    });
+    expect(serverHydrated.root).toEqualHtml(`
+    <cmp-a class=\"hydrated\" s-id=\"1\">
+      <!--r.1-->
+      <!--o.0.1.-->
+      <!--o.0.2.-->
+      <!--o.0.3.-->
+      <!--o.0.4.-->
+      <!--o.0.5.-->
+      <!--o.0.6.-->
+      <main c-id=\"1.0.0.0\">
+        <!--s.1.1.1.0.-->
+        <p c-id=\"0.1\" s-sn=\"\">
+          slotted item 1
+        </p>
+        <!--c.0.2-->
+        <!-- a comment -->
+        <p c-id=\"0.3\" s-sn=\"\">
+          slotted item 2
+        </p>
+        <!--t.0.4-->
+        A text node
+        <p c-id=\"0.5\" s-sn=\"\">
+          slotted item 3
+        </p>
+        <!--c.0.6-->
+        <!-- another comment -->
+      </main>
+    </cmp-a>`);
+
+    const clientHydrated = await newSpecPage({
+      components: [CmpA],
+      html: serverHydrated.root.outerHTML,
+      hydrateClientSide: true,
+    });
+
+    expect(clientHydrated.root).toEqualHtml(`
+      <cmp-a class=\"hydrated\">
+        <mock:shadow-root>
+          <main>
+            <slot></slot>
+          </main>
+        </mock:shadow-root>
+        <p>
+          slotted item 1
+        </p>
+        <!-- a comment -->
+        <p>
+          slotted item 2
+        </p>
+        A text node
+        <p>
+          slotted item 3
+        </p>
+        <!-- another comment -->
+      </cmp-a>
+    `);
+
+    const childNodes = clientHydrated.root.childNodes;
+
+    expect(nodeOrEle(childNodes[0])).toBe(`<p>slotted item 1</p>`);
+    expect(nodeOrEle(childNodes[1])).toBe(` a comment `);
+    expect(nodeOrEle(childNodes[2])).toBe(`<p>slotted item 2</p>`);
+    expect(nodeOrEle(childNodes[3])).toBe(`A text node`);
+    expect(nodeOrEle(childNodes[4])).toBe(`<p>slotted item 3</p>`);
+    expect(nodeOrEle(childNodes[5])).toBe(` another comment `);
+  });
+
+  it('should retain original order of slotted nodes within multiple slots of a `shadow: true` component', async () => {
+    @Component({
+      tag: 'cmp-a',
+      shadow: true,
+    })
+    class CmpA {
+      render() {
+        return (
+          <main>
+            <aside>
+              <slot name="second" />
+            </aside>
+            <section>
+              <slot />
+            </section>
+          </main>
+        );
+      }
+    }
+
+    const serverHydrated = await newSpecPage({
+      components: [CmpA],
+      html: `
+      <cmp-a><!-- comment node --> Default slot <p slot="second">second slot</p><!-- another comment node --></cmp-a>
+      `,
+      hydrateServerSide: true,
+    });
+    expect(serverHydrated.root).toEqualHtml(`
+    <cmp-a class=\"hydrated\" s-id=\"1\">
+      <!--r.1-->
+      <!--o.0.1.-->
+      <!--o.0.2.-->
+      <!--o.0.3.-->
+      <!--o.0.4.-->
+      <main c-id=\"1.0.0.0\">
+        <aside c-id=\"1.1.1.0\">
+          <!--s.1.2.2.0.second-->
+          <p c-id=\"0.3\" slot=\"second\">
+            second slot
+          </p>
+        </aside>
+        <section c-id=\"1.3.1.1\">
+          <!--s.1.4.2.0.-->
+          <!--c.0.1-->
+          <!-- comment node -->
+          <!--t.0.2-->
+          Default slot
+          <!--c.0.4-->
+          <!-- another comment node -->
+        </section>
+      </main>
+    </cmp-a>`);
+
+    const clientHydrated = await newSpecPage({
+      components: [CmpA],
+      html: serverHydrated.root.outerHTML,
+      hydrateClientSide: true,
+    });
+
+    expect(clientHydrated.root.outerHTML).toEqualHtml(`
+      <cmp-a class=\"hydrated\"><template shadowrootmode="open">
+        <main>
+          <aside>
+            <slot name=\"second\"></slot>
+          </aside>
+          <section>
+            <slot></slot>
+          </section>
+        </main></template>
+        <!-- comment node -->
+        Default slot
+        <p slot=\"second\">
+          second slot
+        </p>
+        <!-- another comment node -->
+      </cmp-a>
+    `);
+
+    const childNodes = clientHydrated.root.childNodes;
+
+    expect(nodeOrEle(childNodes[0])).toBe(` comment node `);
+    expect(nodeOrEle(childNodes[1])).toBe(` Default slot `);
+    expect(nodeOrEle(childNodes[2])).toBe(`<p slot=\"second\">second slot</p>`);
+    expect(nodeOrEle(childNodes[3])).toBe(` another comment node `);
+  });
+
+  it('should retain original order of slotted nodes within nested `shadow: true` components', async () => {
+    @Component({
+      tag: 'cmp-a',
+      shadow: true,
+    })
+    class CmpA {
+      render() {
+        return (
+          <main>
+            <slot />
+          </main>
+        );
+      }
+    }
+
+    @Component({
+      tag: 'cmp-b',
+      shadow: true,
+    })
+    class CmpB {
+      render() {
+        return (
+          <section>
+            <slot />
+          </section>
+        );
+      }
+    }
+
+    const serverHydrated = await newSpecPage({
+      components: [CmpA, CmpB],
+      html: `
+      <cmp-a><p>slotted item 1a</p><!-- a comment --!>A text node<!-- another comment a--!><cmp-b><p>slotted item 1b</p><!-- b comment --!>B text node<!-- another comment b--!></cmp-b></cmp-a>
+      `,
+      hydrateServerSide: true,
+    });
+    expect(serverHydrated.root).toEqualHtml(`
+    <cmp-a class=\"hydrated\" s-id=\"1\">
+      <!--r.1-->
+      <!--o.0.1.-->
+      <!--o.0.2.-->
+      <!--o.0.3.-->
+      <!--o.0.4.-->
+      <!--o.0.5.-->
+      <main c-id=\"1.0.0.0\">
+        <!--s.1.1.1.0.-->
+        <p c-id=\"0.1\" s-sn=\"\">
+          slotted item 1a
+        </p>
+        <!--c.0.2-->
+        <!-- a comment -->
+        <!--t.0.3-->
+        A text node
+        <!--c.0.4-->
+        <!-- another comment a-->
+        <cmp-b c-id=\"0.5\" class=\"hydrated\" s-id=\"2\" s-sn=\"\">
+          <!--r.2-->
+          <!--o.0.6.-->
+          <!--o.0.7.-->
+          <!--o.0.8.-->
+          <!--o.0.9.-->
+          <section c-id=\"2.0.0.0\">
+            <!--s.2.1.1.0.-->
+            <p c-id=\"0.6\" s-sn=\"\">
+              slotted item 1b
+            </p>
+            <!--c.0.7-->
+            <!-- b comment -->
+            <!--t.0.8-->
+            B text node
+            <!--c.0.9-->
+            <!-- another comment b-->
+          </section>
+        </cmp-b>
+      </main>
+    </cmp-a>`);
+
+    const clientHydrated = await newSpecPage({
+      components: [CmpA, CmpB],
+      html: serverHydrated.root.outerHTML,
+      hydrateClientSide: true,
+    });
+
+    const childNodes = clientHydrated.root.childNodes;
+
+    expect(nodeOrEle(childNodes[0])).toBe(`<p>slotted item 1a</p>`);
+    expect(nodeOrEle(childNodes[1])).toBe(` a comment `);
+    expect(nodeOrEle(childNodes[2])).toBe(`A text node`);
+    expect(nodeOrEle(childNodes[3])).toBe(` another comment a`);
+    expect(nodeOrEle(childNodes[4].childNodes[0])).toBe(`<p>slotted item 1b</p>`);
+    expect(nodeOrEle(childNodes[4].childNodes[1])).toBe(` b comment `);
+    expect(nodeOrEle(childNodes[4].childNodes[2])).toBe(`B text node`);
+    expect(nodeOrEle(childNodes[4].childNodes[3])).toBe(` another comment b`);
+  });
+
+  it('should retain original order of slotted nodes within a `scoped: true` component', async () => {
+    @Component({
+      tag: 'cmp-a',
+      scoped: true,
+    })
+    class CmpA {
+      render() {
+        return (
+          <main>
+            <slot />
+          </main>
+        );
+      }
+    }
+
+    const serverHydrated = await newSpecPage({
+      components: [CmpA],
+      html: `
+      <cmp-a><p>slotted item 1</p><!-- a comment --><p>slotted item 2</p>A text node<p>slotted item 3</p><!-- another comment --></cmp-a>
+      `,
+      hydrateServerSide: true,
+    });
+    expect(serverHydrated.root).toEqualHtml(`
+    <cmp-a class=\"hydrated\" s-id=\"1\">
+      <!--r.1-->
+      <!--o.0.1.c-->
+      <!--o.0.2.c-->
+      <!--o.0.3.c-->
+      <!--o.0.4.c-->
+      <!--o.0.5.c-->
+      <!--o.0.6.c-->
+      <main c-id=\"1.0.0.0\">
+        <!--s.1.1.1.0.-->
+        <p c-id=\"0.1\" s-sn=\"\">
+          slotted item 1
+        </p>
+        <!--c.0.2-->
+        <!-- a comment -->
+        <p c-id=\"0.3\" s-sn=\"\">
+          slotted item 2
+        </p>
+        <!--t.0.4-->
+        A text node
+        <p c-id=\"0.5\" s-sn=\"\">
+          slotted item 3
+        </p>
+        <!--c.0.6-->
+        <!-- another comment -->
+      </main>
+    </cmp-a>`);
+
+    const clientHydrated = await newSpecPage({
+      components: [CmpA],
+      html: serverHydrated.root.outerHTML,
+      hydrateClientSide: true,
+    });
+
+    // patches this element in the same way we patch all elements in the browser
+    patchPseudoShadowDom(clientHydrated.root);
+
+    expect(clientHydrated.root.outerHTML).toEqualHtml(`
+      <cmp-a class=\"hydrated\">
+        <!--r.1-->
+        <main>
+          <p>
+            slotted item 1
+          </p>
+          <!-- a comment -->
+          <p>
+            slotted item 2
+          </p>
+          A text node
+          <p>
+            slotted item 3
+          </p>
+          <!-- another comment -->
+        </main>
+      </cmp-a>
+    `);
+
+    const childNodes = clientHydrated.root.childNodes;
+
+    expect(nodeOrEle(childNodes[0])).toBe(`<p>slotted item 1</p>`);
+    expect(nodeOrEle(childNodes[1])).toBe(` a comment `);
+    expect(nodeOrEle(childNodes[2])).toBe(`<p>slotted item 2</p>`);
+    expect(nodeOrEle(childNodes[3])).toBe(`A text node`);
+    expect(nodeOrEle(childNodes[4])).toBe(`<p>slotted item 3</p>`);
+    expect(nodeOrEle(childNodes[5])).toBe(` another comment `);
+  });
+
+  it('should retain original order of slotted nodes within multiple slots of a `scoped: true` component', async () => {
+    @Component({
+      tag: 'cmp-a',
+      shadow: false,
+    })
+    class CmpA {
+      render() {
+        return (
+          <main>
+            <aside>
+              <slot name="second" />
+            </aside>
+            <section>
+              <slot />
+            </section>
+          </main>
+        );
+      }
+    }
+
+    const serverHydrated = await newSpecPage({
+      components: [CmpA],
+      html: `
+      <cmp-a><!-- comment node --> Default slot <p slot="second">second slot</p><!-- another comment node --></cmp-a>
+      `,
+      hydrateServerSide: true,
+    });
+    expect(serverHydrated.root).toEqualHtml(`
+    <cmp-a class=\"hydrated\" s-id=\"1\">
+      <!--r.1-->
+      <!--o.0.1-->
+      <!--o.0.2-->
+      <!--o.0.3-->
+      <!--o.0.4-->
+      <main c-id=\"1.0.0.0\">
+        <aside c-id=\"1.1.1.0\">
+          <!--s.1.2.2.0.second-->
+          <p c-id=\"0.3\" slot=\"second\">
+            second slot
+          </p>
+        </aside>
+        <section c-id=\"1.3.1.1\">
+          <!--s.1.4.2.0.-->
+          <!--c.0.1-->
+          <!-- comment node -->
+          <!--t.0.2-->
+          Default slot
+          <!--c.0.4-->
+          <!-- another comment node -->
+        </section>
+      </main>
+    </cmp-a>`);
+
+    const clientHydrated = await newSpecPage({
+      components: [CmpA],
+      html: serverHydrated.root.outerHTML,
+      hydrateClientSide: true,
+    });
+
+    // patches this element in the same way we patch all elements in the browser
+    patchPseudoShadowDom(clientHydrated.root);
+
+    const childNodes = clientHydrated.root.childNodes;
+
+    expect(nodeOrEle(childNodes[0])).toBe(` comment node `);
+    expect(nodeOrEle(childNodes[1])).toBe(` Default slot `);
+    expect(nodeOrEle(childNodes[2])).toBe(`<p slot=\"second\">second slot</p>`);
+    expect(nodeOrEle(childNodes[3])).toBe(` another comment node `);
+  });
+
+  it('should retain original order of slotted nodes within nested `scoped: true` components', async () => {
+    @Component({
+      tag: 'cmp-a',
+      shadow: false,
+    })
+    class CmpA {
+      render() {
+        return (
+          <main>
+            <slot />
+          </main>
+        );
+      }
+    }
+
+    @Component({
+      tag: 'cmp-b',
+      shadow: false,
+    })
+    class CmpB {
+      render() {
+        return (
+          <section>
+            <slot />
+          </section>
+        );
+      }
+    }
+
+    const serverHydrated = await newSpecPage({
+      components: [CmpA, CmpB],
+      html: `
+      <cmp-a><p>slotted item 1a</p><!-- a comment --!>A text node<!-- another comment a--!><cmp-b><p>slotted item 1b</p><!-- b comment --!>B text node<!-- another comment b--!></cmp-b></cmp-a>
+      `,
+      hydrateServerSide: true,
+    });
+    expect(serverHydrated.root).toEqualHtml(`
+    <cmp-a class=\"hydrated\" s-id=\"1\">
+      <!--r.1-->
+      <!--o.0.1-->
+      <!--o.0.2-->
+      <!--o.0.3-->
+      <!--o.0.4-->
+      <!--o.0.5-->
+      <main c-id=\"1.0.0.0\">
+        <!--s.1.1.1.0.-->
+        <p c-id=\"0.1\" s-sn=\"\">
+          slotted item 1a
+        </p>
+        <!--c.0.2-->
+        <!-- a comment -->
+        <!--t.0.3-->
+        A text node
+        <!--c.0.4-->
+        <!-- another comment a-->
+        <cmp-b c-id=\"0.5\" class=\"hydrated\" s-id=\"2\" s-sn=\"\">
+          <!--r.2-->
+          <!--o.0.6-->
+          <!--o.0.7-->
+          <!--o.0.8-->
+          <!--o.0.9-->
+          <section c-id=\"2.0.0.0\">
+            <!--s.2.1.1.0.-->
+            <p c-id=\"0.6\" s-sn=\"\">
+              slotted item 1b
+            </p>
+            <!--c.0.7-->
+            <!-- b comment -->
+            <!--t.0.8-->
+            B text node
+            <!--c.0.9-->
+            <!-- another comment b-->
+          </section>
+        </cmp-b>
+      </main>
+    </cmp-a>`);
+
+    const clientHydrated = await newSpecPage({
+      components: [CmpA, CmpB],
+      html: serverHydrated.root.outerHTML,
+      hydrateClientSide: true,
+    });
+
+    // patches this element in the same way we patch all elements in the browser
+    patchPseudoShadowDom(clientHydrated.root);
+
+    const childNodes = clientHydrated.root.childNodes;
+
+    patchPseudoShadowDom(childNodes[4]);
+
+    expect(nodeOrEle(childNodes[0])).toBe(`<p>slotted item 1a</p>`);
+    expect(nodeOrEle(childNodes[1])).toBe(` a comment `);
+    expect(nodeOrEle(childNodes[2])).toBe(`A text node`);
+    expect(nodeOrEle(childNodes[3])).toBe(` another comment a`);
+    expect(nodeOrEle(childNodes[4].childNodes[0])).toBe(`<p>slotted item 1b</p>`);
+    expect(nodeOrEle(childNodes[4].childNodes[1])).toBe(` b comment `);
+    expect(nodeOrEle(childNodes[4].childNodes[2])).toBe(`B text node`);
+    expect(nodeOrEle(childNodes[4].childNodes[3])).toBe(` another comment b`);
+  });
+});

--- a/src/runtime/test/hydrate-slotted-content-order.spec.tsx
+++ b/src/runtime/test/hydrate-slotted-content-order.spec.tsx
@@ -32,7 +32,7 @@ describe("hydrated components' slotted node order", () => {
       hydrateServerSide: true,
     });
     expect(serverHydrated.root).toEqualHtml(`
-    <cmp-a class=\"hydrated\" s-id=\"1\">
+    <cmp-a class="hydrated" s-id="1">
       <!--r.1-->
       <!--o.0.1.-->
       <!--o.0.2.-->
@@ -40,19 +40,19 @@ describe("hydrated components' slotted node order", () => {
       <!--o.0.4.-->
       <!--o.0.5.-->
       <!--o.0.6.-->
-      <main c-id=\"1.0.0.0\">
+      <main c-id="1.0.0.0">
         <!--s.1.1.1.0.-->
-        <p c-id=\"0.1\" s-sn=\"\">
+        <p c-id="0.1" s-sn="">
           slotted item 1
         </p>
         <!--c.0.2-->
         <!-- a comment -->
-        <p c-id=\"0.3\" s-sn=\"\">
+        <p c-id="0.3" s-sn="">
           slotted item 2
         </p>
         <!--t.0.4-->
         A text node
-        <p c-id=\"0.5\" s-sn=\"\">
+        <p c-id="0.5" s-sn="">
           slotted item 3
         </p>
         <!--c.0.6-->
@@ -67,7 +67,7 @@ describe("hydrated components' slotted node order", () => {
     });
 
     expect(clientHydrated.root).toEqualHtml(`
-      <cmp-a class=\"hydrated\">
+      <cmp-a class="hydrated">
         <mock:shadow-root>
           <main>
             <slot></slot>
@@ -126,20 +126,20 @@ describe("hydrated components' slotted node order", () => {
       hydrateServerSide: true,
     });
     expect(serverHydrated.root).toEqualHtml(`
-    <cmp-a class=\"hydrated\" s-id=\"1\">
+    <cmp-a class="hydrated" s-id="1">
       <!--r.1-->
       <!--o.0.1.-->
       <!--o.0.2.-->
       <!--o.0.3.-->
       <!--o.0.4.-->
-      <main c-id=\"1.0.0.0\">
-        <aside c-id=\"1.1.1.0\">
+      <main c-id="1.0.0.0">
+        <aside c-id="1.1.1.0">
           <!--s.1.2.2.0.second-->
-          <p c-id=\"0.3\" slot=\"second\">
+          <p c-id="0.3" slot="second">
             second slot
           </p>
         </aside>
-        <section c-id=\"1.3.1.1\">
+        <section c-id="1.3.1.1">
           <!--s.1.4.2.0.-->
           <!--c.0.1-->
           <!-- comment node -->
@@ -158,10 +158,10 @@ describe("hydrated components' slotted node order", () => {
     });
 
     expect(clientHydrated.root.outerHTML).toEqualHtml(`
-      <cmp-a class=\"hydrated\"><template shadowrootmode="open">
+      <cmp-a class="hydrated"><template shadowrootmode="open">
         <main>
           <aside>
-            <slot name=\"second\"></slot>
+            <slot name="second"></slot>
           </aside>
           <section>
             <slot></slot>
@@ -169,7 +169,7 @@ describe("hydrated components' slotted node order", () => {
         </main></template>
         <!-- comment node -->
         Default slot
-        <p slot=\"second\">
+        <p slot="second">
           second slot
         </p>
         <!-- another comment node -->
@@ -180,7 +180,7 @@ describe("hydrated components' slotted node order", () => {
 
     expect(nodeOrEle(childNodes[0])).toBe(` comment node `);
     expect(nodeOrEle(childNodes[1])).toBe(` Default slot `);
-    expect(nodeOrEle(childNodes[2])).toBe(`<p slot=\"second\">second slot</p>`);
+    expect(nodeOrEle(childNodes[2])).toBe(`<p slot="second">second slot</p>`);
     expect(nodeOrEle(childNodes[3])).toBe(` another comment node `);
   });
 
@@ -221,16 +221,16 @@ describe("hydrated components' slotted node order", () => {
       hydrateServerSide: true,
     });
     expect(serverHydrated.root).toEqualHtml(`
-    <cmp-a class=\"hydrated\" s-id=\"1\">
+    <cmp-a class="hydrated" s-id="1">
       <!--r.1-->
       <!--o.0.1.-->
       <!--o.0.2.-->
       <!--o.0.3.-->
       <!--o.0.4.-->
       <!--o.0.5.-->
-      <main c-id=\"1.0.0.0\">
+      <main c-id="1.0.0.0">
         <!--s.1.1.1.0.-->
-        <p c-id=\"0.1\" s-sn=\"\">
+        <p c-id="0.1" s-sn="">
           slotted item 1a
         </p>
         <!--c.0.2-->
@@ -239,15 +239,15 @@ describe("hydrated components' slotted node order", () => {
         A text node
         <!--c.0.4-->
         <!-- another comment a-->
-        <cmp-b c-id=\"0.5\" class=\"hydrated\" s-id=\"2\" s-sn=\"\">
+        <cmp-b c-id="0.5" class="hydrated" s-id="2" s-sn="">
           <!--r.2-->
           <!--o.0.6.-->
           <!--o.0.7.-->
           <!--o.0.8.-->
           <!--o.0.9.-->
-          <section c-id=\"2.0.0.0\">
+          <section c-id="2.0.0.0">
             <!--s.2.1.1.0.-->
-            <p c-id=\"0.6\" s-sn=\"\">
+            <p c-id="0.6" s-sn="">
               slotted item 1b
             </p>
             <!--c.0.7-->
@@ -302,7 +302,7 @@ describe("hydrated components' slotted node order", () => {
       hydrateServerSide: true,
     });
     expect(serverHydrated.root).toEqualHtml(`
-    <cmp-a class=\"hydrated\" s-id=\"1\">
+    <cmp-a class="hydrated" s-id="1">
       <!--r.1-->
       <!--o.0.1.c-->
       <!--o.0.2.c-->
@@ -310,19 +310,19 @@ describe("hydrated components' slotted node order", () => {
       <!--o.0.4.c-->
       <!--o.0.5.c-->
       <!--o.0.6.c-->
-      <main c-id=\"1.0.0.0\">
+      <main c-id="1.0.0.0">
         <!--s.1.1.1.0.-->
-        <p c-id=\"0.1\" s-sn=\"\">
+        <p c-id="0.1" s-sn="">
           slotted item 1
         </p>
         <!--c.0.2-->
         <!-- a comment -->
-        <p c-id=\"0.3\" s-sn=\"\">
+        <p c-id="0.3" s-sn="">
           slotted item 2
         </p>
         <!--t.0.4-->
         A text node
-        <p c-id=\"0.5\" s-sn=\"\">
+        <p c-id="0.5" s-sn="">
           slotted item 3
         </p>
         <!--c.0.6-->
@@ -340,9 +340,9 @@ describe("hydrated components' slotted node order", () => {
     patchPseudoShadowDom(clientHydrated.root);
 
     expect(clientHydrated.root.outerHTML).toEqualHtml(`
-      <cmp-a class=\"hydrated\">
+      <cmp-a class="hydrated">
         <!--r.1-->
-        <main>
+        <main class="sc-cmp-a sc-cmp-a-s">
           <p>
             slotted item 1
           </p>
@@ -397,20 +397,20 @@ describe("hydrated components' slotted node order", () => {
       hydrateServerSide: true,
     });
     expect(serverHydrated.root).toEqualHtml(`
-    <cmp-a class=\"hydrated\" s-id=\"1\">
+    <cmp-a class="hydrated" s-id="1">
       <!--r.1-->
       <!--o.0.1-->
       <!--o.0.2-->
       <!--o.0.3-->
       <!--o.0.4-->
-      <main c-id=\"1.0.0.0\">
-        <aside c-id=\"1.1.1.0\">
+      <main c-id="1.0.0.0">
+        <aside c-id="1.1.1.0">
           <!--s.1.2.2.0.second-->
-          <p c-id=\"0.3\" slot=\"second\">
+          <p c-id="0.3" slot="second">
             second slot
           </p>
         </aside>
-        <section c-id=\"1.3.1.1\">
+        <section c-id="1.3.1.1">
           <!--s.1.4.2.0.-->
           <!--c.0.1-->
           <!-- comment node -->
@@ -435,7 +435,7 @@ describe("hydrated components' slotted node order", () => {
 
     expect(nodeOrEle(childNodes[0])).toBe(` comment node `);
     expect(nodeOrEle(childNodes[1])).toBe(` Default slot `);
-    expect(nodeOrEle(childNodes[2])).toBe(`<p slot=\"second\">second slot</p>`);
+    expect(nodeOrEle(childNodes[2])).toBe(`<p slot="second">second slot</p>`);
     expect(nodeOrEle(childNodes[3])).toBe(` another comment node `);
   });
 
@@ -476,16 +476,16 @@ describe("hydrated components' slotted node order", () => {
       hydrateServerSide: true,
     });
     expect(serverHydrated.root).toEqualHtml(`
-    <cmp-a class=\"hydrated\" s-id=\"1\">
+    <cmp-a class="hydrated" s-id="1">
       <!--r.1-->
       <!--o.0.1-->
       <!--o.0.2-->
       <!--o.0.3-->
       <!--o.0.4-->
       <!--o.0.5-->
-      <main c-id=\"1.0.0.0\">
+      <main c-id="1.0.0.0">
         <!--s.1.1.1.0.-->
-        <p c-id=\"0.1\" s-sn=\"\">
+        <p c-id="0.1" s-sn="">
           slotted item 1a
         </p>
         <!--c.0.2-->
@@ -494,15 +494,15 @@ describe("hydrated components' slotted node order", () => {
         A text node
         <!--c.0.4-->
         <!-- another comment a-->
-        <cmp-b c-id=\"0.5\" class=\"hydrated\" s-id=\"2\" s-sn=\"\">
+        <cmp-b c-id="0.5" class="hydrated" s-id="2" s-sn="">
           <!--r.2-->
           <!--o.0.6-->
           <!--o.0.7-->
           <!--o.0.8-->
           <!--o.0.9-->
-          <section c-id=\"2.0.0.0\">
+          <section c-id="2.0.0.0">
             <!--s.2.1.1.0.-->
-            <p c-id=\"0.6\" s-sn=\"\">
+            <p c-id="0.6" s-sn="">
               slotted item 1b
             </p>
             <!--c.0.7-->

--- a/src/runtime/vdom/set-accessor.ts
+++ b/src/runtime/vdom/set-accessor.ts
@@ -11,8 +11,8 @@ import { BUILD } from '@app-data';
 import { isMemberInElement, plt, win } from '@platform';
 import { isComplexType } from '@utils';
 
-import { VNODE_FLAGS, XLINK_NS } from '../runtime-constants';
 import type * as d from '../../declarations';
+import { VNODE_FLAGS, XLINK_NS } from '../runtime-constants';
 
 /**
  * When running a VDom render set properties present on a VDom node onto the

--- a/src/runtime/vdom/set-accessor.ts
+++ b/src/runtime/vdom/set-accessor.ts
@@ -12,6 +12,7 @@ import { isMemberInElement, plt, win } from '@platform';
 import { isComplexType } from '@utils';
 
 import { VNODE_FLAGS, XLINK_NS } from '../runtime-constants';
+import type * as d from '../../declarations';
 
 /**
  * When running a VDom render set properties present on a VDom node onto the
@@ -29,7 +30,7 @@ import { VNODE_FLAGS, XLINK_NS } from '../runtime-constants';
  * @param flags bitflags for Vdom variables
  */
 export const setAccessor = (
-  elm: HTMLElement,
+  elm: d.RenderNode,
   memberName: string,
   oldValue: any,
   newValue: any,
@@ -44,6 +45,11 @@ export const setAccessor = (
       const classList = elm.classList;
       const oldClasses = parseClassList(oldValue);
       const newClasses = parseClassList(newValue);
+      // for `scoped: true` components, new nodes after initial hydration
+      // from SSR don't have the slotted class added. Let's add that now
+      if (elm['s-si'] && newClasses.indexOf(elm['s-si']) < 0) {
+        newClasses.push(elm['s-si']);
+      }
       classList.remove(...oldClasses.filter((c) => c && !newClasses.includes(c)));
       classList.add(...newClasses.filter((c) => c && !oldClasses.includes(c)));
     } else if (BUILD.vdomStyle && memberName === 'style') {

--- a/src/runtime/vdom/vdom-annotations.ts
+++ b/src/runtime/vdom/vdom-annotations.ts
@@ -11,6 +11,7 @@ import {
   SLOT_NODE_ID,
   STENCIL_DOC_DATA,
   TEXT_NODE_ID,
+  COMMENT_NODE_ID,
 } from '../runtime-constants';
 import { insertBefore } from './vdom-render';
 
@@ -51,6 +52,9 @@ export const insertVdomAnnotations = (doc: Document, staticComponents: string[])
 
           if (nodeRef.nodeType === NODE_TYPE.ElementNode) {
             nodeRef.setAttribute(HYDRATE_CHILD_ID, childId);
+            if (typeof nodeRef['s-sn'] === 'string') {
+              nodeRef.setAttribute('s-sn', nodeRef['s-sn']);
+            }
           } else if (nodeRef.nodeType === NODE_TYPE.TextNode) {
             if (hostId === 0) {
               const textContent = nodeRef.nodeValue?.trim();
@@ -63,6 +67,10 @@ export const insertVdomAnnotations = (doc: Document, staticComponents: string[])
             const commentBeforeTextNode = doc.createComment(childId);
             commentBeforeTextNode.nodeValue = `${TEXT_NODE_ID}.${childId}`;
             insertBefore(nodeRef.parentNode, commentBeforeTextNode, nodeRef);
+          } else if (nodeRef.nodeType === NODE_TYPE.CommentNode) {
+            const commentBeforeTextNode = doc.createComment(childId);
+            commentBeforeTextNode.nodeValue = `${COMMENT_NODE_ID}.${childId}`;
+            nodeRef.parentNode.insertBefore(commentBeforeTextNode, nodeRef);
           }
         }
 
@@ -73,7 +81,7 @@ export const insertVdomAnnotations = (doc: Document, staticComponents: string[])
           if (orgLocationParentNode['s-en'] === '') {
             // ending with a "." means that the parent element
             // of this node's original location is a SHADOW dom element
-            // and this node is apart of the root level light dom
+            // and this node is a part of the root level light dom
             orgLocationNodeId += `.`;
           } else if (orgLocationParentNode['s-en'] === 'c') {
             // ending with a ".c" means that the parent element
@@ -222,6 +230,9 @@ const insertChildVNodeAnnotations = (
 
   if (childElm.nodeType === NODE_TYPE.ElementNode) {
     childElm.setAttribute(HYDRATE_CHILD_ID, childId);
+    if (typeof childElm['s-sn'] === 'string') {
+      childElm.setAttribute('s-sn', childElm['s-sn']);
+    }
   } else if (childElm.nodeType === NODE_TYPE.TextNode) {
     const parentNode = childElm.parentNode;
     const nodeName = parentNode?.nodeName;

--- a/src/runtime/vdom/vdom-annotations.ts
+++ b/src/runtime/vdom/vdom-annotations.ts
@@ -2,6 +2,7 @@ import { getHostRef } from '@platform';
 
 import type * as d from '../../declarations';
 import {
+  COMMENT_NODE_ID,
   CONTENT_REF_ID,
   DEFAULT_DOC_DATA,
   HYDRATE_CHILD_ID,
@@ -11,7 +12,6 @@ import {
   SLOT_NODE_ID,
   STENCIL_DOC_DATA,
   TEXT_NODE_ID,
-  COMMENT_NODE_ID,
 } from '../runtime-constants';
 import { insertBefore } from './vdom-render';
 
@@ -52,7 +52,7 @@ export const insertVdomAnnotations = (doc: Document, staticComponents: string[])
 
           if (nodeRef.nodeType === NODE_TYPE.ElementNode) {
             nodeRef.setAttribute(HYDRATE_CHILD_ID, childId);
-            if (typeof nodeRef['s-sn'] === 'string') {
+            if (typeof nodeRef['s-sn'] === 'string' && !nodeRef.getAttribute('slot')) {
               nodeRef.setAttribute('s-sn', nodeRef['s-sn']);
             }
           } else if (nodeRef.nodeType === NODE_TYPE.TextNode) {
@@ -230,7 +230,7 @@ const insertChildVNodeAnnotations = (
 
   if (childElm.nodeType === NODE_TYPE.ElementNode) {
     childElm.setAttribute(HYDRATE_CHILD_ID, childId);
-    if (typeof childElm['s-sn'] === 'string') {
+    if (typeof childElm['s-sn'] === 'string' && !childElm.getAttribute('slot')) {
       childElm.setAttribute('s-sn', childElm['s-sn']);
     }
   } else if (childElm.nodeType === NODE_TYPE.TextNode) {

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -775,7 +775,7 @@ export const updateFallbackSlotVisibility = (elm: d.RenderNode) => {
                 childNode.hidden = true;
                 break;
               }
-            } else {
+            } else if (slotName === siblingNode['s-sn']) {
               // this is a default fallback slot node
               // any element or text node (with content)
               // should hide the default fallback slot node

--- a/test/end-to-end/src/components.d.ts
+++ b/test/end-to-end/src/components.d.ts
@@ -106,6 +106,12 @@ export namespace Components {
     }
     interface NestedScopeCmp {
     }
+    interface NonShadowChild {
+    }
+    interface NonShadowForwardedSlot {
+    }
+    interface NonShadowWrapper {
+    }
     interface PathAliasCmp {
     }
     interface PrerenderCmp {
@@ -132,6 +138,10 @@ export namespace Components {
     interface ScopedCarList {
         "cars": CarData[];
         "selected": CarData;
+    }
+    interface ShadowChild {
+    }
+    interface ShadowWrapper {
     }
     interface SlotCmp {
     }
@@ -363,6 +373,24 @@ declare global {
         prototype: HTMLNestedScopeCmpElement;
         new (): HTMLNestedScopeCmpElement;
     };
+    interface HTMLNonShadowChildElement extends Components.NonShadowChild, HTMLStencilElement {
+    }
+    var HTMLNonShadowChildElement: {
+        prototype: HTMLNonShadowChildElement;
+        new (): HTMLNonShadowChildElement;
+    };
+    interface HTMLNonShadowForwardedSlotElement extends Components.NonShadowForwardedSlot, HTMLStencilElement {
+    }
+    var HTMLNonShadowForwardedSlotElement: {
+        prototype: HTMLNonShadowForwardedSlotElement;
+        new (): HTMLNonShadowForwardedSlotElement;
+    };
+    interface HTMLNonShadowWrapperElement extends Components.NonShadowWrapper, HTMLStencilElement {
+    }
+    var HTMLNonShadowWrapperElement: {
+        prototype: HTMLNonShadowWrapperElement;
+        new (): HTMLNonShadowWrapperElement;
+    };
     interface HTMLPathAliasCmpElement extends Components.PathAliasCmp, HTMLStencilElement {
     }
     var HTMLPathAliasCmpElement: {
@@ -406,6 +434,18 @@ declare global {
     var HTMLScopedCarListElement: {
         prototype: HTMLScopedCarListElement;
         new (): HTMLScopedCarListElement;
+    };
+    interface HTMLShadowChildElement extends Components.ShadowChild, HTMLStencilElement {
+    }
+    var HTMLShadowChildElement: {
+        prototype: HTMLShadowChildElement;
+        new (): HTMLShadowChildElement;
+    };
+    interface HTMLShadowWrapperElement extends Components.ShadowWrapper, HTMLStencilElement {
+    }
+    var HTMLShadowWrapperElement: {
+        prototype: HTMLShadowWrapperElement;
+        new (): HTMLShadowWrapperElement;
     };
     interface HTMLSlotCmpElement extends Components.SlotCmp, HTMLStencilElement {
     }
@@ -459,11 +499,16 @@ declare global {
         "nested-cmp-child": HTMLNestedCmpChildElement;
         "nested-cmp-parent": HTMLNestedCmpParentElement;
         "nested-scope-cmp": HTMLNestedScopeCmpElement;
+        "non-shadow-child": HTMLNonShadowChildElement;
+        "non-shadow-forwarded-slot": HTMLNonShadowForwardedSlotElement;
+        "non-shadow-wrapper": HTMLNonShadowWrapperElement;
         "path-alias-cmp": HTMLPathAliasCmpElement;
         "prerender-cmp": HTMLPrerenderCmpElement;
         "prop-cmp": HTMLPropCmpElement;
         "scoped-car-detail": HTMLScopedCarDetailElement;
         "scoped-car-list": HTMLScopedCarListElement;
+        "shadow-child": HTMLShadowChildElement;
+        "shadow-wrapper": HTMLShadowWrapperElement;
         "slot-cmp": HTMLSlotCmpElement;
         "slot-cmp-container": HTMLSlotCmpContainerElement;
         "slot-parent-cmp": HTMLSlotParentCmpElement;
@@ -545,6 +590,12 @@ declare namespace LocalJSX {
     }
     interface NestedScopeCmp {
     }
+    interface NonShadowChild {
+    }
+    interface NonShadowForwardedSlot {
+    }
+    interface NonShadowWrapper {
+    }
     interface PathAliasCmp {
     }
     interface PrerenderCmp {
@@ -572,6 +623,10 @@ declare namespace LocalJSX {
         "cars"?: CarData[];
         "onCarSelected"?: (event: ScopedCarListCustomEvent<CarData>) => void;
         "selected"?: CarData;
+    }
+    interface ShadowChild {
+    }
+    interface ShadowWrapper {
     }
     interface SlotCmp {
     }
@@ -610,11 +665,16 @@ declare namespace LocalJSX {
         "nested-cmp-child": NestedCmpChild;
         "nested-cmp-parent": NestedCmpParent;
         "nested-scope-cmp": NestedScopeCmp;
+        "non-shadow-child": NonShadowChild;
+        "non-shadow-forwarded-slot": NonShadowForwardedSlot;
+        "non-shadow-wrapper": NonShadowWrapper;
         "path-alias-cmp": PathAliasCmp;
         "prerender-cmp": PrerenderCmp;
         "prop-cmp": PropCmp;
         "scoped-car-detail": ScopedCarDetail;
         "scoped-car-list": ScopedCarList;
+        "shadow-child": ShadowChild;
+        "shadow-wrapper": ShadowWrapper;
         "slot-cmp": SlotCmp;
         "slot-cmp-container": SlotCmpContainer;
         "slot-parent-cmp": SlotParentCmp;
@@ -658,6 +718,9 @@ declare module "@stencil/core" {
             "nested-cmp-child": LocalJSX.NestedCmpChild & JSXBase.HTMLAttributes<HTMLNestedCmpChildElement>;
             "nested-cmp-parent": LocalJSX.NestedCmpParent & JSXBase.HTMLAttributes<HTMLNestedCmpParentElement>;
             "nested-scope-cmp": LocalJSX.NestedScopeCmp & JSXBase.HTMLAttributes<HTMLNestedScopeCmpElement>;
+            "non-shadow-child": LocalJSX.NonShadowChild & JSXBase.HTMLAttributes<HTMLNonShadowChildElement>;
+            "non-shadow-forwarded-slot": LocalJSX.NonShadowForwardedSlot & JSXBase.HTMLAttributes<HTMLNonShadowForwardedSlotElement>;
+            "non-shadow-wrapper": LocalJSX.NonShadowWrapper & JSXBase.HTMLAttributes<HTMLNonShadowWrapperElement>;
             "path-alias-cmp": LocalJSX.PathAliasCmp & JSXBase.HTMLAttributes<HTMLPathAliasCmpElement>;
             "prerender-cmp": LocalJSX.PrerenderCmp & JSXBase.HTMLAttributes<HTMLPrerenderCmpElement>;
             "prop-cmp": LocalJSX.PropCmp & JSXBase.HTMLAttributes<HTMLPropCmpElement>;
@@ -666,6 +729,8 @@ declare module "@stencil/core" {
              * Component that helps display a list of cars
              */
             "scoped-car-list": LocalJSX.ScopedCarList & JSXBase.HTMLAttributes<HTMLScopedCarListElement>;
+            "shadow-child": LocalJSX.ShadowChild & JSXBase.HTMLAttributes<HTMLShadowChildElement>;
+            "shadow-wrapper": LocalJSX.ShadowWrapper & JSXBase.HTMLAttributes<HTMLShadowWrapperElement>;
             "slot-cmp": LocalJSX.SlotCmp & JSXBase.HTMLAttributes<HTMLSlotCmpElement>;
             "slot-cmp-container": LocalJSX.SlotCmpContainer & JSXBase.HTMLAttributes<HTMLSlotCmpContainerElement>;
             "slot-parent-cmp": LocalJSX.SlotParentCmp & JSXBase.HTMLAttributes<HTMLSlotParentCmpElement>;

--- a/test/end-to-end/src/declarative-shadow-dom/test.e2e.ts
+++ b/test/end-to-end/src/declarative-shadow-dom/test.e2e.ts
@@ -355,7 +355,7 @@ describe('renderToString', () => {
         <!--o.29.2.c-->
         <div c-id="31.0.0.0" class="sc-nested-scope-cmp sc-nested-scope-cmp-s some-scope-class">
           <!--s.31.1.1.0.-->
-          <slot c-id="29.2.2.0" class="sc-nested-scope-cmp"></slot>
+          <slot c-id="29.2.2.0" class="sc-nested-scope-cmp" s-sn=""></slot>
         </div>
       </nested-scope-cmp>
     </div>

--- a/test/end-to-end/src/scoped-hydration/non-shadow-forwarded-slot.tsx
+++ b/test/end-to-end/src/scoped-hydration/non-shadow-forwarded-slot.tsx
@@ -1,0 +1,32 @@
+import { Component, Host, h } from '@stencil/core';
+
+@Component({
+  tag: 'non-shadow-forwarded-slot',
+  scoped: true,
+  styles: `
+    :host {
+      display: block;
+      border: 3px solid red;
+    }
+    :host strong {
+      color: red;
+    }
+  `,
+})
+export class Wrapper {
+  render() {
+    return (
+      <Host>
+        <strong>Non shadow parent. Start.</strong>
+        <br />
+
+        <shadow-child>
+          <slot>This is default content in the non-shadow parent slot</slot>
+        </shadow-child>
+
+        <br />
+        <strong>Non shadow parent. End.</strong>
+      </Host>
+    );
+  }
+}

--- a/test/end-to-end/src/scoped-hydration/non-shadow-wrapper.tsx
+++ b/test/end-to-end/src/scoped-hydration/non-shadow-wrapper.tsx
@@ -1,0 +1,25 @@
+import { Component, Host, h } from '@stencil/core';
+
+@Component({
+  tag: 'non-shadow-wrapper',
+  scoped: true,
+  styles: `
+    :host {
+      display: block;
+      border: 3px solid red;
+    }
+  `,
+})
+export class Wrapper {
+  render() {
+    return (
+      <Host>
+        <strong style={{ color: 'red' }}>Non-shadow Wrapper Start</strong>
+        <p>Wrapper Slot before</p>
+        <slot>Wrapper Slot Fallback</slot>
+        <p>Wrapper Slot after</p>
+        <strong style={{ color: 'red' }}>Non-shadow Wrapper End</strong>
+      </Host>
+    );
+  }
+}

--- a/test/end-to-end/src/scoped-hydration/non-shadow.tsx
+++ b/test/end-to-end/src/scoped-hydration/non-shadow.tsx
@@ -1,0 +1,25 @@
+import { Component, Host, h } from '@stencil/core';
+
+@Component({
+  tag: 'non-shadow-child',
+  scoped: true,
+  styles: `
+    :host {
+      display: block;
+      border: 3px solid blue;
+    }
+  `,
+})
+export class MyApp {
+  render() {
+    return (
+      <Host>
+        <br />
+        <strong style={{ color: 'blue' }}>Nested Non-Shadow Component Start</strong>
+        <br />
+        <slot>Slotted fallback content</slot>
+        <strong style={{ color: 'blue' }}>Nested Non-Shadow Component End</strong>
+      </Host>
+    );
+  }
+}

--- a/test/end-to-end/src/scoped-hydration/readme.md
+++ b/test/end-to-end/src/scoped-hydration/readme.md
@@ -1,0 +1,10 @@
+# shadow-wrapper
+
+
+
+<!-- Auto Generated Below -->
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/test/end-to-end/src/scoped-hydration/scoped-hydration.e2e.ts
+++ b/test/end-to-end/src/scoped-hydration/scoped-hydration.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage, E2EPage } from '@stencil/core/testing';
 
+// @ts-ignore may not be existing when project hasn't been built
 type HydrateModule = typeof import('../../hydrate');
 let renderToString: HydrateModule['renderToString'];
 

--- a/test/end-to-end/src/scoped-hydration/scoped-hydration.e2e.ts
+++ b/test/end-to-end/src/scoped-hydration/scoped-hydration.e2e.ts
@@ -14,6 +14,7 @@ async function getElementOrder(page: E2EPage, parent: string) {
 
 describe('`scoped: true` hydration checks', () => {
   beforeAll(async () => {
+    // @ts-ignore may not be existing when project hasn't been built
     const mod = await import('../../hydrate');
     renderToString = mod.renderToString;
   });

--- a/test/end-to-end/src/scoped-hydration/scoped-hydration.e2e.ts
+++ b/test/end-to-end/src/scoped-hydration/scoped-hydration.e2e.ts
@@ -1,0 +1,107 @@
+import { newE2EPage, E2EPage } from '@stencil/core/testing';
+
+type HydrateModule = typeof import('../../hydrate');
+let renderToString: HydrateModule['renderToString'];
+
+async function getElementOrder(page: E2EPage, parent: string) {
+  return await page.evaluate((parent: string) => {
+    const external = Array.from(document.querySelector(parent).children).map((el) => el.tagName);
+    const internal = Array.from((document.querySelector(parent) as any).__children).map((el: Element) => el.tagName);
+    return { internal, external };
+  }, parent);
+}
+
+describe('`scoped: true` hydration checks', () => {
+  beforeAll(async () => {
+    const mod = await import('../../hydrate');
+    renderToString = mod.renderToString;
+  });
+
+  it('shows fallback slot when no content is slotted', async () => {
+    const { html } = await renderToString(
+      `
+        <non-shadow-child></non-shadow-child> 
+        <non-shadow-child>test</non-shadow-child>
+      `,
+      {
+        serializeShadowRoot: true,
+      },
+    );
+    expect(html).toContain('Slotted fallback content');
+    const page = await newE2EPage({ html, url: 'https://stencil.com' });
+    const slots = await page.findAll('slot-fb');
+    expect(await slots[0].getAttribute('hidden')).toBeNull();
+    expect(await slots[1].getAttribute('hidden')).not.toBeNull();
+  });
+
+  it('keeps slotted elements in their assigned position and does not duplicate slotted children', async () => {
+    const { html } = await renderToString(
+      `
+      <non-shadow-wrapper>
+        <non-shadow-child></non-shadow-child>
+      </non-shadow-wrapper>
+    `,
+      {
+        serializeShadowRoot: true,
+      },
+    );
+    const page = await newE2EPage({ html, url: 'https://stencil.com' });
+
+    const { external, internal } = await getElementOrder(page, 'non-shadow-wrapper');
+    expect(external.length).toBe(1);
+    expect(internal.length).toBe(6);
+
+    expect(internal).toEqual(['STRONG', 'P', 'SLOT-FB', 'NON-SHADOW-CHILD', 'P', 'STRONG']);
+    expect(external).toEqual(['NON-SHADOW-CHILD']);
+
+    const slots = await page.findAll('slot-fb');
+    expect(await slots[0].getAttribute('hidden')).not.toBeNull();
+    expect(await slots[1].getAttribute('hidden')).toBeNull();
+  });
+
+  it('forwards slotted nodes into a nested shadow component whilst keeping those nodes in the light dom', async () => {
+    const { html } = await renderToString(
+      `
+      <non-shadow-forwarded-slot>
+        <p>slotted item 1</p>
+        <p>slotted item 2</p>
+        <p>slotted item 3</p>
+      </non-shadow-forwarded-slot>
+    `,
+      {
+        serializeShadowRoot: true,
+      },
+    );
+    const page = await newE2EPage({ html, url: 'https://stencil.com' });
+
+    const { external, internal } = await getElementOrder(page, 'non-shadow-forwarded-slot');
+    expect(external.length).toBe(3);
+    expect(internal.length).toBe(5);
+
+    expect(internal).toEqual(['STRONG', 'BR', 'SHADOW-CHILD', 'BR', 'STRONG']);
+    expect(external).toEqual(['P', 'P', 'P']);
+  });
+
+  it('retains the correct order of different nodes', async () => {
+    const { html } = await renderToString(
+      `
+      <non-shadow-forwarded-slot>
+        Text node 1
+        <!--Comment 1 -->
+        <p>Slotted element 1 </p>
+        <p>Slotted element 2 </p>
+        <!--Comment 2-->
+        Text node 2
+      </non-shadow-forwarded-slot>
+    `,
+      {
+        serializeShadowRoot: true,
+      },
+    );
+    const page = await newE2EPage({ html, url: 'https://stencil.com' });
+
+    expect(await page.evaluate(() => document.querySelector('non-shadow-forwarded-slot').textContent.trim())).toContain(
+      'Text node 1 Comment 1 Slotted element 1 Slotted element 2 Comment 2 Text node 2',
+    );
+  });
+});

--- a/test/end-to-end/src/scoped-hydration/shadow-wrapper.tsx
+++ b/test/end-to-end/src/scoped-hydration/shadow-wrapper.tsx
@@ -1,0 +1,25 @@
+import { Component, Host, h } from '@stencil/core';
+
+@Component({
+  tag: 'shadow-wrapper',
+  shadow: true,
+  styles: `
+    :host {
+      display: block;
+      border: 3px solid red;
+    }
+  `,
+})
+export class Wrapper {
+  render() {
+    return (
+      <Host>
+        <strong style={{ color: 'red' }}>Shadow Wrapper Start</strong>
+        <p>Shadow Slot before</p>
+        <slot>Wrapper Slot Fallback</slot>
+        <p>Shadow Slot after</p>
+        <strong style={{ color: 'red' }}>Shadow Wrapper End</strong>
+      </Host>
+    );
+  }
+}

--- a/test/end-to-end/src/scoped-hydration/shadow.tsx
+++ b/test/end-to-end/src/scoped-hydration/shadow.tsx
@@ -1,0 +1,27 @@
+import { Component, Host, h } from '@stencil/core';
+
+@Component({
+  tag: 'shadow-child',
+  shadow: true,
+  styles: `
+    :host {
+      display: block;
+      border: 3px solid blue;
+    }
+  `,
+})
+export class MyApp {
+  render() {
+    return (
+      <Host>
+        <br />
+        <strong style={{ color: 'blue' }}>Nested Shadow Component Start</strong>
+        <br />
+        <slot>
+          <div>Slotted fallback content</div>
+        </slot>
+        <strong style={{ color: 'blue' }}>Nested Shadow Component End</strong>
+      </Host>
+    );
+  }
+}

--- a/test/end-to-end/stencil.config.ts
+++ b/test/end-to-end/stencil.config.ts
@@ -61,4 +61,7 @@ export const config: Config = {
   hashFileNames: false,
   buildEs5: 'prod',
   sourceMap: true,
+  extras: {
+    experimentalSlotFixes: true,
+  },
 };


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There are lots of rough edges around the use of Stencil's proprietary non-shadow components during SSR

GitHub Issue Number: 
- Fixes https://github.com/ionic-team/stencil/issues/6065
- Fixes https://github.com/ionic-team/stencil/issues/6064
- Fixes https://github.com/ionic-team/stencil/issues/6063
- Fixes https://github.com/ionic-team/stencil/issues/6062
- Fixes https://github.com/ionic-team/stencil/issues/5198

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

A partial re-write of `client-hydrate.ts` (and few minor tweaks in the accompanying files) fixes all these issues.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

^ no breaking changes, but I should mention that during / after hydrating now, there are some changes to the outputted markup:
- A couple more internal tags / comments from the server generated markup
- Fewer Stencil-generated comment nodes left behind after hydration 

These changes could potentially cause users' test snapshots to fail.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
Users would just need to update their snapshots

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

New spec tests. New e2e tests.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

Referring to the linked issues, here's the same repo with the fixes applied:

![image](https://github.com/user-attachments/assets/36525ff7-da0a-4904-8531-4f10f60769a5)

![image](https://github.com/user-attachments/assets/2682fd14-1f9d-4bb3-af5f-bf5a0a0d1bc5)

![image](https://github.com/user-attachments/assets/8241e035-a9ea-4669-80b2-973864bd860e)

![image](https://github.com/user-attachments/assets/c0d0904b-42a3-41bb-a1aa-fdc1f88eed9b)

I appreciate, with a re-factor to `client-hydrate.ts` this big, there's a degree of 'trust me bra' involved - it's difficult to grok. I've done my best to add lots of comments to help elucidate it's dark magic, but if it's too much or too little just let me know.  If you'd like me to talk through what it's doing just let me know :) 