### PR TITLE
fix(hydrate): support dash-case case in hydrate mode

### DIFF
--- a/src/compiler/types/generate-component-types.ts
+++ b/src/compiler/types/generate-component-types.ts
@@ -84,7 +84,7 @@ const attributesToMultiLineString = (attributes: d.TypeInfo, jsxAttributes: bool
         const padding = ' '.repeat(8);
         fullList.push([
           `${padding}/**`,
-          `${padding} * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.`,
+          `${padding} * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.`,
           `${padding} */`
         ].join('\n'));
         fullList.push(`${padding}"${type.attributeName}"${optional ? '?' : ''}: ${type.type};`);

--- a/src/compiler/types/generate-component-types.ts
+++ b/src/compiler/types/generate-component-types.ts
@@ -89,7 +89,7 @@ const attributesToMultiLineString = (attributes: d.TypeInfo, jsxAttributes: bool
             `${padding} */`,
           ].join('\n'),
         );
-        fullList.push(`${padding}"${type.attributeName}"${optional ? '?' : ''}: ${type.type};`);
+        fullList.push(`${padding}"${type.attributeName}"?: ${type.type};`);
       }
 
       return fullList;

--- a/src/compiler/types/generate-component-types.ts
+++ b/src/compiler/types/generate-component-types.ts
@@ -76,6 +76,20 @@ const attributesToMultiLineString = (attributes: d.TypeInfo, jsxAttributes: bool
       }
       const optional = jsxAttributes ? !type.required : type.optional;
       fullList.push(`        "${type.name}"${optional ? '?' : ''}: ${type.type};`);
+
+      /**
+       * deprecated usage of dash-casing in JSX, use camelCase instead
+       */
+      if (type.attributeName && type.attributeName !== type.name) {
+        const padding = ' '.repeat(8);
+        fullList.push([
+          `${padding}/**`,
+          `${padding} * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.`,
+          `${padding} */`
+        ].join('\n'));
+        fullList.push(`${padding}"${type.attributeName}"${optional ? '?' : ''}: ${type.type};`);
+      }
+
       return fullList;
     }, [] as string[])
     .join(`\n`);

