### PR TITLE
fix(runtime): only hydrate styles on client side

### DIFF
--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -247,6 +247,9 @@ export const convertScopedToShadow = (css: string) => css.replace(/\/\*!@([^\/]+
  * and add them to a constructable stylesheet.
  */
 export const hydrateScopedToShadow = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
   const styles = doc.querySelectorAll(`[${HYDRATED_STYLE_ID}]`);
   let i = 0;
   for (; i < styles.length; i++) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: Fixes #6166


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Check if window object is defined before query elements.

ToDo:

- [x] Test in a nextjs environment (stencil-output-targets) if the fix will no cause another regression
- [ ] Test fix in https://github.com/artursopelnik/stenciljsnextjs15-ssr
Note: Repo: https://github.com/artursopelnik/stenciljsnextjs15-ssr is not runnable from the instructions mentioned in the README

Result: Looks from ds-ouput-target perspective.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Any ideas how to test it inside the stencil repository?