### PR TITLE
fix(mock-doc): don't force template tags to have a shadowroot

### DIFF
--- a/src/mock-doc/serialize-node.ts
+++ b/src/mock-doc/serialize-node.ts
@@ -126,19 +126,6 @@ function* streamToHtml(
       yield '<' + tag;
       output.currentLineWidth += tag.length + 1;
 
-      /**
-       * ToDo(https://github.com/ionic-team/stencil/issues/4111): the shadow root class is `#document-fragment`
-       * and has no mode attribute. We should consider adding a mode attribute.
-       */
-      if (
-        tag === 'template' &&
-        (!(node as Element).getAttribute || !(node as Element).getAttribute('shadowrootmode'))
-      ) {
-        const mode = ` shadowrootmode="open"`;
-        yield mode;
-        output.currentLineWidth += mode.length;
-      }
-
       const attrsLength = (node as HTMLElement).attributes.length;
       const attributes =
         opts.prettyHtml && attrsLength > 1

--- a/src/mock-doc/test/html-parse.spec.ts
+++ b/src/mock-doc/test/html-parse.spec.ts
@@ -127,11 +127,11 @@ describe('parseHtml', () => {
       <template>text</template>
     `);
 
-    expect(doc.head.innerHTML).toBe(`<template shadowrootmode="open">text</template>`);
+    expect(doc.head.innerHTML).toBe(`<template>text</template>`);
 
     const tmplElm: HTMLTemplateElement = doc.head.firstElementChild as any;
 
-    expect(tmplElm.outerHTML).toBe(`<template shadowrootmode="open">text</template>`);
+    expect(tmplElm.outerHTML).toBe(`<template>text</template>`);
     expect(tmplElm.content?.firstChild?.textContent).toBe(`text`);
     expect(tmplElm.childNodes).toHaveLength(0);
   });

--- a/src/mock-doc/test/serialize-node.spec.ts
+++ b/src/mock-doc/test/serialize-node.spec.ts
@@ -166,7 +166,7 @@ describe('serializeNodeToHtml', () => {
     doc.body.innerHTML = input;
 
     const output = serializeNodeToHtml(doc.body);
-    expect(output).toBe(`<template shadowrootmode="open">text</template>`);
+    expect(output).toBe(`<template>text</template>`);
   });
 
   it('svg', () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
When we implemented shadow root support we changed the serialization method to force template tags to have a `shadowroot` property even though that is not required.

## What is the new behavior?
Don't set the property implicitly.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Updated unit test.

## Other information

n/a
