### PR TITLE
fix(types): css import type

### DIFF
--- a/src/declarations/stencil-ext-modules.d.ts
+++ b/src/declarations/stencil-ext-modules.d.ts
@@ -1,5 +1,5 @@
 declare module '*.css' {
-  const src: string;
+  const src: () => string;
   export default src;
 }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6567


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Closes #6567

In order to potentially inject `transformTag` calls into css strings (e.g. `${transformTag('my-element')}.active:hover {}`), the return type of css 'modules' changed from `string` to `() => string` (due to the fact we need the string to be resolved at call-time). 

This PR just updates the type to reflect this change

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
