### PR TITLE
fix(types): raise typescript errors even without `components.d.ts`

### DIFF
--- a/src/compiler/build/build.ts
+++ b/src/compiler/build/build.ts
@@ -41,7 +41,7 @@ export const build = async (
     if (buildCtx.hasError) return buildAbort(buildCtx);
 
     // generate types and validate AFTER components.d.ts is written
-    const componentDtsChanged = await validateTypesAfterGeneration(
+    const { hasTypesChanged, needsRebuild } = await validateTypesAfterGeneration(
       config,
       compilerCtx,
       buildCtx,
@@ -50,8 +50,10 @@ export const build = async (
     );
     if (buildCtx.hasError) return buildAbort(buildCtx);
 
-    if (config.watch && componentDtsChanged) {
-      // silent abort for watch mode only
+    if (needsRebuild || (config.watch && hasTypesChanged)) {
+      // Abort and signal that a rebuild is needed:
+      // - needsRebuild: components.d.ts was just generated, need fresh TS program
+      // - watch mode with types changed: let watch trigger rebuild
       return null;
     }
 

--- a/src/compiler/build/full-build.ts
+++ b/src/compiler/build/full-build.ts
@@ -40,6 +40,17 @@ export const createFullBuild = async (
           tsWatchProgram = null;
         }
         resolve(result);
+      } else {
+        // Build returned null, indicating a rebuild is needed (e.g., components.d.ts was just generated).
+        // Close the current TS program and create a fresh one that includes components.d.ts.
+        if (tsWatchProgram) {
+          tsWatchProgram.close();
+          tsWatchProgram = null;
+        }
+        config.logger.debug('Rebuilding with fresh TypeScript program after components.d.ts generation');
+        createTsBuildProgram(config, onBuild).then((program) => {
+          tsWatchProgram = program;
+        });
       }
     };
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #3534


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

If no components.d.ts: 

- Generate components.d.ts
- Flags a re-build is needed
- Creates a fresh TS program and rebuilds

Closes #3534

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
