### PR TITLE
feat(mock-doc): `assignednodes` and `assignedElements`

### DIFF
--- a/src/hydrate/platform/proxy-host-element.ts
+++ b/src/hydrate/platform/proxy-host-element.ts
@@ -88,8 +88,8 @@ export function proxyHostElement(elm: d.HostElement, cstr: d.ComponentConstructo
           return ![undefined, null].includes(parsedAttrValue)
             ? parsedAttrValue
             : origGetter
-              ? origGetter.apply(this)
-              : getValue(this, memberName);
+            ? origGetter.apply(this)
+            : getValue(this, memberName);
         }
         Object.defineProperty(elm, memberName, {
           get: getter,

--- a/src/hydrate/platform/proxy-host-element.ts
+++ b/src/hydrate/platform/proxy-host-element.ts
@@ -88,8 +88,8 @@ export function proxyHostElement(elm: d.HostElement, cstr: d.ComponentConstructo
           return ![undefined, null].includes(parsedAttrValue)
             ? parsedAttrValue
             : origGetter
-            ? origGetter.apply(this)
-            : getValue(this, memberName);
+              ? origGetter.apply(this)
+              : getValue(this, memberName);
         }
         Object.defineProperty(elm, memberName, {
           get: getter,

--- a/src/mock-doc/element.ts
+++ b/src/mock-doc/element.ts
@@ -42,6 +42,12 @@ export function createElement(ownerDocument: any, tagName: string): any {
     case 'script':
       return new MockScriptElement(ownerDocument);
 
+    case 'slot':
+      return new MockSlotElement(ownerDocument);
+
+    case 'slot-fb':
+      return new MockHTMLElement(ownerDocument, tagName);
+
     case 'style':
       return new MockStyleElement(ownerDocument);
 
@@ -53,12 +59,6 @@ export function createElement(ownerDocument: any, tagName: string): any {
 
     case 'ul':
       return new MockUListElement(ownerDocument);
-
-    case 'slot':
-      return new MockSlotElement(ownerDocument);
-
-    case 'slot-fb':
-      return new MockHTMLElement(ownerDocument, tagName);
   }
 
   if (ownerDocument != null && tagName.includes('-')) {
@@ -523,10 +523,6 @@ export class MockSlotElement extends MockHTMLElement {
     super(ownerDocument, 'slot');
   }
 
-  get name() {
-    return this.getAttribute('name') || '';
-  }
-
   assignedNodes(opts?: { flatten: boolean }): (MockNode | Node)[] {
     let nodesToReturn: (MockNode | Node)[] = [];
 
@@ -535,9 +531,10 @@ export class MockSlotElement extends MockHTMLElement {
 
     if (ownerHost.childNodes.length) {
       // try to find lightDOM nodes matching this slot's name (or lack of)
-      if (this.name) {
+      if ((this as any).name) {
         nodesToReturn = ownerHost.childNodes.filter(
-          (n) => n.nodeType === NODE_TYPES.ELEMENT_NODE && (n as MockElement).getAttribute('slot') === this.name,
+          (n) =>
+            n.nodeType === NODE_TYPES.ELEMENT_NODE && (n as MockElement).getAttribute('slot') === (this as any).name,
         );
       } else {
         // find elements that do not have a slot attribute or
@@ -576,8 +573,8 @@ export class MockSlotElement extends MockHTMLElement {
 
     if (ownerHost.children.length) {
       // try to find lightDOM elements matching this slot's name (or lack of)
-      if (this.name) {
-        elesToReturn = ownerHost.children.filter((n) => (n as MockElement).getAttribute('slot') == this.name);
+      if ((this as any).name) {
+        elesToReturn = ownerHost.children.filter((n) => (n as MockElement).getAttribute('slot') == (this as any).name);
       } else {
         elesToReturn = ownerHost.children.filter((n) => !(n as MockElement).getAttribute('slot'));
       }
@@ -601,6 +598,10 @@ export class MockSlotElement extends MockHTMLElement {
     );
   }
 }
+
+patchPropAttributes(MockSlotElement.prototype, {
+  name: String,
+});
 
 type CanvasContext = '2d' | 'webgl' | 'webgl2' | 'bitmaprenderer';
 export class CanvasRenderingContext {

--- a/src/mock-doc/element.ts
+++ b/src/mock-doc/element.ts
@@ -529,63 +529,76 @@ export class MockSlotElement extends MockHTMLElement {
 
   assignedNodes(opts?: { flatten: boolean }): (MockNode | Node)[] {
     let nodesToReturn: (MockNode | Node)[] = [];
+
     const ownerHost = (this.getRootNode() as any).host as MockElement;
     if (!ownerHost) return nodesToReturn;
 
-    // try to find lightDOM nodes matching this slot's name (or lack of)
-    if (this.name && ownerHost.childNodes.length) {
-      nodesToReturn = ownerHost.childNodes.filter(
-        (n) => n.nodeType === NODE_TYPES.ELEMENT_NODE && (n as MockElement).getAttribute('slot') === this.name,
-      );
-    } else if (ownerHost.childNodes.length) {
-      // find elements that do not have a slot attribute or
-      // any other type of node
-      nodesToReturn = ownerHost.childNodes.filter(
-        (n) =>
-          (n.nodeType === NODE_TYPES.ELEMENT_NODE && !(n as MockElement).getAttribute('slot')) ||
-          n.nodeType !== NODE_TYPES.ELEMENT_NODE,
-      );
+    if (ownerHost.childNodes.length) {
+      // try to find lightDOM nodes matching this slot's name (or lack of)
+      if (this.name) {
+        nodesToReturn = ownerHost.childNodes.filter(
+          (n) => n.nodeType === NODE_TYPES.ELEMENT_NODE && (n as MockElement).getAttribute('slot') === this.name,
+        );
+      } else {
+        // find elements that do not have a slot attribute or
+        // any other type of node
+        nodesToReturn = ownerHost.childNodes.filter(
+          (n) =>
+            (n.nodeType === NODE_TYPES.ELEMENT_NODE && !(n as MockElement).getAttribute('slot')) ||
+            n.nodeType !== NODE_TYPES.ELEMENT_NODE,
+        );
+      }
+      if (nodesToReturn.length) return nodesToReturn;
     }
-    if (nodesToReturn.length) return nodesToReturn;
 
     // no flatten option? Return whatever's in this slot (without nested slots)
     if (!opts?.flatten) return this.childNodes.filter((n) => !(n instanceof MockSlotElement));
 
     // flatten option? Return all nodes in this slot (including anything within nested slots)
-    return this.childNodes.reduce((acc, node) => {
-      if (node instanceof MockSlotElement) {
-        acc.push(...node.assignedNodes(opts));
-      } else {
-        acc.push(node);
-      }
-      return acc;
-    }, [] as (MockNode | Node)[]);
+    return this.childNodes.reduce(
+      (acc, node) => {
+        if (node instanceof MockSlotElement) {
+          acc.push(...node.assignedNodes(opts));
+        } else {
+          acc.push(node);
+        }
+        return acc;
+      },
+      [] as (MockNode | Node)[],
+    );
   }
+
   assignedElements(opts?: { flatten: boolean }): (Element | MockHTMLElement)[] {
     let elesToReturn: (Element | MockHTMLElement)[] = [];
+
     const ownerHost = (this.getRootNode() as any).host as MockElement;
     if (!ownerHost) return elesToReturn;
 
-    // try to find lightDOM elements matching this slot's name (or lack of)
-    if (this.name && ownerHost.children.length) {
-      elesToReturn = ownerHost.children.filter((n) => (n as MockElement).getAttribute('slot') == this.name);
-    } else if (ownerHost.children.length) {
-      elesToReturn = ownerHost.children.filter((n) => !(n as MockElement).getAttribute('slot'));
+    if (ownerHost.children.length) {
+      // try to find lightDOM elements matching this slot's name (or lack of)
+      if (this.name) {
+        elesToReturn = ownerHost.children.filter((n) => (n as MockElement).getAttribute('slot') == this.name);
+      } else {
+        elesToReturn = ownerHost.children.filter((n) => !(n as MockElement).getAttribute('slot'));
+      }
+      if (elesToReturn.length) return elesToReturn;
     }
-    if (elesToReturn.length) return elesToReturn;
 
     // no flatten option? Return whatever elements are in this slot (without nested slots)
     if (!opts?.flatten) return this.children.filter((n) => !(n instanceof MockSlotElement));
 
     // flatten option? Return all elements in this slot (including anything within nested slots)
-    return this.children.reduce((acc, node) => {
-      if (node instanceof MockSlotElement) {
-        acc.push(...node.assignedElements(opts));
-      } else {
-        acc.push(node);
-      }
-      return acc;
-    }, [] as (MockElement | Element)[]);
+    return this.children.reduce(
+      (acc, node) => {
+        if (node instanceof MockSlotElement) {
+          acc.push(...node.assignedElements(opts));
+        } else {
+          acc.push(node);
+        }
+        return acc;
+      },
+      [] as (MockElement | Element)[],
+    );
   }
 }
 

--- a/src/mock-doc/element.ts
+++ b/src/mock-doc/element.ts
@@ -1,5 +1,5 @@
-import { NODE_TYPES } from './constants';
 import { cloneAttributes } from './attribute';
+import { NODE_TYPES } from './constants';
 import { getStyleElementText, MockCSSStyleSheet, setStyleElementText } from './css-style-sheet';
 import { createCustomElement } from './custom-element-registry';
 import { MockDocumentFragment } from './document-fragment';
@@ -532,11 +532,14 @@ export class MockSlotElement extends MockHTMLElement {
     const ownerHost = (this.getRootNode() as any).host as MockElement;
     if (!ownerHost) return nodesToReturn;
 
+    // try to find lightDOM nodes matching this slot's name (or lack of)
     if (this.name && ownerHost.childNodes.length) {
       nodesToReturn = ownerHost.childNodes.filter(
         (n) => n.nodeType === NODE_TYPES.ELEMENT_NODE && (n as MockElement).getAttribute('slot') === this.name,
       );
     } else if (ownerHost.childNodes.length) {
+      // find elements that do not have a slot attribute or
+      // any other type of node
       nodesToReturn = ownerHost.childNodes.filter(
         (n) =>
           (n.nodeType === NODE_TYPES.ELEMENT_NODE && !(n as MockElement).getAttribute('slot')) ||
@@ -544,8 +547,11 @@ export class MockSlotElement extends MockHTMLElement {
       );
     }
     if (nodesToReturn.length) return nodesToReturn;
+
+    // no flatten option? Return whatever's in this slot (without nested slots)
     if (!opts?.flatten) return this.childNodes.filter((n) => !(n instanceof MockSlotElement));
 
+    // flatten option? Return all nodes in this slot (including anything within nested slots)
     return this.childNodes.reduce((acc, node) => {
       if (node instanceof MockSlotElement) {
         acc.push(...node.assignedNodes(opts));
@@ -560,14 +566,18 @@ export class MockSlotElement extends MockHTMLElement {
     const ownerHost = (this.getRootNode() as any).host as MockElement;
     if (!ownerHost) return elesToReturn;
 
+    // try to find lightDOM elements matching this slot's name (or lack of)
     if (this.name && ownerHost.children.length) {
       elesToReturn = ownerHost.children.filter((n) => (n as MockElement).getAttribute('slot') == this.name);
     } else if (ownerHost.children.length) {
       elesToReturn = ownerHost.children.filter((n) => !(n as MockElement).getAttribute('slot'));
     }
     if (elesToReturn.length) return elesToReturn;
+
+    // no flatten option? Return whatever elements are in this slot (without nested slots)
     if (!opts?.flatten) return this.children.filter((n) => !(n instanceof MockSlotElement));
 
+    // flatten option? Return all elements in this slot (including anything within nested slots)
     return this.children.reduce((acc, node) => {
       if (node instanceof MockSlotElement) {
         acc.push(...node.assignedElements(opts));

--- a/src/mock-doc/test/element.spec.ts
+++ b/src/mock-doc/test/element.spec.ts
@@ -521,4 +521,86 @@ describe('element', () => {
     expect(ctx).toBeDefined();
     expect(ctx.toDataURL()).toBe('data:,');
   });
+
+  describe('slot', () => {
+    it('returns no nodes via `assignedNodes` when not within a custom element', () => {
+      const slot = doc.createElement('slot');
+      expect(slot.assignedNodes().length).toEqual(0);
+    });
+
+    it('returns correct nodes with `assignedNodes`', () => {
+      const elm = doc.createElement('cmp-a');
+      const shadowRoot = elm.attachShadow({ mode: 'open' });
+      const slot = doc.createElement('slot');
+      shadowRoot.appendChild(slot);
+      slot.innerHTML = '<slot name="nested-slot">Fallback content</slot>';
+
+      elm.innerHTML = `
+        text node 
+        <div>light dom</div>
+        <!-- comment node -->
+        <div slot="nested-slot">nested slot</div>
+      `;
+
+      expect(slot.assignedNodes().length).toEqual(5);
+      expect(slot.assignedNodes()[0].textContent.trim()).toEqual('text node');
+      expect(slot.assignedNodes()[1].textContent.trim()).toEqual('light dom');
+      expect(slot.assignedNodes()[3].textContent.trim()).toEqual('comment node');
+      expect(slot.assignedNodes()[4].textContent.trim()).toEqual('');
+      expect(slot.assignedNodes({ flatten: true }).length).toEqual(5);
+
+      elm.innerHTML = '<div slot="nested-slot">nested slot</div>';
+
+      expect(slot.assignedNodes().length).toEqual(0);
+      expect(slot.assignedNodes({ flatten: true }).length).toEqual(1);
+      expect(slot.assignedNodes({ flatten: true })[0].textContent.trim()).toEqual('nested slot');
+
+      elm.innerHTML = 'text node <div slot="nested-slot">nested slot</div>';
+
+      expect(slot.assignedNodes().length).toEqual(1);
+      expect(slot.assignedNodes({ flatten: true }).length).toEqual(1);
+      expect(slot.assignedNodes()[0].textContent.trim()).toEqual('text node');
+
+      elm.innerHTML = '';
+      expect(slot.assignedNodes().length).toEqual(0);
+      expect(slot.assignedNodes({ flatten: true }).length).toEqual(1);
+      expect(slot.assignedNodes({ flatten: true })[0].textContent.trim()).toEqual('Fallback content');
+    });
+
+    it('returns correct elements with `assignedElements`', () => {
+      const elm = doc.createElement('cmp-a');
+      const shadowRoot = elm.attachShadow({ mode: 'open' });
+      const slot = doc.createElement('slot');
+      shadowRoot.appendChild(slot);
+      slot.innerHTML = '<slot name="nested-slot"><div>Fallback content</div></slot>';
+
+      elm.innerHTML = `
+        text node 
+        <div>light dom</div>
+        <!-- comment node -->
+        <div slot="nested-slot">nested slot</div>
+      `;
+
+      expect(slot.assignedElements().length).toEqual(1);
+      expect(slot.assignedElements()[0].textContent.trim()).toEqual('light dom');
+      expect(slot.assignedElements({ flatten: true }).length).toEqual(1);
+
+      elm.innerHTML = '<div slot="nested-slot">nested slot</div>';
+
+      expect(slot.assignedElements().length).toEqual(0);
+      expect(slot.assignedElements({ flatten: true }).length).toEqual(1);
+      expect(slot.assignedElements({ flatten: true })[0].textContent.trim()).toEqual('nested slot');
+
+      elm.innerHTML = 'text node <div slot="nested-slot">nested slot</div>';
+
+      expect(slot.assignedElements().length).toEqual(0);
+      expect(slot.assignedElements({ flatten: true }).length).toEqual(1);
+      expect(slot.assignedElements({ flatten: true })[0].textContent.trim()).toEqual('nested slot');
+
+      elm.innerHTML = '';
+      expect(slot.assignedElements().length).toEqual(0);
+      expect(slot.assignedElements({ flatten: true }).length).toEqual(1);
+      expect(slot.assignedElements({ flatten: true })[0].textContent.trim()).toEqual('Fallback content');
+    });
+  });
 });

--- a/src/mock-doc/test/element.spec.ts
+++ b/src/mock-doc/test/element.spec.ts
@@ -523,9 +523,11 @@ describe('element', () => {
   });
 
   describe('slot', () => {
-    it('returns no nodes via `assignedNodes` when not within a custom element', () => {
+    it('returns no nodes via `assignedNodes` / `assignedElements` when not within a custom element', () => {
       const slot = doc.createElement('slot');
+      slot.innerHTML = 'invisible <div>Something</div> <!-- not here -->';
       expect(slot.assignedNodes().length).toEqual(0);
+      expect(slot.assignedElements().length).toEqual(0);
     });
 
     it('returns correct nodes with `assignedNodes`', () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: https://github.com/ionic-team/stencil/issues/2830

Within `mock-doc` (i.e SSR hydration and spec tests) the native `assignednodes` and `assignedElements` methods for a `<slot />` are not available.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

A new `MockSlotElement` has been added to the mock-doc `element.ts` with the new methods.

Fixes: https://github.com/ionic-team/stencil/issues/2830

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

- New spec tests for the `<slot />` methods have been added 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
