### PR TITLE
fix(compiler): JSX Runtime Hydration Failure

### DIFF
--- a/src/compiler/bundle/entry-alias-ids.ts
+++ b/src/compiler/bundle/entry-alias-ids.ts
@@ -7,6 +7,8 @@ export const STENCIL_INTERNAL_CLIENT_ID = '@stencil/core/internal/client';
 export const STENCIL_INTERNAL_CLIENT_PATCH_BROWSER_ID = '@stencil/core/internal/client/patch-browser';
 export const STENCIL_INTERNAL_HYDRATE_ID = '@stencil/core/internal/hydrate';
 export const STENCIL_MOCK_DOC_ID = '@stencil/core/mock-doc';
+export const STENCIL_JSX_RUNTIME_ID = '@stencil/core/jsx-runtime';
+export const STENCIL_JSX_DEV_RUNTIME_ID = '@stencil/core/jsx-dev-runtime';
 export const APP_DATA_CONDITIONAL = '?app-data=conditional';
 export const LAZY_BROWSER_ENTRY_ID = '@lazy-browser-entrypoint' + APP_DATA_CONDITIONAL;
 export const LAZY_EXTERNAL_ENTRY_ID = '@lazy-external-entrypoint' + APP_DATA_CONDITIONAL;

--- a/src/compiler/bundle/test/core-resolve-plugin.spec.ts
+++ b/src/compiler/bundle/test/core-resolve-plugin.spec.ts
@@ -1,8 +1,9 @@
-import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
 
 import { createSystem } from '../../../compiler/sys/stencil-sys';
 import type * as d from '../../../declarations';
-import { getHydratedFlagHead, getStencilInternalModule } from '../core-resolve-plugin';
+import { coreResolvePlugin, getHydratedFlagHead, getStencilInternalModule } from '../core-resolve-plugin';
+import { APP_DATA_CONDITIONAL, STENCIL_JSX_RUNTIME_ID } from '../entry-alias-ids';
 
 describe('core resolve plugin', () => {
   const config: d.ValidatedConfig = mockValidatedConfig({
@@ -66,5 +67,15 @@ describe('core resolve plugin', () => {
       hydratedValue: 'block',
     });
     expect(o).toBe(`{display:none}[yup]{display:block}`);
+  });
+
+  describe('jsx-runtime resolution', () => {
+    it('should resolve jsx-runtime to same path as @stencil/core for lazy builds', () => {
+      const compilerCtx = mockCompilerCtx(config);
+      const plugin = coreResolvePlugin(config, compilerCtx, 'client', false, true);
+      const resolved = (plugin.resolveId as Function)(STENCIL_JSX_RUNTIME_ID);
+      expect(resolved).toContain('internal/client/index.js');
+      expect(resolved).toContain(APP_DATA_CONDITIONAL);
+    });
   });
 });

--- a/src/compiler/transformers/update-stencil-core-import.ts
+++ b/src/compiler/transformers/update-stencil-core-import.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
 
-import { STENCIL_CORE_ID } from '../bundle/entry-alias-ids';
+import { STENCIL_CORE_ID, STENCIL_JSX_DEV_RUNTIME_ID, STENCIL_JSX_RUNTIME_ID } from '../bundle/entry-alias-ids';
 
 export const updateStencilCoreImports = (updatedCoreImportPath: string): ts.TransformerFactory<ts.SourceFile> => {
   return () => {
@@ -18,10 +18,7 @@ export const updateStencilCoreImports = (updatedCoreImportPath: string): ts.Tran
             const moduleSpecifierText = s.moduleSpecifier.text;
 
             // Handle @stencil/core/jsx-runtime and @stencil/core/jsx-dev-runtime imports
-            if (
-              moduleSpecifierText === '@stencil/core/jsx-runtime' ||
-              moduleSpecifierText === '@stencil/core/jsx-dev-runtime'
-            ) {
+            if (moduleSpecifierText === STENCIL_JSX_RUNTIME_ID || moduleSpecifierText === STENCIL_JSX_DEV_RUNTIME_ID) {
               // Rewrite to import from the updated core import path
               const newImport = ts.factory.updateImportDeclaration(
                 s,


### PR DESCRIPTION
When using the new JSX runtime (`jsx: "react-jsx"` with `jsxImportSource: "@stencil/core"`), client-side hydration fails with `<undefined></undefined>` appearing in shadow DOM.

## Cause

Rollup bundled `@stencil/core/jsx-runtime` separately from `@stencil/core`, creating duplicate runtime code with different minified VNode property names. The jsx-runtime chunk used `{v: "div"}` for tags while the main runtime expected `{V: "div"}`, causing `vnode.$tag$` to return `undefined`.

## Fix

Modified `coreResolvePlugin` to resolve `@stencil/core/jsx-runtime` to the same internal client path as `@stencil/core`, ensuring consistent minification across all chunks.
