### PR TITLE
fix(ssr): revert change that causes css animations in nextjs to play twice

### DIFF
--- a/src/runtime/client-hydrate.ts
+++ b/src/runtime/client-hydrate.ts
@@ -255,7 +255,7 @@ export const initializeClientHydrate = (
     });
   }
 
-  if (BUILD.shadowDom && shadowRoot && !shadowRoot.childNodes.length) {
+  if (BUILD.shadowDom && shadowRoot) {
     // For `scoped` shadowDOM rendering (not DSD);
     // Add all the root nodes in the shadowDOM (a root node can have a whole nested DOM tree)
     let rnIdex = 0;
@@ -270,7 +270,7 @@ export const initializeClientHydrate = (
          *
          *   TypeError: Failed to execute 'appendChild' on 'Node': parameter 1 is not of type 'Node'
          */
-        if (node) {
+        if (node && !node.isConnected) {
           shadowRoot.appendChild(node);
         }
       }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In 4.35.2 (https://github.com/stenciljs/core/pull/6311) there was a regression that causes CSS animations to restart when an SSR page is hydrated in Next.js dev mode using runtime-based SSR.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
CSS animations only play once.


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
Manually tested.
## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
