### PR TITLE
fix(dist-custom-elements): stop duplicate `@stencil/core`

### DIFF
--- a/src/compiler/bundle/bundle-output.ts
+++ b/src/compiler/bundle/bundle-output.ts
@@ -120,7 +120,7 @@ export const getRollupOptions = (
         compilerCtx,
         bundleOpts.platform,
         !!bundleOpts.externalRuntime,
-        bundleOpts.conditionals.lazyLoad,
+        bundleOpts.conditionals?.lazyLoad ?? false,
       ),
       appDataPlugin(config, compilerCtx, buildCtx, bundleOpts.conditionals, bundleOpts.platform),
       lazyComponentPlugin(buildCtx),

--- a/src/compiler/bundle/bundle-output.ts
+++ b/src/compiler/bundle/bundle-output.ts
@@ -107,6 +107,7 @@ export const getRollupOptions = (
 
   const beforePlugins = config.rollupPlugins.before || [];
   const afterPlugins = config.rollupPlugins.after || [];
+
   const rollupOptions: RollupOptions = {
     input: bundleOpts.inputs,
     output: {
@@ -114,7 +115,13 @@ export const getRollupOptions = (
     },
 
     plugins: [
-      coreResolvePlugin(config, compilerCtx, bundleOpts.platform, !!bundleOpts.externalRuntime),
+      coreResolvePlugin(
+        config,
+        compilerCtx,
+        bundleOpts.platform,
+        !!bundleOpts.externalRuntime,
+        bundleOpts.conditionals.lazyLoad,
+      ),
       appDataPlugin(config, compilerCtx, buildCtx, bundleOpts.conditionals, bundleOpts.platform),
       lazyComponentPlugin(buildCtx),
       loaderPlugin(bundleOpts.loader),

--- a/src/compiler/bundle/core-resolve-plugin.ts
+++ b/src/compiler/bundle/core-resolve-plugin.ts
@@ -56,9 +56,9 @@ export const coreResolvePlugin = (
             external: true,
           };
         }
-        // importing @stencil/core/internal/client directly, so it shouldn't get
-        // the custom app-data conditionals
-        return internalClient;
+        // continue to add ?app-data=conditional - making a custom build
+        // based on component meta. Otherwise, rollup will duplicate the whole of Stencil Core
+        return internalClient + APP_DATA_CONDITIONAL;
       }
       if (id === STENCIL_INTERNAL_CLIENT_PATCH_BROWSER_ID) {
         if (externalRuntime) {

--- a/src/compiler/output-targets/test/output-targets-dist-custom-elements.spec.ts
+++ b/src/compiler/output-targets/test/output-targets-dist-custom-elements.spec.ts
@@ -123,7 +123,7 @@ export * from '${USER_INDEX_ENTRY_ID}';
   describe('bundleCustomElements', () => {
     it('should set a diagnostic if no `dir` prop on the output target', async () => {
       const { config, compilerCtx, buildCtx } = setup();
-      const outputTarget: OutputTargetDistCustomElements = { type: DIST_CUSTOM_ELEMENTS };
+      const outputTarget: OutputTargetDistCustomElements = { type: DIST_CUSTOM_ELEMENTS, externalRuntime: true };
       await bundleCustomElements(config, compilerCtx, buildCtx, outputTarget);
       expect(buildCtx.diagnostics).toEqual([
         {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Setting the `externalRuntime: false` on a `dist-custom-elements` output, *whilst at the same time* including a 3rd party component / lib that `import`s from `@stencil/core`, causes the whole stencil runtime to be included twice:

- once as custom runtime (dictated by flags set via features detected on components at build-time). 
- second as the whole runtime (dictated by the 3rd party lib's `import`)

This duplication in-turn, breaks certain lifecycle events as different internals call different (duplicate) `@stencil/core` functions.

GitHub Issue Number: 
- https://github.com/ionic-team/stencil/issues/6040
- https://github.com/ionic-team/stencil/issues/4135

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

My naive solution is to make sure the same `@stencil/core` rollup id is included for both 3rd party libs and the direct component imports - the full `@stencil/core` build - if it's the `dist-custom-elements` output. 

This stops the duplication. 

This doesn't have any particularly noticeable impact on bundle size.

Fixes: https://github.com/ionic-team/stencil/issues/6040
Fixes: https://github.com/ionic-team/stencil/issues/4135

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

- TBD ... not really sure how to 

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

ATM I have opted for using the same 'custom' stencil core for both `src` and `node_modules` but I may have to rethink.
