### PR TITLE
fix: stop 'experimentalScopedSlotChanges' warning msg on startup

### DIFF
--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -150,8 +150,6 @@ export const validateConfig = (
   validatedConfig.extras.scriptDataOpts = !!validatedConfig.extras.scriptDataOpts;
   validatedConfig.extras.initializeNextTick = !!validatedConfig.extras.initializeNextTick;
   validatedConfig.extras.tagNameTransform = !!validatedConfig.extras.tagNameTransform;
-  // TODO(STENCIL-1086): remove this option when it's the default behavior
-  validatedConfig.extras.experimentalScopedSlotChanges = !!validatedConfig.extras.experimentalScopedSlotChanges;
 
   // TODO(STENCIL-914): remove when `experimentalSlotFixes` is the default behavior
   // If the user set `experimentalSlotFixes` and any individual slot fix flags to `false`, we need to log a warning
@@ -181,11 +179,14 @@ export const validateConfig = (
     validatedConfig.extras.cloneNodeFix = true;
     validatedConfig.extras.slotChildNodesFix = true;
     validatedConfig.extras.scopedSlotTextContentFix = true;
+    validatedConfig.extras.experimentalScopedSlotChanges = true;
   } else {
     validatedConfig.extras.appendChildSlotFix = !!validatedConfig.extras.appendChildSlotFix;
     validatedConfig.extras.cloneNodeFix = !!validatedConfig.extras.cloneNodeFix;
     validatedConfig.extras.slotChildNodesFix = !!validatedConfig.extras.slotChildNodesFix;
     validatedConfig.extras.scopedSlotTextContentFix = !!validatedConfig.extras.scopedSlotTextContentFix;
+    // TODO(STENCIL-1086): remove this option when it's the default behavior
+    validatedConfig.extras.experimentalScopedSlotChanges = !!validatedConfig.extras.experimentalScopedSlotChanges;
   }
 
   setBooleanConfig(


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Given stencil.config options
```
extras: {
    experimentalSlotFixes: true,
  },
 ```
 a warning shows:

```
If the 'experimentalSlotFixes' flag is enabled it will override any slot fix flags which are disabled. In
particular, the following currently-disabled flags will be ignored: experimentalScopedSlotChanges. Please
update your Stencil config accordingly.
```

This was introduced in https://github.com/ionic-team/stencil/pull/6055 due to `experimentalScopedSlotChanges` not being explicitly set (and defaulting to `false`) when `experimentalSlotFixes` is set.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

No warnings

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