--- a/src/compiler/types/generate-component-types.ts
+++ b/src/compiler/types/generate-component-types.ts
@@ -82,11 +82,13 @@ const attributesToMultiLineString = (attributes: d.TypeInfo, jsxAttributes: bool
        */
       if (type.attributeName && type.attributeName !== type.name) {
         const padding = ' '.repeat(8);
-        fullList.push([
-          `${padding}/**`,
-          `${padding} * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.`,
-          `${padding} */`
-        ].join('\n'));
+        fullList.push(
+          [
+            `${padding}/**`,
+            `${padding} * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.`,
+            `${padding} */`,
+          ].join('\n'),
+        );
         fullList.push(`${padding}"${type.attributeName}"${optional ? '?' : ''}: ${type.type};`);
       }
 

--- a/src/compiler/types/generate-prop-types.ts
+++ b/src/compiler/types/generate-prop-types.ts
@@ -20,6 +20,7 @@ export const generatePropTypes = (cmpMeta: d.ComponentCompilerMeta, typeImportDa
       }
       return {
         name: cmpProp.name,
+        attributeName: cmpProp.attribute,
         type: getType(cmpProp, typeImportData, cmpMeta.sourceFilePath),
         optional: cmpProp.optional,
         required: cmpProp.required,

--- a/src/compiler/types/tests/generate-app-types.spec.ts
+++ b/src/compiler/types/tests/generate-app-types.spec.ts
@@ -847,6 +847,10 @@ export namespace Components {
      */
     interface MyComponent {
         "name": UserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType;
     }
 }
 declare global {
@@ -869,6 +873,10 @@ declare namespace LocalJSX {
      */
     interface MyComponent {
         "name"?: UserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType;
     }
     interface IntrinsicElements {
         "my-component": MyComponent;
@@ -949,7 +957,15 @@ export namespace Components {
      */
     interface MyComponent {
         "email": SecondUserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: SecondUserImplementedPropType;
         "name": UserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType;
     }
 }
 declare global {
@@ -972,7 +988,15 @@ declare namespace LocalJSX {
      */
     interface MyComponent {
         "email"?: SecondUserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: SecondUserImplementedPropType;
         "name"?: UserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType;
     }
     interface IntrinsicElements {
         "my-component": MyComponent;
@@ -1063,12 +1087,20 @@ export namespace Components {
      */
     interface MyComponent {
         "name": UserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType;
     }
     /**
      * docs
      */
     interface MyNewComponent {
         "fullName": UserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType;
     }
 }
 declare global {
@@ -1101,12 +1133,20 @@ declare namespace LocalJSX {
      */
     interface MyComponent {
         "name"?: UserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType;
     }
     /**
      * docs
      */
     interface MyNewComponent {
         "fullName"?: UserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType;
     }
     interface IntrinsicElements {
         "my-component": MyComponent;
@@ -1207,12 +1247,20 @@ export namespace Components {
      */
     interface MyComponent {
         "name": UserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType;
     }
     /**
      * docs
      */
     interface MyNewComponent {
         "newName": UserImplementedPropType1;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType1;
     }
 }
 declare global {
@@ -1245,12 +1293,20 @@ declare namespace LocalJSX {
      */
     interface MyComponent {
         "name"?: UserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType;
     }
     /**
      * docs
      */
     interface MyNewComponent {
         "newName"?: UserImplementedPropType1;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType1;
     }
     interface IntrinsicElements {
         "my-component": MyComponent;
@@ -1351,12 +1407,20 @@ export namespace Components {
      */
     interface MyComponent {
         "name": UserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType;
     }
     /**
      * docs
      */
     interface MyNewComponent {
         "name": UserImplementedPropType1;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType1;
     }
 }
 declare global {
@@ -1389,12 +1453,20 @@ declare namespace LocalJSX {
      */
     interface MyComponent {
         "name"?: UserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType;
     }
     /**
      * docs
      */
     interface MyNewComponent {
         "name"?: UserImplementedPropType1;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType1;
     }
     interface IntrinsicElements {
         "my-component": MyComponent;
@@ -1472,6 +1544,10 @@ export namespace Components {
      */
     interface MyComponent {
         "name": UserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType;
     }
 }
 export interface MyComponentCustomEvent<T> extends CustomEvent<T> {
@@ -1509,6 +1585,10 @@ declare namespace LocalJSX {
      */
     interface MyComponent {
         "name"?: UserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType;
         "onMyEvent"?: (event: MyComponentCustomEvent<UserImplementedEventType>) => void;
     }
     interface IntrinsicElements {
@@ -1590,6 +1670,10 @@ export namespace Components {
      */
     interface MyComponent {
         "name": UserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType;
     }
 }
 declare global {
@@ -1612,6 +1696,10 @@ declare namespace LocalJSX {
      */
     interface MyComponent {
         "name"?: UserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType;
     }
     interface IntrinsicElements {
         "my-component": MyComponent;
@@ -1682,6 +1770,10 @@ export namespace Components {
      */
     interface MyComponent {
         "name": UserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType;
     }
 }
 declare global {
@@ -1704,6 +1796,10 @@ declare namespace LocalJSX {
      */
     interface MyComponent {
         "name"?: UserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType;
     }
     interface IntrinsicElements {
         "my-component": MyComponent;
@@ -1762,6 +1858,8 @@ declare module "@stencil/core" {
 
     await generateAppTypes(config, compilerCtx, buildCtx, 'src');
 
+    console.log(mockWriteFile.mock.calls[0][1]);
+
     expect(mockWriteFile).toHaveBeenCalledWith(
       '/components.d.ts',
       `/* eslint-disable */
@@ -1781,6 +1879,10 @@ export namespace Components {
      */
     interface MyComponent {
         "name": UserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType;
     }
 }
 declare global {
@@ -1803,6 +1905,10 @@ declare namespace LocalJSX {
      */
     interface MyComponent {
         "name"?: UserImplementedPropType;
+        /**
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
+         */
+        "my-cmp"?: UserImplementedPropType;
     }
     interface IntrinsicElements {
         "my-component": MyComponent;

--- a/src/compiler/types/tests/generate-prop-types.spec.ts
+++ b/src/compiler/types/tests/generate-prop-types.spec.ts
@@ -44,6 +44,7 @@ describe('generate-prop-types', () => {
 
       const expectedTypeInfo: d.TypeInfo = [
         {
+          attributeName: 'my-cmp',
           jsdoc: '',
           internal: false,
           name: 'propName',
@@ -69,6 +70,7 @@ describe('generate-prop-types', () => {
 
       const expectedTypeInfo: d.TypeInfo = [
         {
+          attributeName: 'my-cmp',
           jsdoc: '',
           internal: false,
           name: 'propName',
@@ -114,6 +116,7 @@ describe('generate-prop-types', () => {
 
       const expectedTypeInfo: d.TypeInfo = [
         {
+          attributeName: 'my-cmp',
           jsdoc: '',
           internal: false,
           name: 'propName',
@@ -149,6 +152,7 @@ describe('generate-prop-types', () => {
 
       const expectedTypeInfo: d.TypeInfo = [
         {
+          attributeName: 'my-cmp',
           jsdoc: '@readonly',
           internal: false,
           name: 'propName',
@@ -176,6 +180,7 @@ describe('generate-prop-types', () => {
 
       const expectedTypeInfo: d.TypeInfo = [
         {
+          attributeName: 'my-cmp',
           jsdoc: '',
           internal: false,
           name: 'propName',

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -2565,6 +2565,7 @@ export interface TypesModule {
 export type TypeInfo = {
   name: string;
   type: string;
+  attributeName?: string;
   optional: boolean;
   required: boolean;
   internal: boolean;

--- a/src/hydrate/platform/proxy-host-element.ts
+++ b/src/hydrate/platform/proxy-host-element.ts
@@ -90,17 +90,18 @@ export function proxyHostElement(elm: d.HostElement, cstr: d.ComponentConstructo
         }
 
         // element
-        Object.defineProperty(elm, memberName, {
-          get: function (this: any) {
+        const getterSetterDescriptor: PropertyDescriptor = {
+          get: function (this: d.RuntimeRef) {
             return getValue(this, memberName);
           },
-          set(this: d.RuntimeRef, newValue) {
-            // proxyComponent, set value
+          set: function (this: d.RuntimeRef, newValue: unknown) {
             setValue(this, memberName, newValue, cmpMeta);
           },
           configurable: true,
           enumerable: true,
-        });
+        };
+        Object.defineProperty(elm, memberName, getterSetterDescriptor);
+        Object.defineProperty(elm, metaAttributeName, getterSetterDescriptor);
 
         if (!(cstr as any).prototype.__stencilAugmented) {
           // instance prototype

--- a/src/runtime/vdom/set-accessor.ts
+++ b/src/runtime/vdom/set-accessor.ts
@@ -39,167 +39,168 @@ export const setAccessor = (
   flags: number,
   initialRender?: boolean,
 ) => {
-  if (oldValue !== newValue) {
-    let isProp = isMemberInElement(elm, memberName);
-    let ln = memberName.toLowerCase();
+  if (oldValue === newValue) {
+    return
+  }
 
-    if (BUILD.vdomClass && memberName === 'class') {
-      const classList = elm.classList;
-      const oldClasses = parseClassList(oldValue);
-      let newClasses = parseClassList(newValue);
+  let isProp = isMemberInElement(elm, memberName);
+  let ln = memberName.toLowerCase();
+  if (BUILD.vdomClass && memberName === 'class') {
+    const classList = elm.classList;
+    const oldClasses = parseClassList(oldValue);
+    let newClasses = parseClassList(newValue);
 
-      if (BUILD.hydrateClientSide && elm['s-si'] && initialRender) {
-        // for `scoped: true` components, new nodes after initial hydration
-        // from SSR don't have the slotted class added. Let's add that now
-        newClasses.push(elm['s-si']);
-        oldClasses.forEach((c) => {
-          if (c.startsWith(elm['s-si'])) newClasses.push(c);
-        });
-        newClasses = [...new Set(newClasses)];
-        classList.add(...newClasses);
-      } else {
-        classList.remove(...oldClasses.filter((c) => c && !newClasses.includes(c)));
-        classList.add(...newClasses.filter((c) => c && !oldClasses.includes(c)));
+    if (BUILD.hydrateClientSide && elm['s-si'] && initialRender) {
+      // for `scoped: true` components, new nodes after initial hydration
+      // from SSR don't have the slotted class added. Let's add that now
+      newClasses.push(elm['s-si']);
+      oldClasses.forEach((c) => {
+        if (c.startsWith(elm['s-si'])) newClasses.push(c);
+      });
+      newClasses = [...new Set(newClasses)];
+      classList.add(...newClasses);
+    } else {
+      classList.remove(...oldClasses.filter((c) => c && !newClasses.includes(c)));
+      classList.add(...newClasses.filter((c) => c && !oldClasses.includes(c)));
+    }
+  } else if (BUILD.vdomStyle && memberName === 'style') {
+    // update style attribute, css properties and values
+    if (BUILD.updatable) {
+      for (const prop in oldValue) {
+        if (!newValue || newValue[prop] == null) {
+          if (!BUILD.hydrateServerSide && prop.includes('-')) {
+            elm.style.removeProperty(prop);
+          } else {
+            (elm as any).style[prop] = '';
+          }
+        }
       }
-    } else if (BUILD.vdomStyle && memberName === 'style') {
-      // update style attribute, css properties and values
-      if (BUILD.updatable) {
-        for (const prop in oldValue) {
-          if (!newValue || newValue[prop] == null) {
-            if (!BUILD.hydrateServerSide && prop.includes('-')) {
-              elm.style.removeProperty(prop);
+    }
+
+    for (const prop in newValue) {
+      if (!oldValue || newValue[prop] !== oldValue[prop]) {
+        if (!BUILD.hydrateServerSide && prop.includes('-')) {
+          elm.style.setProperty(prop, newValue[prop]);
+        } else {
+          (elm as any).style[prop] = newValue[prop];
+        }
+      }
+    }
+  } else if (BUILD.vdomKey && memberName === 'key') {
+    // minifier will clean this up
+  } else if (BUILD.vdomRef && memberName === 'ref') {
+    // minifier will clean this up
+    if (newValue) {
+      newValue(elm);
+    }
+  } else if (
+    BUILD.vdomListener &&
+    (BUILD.lazyLoad ? !isProp : !(elm as any).__lookupSetter__(memberName)) &&
+    memberName[0] === 'o' &&
+    memberName[1] === 'n'
+  ) {
+    // Event Handlers
+    // so if the member name starts with "on" and the 3rd characters is
+    // a capital letter, and it's not already a member on the element,
+    // then we're assuming it's an event listener
+    if (memberName[2] === '-') {
+      // on- prefixed events
+      // allows to be explicit about the dom event to listen without any magic
+      // under the hood:
+      // <my-cmp on-click> // listens for "click"
+      // <my-cmp on-Click> // listens for "Click"
+      // <my-cmp on-ionChange> // listens for "ionChange"
+      // <my-cmp on-EVENTS> // listens for "EVENTS"
+      memberName = memberName.slice(3);
+    } else if (isMemberInElement(win, ln)) {
+      // standard event
+      // the JSX attribute could have been "onMouseOver" and the
+      // member name "onmouseover" is on the window's prototype
+      // so let's add the listener "mouseover", which is all lowercased
+      memberName = ln.slice(2);
+    } else {
+      // custom event
+      // the JSX attribute could have been "onMyCustomEvent"
+      // so let's trim off the "on" prefix and lowercase the first character
+      // and add the listener "myCustomEvent"
+      // except for the first character, we keep the event name case
+      memberName = ln[2] + memberName.slice(3);
+    }
+    if (oldValue || newValue) {
+      // Need to account for "capture" events.
+      // If the event name ends with "Capture", we'll update the name to remove
+      // the "Capture" suffix and make sure the event listener is setup to handle the capture event.
+      const capture = memberName.endsWith(CAPTURE_EVENT_SUFFIX);
+      // Make sure we only replace the last instance of "Capture"
+      memberName = memberName.replace(CAPTURE_EVENT_REGEX, '');
+
+      if (oldValue) {
+        plt.rel(elm, memberName, oldValue, capture);
+      }
+      if (newValue) {
+        plt.ael(elm, memberName, newValue, capture);
+      }
+    }
+  } else if (BUILD.vdomPropOrAttr) {
+    // Set property if it exists and it's not a SVG
+    const isComplex = isComplexType(newValue);
+    if ((isProp || (isComplex && newValue !== null)) && !isSvg) {
+      try {
+        if (!elm.tagName.includes('-')) {
+          const n = newValue == null ? '' : newValue;
+
+          // Workaround for Safari, moving the <input> caret when re-assigning the same valued
+          if (memberName === 'list') {
+            isProp = false;
+          } else if (oldValue == null || (elm as any)[memberName] != n) {
+            if (typeof (elm as any).__lookupSetter__(memberName) === 'function') {
+              (elm as any)[memberName] = n;
             } else {
-              (elm as any).style[prop] = '';
+              elm.setAttribute(memberName, n);
             }
           }
+        } else if ((elm as any)[memberName] !== newValue) {
+          (elm as any)[memberName] = newValue;
         }
+      } catch (e) {
+        /**
+         * in case someone tries to set a read-only property, e.g. "namespaceURI", we just ignore it
+         */
       }
+    }
 
-      for (const prop in newValue) {
-        if (!oldValue || newValue[prop] !== oldValue[prop]) {
-          if (!BUILD.hydrateServerSide && prop.includes('-')) {
-            elm.style.setProperty(prop, newValue[prop]);
-          } else {
-            (elm as any).style[prop] = newValue[prop];
-          }
-        }
+    /**
+     * Need to manually update attribute if:
+     * - memberName is not an attribute
+     * - if we are rendering the host element in order to reflect attribute
+     * - if it's a SVG, since properties might not work in <svg>
+     * - if the newValue is null/undefined or 'false'.
+     */
+    let xlink = false;
+    if (BUILD.vdomXlink) {
+      if (ln !== (ln = ln.replace(/^xlink\:?/, ''))) {
+        memberName = ln;
+        xlink = true;
       }
-    } else if (BUILD.vdomKey && memberName === 'key') {
-      // minifier will clean this up
-    } else if (BUILD.vdomRef && memberName === 'ref') {
-      // minifier will clean this up
-      if (newValue) {
-        newValue(elm);
+    }
+    if (newValue == null || newValue === false) {
+      if (newValue !== false || elm.getAttribute(memberName) === '') {
+        if (BUILD.vdomXlink && xlink) {
+          elm.removeAttributeNS(XLINK_NS, memberName);
+        } else {
+          elm.removeAttribute(memberName);
+        }
       }
     } else if (
-      BUILD.vdomListener &&
-      (BUILD.lazyLoad ? !isProp : !(elm as any).__lookupSetter__(memberName)) &&
-      memberName[0] === 'o' &&
-      memberName[1] === 'n'
+      (!isProp || flags & VNODE_FLAGS.isHost || isSvg) &&
+      !isComplex &&
+      elm.nodeType === NODE_TYPE.ElementNode
     ) {
-      // Event Handlers
-      // so if the member name starts with "on" and the 3rd characters is
-      // a capital letter, and it's not already a member on the element,
-      // then we're assuming it's an event listener
-      if (memberName[2] === '-') {
-        // on- prefixed events
-        // allows to be explicit about the dom event to listen without any magic
-        // under the hood:
-        // <my-cmp on-click> // listens for "click"
-        // <my-cmp on-Click> // listens for "Click"
-        // <my-cmp on-ionChange> // listens for "ionChange"
-        // <my-cmp on-EVENTS> // listens for "EVENTS"
-        memberName = memberName.slice(3);
-      } else if (isMemberInElement(win, ln)) {
-        // standard event
-        // the JSX attribute could have been "onMouseOver" and the
-        // member name "onmouseover" is on the window's prototype
-        // so let's add the listener "mouseover", which is all lowercased
-        memberName = ln.slice(2);
+      newValue = newValue === true ? '' : newValue;
+      if (BUILD.vdomXlink && xlink) {
+        elm.setAttributeNS(XLINK_NS, memberName, newValue);
       } else {
-        // custom event
-        // the JSX attribute could have been "onMyCustomEvent"
-        // so let's trim off the "on" prefix and lowercase the first character
-        // and add the listener "myCustomEvent"
-        // except for the first character, we keep the event name case
-        memberName = ln[2] + memberName.slice(3);
-      }
-      if (oldValue || newValue) {
-        // Need to account for "capture" events.
-        // If the event name ends with "Capture", we'll update the name to remove
-        // the "Capture" suffix and make sure the event listener is setup to handle the capture event.
-        const capture = memberName.endsWith(CAPTURE_EVENT_SUFFIX);
-        // Make sure we only replace the last instance of "Capture"
-        memberName = memberName.replace(CAPTURE_EVENT_REGEX, '');
-
-        if (oldValue) {
-          plt.rel(elm, memberName, oldValue, capture);
-        }
-        if (newValue) {
-          plt.ael(elm, memberName, newValue, capture);
-        }
-      }
-    } else if (BUILD.vdomPropOrAttr) {
-      // Set property if it exists and it's not a SVG
-      const isComplex = isComplexType(newValue);
-      if ((isProp || (isComplex && newValue !== null)) && !isSvg) {
-        try {
-          if (!elm.tagName.includes('-')) {
-            const n = newValue == null ? '' : newValue;
-
-            // Workaround for Safari, moving the <input> caret when re-assigning the same valued
-            if (memberName === 'list') {
-              isProp = false;
-            } else if (oldValue == null || (elm as any)[memberName] != n) {
-              if (typeof (elm as any).__lookupSetter__(memberName) === 'function') {
-                (elm as any)[memberName] = n;
-              } else {
-                elm.setAttribute(memberName, n);
-              }
-            }
-          } else if ((elm as any)[memberName] !== newValue) {
-            (elm as any)[memberName] = newValue;
-          }
-        } catch (e) {
-          /**
-           * in case someone tries to set a read-only property, e.g. "namespaceURI", we just ignore it
-           */
-        }
-      }
-
-      /**
-       * Need to manually update attribute if:
-       * - memberName is not an attribute
-       * - if we are rendering the host element in order to reflect attribute
-       * - if it's a SVG, since properties might not work in <svg>
-       * - if the newValue is null/undefined or 'false'.
-       */
-      let xlink = false;
-      if (BUILD.vdomXlink) {
-        if (ln !== (ln = ln.replace(/^xlink\:?/, ''))) {
-          memberName = ln;
-          xlink = true;
-        }
-      }
-      if (newValue == null || newValue === false) {
-        if (newValue !== false || elm.getAttribute(memberName) === '') {
-          if (BUILD.vdomXlink && xlink) {
-            elm.removeAttributeNS(XLINK_NS, memberName);
-          } else {
-            elm.removeAttribute(memberName);
-          }
-        }
-      } else if (
-        (!isProp || flags & VNODE_FLAGS.isHost || isSvg) &&
-        !isComplex &&
-        elm.nodeType === NODE_TYPE.ElementNode
-      ) {
-        newValue = newValue === true ? '' : newValue;
-        if (BUILD.vdomXlink && xlink) {
-          elm.setAttributeNS(XLINK_NS, memberName, newValue);
-        } else {
-          elm.setAttribute(memberName, newValue);
-        }
+        elm.setAttribute(memberName, newValue);
       }
     }
   }

--- a/src/runtime/vdom/set-accessor.ts
+++ b/src/runtime/vdom/set-accessor.ts
@@ -40,7 +40,7 @@ export const setAccessor = (
   initialRender?: boolean,
 ) => {
   if (oldValue === newValue) {
-    return
+    return;
   }
 
   let isProp = isMemberInElement(elm, memberName);

--- a/test/end-to-end/src/components.d.ts
+++ b/test/end-to-end/src/components.d.ts
@@ -102,6 +102,28 @@ export namespace Components {
         "someMethodWithArgs": (unit: string, value: number) => Promise<string>;
         "someProp": number;
     }
+    interface MyCmp {
+        /**
+          * @readonly
+         */
+        "barProp": string;
+        "fooProp": string;
+        /**
+          * Mode
+         */
+        "mode"?: any;
+    }
+    interface MyJsxCmp {
+        /**
+          * @readonly
+         */
+        "barProp": string;
+        "fooProp": string;
+        /**
+          * Mode
+         */
+        "mode"?: any;
+    }
     interface NestedCmpChild {
     }
     interface NestedCmpParent {
@@ -370,6 +392,18 @@ declare global {
         prototype: HTMLMethodCmpElement;
         new (): HTMLMethodCmpElement;
     };
+    interface HTMLMyCmpElement extends Components.MyCmp, HTMLStencilElement {
+    }
+    var HTMLMyCmpElement: {
+        prototype: HTMLMyCmpElement;
+        new (): HTMLMyCmpElement;
+    };
+    interface HTMLMyJsxCmpElement extends Components.MyJsxCmp, HTMLStencilElement {
+    }
+    var HTMLMyJsxCmpElement: {
+        prototype: HTMLMyJsxCmpElement;
+        new (): HTMLMyJsxCmpElement;
+    };
     interface HTMLNestedCmpChildElement extends Components.NestedCmpChild, HTMLStencilElement {
     }
     var HTMLNestedCmpChildElement: {
@@ -524,6 +558,8 @@ declare global {
         "import-assets": HTMLImportAssetsElement;
         "listen-cmp": HTMLListenCmpElement;
         "method-cmp": HTMLMethodCmpElement;
+        "my-cmp": HTMLMyCmpElement;
+        "my-jsx-cmp": HTMLMyJsxCmpElement;
         "nested-cmp-child": HTMLNestedCmpChildElement;
         "nested-cmp-parent": HTMLNestedCmpParentElement;
         "nested-scope-cmp": HTMLNestedScopeCmpElement;
@@ -616,6 +652,28 @@ declare namespace LocalJSX {
     interface MethodCmp {
         "someProp"?: number;
     }
+    interface MyCmp {
+        /**
+          * @readonly
+         */
+        "barProp"?: string;
+        "fooProp"?: string;
+        /**
+          * Mode
+         */
+        "mode"?: any;
+    }
+    interface MyJsxCmp {
+        /**
+          * @readonly
+         */
+        "barProp"?: string;
+        "fooProp"?: string;
+        /**
+          * Mode
+         */
+        "mode"?: any;
+    }
     interface NestedCmpChild {
     }
     interface NestedCmpParent {
@@ -702,6 +760,8 @@ declare namespace LocalJSX {
         "import-assets": ImportAssets;
         "listen-cmp": ListenCmp;
         "method-cmp": MethodCmp;
+        "my-cmp": MyCmp;
+        "my-jsx-cmp": MyJsxCmp;
         "nested-cmp-child": NestedCmpChild;
         "nested-cmp-parent": NestedCmpParent;
         "nested-scope-cmp": NestedScopeCmp;
@@ -758,6 +818,8 @@ declare module "@stencil/core" {
             "import-assets": LocalJSX.ImportAssets & JSXBase.HTMLAttributes<HTMLImportAssetsElement>;
             "listen-cmp": LocalJSX.ListenCmp & JSXBase.HTMLAttributes<HTMLListenCmpElement>;
             "method-cmp": LocalJSX.MethodCmp & JSXBase.HTMLAttributes<HTMLMethodCmpElement>;
+            "my-cmp": LocalJSX.MyCmp & JSXBase.HTMLAttributes<HTMLMyCmpElement>;
+            "my-jsx-cmp": LocalJSX.MyJsxCmp & JSXBase.HTMLAttributes<HTMLMyJsxCmpElement>;
             "nested-cmp-child": LocalJSX.NestedCmpChild & JSXBase.HTMLAttributes<HTMLNestedCmpChildElement>;
             "nested-cmp-parent": LocalJSX.NestedCmpParent & JSXBase.HTMLAttributes<HTMLNestedCmpParentElement>;
             "nested-scope-cmp": LocalJSX.NestedScopeCmp & JSXBase.HTMLAttributes<HTMLNestedScopeCmpElement>;

--- a/test/end-to-end/src/components.d.ts
+++ b/test/end-to-end/src/components.d.ts
@@ -41,7 +41,7 @@ export namespace Components {
     interface CmpDsd {
         "initialCounter": number;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "initial-counter": number;
     }
@@ -106,7 +106,7 @@ export namespace Components {
         "someMethodWithArgs": (unit: string, value: number) => Promise<string>;
         "someProp": number;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "some-prop": number;
     }
@@ -118,7 +118,7 @@ export namespace Components {
          */
         "barProp": string;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "bar-prop": string;
         /**
@@ -126,7 +126,7 @@ export namespace Components {
          */
         "fooProp": string;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "foo-prop": string;
         /**
@@ -142,7 +142,7 @@ export namespace Components {
          */
         "barProp": string;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "bar-prop": string;
         /**
@@ -150,7 +150,7 @@ export namespace Components {
          */
         "fooProp": string;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "foo-prop": string;
         /**
@@ -184,12 +184,12 @@ export namespace Components {
          */
         "fullName": string;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "full-name": string;
         "lastName": string;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "last-name": string;
         /**
@@ -200,17 +200,17 @@ export namespace Components {
     interface RuntimeDecorators {
         "basicProp": string;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "basic-prop": string;
         "decoratedGetterSetterProp": number;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "decorated-getter-setter-prop": number;
         "decoratedProp": number;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "decorated-prop": number;
     }
@@ -671,7 +671,7 @@ declare namespace LocalJSX {
     interface CmpDsd {
         "initialCounter"?: number;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "initial-counter"?: number;
     }
@@ -710,7 +710,7 @@ declare namespace LocalJSX {
     interface MethodCmp {
         "someProp"?: number;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "some-prop"?: number;
     }
@@ -722,7 +722,7 @@ declare namespace LocalJSX {
          */
         "barProp"?: string;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "bar-prop"?: string;
         /**
@@ -730,7 +730,7 @@ declare namespace LocalJSX {
          */
         "fooProp"?: string;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "foo-prop"?: string;
         /**
@@ -746,7 +746,7 @@ declare namespace LocalJSX {
          */
         "barProp"?: string;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "bar-prop"?: string;
         /**
@@ -754,7 +754,7 @@ declare namespace LocalJSX {
          */
         "fooProp"?: string;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "foo-prop"?: string;
         /**
@@ -788,12 +788,12 @@ declare namespace LocalJSX {
          */
         "fullName"?: string;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "full-name"?: string;
         "lastName"?: string;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "last-name"?: string;
         /**
@@ -804,17 +804,17 @@ declare namespace LocalJSX {
     interface RuntimeDecorators {
         "basicProp"?: string;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "basic-prop"?: string;
         "decoratedGetterSetterProp"?: number;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "decorated-getter-setter-prop"?: number;
         "decoratedProp"?: number;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "decorated-prop"?: number;
     }

--- a/test/end-to-end/src/components.d.ts
+++ b/test/end-to-end/src/components.d.ts
@@ -43,7 +43,7 @@ export namespace Components {
         /**
          * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
-        "initial-counter": number;
+        "initial-counter"?: number;
     }
     interface CmpServerVsClient {
     }
@@ -108,7 +108,7 @@ export namespace Components {
         /**
          * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
-        "some-prop": number;
+        "some-prop"?: number;
     }
     interface MyCmp {
         /**
@@ -120,7 +120,7 @@ export namespace Components {
         /**
          * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
-        "bar-prop": string;
+        "bar-prop"?: string;
         /**
           * foo prop
          */
@@ -128,7 +128,7 @@ export namespace Components {
         /**
          * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
-        "foo-prop": string;
+        "foo-prop"?: string;
         /**
           * Mode
          */
@@ -144,7 +144,7 @@ export namespace Components {
         /**
          * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
-        "bar-prop": string;
+        "bar-prop"?: string;
         /**
           * foo prop
          */
@@ -152,7 +152,7 @@ export namespace Components {
         /**
          * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
-        "foo-prop": string;
+        "foo-prop"?: string;
         /**
           * Mode
          */
@@ -186,12 +186,12 @@ export namespace Components {
         /**
          * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
-        "full-name": string;
+        "full-name"?: string;
         "lastName": string;
         /**
          * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
-        "last-name": string;
+        "last-name"?: string;
         /**
           * Mode
          */
@@ -202,17 +202,17 @@ export namespace Components {
         /**
          * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
-        "basic-prop": string;
+        "basic-prop"?: string;
         "decoratedGetterSetterProp": number;
         /**
          * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
-        "decorated-getter-setter-prop": number;
+        "decorated-getter-setter-prop"?: number;
         "decoratedProp": number;
         /**
          * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
-        "decorated-prop": number;
+        "decorated-prop"?: number;
     }
     interface ScopedCarDetail {
         "car": CarData;

--- a/test/end-to-end/src/components.d.ts
+++ b/test/end-to-end/src/components.d.ts
@@ -40,6 +40,10 @@ export namespace Components {
     }
     interface CmpDsd {
         "initialCounter": number;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "initial-counter": number;
     }
     interface CmpServerVsClient {
     }
@@ -101,13 +105,30 @@ export namespace Components {
          */
         "someMethodWithArgs": (unit: string, value: number) => Promise<string>;
         "someProp": number;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "some-prop": number;
     }
     interface MyCmp {
         /**
+          * bar prop
+          * @returns bar
           * @readonly
          */
         "barProp": string;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "bar-prop": string;
+        /**
+          * foo prop
+         */
         "fooProp": string;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "foo-prop": string;
         /**
           * Mode
          */
@@ -115,10 +136,23 @@ export namespace Components {
     }
     interface MyJsxCmp {
         /**
+          * bar prop
+          * @returns bar
           * @readonly
          */
         "barProp": string;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "bar-prop": string;
+        /**
+          * foo prop
+         */
         "fooProp": string;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "foo-prop": string;
         /**
           * Mode
          */
@@ -149,7 +183,15 @@ export namespace Components {
           * @readonly
          */
         "fullName": string;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "full-name": string;
         "lastName": string;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "last-name": string;
         /**
           * Mode
          */
@@ -157,8 +199,20 @@ export namespace Components {
     }
     interface RuntimeDecorators {
         "basicProp": string;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "basic-prop": string;
         "decoratedGetterSetterProp": number;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "decorated-getter-setter-prop": number;
         "decoratedProp": number;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "decorated-prop": number;
     }
     interface ScopedCarDetail {
         "car": CarData;
@@ -616,6 +670,10 @@ declare namespace LocalJSX {
     }
     interface CmpDsd {
         "initialCounter"?: number;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "initial-counter"?: number;
     }
     interface CmpServerVsClient {
     }
@@ -651,13 +709,30 @@ declare namespace LocalJSX {
     }
     interface MethodCmp {
         "someProp"?: number;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "some-prop"?: number;
     }
     interface MyCmp {
         /**
+          * bar prop
+          * @returns bar
           * @readonly
          */
         "barProp"?: string;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "bar-prop"?: string;
+        /**
+          * foo prop
+         */
         "fooProp"?: string;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "foo-prop"?: string;
         /**
           * Mode
          */
@@ -665,10 +740,23 @@ declare namespace LocalJSX {
     }
     interface MyJsxCmp {
         /**
+          * bar prop
+          * @returns bar
           * @readonly
          */
         "barProp"?: string;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "bar-prop"?: string;
+        /**
+          * foo prop
+         */
         "fooProp"?: string;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "foo-prop"?: string;
         /**
           * Mode
          */
@@ -699,7 +787,15 @@ declare namespace LocalJSX {
           * @readonly
          */
         "fullName"?: string;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "full-name"?: string;
         "lastName"?: string;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "last-name"?: string;
         /**
           * Mode
          */
@@ -707,8 +803,20 @@ declare namespace LocalJSX {
     }
     interface RuntimeDecorators {
         "basicProp"?: string;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "basic-prop"?: string;
         "decoratedGetterSetterProp"?: number;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "decorated-getter-setter-prop"?: number;
         "decoratedProp"?: number;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "decorated-prop"?: number;
     }
     interface ScopedCarDetail {
         "car"?: CarData;

--- a/test/end-to-end/src/hydrate-props/hydrate-props.e2e.ts
+++ b/test/end-to-end/src/hydrate-props/hydrate-props.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-ignore may not be existing when project hasn't been built
 type HydrateModule = typeof import('../../hydrate');
 let renderToString: HydrateModule['renderToString'];
 

--- a/test/end-to-end/src/hydrate-props/hydrate-props.e2e.ts
+++ b/test/end-to-end/src/hydrate-props/hydrate-props.e2e.ts
@@ -2,7 +2,6 @@ type HydrateModule = typeof import('../../hydrate');
 let renderToString: HydrateModule['renderToString'];
 
 describe('different types of decorated properties and states render on both server and client', () => {
-
   beforeAll(async () => {
     // @ts-ignore may not be existing when project hasn't been built
     const mod = await import('../../hydrate');
@@ -10,21 +9,24 @@ describe('different types of decorated properties and states render on both serv
   });
 
   it('renders default values', async () => {
-    const { html } = await renderToString(`
+    const { html } = await renderToString(
+      `
       <my-cmp foo-prop="foo1" bar-prop="bar1"></my-cmp>
       <my-cmp fooProp="foo2" barProp="bar2"></my-cmp>
-    `, {
-      fullDocument: false,
-    });
+    `,
+      {
+        fullDocument: false,
+      },
+    );
     // html template renders kebab case props
-    expect(html).toContain('<!--t.1.1.1.0-->foo1 - bar1<')
+    expect(html).toContain('<!--t.1.1.1.0-->foo1 - bar1<');
     // html template doesn't support camelcase
-    expect(html).toContain('<!--t.4.1.1.0--> - bar<')
+    expect(html).toContain('<!--t.4.1.1.0--> - bar<');
     // jsx template renders kebab case
-    expect(html).toContain('<!--t.2.1.1.0-->foo3 - bar3<')
-    expect(html).toContain('<!--t.5.1.1.0-->foo3 - bar3<')
+    expect(html).toContain('<!--t.2.1.1.0-->foo3 - bar3<');
+    expect(html).toContain('<!--t.5.1.1.0-->foo3 - bar3<');
     // jsx template renders camel case
-    expect(html).toContain('<!--t.3.1.1.0-->foo4 - bar4<')
-    expect(html).toContain('<!--t.6.1.1.0-->foo4 - bar4<')
+    expect(html).toContain('<!--t.3.1.1.0-->foo4 - bar4<');
+    expect(html).toContain('<!--t.6.1.1.0-->foo4 - bar4<');
   });
 });

--- a/test/end-to-end/src/hydrate-props/hydrate-props.e2e.ts
+++ b/test/end-to-end/src/hydrate-props/hydrate-props.e2e.ts
@@ -1,0 +1,30 @@
+type HydrateModule = typeof import('../../hydrate');
+let renderToString: HydrateModule['renderToString'];
+
+describe('different types of decorated properties and states render on both server and client', () => {
+
+  beforeAll(async () => {
+    // @ts-ignore may not be existing when project hasn't been built
+    const mod = await import('../../hydrate');
+    renderToString = mod.renderToString;
+  });
+
+  it('renders default values', async () => {
+    const { html } = await renderToString(`
+      <my-cmp foo-prop="foo1" bar-prop="bar1"></my-cmp>
+      <my-cmp fooProp="foo2" barProp="bar2"></my-cmp>
+    `, {
+      fullDocument: false,
+    });
+    // html template renders kebab case props
+    expect(html).toContain('<!--t.1.1.1.0-->foo1 - bar1<')
+    // html template doesn't support camelcase
+    expect(html).toContain('<!--t.4.1.1.0--> - bar<')
+    // jsx template renders kebab case
+    expect(html).toContain('<!--t.2.1.1.0-->foo3 - bar3<')
+    expect(html).toContain('<!--t.5.1.1.0-->foo3 - bar3<')
+    // jsx template renders camel case
+    expect(html).toContain('<!--t.3.1.1.0-->foo4 - bar4<')
+    expect(html).toContain('<!--t.6.1.1.0-->foo4 - bar4<')
+  });
+});

--- a/test/end-to-end/src/hydrate-props/my-cmp.tsx
+++ b/test/end-to-end/src/hydrate-props/my-cmp.tsx
@@ -1,0 +1,28 @@
+import { Component, h, Prop } from '@stencil/core';
+
+/**
+ * @virtualProp mode - Mode
+ */
+@Component({
+  tag: 'my-cmp',
+  shadow: true,
+})
+export class MyCmp {
+  @Prop()
+  fooProp: string;
+
+  @Prop()
+  get barProp() {
+    return 'bar';
+  }
+
+  render() {
+    return (
+      <div>
+        {this.fooProp} - {this.barProp}
+        <my-jsx-cmp fooProp="foo3" barProp="bar3"></my-jsx-cmp>
+        <my-jsx-cmp foo-prop="foo4" bar-prop="bar4"></my-jsx-cmp>
+      </div>
+    );
+  }
+}

--- a/test/end-to-end/src/hydrate-props/my-cmp.tsx
+++ b/test/end-to-end/src/hydrate-props/my-cmp.tsx
@@ -8,9 +8,16 @@ import { Component, h, Prop } from '@stencil/core';
   shadow: true,
 })
 export class MyCmp {
+  /**
+   * foo prop
+   */
   @Prop()
   fooProp: string;
 
+  /**
+   * bar prop
+   * @returns bar
+   */
   @Prop()
   get barProp() {
     return 'bar';

--- a/test/end-to-end/src/hydrate-props/my-jsx-cmp.tsx
+++ b/test/end-to-end/src/hydrate-props/my-jsx-cmp.tsx
@@ -8,9 +8,16 @@ import { Component, h, Prop } from '@stencil/core';
   shadow: true,
 })
 export class MyJsxCmp {
+  /**
+   * foo prop
+   */
   @Prop()
   fooProp: string;
 
+  /**
+   * bar prop
+   * @returns bar
+   */
   @Prop()
   get barProp() {
     return 'bar';

--- a/test/end-to-end/src/hydrate-props/my-jsx-cmp.tsx
+++ b/test/end-to-end/src/hydrate-props/my-jsx-cmp.tsx
@@ -1,0 +1,26 @@
+import { Component, h, Prop } from '@stencil/core';
+
+/**
+ * @virtualProp mode - Mode
+ */
+@Component({
+  tag: 'my-jsx-cmp',
+  shadow: true,
+})
+export class MyJsxCmp {
+  @Prop()
+  fooProp: string;
+
+  @Prop()
+  get barProp() {
+    return 'bar';
+  }
+
+  render() {
+    return (
+      <div>
+        {this.fooProp} - {this.barProp}
+      </div>
+    );
+  }
+}

--- a/test/end-to-end/src/hydrate-props/readme.md
+++ b/test/end-to-end/src/hydrate-props/readme.md
@@ -9,10 +9,23 @@
 
 | Property  | Attribute  | Description | Type     | Default     |
 | --------- | ---------- | ----------- | -------- | ----------- |
-| `barProp` | `bar-prop` |             | `string` | `'bar'`     |
-| `fooProp` | `foo-prop` |             | `string` | `undefined` |
+| `barProp` | `bar-prop` | bar prop    | `string` | `'bar'`     |
+| `fooProp` | `foo-prop` | foo prop    | `string` | `undefined` |
 | `mode`    | `mode`     | Mode        | `any`    | `undefined` |
 
+
+## Dependencies
+
+### Used by
+
+ - [my-cmp](.)
+
+### Graph
+```mermaid
+graph TD;
+  my-cmp --> my-jsx-cmp
+  style my-jsx-cmp fill:#f9f,stroke:#333,stroke-width:4px
+```
 
 ----------------------------------------------
 

--- a/test/end-to-end/src/hydrate-props/readme.md
+++ b/test/end-to-end/src/hydrate-props/readme.md
@@ -1,0 +1,19 @@
+# hydrate-props
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property  | Attribute  | Description | Type     | Default     |
+| --------- | ---------- | ----------- | -------- | ----------- |
+| `barProp` | `bar-prop` |             | `string` | `'bar'`     |
+| `fooProp` | `foo-prop` |             | `string` | `undefined` |
+| `mode`    | `mode`     | Mode        | `any`    | `undefined` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/test/wdio/src/components.d.ts
+++ b/test/wdio/src/components.d.ts
@@ -21,7 +21,7 @@ export namespace Components {
     interface CmpD {
         "uniqueId": string;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "unique-id": string;
     }
@@ -140,7 +140,7 @@ declare namespace LocalJSX {
     interface CmpD {
         "uniqueId"?: string;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "unique-id"?: string;
     }

--- a/test/wdio/src/components.d.ts
+++ b/test/wdio/src/components.d.ts
@@ -23,7 +23,7 @@ export namespace Components {
         /**
          * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
-        "unique-id": string;
+        "unique-id"?: string;
     }
     interface CmpScopedA {
     }

--- a/test/wdio/src/components.d.ts
+++ b/test/wdio/src/components.d.ts
@@ -20,6 +20,10 @@ export namespace Components {
     }
     interface CmpD {
         "uniqueId": string;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "unique-id": string;
     }
     interface CmpScopedA {
     }
@@ -135,6 +139,10 @@ declare namespace LocalJSX {
     }
     interface CmpD {
         "uniqueId"?: string;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "unique-id"?: string;
     }
     interface CmpScopedA {
     }

--- a/test/wdio/ts-target-props/components.d.ts
+++ b/test/wdio/ts-target-props/components.d.ts
@@ -9,17 +9,17 @@ export namespace Components {
     interface TsTargetProps {
         "basicProp": string;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "basic-prop": string;
         "decoratedGetterSetterProp": number;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "decorated-getter-setter-prop": number;
         "decoratedProp": number;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "decorated-prop": number;
     }
@@ -39,17 +39,17 @@ declare namespace LocalJSX {
     interface TsTargetProps {
         "basicProp"?: string;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "basic-prop"?: string;
         "decoratedGetterSetterProp"?: number;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "decorated-getter-setter-prop"?: number;
         "decoratedProp"?: number;
         /**
-         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
         "decorated-prop"?: number;
     }

--- a/test/wdio/ts-target-props/components.d.ts
+++ b/test/wdio/ts-target-props/components.d.ts
@@ -11,17 +11,17 @@ export namespace Components {
         /**
          * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
-        "basic-prop": string;
+        "basic-prop"?: string;
         "decoratedGetterSetterProp": number;
         /**
          * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
-        "decorated-getter-setter-prop": number;
+        "decorated-getter-setter-prop"?: number;
         "decoratedProp": number;
         /**
          * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
          */
-        "decorated-prop": number;
+        "decorated-prop"?: number;
     }
 }
 declare global {

--- a/test/wdio/ts-target-props/components.d.ts
+++ b/test/wdio/ts-target-props/components.d.ts
@@ -8,8 +8,20 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 export namespace Components {
     interface TsTargetProps {
         "basicProp": string;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "basic-prop": string;
         "decoratedGetterSetterProp": number;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "decorated-getter-setter-prop": number;
         "decoratedProp": number;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "decorated-prop": number;
     }
 }
 declare global {
@@ -26,8 +38,20 @@ declare global {
 declare namespace LocalJSX {
     interface TsTargetProps {
         "basicProp"?: string;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "basic-prop"?: string;
         "decoratedGetterSetterProp"?: number;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "decorated-getter-setter-prop"?: number;
         "decoratedProp"?: number;
+        /**
+         * @deprecated dash-casing is not supported in JSX, use camelCase instead. Support for it will be removed in Stencil v5.
+         */
+        "decorated-prop"?: number;
     }
     interface IntrinsicElements {
         "ts-target-props": TsTargetProps;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?

Component properties can be read in the following 2 environments:

- an HTML template, e.g. a Stencil runtime is loaded within an HTML page or you pass in a template to a `renderToString` function.
- a JSX template, e.g. within the `render` method of a component

According to the [property casing](https://stenciljs.com/docs/properties#variable-casing) docs we expect camelcase in JSX and dash-case case in html templates. It appears however that Stencil supported dash-casing in JSX templates as well, though only at runtime (e.g. not in the hydrate module).

fixes #6150

## What is the new behavior?

This patch adds support for dash-casing in JSX templates when running the hydrate script, to align with the runtime behavior. In general, dash-casing should only be used in HTML templates and not in JSX. However removing this capability may break peoples components as it is unclear how many folks are using dash casing.

Therefore I have added the dash-cased property as a type to the `components.d.ts` file and marked it as deprecated. I will create a v5 issue for it for us to re-evaluate whether we actually want to remove this or if it makes sense to keep it.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Added an e2e test case for it.

## Other information

n/a
