### PR TITLE
feat(runtime): add Invoker Commands API attributes to button

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1036,7 +1036,7 @@ export namespace JSXBase {
     popoverTargetAction?: string;
     popoverTargetElement?: Element | null;
     popoverTarget?: string;
-    
+
     // invoker commands
     command?: string;
     commandFor?: string;


### PR DESCRIPTION
## What is the current behavior?
The `ButtonHTMLAttributes` interface in `stencil-public-runtime.ts` does not include the Invoker Commands API attributes (`command` and `commandfor`), which are part of the new HTML spec for declarative element invocation.

GitHub Issue Number: N/A

## What is the new behavior?
 Adds `command`, `commandFor`, and `commandfor` attributes to `ButtonHTMLAttributes`, enabling TypeScript support for the Invoker Commands API when using `<button>` elements in Stencil JSX.

## Documentation

N/A - This is a TypeScript type definition update to match the HTML spec.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Testing - N/A


## Other information
- [Invoker Commands Explainer](https://open-ui.org/components/invokers.explainer/)
- [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_commands_API)

