### PR TITLE
fix(ssr): correctly resolve slots during hydration

### DIFF
--- a/src/runtime/client-hydrate.ts
+++ b/src/runtime/client-hydrate.ts
@@ -109,7 +109,7 @@ export const initializeClientHydrate = (
     }
 
     if (childRenderNode.$tag$ === 'slot') {
-      childRenderNode.$name$ = childRenderNode.$elm$['s-sn'] || (childRenderNode.$elm$ as any)['name'];
+      childRenderNode.$name$ = childRenderNode.$elm$['s-sn'] || (childRenderNode.$elm$ as any)['name'] || null;
       if (childRenderNode.$children$) {
         childRenderNode.$flags$ |= VNODE_FLAGS.isSlotFallback;
 

--- a/src/runtime/client-hydrate.ts
+++ b/src/runtime/client-hydrate.ts
@@ -109,6 +109,7 @@ export const initializeClientHydrate = (
     }
 
     if (childRenderNode.$tag$ === 'slot') {
+      childRenderNode.$name$ = childRenderNode.$elm$['s-sn'] || (childRenderNode.$elm$ as any)['name'];
       if (childRenderNode.$children$) {
         childRenderNode.$flags$ |= VNODE_FLAGS.isSlotFallback;
 

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -913,7 +913,7 @@ function addRemoveSlotScopedClass(
     // let's add a scoped-slot class to this slotted node's parent
     newParent.classList?.add(scopeId + '-s');
 
-    if (oldParent && oldParent.classList.contains(scopeId + '-s')) {
+    if (oldParent && oldParent.classList?.contains(scopeId + '-s')) {
       let child = ((oldParent as d.RenderNode).__childNodes || oldParent.childNodes)[0] as d.RenderNode;
       let found = false;
 

--- a/test/wdio/ssr-hydration/cmp.test.tsx
+++ b/test/wdio/ssr-hydration/cmp.test.tsx
@@ -50,17 +50,19 @@ describe('ssr-shadow-cmp', () => {
     // wait for Stencil to take over and reconcile
     await browser.waitUntil(async () => customElements.get('ssr-shadow-cmp'));
     expect(typeof customElements.get('ssr-shadow-cmp')).toBe('function');
+
     await expect(getNodeNames(document.querySelector('ssr-shadow-cmp').childNodes)).toBe(
       `text comment div comment text`,
     );
 
     document.querySelector('#stage')?.remove();
+    await browser.waitUntil(async () => !document.querySelector('#stage'));
   });
 
   it('checks perf when loading lots of the same component', async () => {
     performance.mark('start');
 
-    const { html } = await renderToString(
+    await renderToString(
       Array(50)
         .fill(0)
         .map((_, i) => `<ssr-shadow-cmp>Value ${i}</ssr-shadow-cmp>`)
@@ -71,15 +73,39 @@ describe('ssr-shadow-cmp', () => {
         constrainTimeouts: false,
       },
     );
-    const stage = document.createElement('div');
-    stage.setAttribute('id', 'stage');
-    stage.setHTMLUnsafe(html);
-    document.body.appendChild(stage);
-
     performance.mark('end');
     const renderTime = performance.measure('render', 'start', 'end').duration;
+    await expect(renderTime).toBeLessThan(50);
+  });
 
-    await expect(renderTime).toBeLessThan(100);
+  it('resolves slots correctly during client-side hydration', async () => {
+    if (!document.querySelector('#stage')) {
+      const { html } = await renderToString(
+        `
+        <ssr-shadow-cmp>
+          <p>Default slot content</p>
+        </ssr-shadow-cmp>
+      `,
+        {
+          fullDocument: true,
+          serializeShadowRoot: true,
+          constrainTimeouts: false,
+        },
+      );
+      const stage = document.createElement('div');
+      stage.setAttribute('id', 'stage');
+      stage.setHTMLUnsafe(html);
+      document.body.appendChild(stage);
+    }
+
+    // @ts-expect-error resolved through WDIO
+    const { defineCustomElements } = await import('/dist/loader/index.js');
+    defineCustomElements().catch(console.error);
+
+    // wait for Stencil to take over and reconcile
+    await browser.waitUntil(async () => customElements.get('ssr-shadow-cmp'));
+    expect(typeof customElements.get('ssr-shadow-cmp')).toBe('function');
+    await expect(document.querySelector('ssr-shadow-cmp').textContent).toBe(' Default slot content ');
 
     document.querySelector('#stage')?.remove();
   });

--- a/test/wdio/ssr-hydration/cmp.test.tsx
+++ b/test/wdio/ssr-hydration/cmp.test.tsx
@@ -84,6 +84,7 @@ describe('ssr-shadow-cmp', () => {
         `
         <ssr-shadow-cmp>
           <p>Default slot content</p>
+          <p slot="client-only">Client-only slot content</p>
         </ssr-shadow-cmp>
       `,
         {
@@ -105,8 +106,12 @@ describe('ssr-shadow-cmp', () => {
     // wait for Stencil to take over and reconcile
     await browser.waitUntil(async () => customElements.get('ssr-shadow-cmp'));
     expect(typeof customElements.get('ssr-shadow-cmp')).toBe('function');
-    await expect(document.querySelector('ssr-shadow-cmp').textContent).toBe(' Default slot content ');
 
-    document.querySelector('#stage')?.remove();
+    await browser.waitUntil(async () => document.querySelector('ssr-shadow-cmp [slot="client-only"]'));
+    await expect(document.querySelector('ssr-shadow-cmp').textContent).toBe(
+      ' Default slot content Client-only slot content ',
+    );
+
+    // document.querySelector('#stage')?.remove();
   });
 });

--- a/test/wdio/ssr-hydration/cmp.test.tsx
+++ b/test/wdio/ssr-hydration/cmp.test.tsx
@@ -112,6 +112,6 @@ describe('ssr-shadow-cmp', () => {
       ' Default slot content Client-only slot content ',
     );
 
-    // document.querySelector('#stage')?.remove();
+    document.querySelector('#stage')?.remove();
   });
 });

--- a/test/wdio/ssr-hydration/cmp.tsx
+++ b/test/wdio/ssr-hydration/cmp.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Prop } from '@stencil/core';
+import { Build, Component, h, Prop } from '@stencil/core';
 
 @Component({
   tag: 'ssr-shadow-cmp',
@@ -20,7 +20,9 @@ export class SsrShadowCmp {
           'option--novalue': !this.value,
         }}
       >
+        <slot name="top" />
         <slot />
+        {Build.isBrowser && <slot name="client-only" />}
       </div>
     );
   }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: https://github.com/ionic-team/stencil/issues/6130

Slots can get incorrectly rendered / resolved during client-side hydration from SSR content

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Slot elements are given their respective `$name$` when the SSR > VDOM is created. 
This means old to updated VDOM (then DOM) is correctly correctly resolved - slots are no longer overwritten.

Fixes https://github.com/ionic-team/stencil/issues/6130

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

- New wdio test

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
