### PR TITLE
fix(ssr): stop stripping comment nodes 

### DIFF
--- a/src/runtime/client-hydrate.ts
+++ b/src/runtime/client-hydrate.ts
@@ -220,13 +220,6 @@ export const initializeClientHydrate = (
     for (rnIdex; rnIdex < rnLen; rnIdex++) {
       shadowRoot.appendChild(shadowRootNodes[rnIdex] as any);
     }
-
-    // Tidy up left-over / unnecessary comments to stop frameworks complaining about DOM mismatches
-    Array.from(hostElm.childNodes).forEach((node) => {
-      if (node.nodeType === NODE_TYPE.CommentNode && typeof (node as d.RenderNode)['s-sn'] !== 'string') {
-        node.parentNode.removeChild(node);
-      }
-    });
   }
 
   hostRef.$hostElement$ = hostElm;

--- a/src/runtime/test/hydrate-shadow-in-shadow.spec.tsx
+++ b/src/runtime/test/hydrate-shadow-in-shadow.spec.tsx
@@ -60,6 +60,7 @@ describe('hydrate, shadow in shadow', () => {
             <mock:shadow-root>
               <slot></slot>
             </mock:shadow-root>
+            <!---->
             <slot></slot>
           </cmp-b>
         </mock:shadow-root>

--- a/src/runtime/test/shadow.spec.tsx
+++ b/src/runtime/test/shadow.spec.tsx
@@ -135,4 +135,36 @@ describe('shadow', () => {
     expect(page.root).toEqualHtml(expected);
     expect(page.root).toEqualLightHtml(expected);
   });
+
+  it('test shadow root innerHTML', async () => {
+    @Component({
+      tag: 'cmp-a',
+      shadow: true,
+    })
+    class CmpA {
+      render() {
+        return <div>Shadow Content</div>;
+      }
+    }
+
+    const page = await newSpecPage({
+      components: [CmpA],
+      html: `
+        <cmp-a>
+          Light Content
+        </cmp-a>
+      `,
+    });
+
+    expect(page.root).toEqualHtml(`
+      <cmp-a>
+        <mock:shadow-root>
+          <div>
+            Shadow Content
+          </div>
+        </mock:shadow-root>
+        Light Content
+      </cmp-a>
+    `);
+  });
 });

--- a/test/wdio/ssr-hydration/cmp.test.tsx
+++ b/test/wdio/ssr-hydration/cmp.test.tsx
@@ -43,8 +43,6 @@ describe('ssr-shadow-cmp', () => {
       document.body.appendChild(stage);
     }
 
-    // expect(typeof customElements.get('ssr-shadow-cmp')).toBe('undefined');
-
     // @ts-expect-error resolved through WDIO
     const { defineCustomElements } = await import('/dist/loader/index.js');
     defineCustomElements().catch(console.error);

--- a/test/wdio/ssr-hydration/cmp.test.tsx
+++ b/test/wdio/ssr-hydration/cmp.test.tsx
@@ -1,0 +1,61 @@
+import { renderToString } from '../hydrate/index.mjs';
+
+describe('ssr-shadow-cmp', () => {
+  function getNodeNames(chidNodes: NodeListOf<ChildNode>) {
+    return Array.from(chidNodes)
+      .flatMap((node) => {
+        if (node.nodeType === 3) {
+          if (node.textContent?.trim()) {
+            return 'text';
+          } else {
+            return [];
+          }
+        } else if (node.nodeType === 8) {
+          return 'comment';
+        } else {
+          return node.nodeName.toLowerCase();
+        }
+      })
+      .join(' ');
+  }
+
+  it('verifies all nodes are preserved during hydration', async () => {
+    if (!document.querySelector('#stage')) {
+      const { html } = await renderToString(
+        `
+        <ssr-shadow-cmp>
+          A text node
+          <!-- a comment -->
+          <div>An element</div>
+          <!-- another comment -->
+          Another text node
+        </ssr-shadow-cmp>
+      `,
+        {
+          fullDocument: true,
+          serializeShadowRoot: true,
+          constrainTimeouts: false,
+        },
+      );
+      const stage = document.createElement('div');
+      stage.setAttribute('id', 'stage');
+      stage.setHTMLUnsafe(html);
+      document.body.appendChild(stage);
+    }
+
+    // expect(typeof customElements.get('ssr-shadow-cmp')).toBe('undefined');
+
+    // @ts-expect-error resolved through WDIO
+    const { defineCustomElements } = await import('/dist/loader/index.js');
+    defineCustomElements().catch(console.error);
+
+    // wait for Stencil to take over and reconcile
+    await browser.waitUntil(async () => customElements.get('ssr-shadow-cmp'));
+    expect(typeof customElements.get('ssr-shadow-cmp')).toBe('function');
+    await expect(getNodeNames(document.querySelector('ssr-shadow-cmp').childNodes)).toBe(
+      `text comment div comment text`,
+    );
+
+    document.querySelector('#stage')?.remove();
+  });
+});

--- a/test/wdio/ssr-hydration/cmp.tsx
+++ b/test/wdio/ssr-hydration/cmp.tsx
@@ -1,0 +1,15 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'ssr-shadow-cmp',
+  shadow: true,
+})
+export class SsrShadowCmp {
+  render() {
+    return (
+      <div>
+        <slot />
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`client-hydrate.ts` is currently stripping out extra comment nodes of `shadow: true` components (this was originally to remove stencil's "internal" comments, which could pollute the component), but in doing so it removes slotted comment nodes which can be used by external tools / libs.

After testing, I see stencil's internal comments are removed during other stages of client-side hydration so this extra comment removal is unnecessary (the only time extra comments are seen is during unit tests due to a limitation / difference in how components are rendered on 'server')

GitHub Issue Number: https://github.com/ionic-team/stencil/issues/6120


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixes https://github.com/ionic-team/stencil/issues/6120

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

- New unit test
- New wdio test

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
