### PR TITLE
FIX {CORE-6235} Allow self components be used as event type

### DIFF
--- a/src/compiler/types/generate-event-listener-types.ts
+++ b/src/compiler/types/generate-event-listener-types.ts
@@ -25,7 +25,13 @@ export const generateEventListenerTypes = (
     return { htmlElementEventMap: [], htmlElementEventListenerProperties: [] };
   }
   return {
-    htmlElementEventMap: getHtmlElementEventMap(cmpEvents, typeImportData, cmp.sourceFilePath, htmlElementEventMapName, tagNameAsPascal),
+    htmlElementEventMap: getHtmlElementEventMap(
+      cmpEvents,
+      typeImportData,
+      cmp.sourceFilePath,
+      htmlElementEventMapName,
+      tagNameAsPascal,
+    ),
     htmlElementEventListenerProperties: [
       `        addEventListener<K extends keyof ${htmlElementEventMapName}>(type: K, listener: (this: ${htmlElementName}, ev: ${cmpEventInterface}<${htmlElementEventMapName}[K]>) => any, options?: boolean | AddEventListenerOptions): void;`,
       '        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;',
@@ -55,15 +61,12 @@ const getHtmlElementEventMap = (
   typeImportData: d.TypesImportData,
   sourceFilePath: string,
   htmlElementEventMapName: string,
-  tagNameAsPascal: string
+  tagNameAsPascal: string,
 ): string[] => {
   const eventMapProperties = cmpEvents.map((cmpEvent) => {
     const rawType = getEventGenericType(cmpEvent, typeImportData, sourceFilePath);
-    const maybePrefixedType = (rawType === tagNameAsPascal)
-      ? `Components.${rawType}`
-      : rawType;
+    const maybePrefixedType = rawType === tagNameAsPascal ? `Components.${rawType}` : rawType;
     return `        "${cmpEvent.name}": ${maybePrefixedType};`;
-
   });
   return [`    interface ${htmlElementEventMapName} {`, ...eventMapProperties, `    }`];
 };

--- a/src/compiler/types/tests/generate-event-listener-types.spec.ts
+++ b/src/compiler/types/tests/generate-event-listener-types.spec.ts
@@ -261,5 +261,36 @@ describe('generate-event-listener-types', () => {
 
       expect(generateEventListenerTypes(componentMeta, stubImportTypes)).toEqual(expectedEventListenerTypes);
     });
+
+    it('correctly prefixes event type with Components namespace when type matches component name', () => {
+      const stubImportTypes = stubTypesImportData();
+
+      const eventName = 'myEvent';
+      const componentName = 'StubCmp';
+      const stubEvent = stubComponentCompilerEvent({
+        name: eventName,
+        method: eventName,
+        complexType: {
+          original: componentName,
+          resolved: '',
+          references: {},
+        },
+      });
+
+      const componentMeta = stubComponentCompilerMeta({
+        tagName: 'stub-cmp',
+        events: [stubEvent],
+      });
+
+      const { htmlElementEventMap } = generateEventListenerTypes(componentMeta, stubImportTypes);
+
+      const expectedHtmlElementEventMap = [
+        `    interface HTML${componentName}ElementEventMap {`,
+        `        "${eventName}": Components.${componentName};`,
+        '    }',
+      ];
+
+      expect(htmlElementEventMap).toEqual(expectedHtmlElementEventMap);
+    });
   });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6235 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The generator logic has been updated so that when the event generic type exactly matches the component’s PascalCase name, it is prefixed accordingly with Components. For example:

    interface HTMLMyComponentElementEventMap {
      "myEvent": Components.MyComponent;
    }

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Unit & Manual/Visual Testing

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

No more:
```bash
[ ERROR ]  TypeScript: src/components.d.ts:24:18
Cannot find name 'MyComponent'.

L23:  interface HTMLMyComponentElementEventMap {
L24:      "myEvent": MyComponent;
L25:  }
```
