### PR TITLE
fix(runtime): `scoped: true` slot fallback with forwarded slot

### DIFF
--- a/src/runtime/slot-polyfill-utils.ts
+++ b/src/runtime/slot-polyfill-utils.ts
@@ -26,7 +26,7 @@ export const updateFallbackSlotVisibility = (elm: d.RenderNode) => {
     getHostSlotNodes(childNodes as any, (elm as HTMLElement).tagName).forEach((slotNode) => {
       if (slotNode.nodeType === NODE_TYPE.ElementNode && slotNode.tagName === 'SLOT-FB') {
         // this is a slot fallback node
-        if (getSlotChildSiblings(slotNode, getSlotName(slotNode), false)?.length) {
+        if (getSlotChildSiblings(slotNode, getSlotName(slotNode), false).length) {
           // has slotted nodes, hide fallback
           slotNode.hidden = true;
         } else {
@@ -108,7 +108,7 @@ export const getSlotChildSiblings = (slot: d.RenderNode, slotName: string, inclu
   let node = slot;
 
   while ((node = node.nextSibling as any)) {
-    if (getSlotName(node) === slotName) childNodes.push(node as any);
+    if (getSlotName(node) === slotName && (includeSlot || !node['s-sr'])) childNodes.push(node as any);
   }
   return childNodes;
 };

--- a/src/runtime/test/hydrate-slot-fallback.spec.tsx
+++ b/src/runtime/test/hydrate-slot-fallback.spec.tsx
@@ -443,7 +443,7 @@ describe('hydrate, slot fallback', () => {
         return (
           <article>
             <cmp-b>
-              <slot>Fallback content parent - should not be hidden</slot>
+              <slot>Fallback content parent - should be hidden</slot>
             </cmp-b>
           </article>
         );
@@ -458,7 +458,7 @@ describe('hydrate, slot fallback', () => {
       render() {
         return (
           <section>
-            <slot>Fallback content child - should be hidden</slot>
+            <slot>Fallback content child - should not be hidden</slot>
           </section>
         );
       }
@@ -479,13 +479,13 @@ describe('hydrate, slot fallback', () => {
             <!--r.2-->
             <!--o.1.2.-->
             <section c-id=\"2.0.0.0\">
-              <slot-fb c-id=\"2.1.1.0\" hidden=\"\" s-sn=\"\">
+              <slot-fb c-id=\"2.1.1.0\" s-sn=\"\">
                 <!--t.2.2.2.0-->
-                Fallback content child - should be hidden
+                Fallback content child - should not be hidden
               </slot-fb>
               <slot-fb c-id=\"1.2.2.0\" s-sn=\"\">
                 <!--t.1.3.3.0-->
-                Fallback content parent - should not be hidden
+                Fallback content parent - should be hidden
               </slot-fb>
             </section>
           </cmp-b>
@@ -507,12 +507,12 @@ describe('hydrate, slot fallback', () => {
             <mock:shadow-root>
               <section>
                 <slot>
-                  Fallback content child - should be hidden
+                  Fallback content child - should not be hidden
                 </slot>
               </section>
             </mock:shadow-root>
             <slot-fb class="sc-cmp-a">
-              Fallback content parent - should not be hidden
+              Fallback content parent - should be hidden
             </slot-fb>
           </cmp-b>
         </article>

--- a/test/wdio/slot-fallback-with-forwarded-slot/child-component.tsx
+++ b/test/wdio/slot-fallback-with-forwarded-slot/child-component.tsx
@@ -1,0 +1,24 @@
+import { Component, h, Host,Prop } from '@stencil/core';
+
+@Component({
+  tag: 'slot-forward-child-fallback',
+  scoped: true,
+  styles: `
+    :host {
+      display: block;
+    }
+  `,
+})
+export class ChildComponent {
+  @Prop() label: string;
+
+  render() {
+    return (
+      <Host>
+        <div>
+          <slot name="label">{this.label}</slot>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/test/wdio/slot-fallback-with-forwarded-slot/child-component.tsx
+++ b/test/wdio/slot-fallback-with-forwarded-slot/child-component.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Host,Prop } from '@stencil/core';
+import { Component, h, Host, Prop } from '@stencil/core';
 
 @Component({
   tag: 'slot-forward-child-fallback',

--- a/test/wdio/slot-fallback-with-forwarded-slot/cmp.test.tsx
+++ b/test/wdio/slot-fallback-with-forwarded-slot/cmp.test.tsx
@@ -1,0 +1,51 @@
+import { h } from '@stencil/core';
+import { render } from '@wdio/browser-runner/stencil';
+
+describe('slot-fallback-with-forwarded-slot', () => {
+  it('renders fallback via prop', async () => {
+    // @ts-expect-error - wdio complaining about missing prop
+    const { $root, root } = render({
+      template: () => <slot-forward-root label="Slot fallback via property"></slot-forward-root>,
+    });
+    await $root.$('slot-fb');
+    const fb: HTMLElement = document.querySelector('slot-fb');
+
+    expect(await $root.getText()).toBe('');
+    expect(fb.textContent).toBe('Slot fallback via property');
+    expect(fb.getAttribute('hidden')).toBe(null);
+    expect(fb.hidden).toBe(false);
+
+    const p = document.createElement('p');
+    p.textContent = 'Slot content via slot';
+    p.slot = 'label';
+    root.appendChild(p);
+
+    expect(await $root.getText()).toBe('Slot content via slot');
+    expect(fb.getAttribute('hidden')).toBe('');
+    expect(fb.hidden).toBe(true);
+  });
+
+  it('should hide slot-fb elements when slotted content exists', async () => {
+    // @ts-expect-error - wdio complaining about missing prop
+    const { $root, root } = render({
+      template: () => (
+        <slot-forward-root label="Slot fallback via property">
+          <div slot="label">Slot content via slot</div>
+        </slot-forward-root>
+      ),
+    });
+    await $root.$('slot-fb');
+    const fb: HTMLElement = document.querySelector('slot-fb');
+
+    expect(await $root.getText()).toBe('Slot content via slot');
+    expect(fb.textContent).toBe('Slot fallback via property');
+    expect(fb.getAttribute('hidden')).toBe('');
+    expect(fb.hidden).toBe(true);
+
+    root.removeChild(root.childNodes[0]);
+
+    expect(await $root.getText()).toBe('');
+    expect(fb.getAttribute('hidden')).toBe(null);
+    expect(fb.hidden).toBe(false);
+  });
+});

--- a/test/wdio/slot-fallback-with-forwarded-slot/parent-component.tsx
+++ b/test/wdio/slot-fallback-with-forwarded-slot/parent-component.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Host,Prop } from '@stencil/core';
+import { Component, h, Host, Prop } from '@stencil/core';
 
 @Component({
   tag: 'slot-forward-root',

--- a/test/wdio/slot-fallback-with-forwarded-slot/parent-component.tsx
+++ b/test/wdio/slot-fallback-with-forwarded-slot/parent-component.tsx
@@ -1,0 +1,24 @@
+import { Component, h, Host,Prop } from '@stencil/core';
+
+@Component({
+  tag: 'slot-forward-root',
+  scoped: true,
+  styles: `
+    :host {
+      display: block;
+    }
+  `,
+})
+export class MyComponent {
+  @Prop() label: string;
+
+  render() {
+    return (
+      <Host>
+        <slot-forward-child-fallback label={this.label}>
+          <slot name="label" />
+        </slot-forward-child-fallback>
+      </Host>
+    );
+  }
+}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: https://github.com/ionic-team/stencil/issues/6170


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

When assessing whether to hide / show fallback slot content,  it now additionally strips out any nested `<slot />` nodes.

Fixes: https://github.com/ionic-team/stencil/issues/6170


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

- New wdio tests

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
