### PR TITLE
fix(runtime): skip setter when removing reflected bool attr

### DIFF
--- a/src/runtime/proxy-component.ts
+++ b/src/runtime/proxy-component.ts
@@ -379,6 +379,7 @@ export const proxyComponent = (
 
           // special handling of boolean attributes. Null (removal) means false.
           // everything else means true (including an empty string
+          const attrWasRemoved = newValue === null;
           const propFlags = members.find(([m]) => m === propName);
           if (propFlags && propFlags[1][0] & MEMBER_FLAGS.Boolean) {
             (newValue as any) = newValue === null || newValue === 'false' ? false : true;
@@ -386,8 +387,15 @@ export const proxyComponent = (
 
           // test whether this property either has no 'getter' or if it does, does it also have a 'setter'
           // before attempting to write back to component props
+          //
+          // Guard: skip when the attribute was removed (attrWasRemoved) but the current prop is
+          // already undefined. Both mean "not set" for a boolean prop, so the assignment would be
+          // spurious. Without this guard the setter fires reentrant mid-render when
+          // taskQueue:'immediate' is used, corrupting the vdom patch and crashing with
+          // "Cannot read properties of null (reading 'nodeType')".
+          const isSpuriousBooleanRemoval = attrWasRemoved && this[propName] === undefined;
           const propDesc = Object.getOwnPropertyDescriptor(prototype, propName);
-          if (newValue != this[propName] && (!propDesc.get || !!propDesc.set)) {
+          if (!isSpuriousBooleanRemoval && newValue != this[propName] && (!propDesc.get || !!propDesc.set)) {
             this[propName] = newValue;
           }
         });

--- a/src/runtime/proxy-component.ts
+++ b/src/runtime/proxy-component.ts
@@ -377,23 +377,24 @@ export const proxyComponent = (
             return;
           }
 
+          const propFlags = members.find(([m]) => m === propName);
+          const isBooleanTarget = propFlags && propFlags[1][0] & MEMBER_FLAGS.Boolean;
+
+          // Guard: skip when the attribute was removed but the current prop is
+          // already undefined. Both mean "not set" for a boolean prop, so the assignment would be
+          // spurious. Without this guard the setter fires reentrant mid-render when
+          // taskQueue:'immediate' is used, corrupting the vdom patch and crashing with
+          // "Cannot read properties of null (reading 'nodeType')".
+          const isSpuriousBooleanRemoval = isBooleanTarget && newValue === null && this[propName] === undefined;
+
           // special handling of boolean attributes. Null (removal) means false.
           // everything else means true (including an empty string
-          const attrWasRemoved = newValue === null;
-          const propFlags = members.find(([m]) => m === propName);
-          if (propFlags && propFlags[1][0] & MEMBER_FLAGS.Boolean) {
+          if (isBooleanTarget) {
             (newValue as any) = newValue === null || newValue === 'false' ? false : true;
           }
 
           // test whether this property either has no 'getter' or if it does, does it also have a 'setter'
           // before attempting to write back to component props
-          //
-          // Guard: skip when the attribute was removed (attrWasRemoved) but the current prop is
-          // already undefined. Both mean "not set" for a boolean prop, so the assignment would be
-          // spurious. Without this guard the setter fires reentrant mid-render when
-          // taskQueue:'immediate' is used, corrupting the vdom patch and crashing with
-          // "Cannot read properties of null (reading 'nodeType')".
-          const isSpuriousBooleanRemoval = attrWasRemoved && this[propName] === undefined;
           const propDesc = Object.getOwnPropertyDescriptor(prototype, propName);
           if (!isSpuriousBooleanRemoval && newValue != this[propName] && (!propDesc.get || !!propDesc.set)) {
             this[propName] = newValue;

--- a/src/runtime/test/attr.spec.tsx
+++ b/src/runtime/test/attr.spec.tsx
@@ -431,5 +431,47 @@ describe('attribute', () => {
       </cmp-draggable>
     `);
     });
+    it('should correctly reflect boolean | undefined prop when toggled between true and undefined', async () => {
+      @Component({ tag: 'cmp-reflect-bool-toggle', shadow: true })
+      class CmpReflectBoolToggle {
+        @Prop({ reflect: true, mutable: true }) active: boolean | undefined = undefined;
+
+        render() {
+          return <div>{String(this.active)}</div>;
+        }
+      }
+
+      const { root, waitForChanges } = await newSpecPage({
+        components: [CmpReflectBoolToggle],
+        html: `<cmp-reflect-bool-toggle></cmp-reflect-bool-toggle>`,
+      });
+
+      // undefined: no attribute
+      expect(root.hasAttribute('active')).toBe(false);
+      expect(root.active).toBeUndefined();
+
+      // undefined → true: attribute appears
+      root.active = true;
+      await waitForChanges();
+      expect(root.hasAttribute('active')).toBe(true);
+      expect(root.active).toBe(true);
+
+      // true → undefined: attribute removed, prop must stay undefined (not coerced to false)
+      root.active = undefined;
+      await waitForChanges();
+      expect(root.hasAttribute('active')).toBe(false);
+      expect(root.active).toBeUndefined();
+
+      // undefined → true again: recovers correctly
+      root.active = true;
+      await waitForChanges();
+      expect(root.hasAttribute('active')).toBe(true);
+      expect(root.active).toBe(true);
+
+      // external removeAttribute while prop is true: must update prop to false
+      root.removeAttribute('active');
+      await waitForChanges();
+      expect(root.active).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## What is the current behavior?

When a boolean prop with `reflect: true` is `undefined` and Stencil removes the reflected attribute, `attributeChangedCallback` received null and coerced it to false. With `taskQueue: 'immediate'` this fired the setter reentrant mid-render, corrupting the vdom patch and crashing with "Cannot read properties of null (reading 'nodeType')".

Guard against this by skipping the setter when the attribute was removed (newValue was null) and the prop is already undefined. Both represent the same "not set" state for a boolean prop.

fixes: #6672

## What is the new behavior?

Before the boolean coercion, the code checks if the attribute was removed (`newValue === null`) and the prop is already `undefined`. If so, the setter call is skipped — both states mean "not set" for a boolean prop. External attribute removal while the prop holds a real value continues to work correctly.

## Documentation

No documentation changes required.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Testing

New spec added to `src/runtime/test/attr.spec.tsx` inside `describe('reflect')`. It covers the full cycle: `undefined → true → undefined → true → removeAttribute` — verifying prop value and attribute presence at each step, including that external removal still updates the prop to `false`.

## Other information

