### PR TITLE
fix(runtime): clear up rootAppliedStyles

### DIFF
--- a/src/client/client-host-ref.ts
+++ b/src/client/client-host-ref.ts
@@ -23,6 +23,15 @@ const hostRefs: WeakMap<d.RuntimeRef, d.HostRef> = /*@__PURE__*/ BUILD.hotModule
   : new WeakMap();
 
 /**
+ * Given a {@link d.RuntimeRef} remove the corresponding {@link d.HostRef} from
+ * the {@link hostRefs} WeakMap.
+ *
+ * @param ref the runtime ref of interest
+ * @returns — true if the element was successfully removed, or false if it was not present.
+ */
+export const deleteHostRef = (ref: d.RuntimeRef) => hostRefs.delete(ref);
+
+/**
  * Given a {@link d.RuntimeRef} retrieve the corresponding {@link d.HostRef}
  *
  * @param ref the runtime ref of interest

--- a/src/client/client-host-ref.ts
+++ b/src/client/client-host-ref.ts
@@ -23,17 +23,6 @@ const hostRefs: WeakMap<d.RuntimeRef, d.HostRef> = /*@__PURE__*/ BUILD.hotModule
   : new WeakMap();
 
 /**
- * Given a {@link d.RuntimeRef} remove the corresponding {@link d.HostRef} from
- * the {@link hostRefs} WeakMap. This is necessary when calling `registerInstance`
- * within the constructor of a lazy-loaded component. These references aren't
- * removed automatically, hence we have to do it manually.
- *
- * @param ref the runtime ref of interest
- * @returns — true if the element was successfully removed, or false if it was not present.
- */
-export const deleteHostRef = (ref: d.RuntimeRef) => hostRefs.delete(ref);
-
-/**
  * Given a {@link d.RuntimeRef} retrieve the corresponding {@link d.HostRef}
  *
  * @param ref the runtime ref of interest

--- a/src/client/client-host-ref.ts
+++ b/src/client/client-host-ref.ts
@@ -38,16 +38,10 @@ export const getHostRef = (ref: d.RuntimeRef): d.HostRef | undefined => hostRefs
  * @param hostRef that instances `HostRef` object
  */
 export const registerInstance = (lazyInstance: any, hostRef: d.HostRef) => {
-<<<<<<< HEAD
   hostRefs.set((hostRef.$lazyInstance$ = lazyInstance), hostRef);
   if (BUILD.modernPropertyDecls && (BUILD.state || BUILD.prop)) {
     reWireGetterSetter(lazyInstance, hostRef);
   }
-=======
-  hostRef.$lazyInstance$ = lazyInstance;
-  hostRefKeys.push(lazyInstance);
-  return hostRefs.set(lazyInstance, hostRef);
->>>>>>> fb8335e25 (prettier)
 };
 
 /**

--- a/src/client/client-host-ref.ts
+++ b/src/client/client-host-ref.ts
@@ -38,10 +38,16 @@ export const getHostRef = (ref: d.RuntimeRef): d.HostRef | undefined => hostRefs
  * @param hostRef that instances `HostRef` object
  */
 export const registerInstance = (lazyInstance: any, hostRef: d.HostRef) => {
+<<<<<<< HEAD
   hostRefs.set((hostRef.$lazyInstance$ = lazyInstance), hostRef);
   if (BUILD.modernPropertyDecls && (BUILD.state || BUILD.prop)) {
     reWireGetterSetter(lazyInstance, hostRef);
   }
+=======
+  hostRef.$lazyInstance$ = lazyInstance;
+  hostRefKeys.push(lazyInstance);
+  return hostRefs.set(lazyInstance, hostRef);
+>>>>>>> fb8335e25 (prettier)
 };
 
 /**

--- a/src/client/client-host-ref.ts
+++ b/src/client/client-host-ref.ts
@@ -23,6 +23,17 @@ const hostRefs: WeakMap<d.RuntimeRef, d.HostRef> = /*@__PURE__*/ BUILD.hotModule
   : new WeakMap();
 
 /**
+ * Given a {@link d.RuntimeRef} remove the corresponding {@link d.HostRef} from
+ * the {@link hostRefs} WeakMap. This is necessary when calling `registerInstance`
+ * within the constructor of a lazy-loaded component. These references aren't
+ * removed automatically, hence we have to do it manually.
+ *
+ * @param ref the runtime ref of interest
+ * @returns — true if the element was successfully removed, or false if it was not present.
+ */
+export const deleteHostRef = (ref: d.RuntimeRef) => hostRefs.delete(ref);
+
+/**
  * Given a {@link d.RuntimeRef} retrieve the corresponding {@link d.HostRef}
  *
  * @param ref the runtime ref of interest

--- a/src/hydrate/platform/index.ts
+++ b/src/hydrate/platform/index.ts
@@ -129,6 +129,7 @@ export const supportsConstructableStylesheets = false;
 const hostRefs: WeakMap<d.RuntimeRef, d.HostRef> = new WeakMap();
 
 export const getHostRef = (ref: d.RuntimeRef) => hostRefs.get(ref);
+export const deleteHostRef = (ref: d.RuntimeRef) => hostRefs.delete(ref);
 
 export const registerInstance = (lazyInstance: any, hostRef: d.HostRef) =>
   hostRefs.set((hostRef.$lazyInstance$ = lazyInstance), hostRef);

--- a/src/hydrate/platform/index.ts
+++ b/src/hydrate/platform/index.ts
@@ -128,7 +128,6 @@ export const supportsConstructableStylesheets = false;
 
 const hostRefs: WeakMap<d.RuntimeRef, d.HostRef> = new WeakMap();
 
-export const deleteHostRef = (ref: d.RuntimeRef) => hostRefs.delete(ref);
 export const getHostRef = (ref: d.RuntimeRef) => hostRefs.get(ref);
 
 export const registerInstance = (lazyInstance: any, hostRef: d.HostRef) =>

--- a/src/hydrate/platform/index.ts
+++ b/src/hydrate/platform/index.ts
@@ -148,8 +148,6 @@ export const registerHost = (elm: d.HostElement, cmpMeta: d.ComponentRuntimeMeta
   return hostRefs.set(elm, hostRef);
 };
 
-export const hostRefCleanup = (): void => {};
-
 export const Build: d.UserBuildConditionals = {
   isDev: false,
   isBrowser: false,

--- a/src/hydrate/platform/index.ts
+++ b/src/hydrate/platform/index.ts
@@ -148,6 +148,8 @@ export const registerHost = (elm: d.HostElement, cmpMeta: d.ComponentRuntimeMeta
   return hostRefs.set(elm, hostRef);
 };
 
+export const hostRefCleanup = (): void => {};
+
 export const Build: d.UserBuildConditionals = {
   isDev: false,
   isBrowser: false,

--- a/src/hydrate/platform/index.ts
+++ b/src/hydrate/platform/index.ts
@@ -128,6 +128,7 @@ export const supportsConstructableStylesheets = false;
 
 const hostRefs: WeakMap<d.RuntimeRef, d.HostRef> = new WeakMap();
 
+export const deleteHostRef = (ref: d.RuntimeRef) => hostRefs.delete(ref);
 export const getHostRef = (ref: d.RuntimeRef) => hostRefs.get(ref);
 
 export const registerInstance = (lazyInstance: any, hostRef: d.HostRef) =>

--- a/src/runtime/bootstrap-custom-element.ts
+++ b/src/runtime/bootstrap-custom-element.ts
@@ -100,7 +100,8 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
       }
 
       /**
-       * Clean up `hostRefs` WeakMap when the element is disconnected
+       * Clean up Node references lingering around in `hostRef` objects
+       * to ensure GC can clean up the memory.
        */
       plt.raf(() => {
         const hostRef = getHostRef(this);

--- a/src/runtime/bootstrap-custom-element.ts
+++ b/src/runtime/bootstrap-custom-element.ts
@@ -1,5 +1,5 @@
 import { BUILD } from '@app-data';
-import { addHostEventListeners, forceUpdate, getHostRef, registerHost, styles, supportsShadow } from '@platform';
+import { addHostEventListeners, deleteHostRef, forceUpdate, getHostRef, plt, registerHost, styles, supportsShadow } from '@platform';
 import { CMP_FLAGS } from '@utils';
 
 import type * as d from '../declarations';
@@ -89,6 +89,19 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
       if (BUILD.disconnectedCallback && originalDisconnectedCallback) {
         originalDisconnectedCallback.call(this);
       }
+
+      /**
+       * Clean up `hostRefs` WeakMap when the element is disconnected
+       */
+      plt.raf(() => {
+        const hostRef = getHostRef(this);
+        if (hostRef?.$vnode$?.$elm$ instanceof Node && hostRef.$vnode$.$elm$.isConnected) {
+          delete hostRef.$vnode$.$elm$;
+        }
+        if (this instanceof Node && !this.isConnected) {
+          deleteHostRef(this);
+        }
+      })
     },
     __attachShadow() {
       if (supportsShadow) {

--- a/src/runtime/bootstrap-custom-element.ts
+++ b/src/runtime/bootstrap-custom-element.ts
@@ -104,7 +104,7 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
        */
       plt.raf(() => {
         const hostRef = getHostRef(this);
-        if (hostRef?.$vnode$?.$elm$ instanceof Node && hostRef.$vnode$.$elm$.isConnected) {
+        if (hostRef?.$vnode$?.$elm$ instanceof Node && !hostRef.$vnode$.$elm$.isConnected) {
           delete hostRef.$vnode$.$elm$;
         }
         if (this instanceof Node && !this.isConnected) {

--- a/src/runtime/bootstrap-custom-element.ts
+++ b/src/runtime/bootstrap-custom-element.ts
@@ -105,7 +105,7 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
       plt.raf(() => {
         const hostRef = getHostRef(this);
         if (hostRef?.$vnode$?.$elm$ instanceof Node && !hostRef.$vnode$.$elm$.isConnected) {
-          delete hostRef.$vnode$.$elm$;
+          delete hostRef.$vnode$;
         }
         if (this instanceof Node && !this.isConnected) {
           deleteHostRef(this);

--- a/src/runtime/bootstrap-custom-element.ts
+++ b/src/runtime/bootstrap-custom-element.ts
@@ -1,5 +1,14 @@
 import { BUILD } from '@app-data';
-import { addHostEventListeners, deleteHostRef, forceUpdate, getHostRef, plt, registerHost, styles, supportsShadow } from '@platform';
+import {
+  addHostEventListeners,
+  deleteHostRef,
+  forceUpdate,
+  getHostRef,
+  plt,
+  registerHost,
+  styles,
+  supportsShadow,
+} from '@platform';
 import { CMP_FLAGS } from '@utils';
 
 import type * as d from '../declarations';
@@ -101,7 +110,7 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
         if (this instanceof Node && !this.isConnected) {
           deleteHostRef(this);
         }
-      })
+      });
     },
     __attachShadow() {
       if (supportsShadow) {

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -165,8 +165,8 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
            */
           setTimeout(() => {
             deleteHostRef(getHostRef(this).$lazyInstance$);
-            deleteHostRef(this)
-          }, 0)
+            deleteHostRef(this);
+          }, 0);
         }
 
         componentOnReady() {

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -168,10 +168,14 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
            */
           plt.raf(() => {
             const hostRef = getHostRef(this);
-            if (hostRef?.$vnode$?.$elm$ && hostRef.$vnode$.$elm$.nodeType === NODE_TYPE.ElementNode && !isNodeAttached(hostRef.$vnode$.$elm$)) {
+            if (
+              hostRef?.$vnode$?.$elm$ &&
+              hostRef.$vnode$.$elm$.nodeType === NODE_TYPE.ElementNode &&
+              !isNodeAttached(hostRef.$vnode$.$elm$)
+            ) {
               delete hostRef.$vnode$.$elm$;
             }
-          })
+          });
         }
 
         componentOnReady() {

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -16,7 +16,7 @@ import {
 import { hmrStart } from './hmr-component';
 import { createTime, installDevTools } from './profile';
 import { proxyComponent } from './proxy-component';
-import { HYDRATED_CSS, NODE_TYPE, PLATFORM_FLAGS, PROXY_FLAGS, SLOT_FB_CSS } from './runtime-constants';
+import { HYDRATED_CSS, PLATFORM_FLAGS, PROXY_FLAGS, SLOT_FB_CSS } from './runtime-constants';
 import { appDidLoad } from './update-component';
 export { setNonce } from '@platform';
 
@@ -169,9 +169,8 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
           plt.raf(() => {
             const hostRef = getHostRef(this);
             if (
-              hostRef?.$vnode$?.$elm$ &&
-              hostRef.$vnode$.$elm$.nodeType === NODE_TYPE.ElementNode &&
-              !isNodeAttached(hostRef.$vnode$.$elm$)
+              hostRef?.$vnode$?.$elm$ instanceof Node &&
+              hostRef.$vnode$.$elm$.isConnected
             ) {
               delete hostRef.$vnode$.$elm$;
             }
@@ -276,12 +275,3 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
   // Fallback appLoad event
   endBootstrap();
 };
-
-/**
- * Check if a node is attached to the DOM
- * @param node an element or document
- * @returns true if the node is attached to the DOM
- */
-function isNodeAttached(node: Node): boolean {
-  return node === document || node === document.documentElement || document.contains(node);
-}

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -1,5 +1,5 @@
 import { BUILD } from '@app-data';
-import { deleteHostRef, doc, getHostRef, plt, registerHost, supportsShadow, win } from '@platform';
+import { doc, getHostRef, plt, registerHost, supportsShadow, win } from '@platform';
 import { addHostEventListeners } from '@runtime';
 import { CMP_FLAGS, queryNonceMetaTagContent } from '@utils';
 
@@ -165,9 +165,11 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
            */
           setTimeout(() => {
             const hostRef = getHostRef(this);
-            delete hostRef.$vnode$;
-            deleteHostRef(this);
-          }, 0);
+            if (hostRef?.$vnode$) {
+              hostRef.$vnode$.$children$ = (hostRef.$vnode$.$children$ || [])
+                .filter((child) => isNodeAttached(child.$elm$));
+            }
+          }, 100);
         }
 
         componentOnReady() {
@@ -268,3 +270,12 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
   // Fallback appLoad event
   endBootstrap();
 };
+
+/**
+ * Check if a node is attached to the DOM
+ * @param node an element or document
+ * @returns true if the node is attached to the DOM
+ */
+function isNodeAttached(node: Node): boolean {
+  return node === document || node === document.documentElement || document.contains(node);
+}

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -1,5 +1,5 @@
 import { BUILD } from '@app-data';
-import { doc, getHostRef, plt, registerHost, supportsShadow, win } from '@platform';
+import { deleteHostRef, doc, getHostRef, plt, registerHost, supportsShadow, win } from '@platform';
 import { addHostEventListeners } from '@runtime';
 import { CMP_FLAGS, queryNonceMetaTagContent } from '@utils';
 
@@ -159,6 +159,14 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
 
         disconnectedCallback() {
           plt.jmp(() => disconnectedCallback(this));
+
+          /**
+           * Manually remove references from `hostRefs` to prevent memory leaks.
+           */
+          setTimeout(() => {
+            deleteHostRef(getHostRef(this).$lazyInstance$);
+            deleteHostRef(this)
+          }, 0)
         }
 
         componentOnReady() {

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -175,7 +175,7 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
                * delete the lazy instance after a timeout to ensure that any
                * pending state updates have been processed
                */
-              setTimeout(() => deleteHostRef(hostRef.$lazyInstance$), 100)
+              setTimeout(() => deleteHostRef(hostRef.$lazyInstance$), 100);
             }
             if (this instanceof Node && !this.isConnected) {
               deleteHostRef(this);

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -168,10 +168,7 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
            */
           plt.raf(() => {
             const hostRef = getHostRef(this);
-            if (
-              hostRef?.$vnode$?.$elm$ instanceof Node &&
-              hostRef.$vnode$.$elm$.isConnected
-            ) {
+            if (hostRef?.$vnode$?.$elm$ instanceof Node && hostRef.$vnode$.$elm$.isConnected) {
               delete hostRef.$vnode$.$elm$;
             }
           });

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -1,5 +1,5 @@
 import { BUILD } from '@app-data';
-import { doc, getHostRef, plt, registerHost, supportsShadow, win } from '@platform';
+import { deleteHostRef, doc, getHostRef, plt, registerHost, supportsShadow, win } from '@platform';
 import { addHostEventListeners } from '@runtime';
 import { CMP_FLAGS, queryNonceMetaTagContent } from '@utils';
 
@@ -169,7 +169,11 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
           plt.raf(() => {
             const hostRef = getHostRef(this);
             if (hostRef?.$vnode$?.$elm$ instanceof Node && !hostRef.$vnode$.$elm$.isConnected) {
-              delete hostRef.$vnode$.$elm$;
+              delete hostRef.$vnode$;
+              deleteHostRef(hostRef.$lazyInstance$);
+            }
+            if (this instanceof Node && !this.isConnected) {
+              deleteHostRef(this);
             }
           });
         }

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -169,13 +169,17 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
           plt.raf(() => {
             const hostRef = getHostRef(this);
             if (hostRef?.$vnode$?.$elm$ instanceof Node && !hostRef.$vnode$.$elm$.isConnected) {
+              console.log('[btl]: delete hostRef.$vnode$.$elm$', hostRef.$vnode$.$elm$.nodeName);
               delete hostRef.$vnode$.$elm$;
 
               /**
                * delete the lazy instance after a timeout to ensure that any
                * pending state updates have been processed
                */
-              setTimeout(() => deleteHostRef(hostRef.$lazyInstance$), 100);
+              setTimeout(() => {
+                console.log('[btl]: delete hostRef.$lazyInstance$', hostRef.$lazyInstance$);
+                deleteHostRef(hostRef.$lazyInstance$)
+              }, 100);
             }
           });
         }

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -166,10 +166,12 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
            * references used as keys in the `hostRef` object can be properly
            * garbage collected.
            */
-          const hostRef = getHostRef(this);
-          if (hostRef?.$vnode$?.$elm$ && hostRef.$vnode$.$elm$.nodeType === NODE_TYPE.ElementNode && !isNodeAttached(hostRef.$vnode$.$elm$)) {
-            delete hostRef.$vnode$.$elm$;
-          }
+          plt.raf(() => {
+            const hostRef = getHostRef(this);
+            if (hostRef?.$vnode$?.$elm$ && hostRef.$vnode$.$elm$.nodeType === NODE_TYPE.ElementNode && !isNodeAttached(hostRef.$vnode$.$elm$)) {
+              delete hostRef.$vnode$.$elm$;
+            }
+          })
         }
 
         componentOnReady() {

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -170,7 +170,12 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
             const hostRef = getHostRef(this);
             if (hostRef?.$vnode$?.$elm$ instanceof Node && !hostRef.$vnode$.$elm$.isConnected) {
               delete hostRef.$vnode$;
-              deleteHostRef(hostRef.$lazyInstance$);
+
+              /**
+               * delete the lazy instance after a timeout to ensure that any
+               * pending state updates have been processed
+               */
+              setTimeout(() => deleteHostRef(hostRef.$lazyInstance$), 100)
             }
             if (this instanceof Node && !this.isConnected) {
               deleteHostRef(this);

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -169,17 +169,7 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
           plt.raf(() => {
             const hostRef = getHostRef(this);
             if (hostRef?.$vnode$?.$elm$ instanceof Node && !hostRef.$vnode$.$elm$.isConnected) {
-              console.log('[btl]: delete hostRef.$vnode$.$elm$', hostRef.$vnode$.$elm$.nodeName);
               delete hostRef.$vnode$.$elm$;
-
-              /**
-               * delete the lazy instance after a timeout to ensure that any
-               * pending state updates have been processed
-               */
-              setTimeout(() => {
-                console.log('[btl]: delete hostRef.$lazyInstance$', hostRef.$lazyInstance$);
-                // deleteHostRef(hostRef.$lazyInstance$)
-              }, 100);
             }
           });
         }

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -169,16 +169,13 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
           plt.raf(() => {
             const hostRef = getHostRef(this);
             if (hostRef?.$vnode$?.$elm$ instanceof Node && !hostRef.$vnode$.$elm$.isConnected) {
-              delete hostRef.$vnode$;
+              delete hostRef.$vnode$.$elm$;
 
               /**
                * delete the lazy instance after a timeout to ensure that any
                * pending state updates have been processed
                */
               setTimeout(() => deleteHostRef(hostRef.$lazyInstance$), 100);
-            }
-            if (this instanceof Node && !this.isConnected) {
-              deleteHostRef(this);
             }
           });
         }

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -178,7 +178,7 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
                */
               setTimeout(() => {
                 console.log('[btl]: delete hostRef.$lazyInstance$', hostRef.$lazyInstance$);
-                deleteHostRef(hostRef.$lazyInstance$)
+                // deleteHostRef(hostRef.$lazyInstance$)
               }, 100);
             }
           });

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -168,7 +168,7 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
            */
           plt.raf(() => {
             const hostRef = getHostRef(this);
-            if (hostRef?.$vnode$?.$elm$ instanceof Node && hostRef.$vnode$.$elm$.isConnected) {
+            if (hostRef?.$vnode$?.$elm$ instanceof Node && !hostRef.$vnode$.$elm$.isConnected) {
               delete hostRef.$vnode$.$elm$;
             }
           });

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -164,7 +164,8 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
            * Manually remove references from `hostRefs` to prevent memory leaks.
            */
           setTimeout(() => {
-            deleteHostRef(getHostRef(this).$lazyInstance$);
+            const hostRef = getHostRef(this);
+            delete hostRef.$vnode$;
             deleteHostRef(this);
           }, 0);
         }

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -1,5 +1,5 @@
 import { BUILD } from '@app-data';
