### PR TITLE
fix(mock-doc): handle undefined delay in setTimeout/setInterval

### DIFF
--- a/src/mock-doc/window.ts
+++ b/src/mock-doc/window.ts
@@ -463,7 +463,7 @@ export class MockWindow {
       this.__timeouts = new Set();
     }
 
-    ms = Math.min(ms, this.__maxTimeout);
+    ms = Math.min(ms ?? 0, this.__maxTimeout);
 
     if (this.__allowInterval) {
       const intervalId = this.__setInterval(() => {
@@ -521,7 +521,7 @@ export class MockWindow {
       this.__timeouts = new Set();
     }
 
-    ms = Math.min(ms, this.__maxTimeout);
+    ms = Math.min(ms ?? 0, this.__maxTimeout);
 
     const timeoutId = this.__setTimeout.call(
       nativeWindow || this,


### PR DESCRIPTION
This PR resolves the `TimeoutNaNWarning` that may be emitted by Node.js during SSR hydration when `setTimeout` or `setInterval` is called without a delay argument.

## Problem

When components call `setTimeout(callback)` without specifying a delay during SSR, the `MockWindow` implementation could potentially pass `NaN` to the native `setTimeout`:

```javascript
ms = Math.min(ms, this.__maxTimeout);  // Math.min(undefined, 0) → NaN
```

Node.js may then coerce `NaN` to 1ms and emit a warning:

```
(node:46) TimeoutNaNWarning: NaN is not a number.
Timeout duration was set to 1.
```

## Proposed Solution

Use nullish coalescing to default `undefined` to `0` before the `Math.min` call:

```javascript
ms = Math.min(ms ?? 0, this.__maxTimeout);
```

This should align with browser behavior where `setTimeout(fn)` and `setTimeout(fn, undefined)` both default to 0ms delay.
