### PR TITLE
fix(ts): moduleResolution can now be `bundler`. Configurable module / noEmitOnError

### DIFF
--- a/src/compiler/transpile/ts-config.ts
+++ b/src/compiler/transpile/ts-config.ts
@@ -26,12 +26,12 @@ export const getTsOptionsToExtend = (config: d.ValidatedConfig): ts.CompilerOpti
     // if the `DIST_TYPES` output target is present then we'd like to emit
     // declaration files
     declaration: config.outputTargets.some(isOutputTargetDistTypes),
-    module: config.tsCompilerOptions.module || ts.ModuleKind.ESNext,
+    module: config.tsCompilerOptions?.module || ts.ModuleKind.ESNext,
     moduleResolution:
-      config.tsCompilerOptions.moduleResolution === ts.ModuleResolutionKind.Bundler
+      config.tsCompilerOptions?.moduleResolution === ts.ModuleResolutionKind.Bundler
         ? ts.ModuleResolutionKind.Bundler
         : ts.ModuleResolutionKind.NodeJs,
-    noEmitOnError: config.tsCompilerOptions.noEmitOnError || false,
+    noEmitOnError: config.tsCompilerOptions?.noEmitOnError || false,
     outDir: config.cacheDir || config.sys.tmpDirSync(),
     sourceMap: config.sourceMap,
     inlineSources: config.sourceMap,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #4229

ts `moduleResolution` is currently fixed at NodeJs / 'node10' meaning package.json `exports.types` is not read.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixes #4229

ts `moduleResolution` can now be set to `bundler` - package.json `exports.types` is read.

Additionally, `module` and `noEmitOnError` is now also configurable. 

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
