### PR TITLE
fix(mock-doc): don't show error message for SSR workflows

### DIFF
--- a/src/mock-doc/node.ts
+++ b/src/mock-doc/node.ts
@@ -234,10 +234,15 @@ export class MockElement extends MockNode {
   attachInternals(): MockElementInternals {
     return new Proxy({} as unknown as MockElementInternals, {
       get: function (_target, prop, _receiver) {
-        console.error(
-          `NOTE: Property ${String(prop)} was accessed on ElementInternals, but this property is not implemented.
-Testing components with ElementInternals is fully supported in e2e tests.`,
-        );
+        /**
+         * only print warning when running in a test environment
+         */
+        if ('process' in globalThis && globalThis.process.env.__STENCIL_SPEC_TESTS__) {
+          console.error(
+            `NOTE: Property ${String(prop)} was accessed on ElementInternals, but this property is not implemented.
+  Testing components with ElementInternals is fully supported in e2e tests.`
+          );
+        }
       },
     });
   }

--- a/src/mock-doc/node.ts
+++ b/src/mock-doc/node.ts
@@ -240,7 +240,7 @@ export class MockElement extends MockNode {
         if ('process' in globalThis && globalThis.process.env.__STENCIL_SPEC_TESTS__) {
           console.error(
             `NOTE: Property ${String(prop)} was accessed on ElementInternals, but this property is not implemented.
-  Testing components with ElementInternals is fully supported in e2e tests.`
+  Testing components with ElementInternals is fully supported in e2e tests.`,
           );
         }
       },


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
An error message is shown when user render a component using element internals via SSR.

GitHub Issue Number: fixes #6073

## What is the new behavior?
Error message is only shown when using Stencil testrunner.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

There hasn't been any tests for this error message in the first place and creating one would be too much effort for the value it provides.

## Other information

n/a
