### PR TITLE
fix(runtime): check shadow root nodes before appending them

### DIFF
--- a/src/runtime/client-hydrate.ts
+++ b/src/runtime/client-hydrate.ts
@@ -279,7 +279,17 @@ export const initializeClientHydrate = (
     const rnLen = shadowRootNodes.length;
     if (rnLen) {
       for (rnIdex; rnIdex < rnLen; rnIdex++) {
-        shadowRoot.appendChild(shadowRootNodes[rnIdex]);
+        const node = shadowRootNodes[rnIdex];
+
+        /**
+         * in apps with a lot of components the `shadowRootNodes` array can be modified while iterating over it
+         * so we need to check if the node is still in the array before appending it to avoid any errors like:
+         *
+         *   TypeError: Failed to execute 'appendChild' on 'Node': parameter 1 is not of type 'Node'
+         */
+        if (node) {
+          shadowRoot.appendChild(node);
+        }
       }
 
       Array.from(hostElm.childNodes).forEach((node) => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A

Currently, during client-side hydration of shadow DOM components, the `shadowRootNodes` array can be modified while being iterated over in applications with many components. This causes a race condition where `shadowRoot.appendChild()` is called with `undefined` or invalid nodes, resulting in the following error:

```
TypeError: Failed to execute 'appendChild' on 'Node': parameter 1 is not of type 'Node'
```

This error occurs in the `initializeClientHydrate` function when iterating through the `shadowRootNodes` array to append shadow DOM nodes to the shadow root.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The fix adds a null/undefined check before calling `shadowRoot.appendChild()` to ensure that only valid nodes are appended to the shadow root. The code now:

1. Extracts the node from the `shadowRootNodes` array at the current index
2. Checks if the node exists and is valid before attempting to append it
3. Only calls `shadowRoot.appendChild(node)` if the node is truthy

This prevents the `TypeError` from occurring in applications with many components where the `shadowRootNodes` array may be modified during iteration.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

This is a defensive fix that adds a safety check without changing the public API or expected behavior.

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

The fix has been tested by:
- Verifying that the existing hydration logic continues to work correctly
- Ensuring that the null check prevents the `TypeError` from occurring
- Testing with applications that have many components to reproduce the race condition scenario

The change is minimal and defensive, adding only a null check to prevent runtime errors without affecting the normal operation of shadow DOM hydration.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

This fix specifically addresses a race condition that occurs in applications with many components during client-side hydration. The issue is more likely to occur in complex applications where multiple components are being hydrated simultaneously, potentially causing the `shadowRootNodes` array to be modified during iteration.

The fix is conservative and maintains backward compatibility while preventing a runtime error that could break application functionality.