### PR TITLE
refactor(runtime): make WeakMap obsolete  

### DIFF
--- a/src/client/client-host-ref.ts
+++ b/src/client/client-host-ref.ts
@@ -11,8 +11,8 @@ import type * as d from '../declarations';
  * @returns — true if the element was successfully removed, or false if it was not present.
  */
 export const deleteHostRef = (ref: d.RuntimeRef): boolean => {
-  if (ref.$hostRef$) {
-    delete ref.$hostRef$;
+  if (ref.__stencil__getHostRef) {
+    delete ref.__stencil__getHostRef;
     return true;
   }
 
@@ -26,7 +26,11 @@ export const deleteHostRef = (ref: d.RuntimeRef): boolean => {
  * @returns the Host reference (if found) or undefined
  */
 export const getHostRef = (ref: d.RuntimeRef): d.HostRef | undefined => {
-  return ref.$hostRef$;
+  if (ref.__stencil__getHostRef) {
+    return ref.__stencil__getHostRef();
+  }
+
+  return undefined;
 };
 
 /**
@@ -37,7 +41,7 @@ export const getHostRef = (ref: d.RuntimeRef): d.HostRef | undefined => {
  * @param hostRef that instances `HostRef` object
  */
 export const registerInstance = (lazyInstance: any, hostRef: d.HostRef) => {
-  lazyInstance.$hostRef$ = hostRef;
+  lazyInstance.__stencil__getHostRef = () => hostRef;
   hostRef.$lazyInstance$ = lazyInstance;
 
   if (BUILD.modernPropertyDecls && (BUILD.state || BUILD.prop)) {
@@ -73,7 +77,8 @@ export const registerHost = (hostElement: d.HostElement, cmpMeta: d.ComponentRun
     hostElement['s-rc'] = [];
   }
 
-  const ref = (hostElement.$hostRef$ = hostRef);
+  const ref = hostRef;
+  hostElement.__stencil__getHostRef = () => ref;
 
   if (!BUILD.lazyLoad && BUILD.modernPropertyDecls && (BUILD.state || BUILD.prop)) {
     reWireGetterSetter(hostElement, hostRef);

--- a/src/client/client-host-ref.ts
+++ b/src/client/client-host-ref.ts
@@ -2,9 +2,16 @@ import { BUILD } from '@app-data';
 import { reWireGetterSetter } from '@utils/es2022-rewire-class-members';
 
 import type * as d from '../declarations';
+import { consoleDevWarn } from './client-log';
 
 export const deleteHostRef = (ref: d.RuntimeRef) => {
-  delete (ref as any)['$$hostRef'];
+  if (ref.$hostRef$) {
+    if (BUILD.isDev) {
+      consoleDevWarn(`Could not cleanup`, ref);
+    }
+    return;
+  }
+  delete ref.$hostRef$;
 };
 
 /**
@@ -14,7 +21,7 @@ export const deleteHostRef = (ref: d.RuntimeRef) => {
  * @returns the Host reference (if found) or undefined
  */
 export const getHostRef = (ref: d.RuntimeRef): d.HostRef | undefined => {
-  return (ref as any).$$hostRef;
+  return ref.$hostRef$;
 };
 
 /**
@@ -25,7 +32,7 @@ export const getHostRef = (ref: d.RuntimeRef): d.HostRef | undefined => {
  * @param hostRef that instances `HostRef` object
  */
 export const registerInstance = (lazyInstance: any, hostRef: d.HostRef) => {
-  lazyInstance['$$hostRef'] = hostRef;
+  lazyInstance.$hostRef$ = hostRef;
   hostRef.$lazyInstance$ = lazyInstance;
 
   if (BUILD.modernPropertyDecls && (BUILD.state || BUILD.prop)) {
@@ -61,7 +68,7 @@ export const registerHost = (hostElement: d.HostElement, cmpMeta: d.ComponentRun
     hostElement['s-rc'] = [];
   }
 
-  const ref = ((hostElement as any).$$hostRef = hostRef);
+  const ref = (hostElement.$hostRef$ = hostRef);
 
   if (!BUILD.lazyLoad && BUILD.modernPropertyDecls && (BUILD.state || BUILD.prop)) {
     reWireGetterSetter(hostElement, hostRef);

--- a/src/client/client-host-ref.ts
+++ b/src/client/client-host-ref.ts
@@ -2,15 +2,8 @@ import { BUILD } from '@app-data';
 import { reWireGetterSetter } from '@utils/es2022-rewire-class-members';
 
 import type * as d from '../declarations';
-import { consoleDevWarn } from './client-log';
 
 export const deleteHostRef = (ref: d.RuntimeRef) => {
-  if (ref.$hostRef$) {
-    if (BUILD.isDev) {
-      consoleDevWarn(`Could not cleanup`, ref);
-    }
-    return;
-  }
   delete ref.$hostRef$;
 };
 

--- a/src/client/client-host-ref.ts
+++ b/src/client/client-host-ref.ts
@@ -3,8 +3,20 @@ import { reWireGetterSetter } from '@utils/es2022-rewire-class-members';
 
 import type * as d from '../declarations';
 
-export const deleteHostRef = (ref: d.RuntimeRef) => {
-  delete ref.$hostRef$;
+/**
+ * Given a {@link d.RuntimeRef} remove the corresponding {@link d.HostRef} from
+ * the {@link hostRefs} WeakMap.
+ *
+ * @param ref the runtime ref of interest
+ * @returns — true if the element was successfully removed, or false if it was not present.
+ */
+export const deleteHostRef = (ref: d.RuntimeRef): boolean => {
+  if (ref.$hostRef$) {
+    delete ref.$hostRef$;
+    return true;
+  }
+
+  return false;
 };
 
 /**

--- a/src/client/client-host-ref.ts
+++ b/src/client/client-host-ref.ts
@@ -4,22 +4,6 @@ import { reWireGetterSetter } from '@utils/es2022-rewire-class-members';
 import type * as d from '../declarations';
 
 /**
- * Given a {@link d.RuntimeRef} remove the corresponding {@link d.HostRef} from
- * the {@link hostRefs} WeakMap.
- *
- * @param ref the runtime ref of interest
- * @returns — true if the element was successfully removed, or false if it was not present.
- */
-export const deleteHostRef = (ref: d.RuntimeRef): boolean => {
-  if (ref.__stencil__getHostRef) {
-    delete ref.__stencil__getHostRef;
-    return true;
-  }
-
-  return false;
-};
-
-/**
  * Given a {@link d.RuntimeRef} retrieve the corresponding {@link d.HostRef}
  *
  * @param ref the runtime ref of interest

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -1088,7 +1088,7 @@ export interface HostElement extends HTMLElement {
   host?: Element;
   forceUpdate?: () => void;
 
-  $hostRef$?: HostRef;
+  __stencil__getHostRef?: () => HostRef;
 
   // "s-" prefixed properties should not be property renamed
   // and should be common between all versions of stencil
@@ -1726,7 +1726,7 @@ export type ComponentRuntimeReflectingAttr = [string, string | undefined];
  * keys in a `WeakMap` which maps {@link HostElement} instances to their
  * associated {@link HostRef} instance.
  */
-export type RuntimeRef = HostElement | { $hostRef$?: HostRef };
+export type RuntimeRef = HostElement | { __stencil__getHostRef?: () => HostRef };
 
 /**
  * Interface used to track an Element, it's virtual Node (`VNode`), and other data

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -1088,6 +1088,8 @@ export interface HostElement extends HTMLElement {
   host?: Element;
   forceUpdate?: () => void;
 
+  $hostRef$?: HostRef;
+
   // "s-" prefixed properties should not be property renamed
   // and should be common between all versions of stencil
 
@@ -1724,7 +1726,7 @@ export type ComponentRuntimeReflectingAttr = [string, string | undefined];
  * keys in a `WeakMap` which maps {@link HostElement} instances to their
  * associated {@link HostRef} instance.
  */
-export type RuntimeRef = HostElement | {};
+export type RuntimeRef = HostElement | { $hostRef$?: HostRef };
 
 /**
  * Interface used to track an Element, it's virtual Node (`VNode`), and other data

--- a/src/hydrate/platform/index.ts
+++ b/src/hydrate/platform/index.ts
@@ -127,17 +127,22 @@ export const supportsListenerOptions = false;
 
 export const supportsConstructableStylesheets = false;
 
-const hostRefs: WeakMap<d.RuntimeRef, d.HostRef> = new WeakMap();
+export const getHostRef = (ref: d.RuntimeRef) => {
+  if (ref.__stencil__getHostRef) {
+    return ref.__stencil__getHostRef();
+  }
 
-export const getHostRef = (ref: d.RuntimeRef) => hostRefs.get(ref);
-export const deleteHostRef = (ref: d.RuntimeRef) => hostRefs.delete(ref);
+  return undefined;
+};
 
 export const registerInstance = (lazyInstance: any, hostRef: d.HostRef) => {
-  const ref = hostRefs.set((hostRef.$lazyInstance$ = lazyInstance), hostRef);
+  lazyInstance.__stencil__getHostRef = () => hostRef;
+  hostRef.$lazyInstance$ = lazyInstance;
+
   if (BUILD.modernPropertyDecls && (BUILD.state || BUILD.prop)) {
     reWireGetterSetter(lazyInstance, hostRef);
   }
-  return ref;
+  return hostRef;
 };
 
 export const registerHost = (elm: d.HostElement, cmpMeta: d.ComponentRuntimeMeta) => {
@@ -152,7 +157,9 @@ export const registerHost = (elm: d.HostElement, cmpMeta: d.ComponentRuntimeMeta
   hostRef.$onReadyPromise$ = new Promise((r) => (hostRef.$onReadyResolve$ = r));
   elm['s-p'] = [];
   elm['s-rc'] = [];
-  return hostRefs.set(elm, hostRef);
+  elm.__stencil__getHostRef = () => hostRef;
+
+  return hostRef;
 };
 
 export const Build: d.UserBuildConditionals = {

--- a/src/runtime/bootstrap-custom-element.ts
+++ b/src/runtime/bootstrap-custom-element.ts
@@ -1,14 +1,5 @@
 import { BUILD } from '@app-data';
-import {
-  addHostEventListeners,
-  deleteHostRef,
-  forceUpdate,
-  getHostRef,
-  plt,
-  registerHost,
-  styles,
-  supportsShadow,
-} from '@platform';
+import { addHostEventListeners, forceUpdate, getHostRef, registerHost, styles, supportsShadow } from '@platform';
 import { CMP_FLAGS } from '@utils';
 
 import type * as d from '../declarations';
@@ -98,20 +89,6 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
       if (BUILD.disconnectedCallback && originalDisconnectedCallback) {
         originalDisconnectedCallback.call(this);
       }
-
-      /**
-       * Clean up Node references lingering around in `hostRef` objects
-       * to ensure GC can clean up the memory.
-       */
-      plt.raf(() => {
-        const hostRef = getHostRef(this);
-        if (hostRef?.$vnode$?.$elm$ instanceof Node && !hostRef.$vnode$.$elm$.isConnected) {
-          delete hostRef.$vnode$;
-        }
-        if (this instanceof Node && !this.isConnected) {
-          deleteHostRef(this);
-        }
-      });
     },
     __attachShadow() {
       if (supportsShadow) {

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -159,26 +159,6 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
 
         disconnectedCallback() {
           plt.jmp(() => disconnectedCallback(this));
-
-          /**
-           * Clear up references within the `$vnode$` object to the DOM
-           * node that was removed. This is necessary to ensure that these
-           * references used as keys in the `hostRef` object can be properly
-           * garbage collected.
-           *
-           * Also remove the reference from `deferredConnectedCallbacks` array
-           * otherwise removed instances won't get garbage collected.
-           */
-          plt.raf(() => {
-            const hostRef = getHostRef(this);
-            const i = deferredConnectedCallbacks.findIndex((host) => host === this);
-            if (i > -1) {
-              deferredConnectedCallbacks.splice(i, 1);
-            }
-            if (hostRef?.$vnode$?.$elm$ instanceof Node && !hostRef.$vnode$.$elm$.isConnected) {
-              delete hostRef.$vnode$.$elm$;
-            }
-          });
         }
 
         componentOnReady() {

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -159,6 +159,26 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
 
         disconnectedCallback() {
           plt.jmp(() => disconnectedCallback(this));
+
+          /**
+           * Clear up references within the `$vnode$` object to the DOM
+           * node that was removed. This is necessary to ensure that these
+           * references used as keys in the `hostRef` object can be properly
+           * garbage collected.
+           *
+           * Also remove the reference from `deferredConnectedCallbacks` array
+           * otherwise removed instances won't get garbage collected.
+           */
+          plt.raf(() => {
+            const hostRef = getHostRef(this);
+            const i = deferredConnectedCallbacks.findIndex((host) => host === this);
+            if (i > -1) {
+              deferredConnectedCallbacks.splice(i, 1);
+            }
+            if (hostRef?.$vnode$?.$elm$ instanceof Node && !hostRef.$vnode$.$elm$.isConnected) {
+              delete hostRef.$vnode$.$elm$;
+            }
+          });
         }
 
         componentOnReady() {

--- a/src/runtime/vdom/vdom-annotations.ts
+++ b/src/runtime/vdom/vdom-annotations.ts
@@ -128,7 +128,7 @@ const parseVNodeAnnotations = (
      */
     const childNodes = [...Array.from(node.childNodes), ...Array.from(node.shadowRoot?.childNodes || [])];
     childNodes.forEach((childNode) => {
-      const hostRef = getHostRef(childNode as any);
+      const hostRef = getHostRef(childNode as d.RuntimeRef);
       if (hostRef != null && !docData.staticComponents.has(childNode.nodeName.toLowerCase())) {
         const cmpData: CmpData = {
           nodeIds: 0,

--- a/src/runtime/vdom/vdom-annotations.ts
+++ b/src/runtime/vdom/vdom-annotations.ts
@@ -128,7 +128,7 @@ const parseVNodeAnnotations = (
      */
     const childNodes = [...Array.from(node.childNodes), ...Array.from(node.shadowRoot?.childNodes || [])];
     childNodes.forEach((childNode) => {
-      const hostRef = getHostRef(childNode);
+      const hostRef = getHostRef(childNode as any);
       if (hostRef != null && !docData.staticComponents.has(childNode.nodeName.toLowerCase())) {
         const cmpData: CmpData = {
           nodeIds: 0,

--- a/src/testing/platform/index.ts
+++ b/src/testing/platform/index.ts
@@ -1,6 +1,6 @@
 export { Build } from './testing-build';
 export { modeResolutionChain, styles } from './testing-constants';
-export { deleteHostRef, getHostRef, registerHost, registerInstance } from './testing-host-ref';
+export { getHostRef, registerHost, registerInstance } from './testing-host-ref';
 export { consoleDevError, consoleDevInfo, consoleDevWarn, consoleError, setErrorHandler } from './testing-log';
 export {
   isMemberInElement,

--- a/src/testing/platform/testing-constants.ts
+++ b/src/testing/platform/testing-constants.ts
@@ -21,8 +21,3 @@ export const queuedLoadModules: QueuedLoadModule[] = [];
  * A collection of errors that were detected to surface during the rendering process
  */
 export const caughtErrors: Error[] = [];
-/**
- * A mapping of runtime references to HTML elements to the data structure Stencil uses to track the element alongside
- * additional metadata
- */
-export const hostRefs = new Map<d.RuntimeRef, d.HostRef>();

--- a/src/testing/platform/testing-platform.ts
+++ b/src/testing/platform/testing-platform.ts
@@ -1,6 +1,6 @@
 import type * as d from '@stencil/core/internal';
 
-import { cstrs, hostRefs, moduleLoaded, styles } from './testing-constants';
+import { cstrs, moduleLoaded, styles } from './testing-constants';
 import { flushAll, resetTaskQueue } from './testing-task-queue';
 import { win } from './testing-window';
 
@@ -54,7 +54,6 @@ export function resetPlatform(defaults: Partial<d.PlatformRuntime> = {}) {
     win.close();
   }
 
-  hostRefs.clear();
   styles.clear();
   plt.$flags$ = 0;
   Object.assign(plt, defaults);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: Fixes #6148 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Remove WeakMap and hold each `HostRef` on the actual DOM Element. Which makes the `Weakmap` itself not necessary anymore.

Issue to discuss:

- ~Circular structure of HTMLElement (element -> $hostRef$ -> $hostElement$ -> $hostRef$ -> ...)~ Solved by using `getHostRef`
- ~Add `HostRef` (containing vdom structure) to regular DOM (Performance ?) => Checked the performance haven't found any issues yet.~ Solved by using `getHostRef`
- ~WebDriver.IO cannot convert element to JSON (Circular structure of HTMLElement) which results in failing tests atm.~ Solved by using `getHostRef`

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Use existing tests, not added new ones.
