### PR TITLE
fix(build): absolute to relative path conversion: greedy extension replacement

### DIFF
--- a/src/compiler/transformers/map-imports-to-path-aliases.ts
+++ b/src/compiler/transformers/map-imports-to-path-aliases.ts
@@ -60,7 +60,7 @@ export const mapImportsToPathAliases = (
               // from the import path
               const extensionRegex = new RegExp(
                 Object.values(ts.Extension)
-                  .map((extension) => `${extension}$`)
+                  .map((extension) => `${extension.replace('.', '\\.')}$`)
                   .join('|'),
               );
 

--- a/src/compiler/transformers/test/map-imports-to-path-aliases.spec.ts
+++ b/src/compiler/transformers/test/map-imports-to-path-aliases.spec.ts
@@ -125,6 +125,25 @@ describe('mapImportsToPathAliases', () => {
     expect(module.outputText).toContain('import { utils } from "./utils";');
   });
 
+  it('is not greedy with extension regex replacement', () => {
+    resolveModuleNameSpy.mockReturnValue({
+      resolvedModule: {
+        isExternalLibraryImport: false,
+        extension: Extension.Ts,
+        resolvedFileName: 'utils/something-ending-with-d.ts',
+      },
+    });
+    const inputText = `
+        import { utils } from "@utils/something-ending-with-d";
+
+        utils.test();
+    `;
+
+    module = transpileModule(inputText, config, null, [], [mapImportsToPathAliases(config, '', outputTarget)]);
+
+    expect(module.outputText).toContain('import { utils } from "./utils/something-ending-with-d";');
+  });
+
   // The resolved module is not part of the output directory
   it('generates the correct relative path when the resolved module is outside the transpiled project', () => {
     config.srcDir = '/test-dir';


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6418

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixes #6418

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
