### PR TITLE
fix(css): pseudo-element selectors in nested media queries

### DIFF
--- a/src/compiler/style/css-parser/parse-css.ts
+++ b/src/compiler/style/css-parser/parse-css.ts
@@ -539,10 +539,16 @@ export const parseCss = (css: string, filePath?: string): ParseCssResults => {
           const lookAhead = css.match(/^[^{}]+/);
           hasOpenBrace = lookAhead && css[lookAhead[0].length] === '{';
         } else {
-          // For other starts, look for '{' before a property declaration ':'
-          // Match everything that could be a selector (up to but not including property ':')
-          const lookAhead = css.match(/^[^{}:;]+/);
-          hasOpenBrace = lookAhead && css[lookAhead[0].length] === '{';
+          // For other starts, check if this is a selector (not a declaration)
+          // A selector will have a '{' relatively soon without a declaration-style ':' first
+          // Match up to ';' or '{', whichever comes first
+          const lookAhead = css.match(/^[^{};]+/);
+          if (lookAhead) {
+            const nextSigChar = css[lookAhead[0].length];
+            // If the next significant character is '{', this is a nested rule
+            // If it's ';', this is likely a declaration
+            hasOpenBrace = nextSigChar === '{';
+          }
         }
 
         if (hasOpenBrace) {

--- a/src/compiler/style/css-parser/test/escaped-selectors.spec.ts
+++ b/src/compiler/style/css-parser/test/escaped-selectors.spec.ts
@@ -1,5 +1,5 @@
-import { parseCss } from '../css-parser/parse-css';
-import { serializeCss } from '../css-parser/serialize-css';
+import { parseCss } from '../parse-css';
+import { serializeCss } from '../serialize-css';
 
 describe('Escaped CSS Selectors', () => {
   it('should parse selectors with escaped brackets (Tailwind-style)', () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6471


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Closes #6471

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
