### PR TITLE
fix(styles): css import functions and media queries

### DIFF
--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -2097,6 +2097,7 @@ export interface CssImportData {
   filePath: string;
   altFilePath?: string;
   styleText?: string | null;
+  modifiers?: string;
 }
 
 export interface CssToEsmImportData {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6432

Stencil cannot currently handle css imports with functions and media queries. Some examples include:

```css
@import "grid.css" supports(display: grid) screen and (width <= 400px);
@import "flex.css" supports((not (display: grid)) and (display: flex)) screen and (width <= 400px);
@import "whatever.css" supports((selector(h2 > p)) and (font-tech(color-COLRv1)));
@import "theme.css" layer(utilities);
```

^ these will throw an import error

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Closes #6432

Now import modifiers are handled appropriately and `@layer`, `@supports` and `@media` blocks are created and nested.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
