### PR TITLE
fix(testing): support `jsxImportSource` in internal jest test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,16 @@
       "import": "./internal/testing/index.js",
       "require": "./internal/testing/index.js"
     },
+    "./internal/testing/jsx-runtime": {
+      "types": "./internal/testing/jsx-runtime.d.ts",
+      "import": "./internal/testing/jsx-runtime.js",
+      "require": "./internal/testing/jsx-runtime.js"
+    },
+    "./internal/testing/jsx-dev-runtime": {
+      "types": "./internal/testing/jsx-dev-runtime.d.ts",
+      "import": "./internal/testing/jsx-dev-runtime.js",
+      "require": "./internal/testing/jsx-dev-runtime.js"
+    },
     "./internal/testing/*": {
       "import": "./internal/testing/*"
     },

--- a/scripts/esbuild/internal-platform-testing.ts
+++ b/scripts/esbuild/internal-platform-testing.ts
@@ -28,6 +28,11 @@ export async function getInternalTestingBundle(opts: BuildOptions): Promise<ESBu
     main: 'index.js',
   });
 
+  // Copy JSX runtime files for automatic JSX transform support
+  const srcJsxDir = join(opts.srcDir, 'internal', 'testing');
+  const jsxFiles = ['jsx-runtime.js', 'jsx-runtime.d.ts', 'jsx-dev-runtime.js', 'jsx-dev-runtime.d.ts'];
+  await Promise.all(jsxFiles.map((file) => fs.copyFile(join(srcJsxDir, file), join(outputTestingPlatformDir, file))));
+
   const internalTestingAliases = {
     ...getEsbuildAliases(),
     '@platform': inputTestingPlatform,

--- a/src/compiler/config/transpile-options.ts
+++ b/src/compiler/config/transpile-options.ts
@@ -119,6 +119,14 @@ export const getTranspileConfig = (input: TranspileOptions): TranspileConfig => 
     tsCompilerOptions.paths = { ...compileOpts.paths };
   }
 
