### PR TITLE
fix(mock-doc): add missing `part` setter to MockElement

### DIFF
--- a/src/mock-doc/node.ts
+++ b/src/mock-doc/node.ts
@@ -381,6 +381,10 @@ export class MockElement extends MockNode {
     return new MockTokenList(this as any, 'part');
   }
 
+  set part(value: string | MockTokenList) {
+    this.setAttributeNS(null, 'part', String(value));
+  }
+
   click() {
     dispatchEvent(this, new MockEvent('click', { bubbles: true, cancelable: true, composed: true }));
   }

--- a/src/runtime/vdom/test/set-accessor.spec.ts
+++ b/src/runtime/vdom/test/set-accessor.spec.ts
@@ -147,6 +147,27 @@ describe('setAccessor for custom elements', () => {
     });
   });
 
+  it('should set part as an attribute on a custom element', () => {
+    setAccessor(elm, 'part', undefined, 'my-part', false, 0);
+    expect(elm.getAttribute('part')).toBe('my-part');
+  });
+
+  it('should update part attribute on a custom element', () => {
+    setAccessor(elm, 'part', undefined, 'old-part', false, 0);
+    expect(elm.getAttribute('part')).toBe('old-part');
+
+    setAccessor(elm, 'part', 'old-part', 'new-part', false, 0);
+    expect(elm.getAttribute('part')).toBe('new-part');
+  });
+
+  it('should remove part attribute when value is null', () => {
+    setAccessor(elm, 'part', undefined, 'my-part', false, 0);
+    expect(elm.getAttribute('part')).toBe('my-part');
+
+    setAccessor(elm, 'part', 'my-part', null, false, 0);
+    expect(elm.hasAttribute('part')).toBe(false);
+  });
+
   it('should set object property to child', () => {
     const oldValue: any = 'someval';
     const newValue: any = { some: 'obj' };


### PR DESCRIPTION
## What is the current behavior?

`MockElement.part` has a getter but no setter. When `setAccessor` does `elm.part = "value"` on custom elements, it overwrites the getter with a plain string on the instance. `setAttribute` is never called and the `part` attribute is silently lost in spec test snapshots.

GitHub Issue Number: https://github.com/stenciljs/core/issues/6611

## What is the new behavior?

Closes #6611

Added a `set part()` setter to `MockElement`, matching how `className`/`classList` work. The `part` attribute now correctly appears on custom elements in spec tests.

## Documentation

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing
Added some regression tests


closes #6611
