### PR TITLE
fix(dist-custom-elements): stop `render` being stripped from imports

### DIFF
--- a/src/compiler/transformers/update-stencil-core-import.ts
+++ b/src/compiler/transformers/update-stencil-core-import.ts
@@ -112,4 +112,5 @@ const KEEP_IMPORTS = new Set([
   'jsx',
   'jsxs',
   'jsxDEV',
+  'render',
 ]);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6621


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Closes #6621

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
