### PR TITLE
fix(runtime): append newChild if parent node doesn't match with patched node

### DIFF
--- a/src/runtime/dom-extras.ts
+++ b/src/runtime/dom-extras.ts
@@ -299,6 +299,21 @@ const patchInsertBefore = (HostElementPrototype: HTMLElement) => {
       });
       if (found) return newChild;
     }
+
+    /**
+     * Fixes an issue where slotted elements are dynamically relocated in React, such as after data fetch.
+     *
+     * When a slotted element is passed to another scoped component (e.g., <A><C slot="header"/></A>),
+     * the child’s __parentNode (original parent node property) does not match this.
+     *
+     * To prevent errors, this checks if the current child's parent node differs from this.
+     * If so, appendChild(newChild) is called to ensure the child is correctly inserted,
+     * allowing Stencil to properly manage the slot placement.
+     */
+    const parentNode = (currentChild as d.PatchedSlotNode)?.__parentNode;
+    if (parentNode && !this.isSameNode(parentNode)) {
+      return this.appendChild(newChild);
+    }
     return (this as d.RenderNode).__insertBefore(newChild, currentChild);
   };
 };


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6140 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
If patched node (this) is not the same node of currentChild, it uses appendChild to insert the newChild to patched node


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
