### PR TITLE
fix(ssr): stop removing slotted whitespace

### DIFF
--- a/src/runtime/client-hydrate.ts
+++ b/src/runtime/client-hydrate.ts
@@ -200,8 +200,10 @@ export const initializeClientHydrate = (
       const hostEle = hosts[slottedItem.hostId as any];
 
       if (hostEle.shadowRoot && slottedItem.node.parentElement !== hostEle) {
-        // shadowDOM - move the item to the element root for native slotting
-        hostEle.appendChild(slottedItem.node);
+        // shadowDOM. This slotted node got left behind.
+        // Move the item to the element root for native slotting
+        // insert node after the previous node in the slotGroup
+        hostEle.insertBefore(slottedItem.node, slotGroup[snGroupIdx - 1]?.node?.nextSibling);
       }
 
       // This node is either slotted in a non-shadow host, OR *that* host is nested in a non-shadow host

--- a/test/end-to-end/src/scoped-hydration/scoped-hydration.e2e.ts
+++ b/test/end-to-end/src/scoped-hydration/scoped-hydration.e2e.ts
@@ -132,7 +132,7 @@ describe('`scoped: true` hydration checks', () => {
     const page = await newE2EPage({ html, url: 'https://stencil.com' });
 
     expect(await page.evaluate(() => document.querySelector('non-shadow-forwarded-slot').textContent.trim())).toContain(
-      'Text node 1 Comment 1 Slotted element 1 Slotted element 2 Comment 2 Text node 2',
+      'Text node 1 Comment 1  Slotted element 1  Slotted element 2  Comment 2 Text node 2',
     );
   });
 
@@ -157,18 +157,25 @@ describe('`scoped: true` hydration checks', () => {
     expect(await page.evaluate(() => root.firstChild.textContent)).toBe('First slot element');
     expect(await page.evaluate(() => root.firstChild.nextSibling.textContent)).toBe(' Default slot text node  ');
     expect(await page.evaluate(() => root.firstChild.nextSibling.nextSibling.textContent)).toBe('Second slot element');
-    expect(await page.evaluate(() => root.firstChild.nextSibling.nextSibling.nextSibling.textContent)).toBe(
+    expect(await page.evaluate(() => root.firstChild.nextSibling.nextSibling.nextSibling.nextSibling.textContent)).toBe(
       ' Default slot comment node  ',
     );
 
-    expect(await page.evaluate(() => root.lastChild.textContent)).toBe(' Default slot comment node  ');
-    expect(await page.evaluate(() => root.lastChild.previousSibling.textContent)).toBe('Second slot element');
-    expect(await page.evaluate(() => root.lastChild.previousSibling.previousSibling.textContent)).toBe(
-      ' Default slot text node  ',
-    );
+    expect(await page.evaluate(() => root.lastChild.previousSibling.textContent)).toBe(' Default slot comment node  ');
     expect(await page.evaluate(() => root.lastChild.previousSibling.previousSibling.previousSibling.textContent)).toBe(
-      'First slot element',
+      'Second slot element',
     );
+    expect(
+      await page.evaluate(
+        () => root.lastChild.previousSibling.previousSibling.previousSibling.previousSibling.textContent,
+      ),
+    ).toBe(' Default slot text node  ');
+    expect(
+      await page.evaluate(
+        () =>
+          root.lastChild.previousSibling.previousSibling.previousSibling.previousSibling.previousSibling.textContent,
+      ),
+    ).toBe('First slot element');
   });
 
   it('Steps through only "lightDOM" elements', async () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6434

Because whitespace nodes have no 'meta' associated with them (comment nodes including positional ids as generated by the server), it is hard to re-hydrate them safely in Stencil when rendering via the `scoped` technique. 

The net result is, whitespace nodes can get added in the wrong order which causes hydration mismatch errors. 
Stencil countered this by simply stripping out spacing, but this lead to valid / visually important spacing being removed (e.g. between inline elements like i, em, strong)

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Closes #6434

Whitespace is no longer removed and positional meta is added during hydration, using sibling data and falling back to sensible defaults.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
