### PR TITLE
fix(test): stop re-running prototype augment in spec tests.

### DIFF
--- a/src/runtime/proxy-component.ts
+++ b/src/runtime/proxy-component.ts
@@ -29,6 +29,14 @@ export const proxyComponent = (
 ): d.ComponentConstructor => {
   const prototype = (Cstr as any).prototype;
 
+  if (BUILD.isTesting) {
+    if (prototype.done) {
+      // @ts-expect-error - we don't want to re-augment the prototype. This happens during spec tests.
+      return;
+    }
+    prototype.done = true;
+  }
+
   /**
    * proxy form associated custom element lifecycle callbacks
    * @ref https://web.dev/articles/more-capable-form-controls#lifecycle_callbacks
@@ -113,9 +121,9 @@ export const proxyComponent = (
                 // the element is not constructing
                 (ref && ref.$flags$ & HOST_FLAGS.isConstructingInstance) === 0 &&
                 // the member is a prop
-                (cmpMeta.$members$[memberName][0] & MEMBER_FLAGS.Prop) !== 0 &&
+                (memberFlags & MEMBER_FLAGS.Prop) !== 0 &&
                 // the member is not mutable
-                (cmpMeta.$members$[memberName][0] & MEMBER_FLAGS.Mutable) === 0
+                (memberFlags & MEMBER_FLAGS.Mutable) === 0
               ) {
                 consoleDevWarn(
                   `@Prop() "${memberName}" on <${cmpMeta.$tagName$}> is immutable but was modified from within the component.\nMore information: https://stenciljs.com/docs/properties#prop-mutability`,

--- a/src/runtime/test/prop-warnings.spec.tsx
+++ b/src/runtime/test/prop-warnings.spec.tsx
@@ -1,6 +1,18 @@
 import { Component, h, Method, Prop } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 
+@Component({
+  tag: 'shared-cmp',
+  shadow: true,
+})
+class SharedCmp {
+  @Prop() a = 'Boom!';
+
+  render() {
+    return `${this.a}`;
+  }
+}
+
 describe('prop', () => {
   const spy = jest.spyOn(console, 'warn').mockImplementation();
 
@@ -87,6 +99,30 @@ describe('prop', () => {
     await waitForChanges();
 
     expect(root).toEqualHtml('<cmp-a>2</cmp-a>');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should not show warning when component is used across multiple tests - first time', async () => {
+    const { root, waitForChanges } = await newSpecPage({
+      components: [SharedCmp],
+      html: `<shared-cmp></shared-cmp>`,
+    });
+
+    root.a = 'Bam!';
+    await waitForChanges();
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should not show warning when component is used across multiple tests - second time', async () => {
+    const { root, waitForChanges } = await newSpecPage({
+      components: [SharedCmp],
+      html: `<shared-cmp></shared-cmp>`,
+    });
+
+    root.a = 'Boom!';
+    await waitForChanges();
+
     expect(spy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Prototypes used to be re-written with every spec test. Because we re-use accessors now this re-writing no longer happes.

GitHub Issue Number: https://github.com/ionic-team/stencil/issues/6104

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

A simple flag is set on the incoming prototype in `proxyComponent` during testing to make sure we don't re-augment it. 

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

- A new unit test to catch this has been added

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
