### PR TITLE
fix(ssr): multiple component instances sharing initial properties

### DIFF
--- a/src/hydrate/platform/proxy-host-element.ts
+++ b/src/hydrate/platform/proxy-host-element.ts
@@ -108,8 +108,9 @@ export function proxyHostElement(elm: d.HostElement, cstr: d.ComponentConstructo
 
             // if we have a parsed value from an attribute / or userland prop use that first.
             // otherwise if we have a getter already applied, use that.
-            return attrPropVal !== undefined
-              ? attrPropVal
+            const ref = getHostRef(this);
+            return ref.$instanceValues$?.get(memberName) !== undefined
+              ? ref.$instanceValues$?.get(memberName)
               : origGetter
                 ? origGetter.apply(this)
                 : getValue(this, memberName);

--- a/test/end-to-end/src/ssr-runtime-decorators/ssr-runtime-decorators.e2e.ts
+++ b/test/end-to-end/src/ssr-runtime-decorators/ssr-runtime-decorators.e2e.ts
@@ -107,4 +107,34 @@ describe('different types of decorated properties and states render on both serv
     expect(await txt('basicState')).toBe('basicState');
     expect(await txt('decoratedState')).toBe('10');
   });
+
+  it('renders different values on different component instances ', async () => {
+    const doc = await renderToString(`
+      <runtime-decorators></runtime-decorators>
+      <runtime-decorators 
+        decorated-prop="200"
+        decorated-getter-setter-prop="-5"
+        basic-prop="basicProp via attribute"
+        basic-state="basicState via attribute"
+        decorated-state="decoratedState via attribute"
+      ></runtime-decorators>
+    `);
+    html = doc.html;
+
+    // first component should have default values
+
+    expect(htmlTxt('basicProp')).toBe('basicProp');
+    expect(htmlTxt('decoratedProp')).toBe('-5');
+    expect(htmlTxt('decoratedGetterSetterProp')).toBe('999');
+    expect(htmlTxt('basicState')).toBe('basicState');
+    expect(htmlTxt('decoratedState')).toBe('10');
+
+    page = await newE2EPage({ html, url: 'https://stencil.com' });
+
+    expect(await txt('basicProp')).toBe('basicProp');
+    expect(await txt('decoratedProp')).toBe('-5');
+    expect(await txt('decoratedGetterSetterProp')).toBe('999');
+    expect(await txt('basicState')).toBe('basicState');
+    expect(await txt('decoratedState')).toBe('10');
+  });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

A regression added (https://github.com/ionic-team/stencil/pull/6084) during hydration, caused the value to be set on / got from the enclosure to the last component instance.

GitHub Issue Number: https://github.com/ionic-team/stencil/issues/6125

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixes: https://github.com/ionic-team/stencil/issues/6125

The prototype 'get' now uses the current instance ref to get the initial value


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

- additional e2e test

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
