### PR TITLE
fix(css): strip comments before adding css to js

### DIFF
--- a/src/compiler/style/css-to-esm.ts
+++ b/src/compiler/style/css-to-esm.ts
@@ -168,6 +168,11 @@ const generateTransformCssToEsm = (
     results.styleText = addTagTransformToCssString(results.styleText, input.tags);
   }
 
+  // Strip CSS comments before embedding in template literal
+  // This includes /** */ and /*! */ comments (Sass loud comments)
+  // Note: Style docs have already been parsed in transformCssToEsmModule
+  results.styleText = stripCssComments(results.styleText);
+
   if (input.module === 'cjs') {
     // CommonJS
     if (input.addTagTransformers) {

--- a/src/compiler/style/test/css-to-esm.spec.ts
+++ b/src/compiler/style/test/css-to-esm.spec.ts
@@ -277,7 +277,23 @@ describe('transformCssToEsm', () => {
 
       const result = transformCssToEsmSync(mockInput);
 
-      expect(result.output).toContain('const mdMyComponentCss = () => `/* This is just a comment */`;');
+      // Comments are stripped to prevent Rollup parse errors when CSS is embedded in template literals
+      expect(result.output).toContain('const mdMyComponentCss = () => ``;');
+    });
+
+    it('should strip Sass loud comments to prevent Rollup errors', () => {
+      mockInput.input = `/*! Sass loud comment */
+.my-class {
+  color: red;
+}`;
+
+      const result = transformCssToEsmSync(mockInput);
+
+      // Loud comments (/*! */) should be stripped like regular comments
+      expect(result.output).not.toContain('/*');
+      expect(result.output).not.toContain('*/');
+      expect(result.output).toContain('.my-class');
+      expect(result.output).toContain('color: red');
     });
   });
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6485


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Closes #6485

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
