### PR TITLE
fix(runtime): fix NotFoundError in addStyle function with referenceNode parent check

### DIFF
--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -105,7 +105,10 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
                 preconnectLinks.length > 0
                   ? preconnectLinks[preconnectLinks.length - 1].nextSibling
                   : styleContainerNode.querySelector('style');
-              (styleContainerNode as HTMLElement).insertBefore(styleElm, referenceNode);
+              (styleContainerNode as HTMLElement).insertBefore(
+                styleElm,
+                referenceNode?.parentNode === styleContainerNode ? referenceNode : null,
+              );
             } else if ('host' in styleContainerNode) {
               if (supportsConstructableStylesheets) {
                 /**


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
addStyle function causes NotFoundError in for some components in our micro front end app.

GitHub Issue Number: [6106](https://github.com/ionic-team/stencil/issues/6106)


## What is the new behavior?
referenceNode's parentNode is checked to prevent insertBefore throwing NotFoundError method.
If the referenceNode is not a direct child of the element receiving the styleNode as the child, referenceNode is not used.


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
