### PR TITLE
fix(dist-custom-elements): apply `initializeNextTick` config setting

### DIFF
--- a/src/compiler/output-targets/dist-custom-elements/custom-elements-build-conditionals.ts
+++ b/src/compiler/output-targets/dist-custom-elements/custom-elements-build-conditionals.ts
@@ -25,6 +25,8 @@ export const getCustomElementsBuildConditionals = (
   build.hydrateServerSide = false;
   build.asyncQueue = config.taskQueue === 'congestionAsync';
   build.taskQueue = config.taskQueue !== 'immediate';
+  build.initializeNextTick = config.extras.initializeNextTick;
+
   updateBuildConditionals(config, build);
   build.devTools = false;
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When investigating #6373 we discovered the `initializeNextTick` extras option does not apply to the `dist-custom-elements` output

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
