### PR TITLE
fix(runtime): don't include loadModule logic in hydrate runtime

### DIFF
--- a/src/runtime/initialize-component.ts
+++ b/src/runtime/initialize-component.ts
@@ -33,7 +33,7 @@ export const initializeComponent = async (
     hostRef.$flags$ |= HOST_FLAGS.hasInitializedComponent;
 
     const bundleId = cmpMeta.$lazyBundleId$;
-    if ((BUILD.lazyLoad || BUILD.hydrateClientSide) && bundleId) {
+    if (BUILD.lazyLoad && bundleId) {
       // lazy loaded components
       // request the component's implementation to be
       // wired up with the host element


### PR DESCRIPTION
## What is the current behavior?
When compiling for `dist-custom-element`, there is no need to include the lazy load functionality into the runtime. In fact it causes issues with Next.js and Turbopack when using SSR:


<img width="459" alt="Stencil Screenshot Dec 20 2024" src="https://github.com/user-attachments/assets/ea6fb37a-6ff9-4a98-8101-d92921be5afc" />

The [original PR](https://github.com/ionic-team/stencil/pull/1953) does seem to provide any hints as to why this was introduced.

## What is the new behavior?
Don't include the `loadModule` function within `dist-custom-element` runtimes when a `hyrdate` output target is used.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