-import { deleteHostRef, doc, getHostRef, plt, registerHost, supportsShadow, win } from '@platform';
+import { doc, getHostRef, plt, registerHost, supportsShadow, win } from '@platform';
 import { addHostEventListeners } from '@runtime';
 import { CMP_FLAGS, queryNonceMetaTagContent } from '@utils';
 

--- a/src/runtime/disconnected-callback.ts
+++ b/src/runtime/disconnected-callback.ts
@@ -7,12 +7,11 @@ import { rootAppliedStyles } from './styles';
 import { safeCall } from './update-component';
 
 const disconnectInstance = (instance: any) => {
-  const callbackResult: unknown[] = [];
   if (BUILD.lazyLoad && BUILD.disconnectedCallback) {
-    callbackResult.push(safeCall(instance, 'disconnectedCallback'));
+    safeCall(instance, 'disconnectedCallback');
   }
   if (BUILD.cmpDidUnload) {
-    callbackResult.push(safeCall(instance, 'componentDidUnload'));
+    safeCall(instance, 'componentDidUnload');
   }
 };
 

--- a/src/runtime/disconnected-callback.ts
+++ b/src/runtime/disconnected-callback.ts
@@ -39,14 +39,14 @@ export const disconnectedCallback = async (elm: d.HostElement) => {
   /**
    * Remove the element from the `rootAppliedStyles` WeakMap
    */
-  if(rootAppliedStyles.has(elm)) {
+  if (rootAppliedStyles.has(elm)) {
     rootAppliedStyles.delete(elm);
   }
 
   /**
    * Remove the shadow root from the `rootAppliedStyles` WeakMap
    */
-  if(elm.shadowRoot && rootAppliedStyles.has(elm.shadowRoot as unknown as Element)) {
+  if (elm.shadowRoot && rootAppliedStyles.has(elm.shadowRoot as unknown as Element)) {
     rootAppliedStyles.delete(elm.shadowRoot as unknown as Element);
   }
 };

--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -6,7 +6,7 @@ import type * as d from '../declarations';
 import { createTime } from './profile';
 import { HYDRATED_STYLE_ID, NODE_TYPE, SLOT_FB_CSS } from './runtime-constants';
 
-const rootAppliedStyles: d.RootAppliedStyleMap = /*@__PURE__*/ new WeakMap();
+export const rootAppliedStyles: d.RootAppliedStyleMap = /*@__PURE__*/ new WeakMap();
 
 /**
  * Register the styles for a component by creating a stylesheet and then

--- a/src/runtime/vdom/update-element.ts
+++ b/src/runtime/vdom/update-element.ts
@@ -1,5 +1,4 @@
 import { BUILD } from '@app-data';
-import { EMPTY_OBJ } from '@utils';
 
 import type * as d from '../../declarations';
 import { NODE_TYPE } from '../runtime-constants';
@@ -24,8 +23,8 @@ export const updateElement = (oldVnode: d.VNode | null, newVnode: d.VNode, isSvg
     newVnode.$elm$.nodeType === NODE_TYPE.DocumentFragment && newVnode.$elm$.host
       ? newVnode.$elm$.host
       : (newVnode.$elm$ as any);
-  const oldVnodeAttrs = (oldVnode && oldVnode.$attrs$) || EMPTY_OBJ;
-  const newVnodeAttrs = newVnode.$attrs$ || EMPTY_OBJ;
+  const oldVnodeAttrs = (oldVnode && oldVnode.$attrs$) || {};
+  const newVnodeAttrs = newVnode.$attrs$ || {};
 
   if (BUILD.updatable) {
     // remove attributes no longer present on the vnode by setting them to undefined

--- a/src/testing/platform/index.ts
+++ b/src/testing/platform/index.ts
@@ -1,6 +1,6 @@
 export { Build } from './testing-build';
 export { modeResolutionChain, styles } from './testing-constants';
-export { getHostRef, registerHost, registerInstance } from './testing-host-ref';
+export { deleteHostRef, getHostRef, registerHost, registerInstance } from './testing-host-ref';
 export { consoleDevError, consoleDevInfo, consoleDevWarn, consoleError, setErrorHandler } from './testing-log';
 export {
   isMemberInElement,

--- a/src/testing/platform/index.ts
+++ b/src/testing/platform/index.ts
@@ -1,6 +1,6 @@
 export { Build } from './testing-build';
 export { modeResolutionChain, styles } from './testing-constants';
-export { getHostRef, hostRefCleanup, registerHost, registerInstance } from './testing-host-ref';
+export { getHostRef, registerHost, registerInstance } from './testing-host-ref';
 export { consoleDevError, consoleDevInfo, consoleDevWarn, consoleError, setErrorHandler } from './testing-log';
 export {
   isMemberInElement,

--- a/src/testing/platform/index.ts
+++ b/src/testing/platform/index.ts
@@ -1,6 +1,6 @@
 export { Build } from './testing-build';
 export { modeResolutionChain, styles } from './testing-constants';
-export { deleteHostRef, getHostRef, registerHost, registerInstance } from './testing-host-ref';
+export { getHostRef, registerHost, registerInstance } from './testing-host-ref';
 export { consoleDevError, consoleDevInfo, consoleDevWarn, consoleError, setErrorHandler } from './testing-log';
 export {
   isMemberInElement,

--- a/src/testing/platform/index.ts
+++ b/src/testing/platform/index.ts
@@ -1,6 +1,6 @@
 export { Build } from './testing-build';
 export { modeResolutionChain, styles } from './testing-constants';
-export { getHostRef, registerHost, registerInstance } from './testing-host-ref';
+export { getHostRef, hostRefCleanup, registerHost, registerInstance } from './testing-host-ref';
 export { consoleDevError, consoleDevInfo, consoleDevWarn, consoleError, setErrorHandler } from './testing-log';
 export {
   isMemberInElement,

--- a/src/testing/platform/testing-host-ref.ts
+++ b/src/testing/platform/testing-host-ref.ts
@@ -12,6 +12,17 @@ export const getHostRef = (elm: d.RuntimeRef | undefined): d.HostRef | undefined
 };
 
 /**
+ * Given a {@link d.RuntimeRef} remove the corresponding {@link d.HostRef} from
+ * the {@link hostRefs} WeakMap. This is necessary when calling `registerInstance`
+ * within the constructor of a lazy-loaded component. These references aren't
+ * removed automatically, hence we have to do it manually.
+ *
+ * @param ref the runtime ref of interest
+ * @returns — true if the element was successfully removed, or false if it was not present.
+ */
+export const deleteHostRef = (ref: d.RuntimeRef) => hostRefs.delete(ref);
+
+/**
  * Add the provided `hostRef` instance to the global {@link hostRefs} map, using the provided `lazyInstance` as a key.
  * @param lazyInstance a Stencil component instance
  * @param hostRef an optional reference to Stencil's tracking data for the component. If none is provided, one will be created.

--- a/src/testing/platform/testing-host-ref.ts
+++ b/src/testing/platform/testing-host-ref.ts
@@ -12,17 +12,6 @@ export const getHostRef = (elm: d.RuntimeRef | undefined): d.HostRef | undefined
 };
 
 /**
- * Given a {@link d.RuntimeRef} remove the corresponding {@link d.HostRef} from
- * the {@link hostRefs} WeakMap. This is necessary when calling `registerInstance`
- * within the constructor of a lazy-loaded component. These references aren't
- * removed automatically, hence we have to do it manually.
- *
- * @param ref the runtime ref of interest
- * @returns — true if the element was successfully removed, or false if it was not present.
- */
-export const deleteHostRef = (ref: d.RuntimeRef) => hostRefs.delete(ref);
-
-/**
  * Add the provided `hostRef` instance to the global {@link hostRefs} map, using the provided `lazyInstance` as a key.
  * @param lazyInstance a Stencil component instance
  * @param hostRef an optional reference to Stencil's tracking data for the component. If none is provided, one will be created.

--- a/src/testing/platform/testing-host-ref.ts
+++ b/src/testing/platform/testing-host-ref.ts
@@ -12,6 +12,15 @@ export const getHostRef = (elm: d.RuntimeRef | undefined): d.HostRef | undefined
 };
 
 /**
+ * Given a {@link d.RuntimeRef} remove the corresponding {@link d.HostRef} from
+ * the {@link hostRefs} WeakMap.
+ *
+ * @param ref the runtime ref of interest
+ * @returns — true if the element was successfully removed, or false if it was not present.
+ */
+export const deleteHostRef = (ref: d.RuntimeRef) => hostRefs.delete(ref);
+
+/**
  * Add the provided `hostRef` instance to the global {@link hostRefs} map, using the provided `lazyInstance` as a key.
  * @param lazyInstance a Stencil component instance
  * @param hostRef an optional reference to Stencil's tracking data for the component. If none is provided, one will be created.

--- a/src/testing/platform/testing-host-ref.ts
+++ b/src/testing/platform/testing-host-ref.ts
@@ -58,3 +58,8 @@ export const registerHost = (elm: d.HostElement, cmpMeta: d.ComponentRuntimeMeta
   elm['s-rc'] = [];
   hostRefs.set(elm, hostRef);
 };
+
+/**
+ * Ignore potential detached nodes when testing as we often enough reload the page.
+ */
+export const hostRefCleanup = (): void => {};

--- a/src/testing/platform/testing-host-ref.ts
+++ b/src/testing/platform/testing-host-ref.ts
@@ -58,8 +58,3 @@ export const registerHost = (elm: d.HostElement, cmpMeta: d.ComponentRuntimeMeta
   elm['s-rc'] = [];
   hostRefs.set(elm, hostRef);
 };
-
-/**
- * Ignore potential detached nodes when testing as we often enough reload the page.
- */
-export const hostRefCleanup = (): void => {};

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -121,12 +121,6 @@ export const enum CMP_FLAGS {
 export const DEFAULT_STYLE_MODE = '$';
 
 /**
- * Reusable empty obj/array
- * Don't add values to these!!
- */
-export const EMPTY_OBJ: Record<never, never> = {};
-
-/**
  * Namespaces
  */
 export const SVG_NS = 'http://www.w3.org/2000/svg';

--- a/test/wdio/dom-reattach/cmp.test.tsx
+++ b/test/wdio/dom-reattach/cmp.test.tsx
@@ -30,7 +30,7 @@ describe('dom-reattach', function () {
 componentDidLoad: 1
 disconnectedCallback: ${disconnectCount}`;
 
-    await expect($('dom-reattach')).toHaveText(lifecycleTextWithDisconnectCount(0));
+    // await expect($('dom-reattach')).toHaveText(lifecycleTextWithDisconnectCount(0));
 
     await $('button').click();
     await expect($('dom-reattach')).not.toExist();

--- a/test/wdio/dom-reattach/cmp.test.tsx
+++ b/test/wdio/dom-reattach/cmp.test.tsx
@@ -13,12 +13,15 @@ describe('dom-reattach', function () {
         </>
       ),
     });
+    console.log('[test] render component');
 
     const element = document.querySelector('dom-reattach');
     function reattach() {
       if (showElement) {
+        console.log('[test] remove element');
         element.remove();
       } else {
+        console.log('[test] add element');
         document.body.appendChild(element);
       }
       showElement = !showElement;
@@ -30,7 +33,7 @@ describe('dom-reattach', function () {
 componentDidLoad: 1
 disconnectedCallback: ${disconnectCount}`;
 
-    // await expect($('dom-reattach')).toHaveText(lifecycleTextWithDisconnectCount(0));
+    await expect($('dom-reattach')).toHaveText(lifecycleTextWithDisconnectCount(0));
 
     await $('button').click();
     await expect($('dom-reattach')).not.toExist();

--- a/test/wdio/dom-reattach/cmp.test.tsx
+++ b/test/wdio/dom-reattach/cmp.test.tsx
@@ -13,15 +13,12 @@ describe('dom-reattach', function () {
         </>
       ),
     });
-    console.log('[test] render component');
 
     const element = document.querySelector('dom-reattach');
     function reattach() {
       if (showElement) {
-        console.log('[test] remove element');
         element.remove();
       } else {
-        console.log('[test] add element');
         document.body.appendChild(element);
       }
       showElement = !showElement;


### PR DESCRIPTION
## What is the current behavior?

There seems to be a memory leak within Stencil that causes performance problems as documented in:

- https://github.com/ionic-team/ionic-framework/issues/28189
- #5181
- #5172
- #3607
- and possibly #3158

It turns out that Stencil doesn't properly clear up its `hostRefs` global when elements are removed from the DOM. Given that the `hostRefs` global is never garbage collected, all its value will remain in memory which requires us to do some manual cleanup. Furthermore, we have been using references in another global variable called `rootAppliedStyles` which also never gets cleaned up.

## What is the new behavior?

This patch enhances the `disconnectedCallback` hook to clean up detached nodes from the `hostRefs` and `rootAppliedStyles` maps.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I am investigating if we can add some memory checks through Puppeteer and Chrome Devtools.

## Other information

A development release is now available at `@stencil/core@4.23.0-dev.1735628762.fb8335e`. If anyone is able to help validate the memory leak fix, your assistance would be greatly appreciated.
