### PR TITLE
fix(ssr): exponential perf slow down

### DIFF
--- a/src/hydrate/platform/proxy-host-element.ts
+++ b/src/hydrate/platform/proxy-host-element.ts
@@ -97,27 +97,30 @@ export function proxyHostElement(elm: d.HostElement, cstr: d.ComponentConstructo
           enumerable: true,
         });
 
-        // instance
-        Object.defineProperty((cstr as any).prototype, memberName, {
-          get: function (this: any) {
-            if (origGetter && attrPropVal === undefined && !getValue(this, memberName)) {
-              // if the initial value comes from an instance getter
-              // the element will never have the value set. So let's do that now.
-              setValue(this, memberName, origGetter.apply(this), cmpMeta);
-            }
+        if (!(cstr as any).prototype.done) {
+          // instance prototype.
+          // This only needs setting up once.
+          Object.defineProperty((cstr as any).prototype, memberName, {
+            get: function (this: any) {
+              if (origGetter && attrPropVal === undefined && !getValue(this, memberName)) {
+                // if the initial value comes from an instance getter
+                // the element will never have the value set. So let's do that now.
+                setValue(this, memberName, origGetter.apply(this), cmpMeta);
+              }
 
-            // if we have a parsed value from an attribute / or userland prop use that first.
-            // otherwise if we have a getter already applied, use that.
-            const ref = getHostRef(this);
-            return ref.$instanceValues$?.get(memberName) !== undefined
-              ? ref.$instanceValues$?.get(memberName)
-              : origGetter
-                ? origGetter.apply(this)
-                : getValue(this, memberName);
-          },
-          configurable: true,
-          enumerable: true,
-        });
+              // if we have a parsed value from an attribute / or userland prop use that first.
+              // otherwise if we have a getter already applied, use that.
+              const ref = getHostRef(this);
+              return ref.$instanceValues$?.get(memberName) !== undefined
+                ? ref.$instanceValues$?.get(memberName)
+                : origGetter
+                  ? origGetter.apply(this)
+                  : getValue(this, memberName);
+            },
+            configurable: true,
+            enumerable: true,
+          });
+        }
       } else if (memberFlags & MEMBER_FLAGS.Method) {
         Object.defineProperty(elm, memberName, {
           value(this: d.HostElement, ...args: any[]) {
@@ -131,6 +134,7 @@ export function proxyHostElement(elm: d.HostElement, cstr: d.ComponentConstructo
         });
       }
     });
+    (cstr as any).prototype.done = true;
   }
 }
 

--- a/src/hydrate/platform/proxy-host-element.ts
+++ b/src/hydrate/platform/proxy-host-element.ts
@@ -97,11 +97,14 @@ export function proxyHostElement(elm: d.HostElement, cstr: d.ComponentConstructo
           enumerable: true,
         });
 
-        if (!(cstr as any).prototype.done) {
-          // instance prototype.
-          // This only needs setting up once.
+        if (!(cstr as any).prototype.__stencilAugmented) {
+          // instance prototype
           Object.defineProperty((cstr as any).prototype, memberName, {
             get: function (this: any) {
+              const ref = getHostRef(this);
+              // incoming value from a attr / prop?
+              const attrPropVal = ref.$instanceValues$?.get(memberName);
+
               if (origGetter && attrPropVal === undefined && !getValue(this, memberName)) {
                 // if the initial value comes from an instance getter
                 // the element will never have the value set. So let's do that now.
@@ -110,9 +113,8 @@ export function proxyHostElement(elm: d.HostElement, cstr: d.ComponentConstructo
 
               // if we have a parsed value from an attribute / or userland prop use that first.
               // otherwise if we have a getter already applied, use that.
-              const ref = getHostRef(this);
-              return ref.$instanceValues$?.get(memberName) !== undefined
-                ? ref.$instanceValues$?.get(memberName)
+              return attrPropVal !== undefined
+                ? attrPropVal
                 : origGetter
                   ? origGetter.apply(this)
                   : getValue(this, memberName);
@@ -134,7 +136,8 @@ export function proxyHostElement(elm: d.HostElement, cstr: d.ComponentConstructo
         });
       }
     });
-    (cstr as any).prototype.done = true;
+    // instance prototype should only be processed once
+    (cstr as any).prototype.__stencilAugmented = true;
   }
 }
 

--- a/src/runtime/proxy-component.ts
+++ b/src/runtime/proxy-component.ts
@@ -30,11 +30,11 @@ export const proxyComponent = (
   const prototype = (Cstr as any).prototype;
 
   if (BUILD.isTesting) {
-    if (prototype.done) {
+    if (prototype.__stencilAugmented) {
       // @ts-expect-error - we don't want to re-augment the prototype. This happens during spec tests.
       return;
     }
-    prototype.done = true;
+    prototype.__stencilAugmented = true;
   }
 
   /**

--- a/test/wdio/ssr-hydration/cmp.test.tsx
+++ b/test/wdio/ssr-hydration/cmp.test.tsx
@@ -56,4 +56,31 @@ describe('ssr-shadow-cmp', () => {
 
     document.querySelector('#stage')?.remove();
   });
+
+  it('checks perf when loading lots of the same component', async () => {
+    performance.mark('start');
+
+    const { html } = await renderToString(
+      Array(50)
+        .fill(0)
+        .map((_, i) => `<ssr-shadow-cmp>Value ${i}</ssr-shadow-cmp>`)
+        .join(''),
+      {
+        fullDocument: true,
+        serializeShadowRoot: true,
+        constrainTimeouts: false,
+      },
+    );
+    const stage = document.createElement('div');
+    stage.setAttribute('id', 'stage');
+    stage.setHTMLUnsafe(html);
+    document.body.appendChild(stage);
+
+    performance.mark('end');
+    const renderTime = performance.measure('render', 'start', 'end').duration;
+
+    await expect(renderTime).toBeLessThan(100);
+
+    document.querySelector('#stage')?.remove();
+  });
 });

--- a/test/wdio/ssr-hydration/cmp.tsx
+++ b/test/wdio/ssr-hydration/cmp.tsx
@@ -1,13 +1,25 @@
-import { Component, h } from '@stencil/core';
+import { Component, h, Prop } from '@stencil/core';
 
 @Component({
   tag: 'ssr-shadow-cmp',
   shadow: true,
 })
 export class SsrShadowCmp {
+  @Prop() value: string;
+  @Prop() label: string;
+  @Prop() selected: boolean;
+  @Prop() disabled: boolean;
+
   render() {
     return (
-      <div>
+      <div
+        class={{
+          option: true,
+          'option--selected': this.selected,
+          'option--disabled': this.disabled,
+          'option--novalue': !this.value,
+        }}
+      >
         <slot />
       </div>
     );


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

A regression added in `hydrate/proxy-host-element.ts` < the more of the same component rendered on the page, the more times the prototype would be augmented - causing an ever deepening chain of getters.

GitHub Issue Number: https://github.com/ionic-team/stencil/issues/6127

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

A simple property is added to the incoming prototype, making sure we only add augment it once.

Fixes https://github.com/ionic-team/stencil/issues/6127

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

- A new wdio perf test has been added

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

![image](https://github.com/user-attachments/assets/b732f4ed-6b20-42ba-acf3-69a3a16b1d9b)

