### PR TITLE
fix: guard attachShadow call for SSR DOMs without native support

### DIFF
--- a/src/utils/shadow-root.ts
+++ b/src/utils/shadow-root.ts
@@ -26,6 +26,13 @@ export function createShadowRoot(this: HTMLElement, cmpMeta: d.ComponentRuntimeM
     }
   }
 
+  // Guard against server-side DOM implementations (e.g. Domino) that do not
+  // provide `attachShadow` on host elements.  In those environments we fall
+  // back gracefully so hydration can continue without crashing (#6605).
+  if (typeof this.attachShadow !== 'function') {
+    return;
+  }
+
   const shadowRoot = this.attachShadow(opts);
 
   // Initialize if undefined, set to CSSStyleSheet or null


### PR DESCRIPTION
## Problem

When using Stencil's hydrate runtime with server-side DOM implementations that don't provide `attachShadow` (e.g., Domino used by Angular SSR), the hydration process crashes with:

```
TypeError: this.attachShadow is not a function
    at createShadowRoot ...
    at proxyHostElement ...
```

This affects Angular SSR + Ionic applications where `@angular/ssr` uses Domino as its DOM implementation.

## Fix

Added a `typeof` guard in `createShadowRoot()` (`src/utils/shadow-root.ts`) that checks whether `attachShadow` is available on the host element before calling it. When it's missing (SSR environments), the function returns early, allowing hydration to continue without crashing.

This is a minimal, safe change — in browser environments `attachShadow` is always available so the guard is never hit. In SSR environments, the shadow root simply isn't created, which matches the expected SSR behavior (shadow roots are typically handled during client-side hydration).

## Call path

`proxyHostElement()` → `createShadowRoot.call(elm, cmpMeta)` → `this.attachShadow(opts)` 💥

After fix: `this.attachShadow` checked first → early return if missing → no crash.

Fixes #6605