### PR TITLE
fix(css): make scoped 'slotted' selector replacement less greedy

### DIFF
--- a/src/utils/shadow-css.ts
+++ b/src/utils/shadow-css.ts
@@ -645,7 +645,9 @@ export const scopeCss = (cssText: string, scopeId: string, commentOriginalSelect
   }
 
   scoped.slottedSelectors.forEach((slottedSelector) => {
-    const regex = new RegExp(escapeRegExpSpecialCharacters(slottedSelector.orgSelector), 'g');
+    // Use lookahead to ensure we only match complete selectors, not partial substrings
+    // A selector ends at ',' (separator), '{' (declaration block), or end of string
+    const regex = new RegExp(escapeRegExpSpecialCharacters(slottedSelector.orgSelector) + '(?=\\s*[,{]|$)', 'g');
     cssText = cssText.replace(regex, slottedSelector.updatedSelector);
   });
 

--- a/src/utils/test/scope-css.spec.ts
+++ b/src/utils/test/scope-css.spec.ts
@@ -292,6 +292,15 @@ describe('scopeCSS', function () {
         '@supports selector(::slotted(*)) {.sc-cmp-s > * {color:red;}}',
       );
     });
+
+    it('should not match partial selectors when expanding slotted with descendants', () => {
+      // This tests a bug where :host ::slotted(p) b a would incorrectly include
+      // an extra selector from :host ::slotted(p) b due to substring matching
+      const r = s(':host ::slotted(p) b {} :host ::slotted(p) b a {}', 'sc-my-component');
+      expect(r).toEqual(
+        '.sc-my-component-h.sc-my-component-s > p b, .sc-my-component-h .sc-my-component-s > p b {} .sc-my-component-h.sc-my-component-s > p b a, .sc-my-component-h .sc-my-component-s > p b a {}',
+      );
+    });
   });
 
   it('should handle ::shadow', () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #5879


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Closes #5879

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