+  if (input.jsx !== undefined) {
+    tsCompilerOptions.jsx = input.jsx;
+  }
+
+  if (isString(input.jsxImportSource)) {
+    tsCompilerOptions.jsxImportSource = input.jsxImportSource;
+  }
+
   const transformOpts: TransformOptions = {
     coreImportPath: compileOpts.coreImportPath,
     componentExport: compileOpts.componentExport as any,

--- a/src/compiler/transformers/update-stencil-core-import.ts
+++ b/src/compiler/transformers/update-stencil-core-import.ts
@@ -15,7 +15,27 @@ export const updateStencilCoreImports = (updatedCoreImportPath: string): ts.Tran
       tsSourceFile.statements.forEach((s) => {
         if (ts.isImportDeclaration(s)) {
           if (s.moduleSpecifier != null && ts.isStringLiteral(s.moduleSpecifier)) {
-            if (s.moduleSpecifier.text === STENCIL_CORE_ID) {
+            const moduleSpecifierText = s.moduleSpecifier.text;
+
+            // Handle @stencil/core/jsx-runtime and @stencil/core/jsx-dev-runtime imports
+            if (
+              moduleSpecifierText === '@stencil/core/jsx-runtime' ||
+              moduleSpecifierText === '@stencil/core/jsx-dev-runtime'
+            ) {
+              // Rewrite to import from the updated core import path
+              const newImport = ts.factory.updateImportDeclaration(
+                s,
+                s.modifiers,
+                s.importClause,
+                ts.factory.createStringLiteral(updatedCoreImportPath),
+                s.attributes,
+              );
+              newStatements.push(newImport);
+              madeChanges = true;
+              return;
+            }
+
+            if (moduleSpecifierText === STENCIL_CORE_ID) {
               if (
                 s.importClause &&
                 s.importClause.namedBindings &&
@@ -92,4 +112,7 @@ const KEEP_IMPORTS = new Set([
   'setTagTransformer',
   'transformTag',
   'Mixin',
+  'jsx',
+  'jsxs',
+  'jsxDEV',
 ]);

--- a/src/compiler/transpile/transpile-module.ts
+++ b/src/compiler/transpile/transpile-module.ts
@@ -69,11 +69,16 @@ export const transpileModule = (
     tsCompilerOptions.jsx = ts.JsxEmit.React;
   }
 
-  if (tsCompilerOptions.jsx != null && !isString(tsCompilerOptions.jsxFactory)) {
+  // Only set jsxFactory and jsxFragmentFactory for classic React mode
+  // For ReactJSX and ReactJSXDev modes (automatic runtime), these should not be set
+  const isAutomaticRuntime =
+    tsCompilerOptions.jsx === ts.JsxEmit.ReactJSX || tsCompilerOptions.jsx === ts.JsxEmit.ReactJSXDev;
+
+  if (tsCompilerOptions.jsx != null && !isAutomaticRuntime && !isString(tsCompilerOptions.jsxFactory)) {
     tsCompilerOptions.jsxFactory = 'h';
   }
 
-  if (tsCompilerOptions.jsx != null && !isString(tsCompilerOptions.jsxFragmentFactory)) {
+  if (tsCompilerOptions.jsx != null && !isAutomaticRuntime && !isString(tsCompilerOptions.jsxFragmentFactory)) {
     tsCompilerOptions.jsxFragmentFactory = 'Fragment';
   }
 

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -3052,6 +3052,16 @@ export interface TranspileOptions {
    */
   paths?: { [key: string]: string[] };
   /**
+   * JSX mode for TypeScript compilation. Can be 'react', 'react-jsx', 'react-jsxdev', etc.
+   * Same as the `jsx` TypeScript compiler option.
+   */
+  jsx?: number;
+  /**
+   * Module specifier for JSX factory. Used with automatic JSX runtime.
+   * Same as the `jsxImportSource` TypeScript compiler option.
+   */
+  jsxImportSource?: string;
+  /**
    * Passed in Stencil Compiler System, otherwise falls back to the internal in-memory only system.
    */
   sys?: CompilerSystem;

--- a/src/internal/testing/jsx-dev-runtime.d.ts
+++ b/src/internal/testing/jsx-dev-runtime.d.ts
@@ -1,0 +1,2 @@
+// Type definitions for automatic JSX development runtime in testing
+export { jsxDEV, Fragment, JSX } from '../stencil-core/jsx-dev-runtime';

--- a/src/internal/testing/jsx-dev-runtime.js
+++ b/src/internal/testing/jsx-dev-runtime.js
@@ -1,0 +1,8 @@
+// Export automatic JSX development runtime for testing
+// This file allows TypeScript's automatic JSX transform to work in tests
+// when using jsxImportSource: "@stencil/core/internal/testing" with jsx: "react-jsxdev"
+const testing = require('./index.js');
+module.exports = {
+  jsxDEV: testing.jsxDEV,
+  Fragment: testing.Fragment,
+};

--- a/src/internal/testing/jsx-runtime.d.ts
+++ b/src/internal/testing/jsx-runtime.d.ts
@@ -1,0 +1,2 @@
+// Type definitions for automatic JSX runtime in testing
+export { jsx, jsxs, Fragment, JSX } from '../stencil-core/jsx-runtime';

--- a/src/internal/testing/jsx-runtime.js
+++ b/src/internal/testing/jsx-runtime.js
@@ -1,0 +1,9 @@
+// Export automatic JSX runtime for testing
+// This file allows TypeScript's automatic JSX transform to work in tests
+// when using jsxImportSource: "@stencil/core/internal/testing"
+const testing = require('./index.js');
+module.exports = {
+  jsx: testing.jsx,
+  jsxs: testing.jsxs,
+  Fragment: testing.Fragment,
+};

--- a/src/testing/jest/jest-27-and-under/jest-preprocessor.ts
+++ b/src/testing/jest/jest-27-and-under/jest-preprocessor.ts
@@ -91,6 +91,14 @@ export const jestPreprocessor = {
         if (tsCompilerOptions.paths) {
           opts.paths = tsCompilerOptions.paths;
         }
+        if (tsCompilerOptions.jsx !== undefined) {
+          opts.jsx = tsCompilerOptions.jsx;
+        }
+        // Override jsxImportSource to use internal/testing for Jest tests
+        // This ensures TypeScript emits imports from the testing bundle instead of jsx-runtime
+        if (tsCompilerOptions.jsxImportSource) {
+          opts.jsxImportSource = '@stencil/core/internal/testing';
+        }
       }
 
       const results = transpile(sourceText, opts);

--- a/src/testing/jest/jest-28/jest-preprocessor.ts
+++ b/src/testing/jest/jest-28/jest-preprocessor.ts
@@ -49,6 +49,14 @@ export const jestPreprocessor = {
         if (tsCompilerOptions.paths) {
           opts.paths = tsCompilerOptions.paths;
         }
+        if (tsCompilerOptions.jsx !== undefined) {
+          opts.jsx = tsCompilerOptions.jsx;
+        }
+        // Override jsxImportSource to use internal/testing for Jest tests
+        // This ensures TypeScript emits imports from the testing bundle instead of jsx-runtime
+        if (tsCompilerOptions.jsxImportSource) {
+          opts.jsxImportSource = '@stencil/core/internal/testing';
+        }
       }
 
       const results = transpile(sourceText, opts);

--- a/src/testing/jest/jest-29/jest-preprocessor.ts
+++ b/src/testing/jest/jest-29/jest-preprocessor.ts
@@ -49,6 +49,14 @@ export const jestPreprocessor = {
         if (tsCompilerOptions.paths) {
           opts.paths = tsCompilerOptions.paths;
         }
+        if (tsCompilerOptions.jsx !== undefined) {
+          opts.jsx = tsCompilerOptions.jsx;
+        }
+        // Override jsxImportSource to use internal/testing for Jest tests
+        // This ensures TypeScript emits imports from the testing bundle instead of jsx-runtime
+        if (tsCompilerOptions.jsxImportSource) {
+          opts.jsxImportSource = '@stencil/core/internal/testing';
+        }
       }
 
       const results = transpile(sourceText, opts);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6546


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Closes #6546

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
