### PR TITLE
fix: cache host refs in public render() method

### DIFF
--- a/src/runtime/render.ts
+++ b/src/runtime/render.ts
@@ -2,7 +2,19 @@ import type * as d from '../declarations';
 import { renderVdom } from './vdom/vdom-render';
 
 /**
+ * A WeakMap to persist HostRef objects across multiple render() calls to the
+ * same container. This enables VNode diffing on re-renders — without it, each
+ * call creates a fresh HostRef with no previous VNode, causing renderVdom to
+ * replace the entire DOM subtree instead of patching only what changed.
+ */
+const hostRefCache = new WeakMap<Element, d.HostRef>();
+
+/**
  * Method to render a virtual DOM tree to a container element.
+ *
+ * Supports efficient re-renders: calling `render()` again on the same container
+ * will diff the new VNode tree against the previous one and only update what changed,
+ * preserving existing DOM elements and their state.
  *
  * @example
  * ```tsx
@@ -20,16 +32,22 @@ import { renderVdom } from './vdom/vdom-render';
  * @param container - The container element to render the virtual DOM tree to
  */
 export function render(vnode: d.VNode, container: Element) {
-  const cmpMeta: d.ComponentRuntimeMeta = {
-    $flags$: 0,
-    $tagName$: container.tagName,
-  };
+  let ref = hostRefCache.get(container);
 
-  const ref: d.HostRef = {
-    $flags$: 0,
-    $cmpMeta$: cmpMeta,
-    $hostElement$: container as d.HostElement,
-  };
+  if (!ref) {
+    const cmpMeta: d.ComponentRuntimeMeta = {
+      $flags$: 0,
+      $tagName$: container.tagName,
+    };
+
+    ref = {
+      $flags$: 0,
+      $cmpMeta$: cmpMeta,
+      $hostElement$: container as d.HostElement,
+    };
+
+    hostRefCache.set(container, ref);
+  }
 
   renderVdom(ref, vnode);
 }

--- a/test/wdio/render/render.test.tsx
+++ b/test/wdio/render/render.test.tsx
@@ -49,4 +49,81 @@ describe('Render VDOM', () => {
     await expect(listItems[6]).toHaveText('this.waldo: true');
     await expect(listItems[7]).toHaveText('this.kidsNames: John, Jane, Jim');
   });
+
+  it('preserves DOM elements when re-rendering to the same container', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    // Initial render with three items
+    render(
+      <ul>
+        <li key="a">Alpha</li>
+        <li key="b">Beta</li>
+        <li key="c">Gamma</li>
+      </ul>,
+      container,
+    );
+
+    const ul = container.querySelector('ul')!;
+    const originalLi = ul.querySelector('li:nth-child(2)')!;
+    expect(ul.children.length).toBe(3);
+
+    // Re-render with a modified list: remove "Beta", add "Delta"
+    render(
+      <ul>
+        <li key="a">Alpha</li>
+        <li key="c">Gamma</li>
+        <li key="d">Delta</li>
+      </ul>,
+      container,
+    );
+
+    // The <ul> element should be the SAME DOM node (not recreated)
+    const ulAfter = container.querySelector('ul')!;
+    expect(ulAfter).toBe(ul);
+
+    // The list should reflect the new children
+    expect(ulAfter.children.length).toBe(3);
+    await expect($(ulAfter.children[0])).toHaveText('Alpha');
+    await expect($(ulAfter.children[1])).toHaveText('Gamma');
+    await expect($(ulAfter.children[2])).toHaveText('Delta');
+
+    // "Beta" should no longer be in the DOM
+    expect(originalLi.parentNode).toBeFalsy();
+  });
+
+  it('preserves custom element state across re-renders', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    // Initial render with an input element
+    render(
+      <div>
+        <input type="text" id="test-input" />
+        <span>count: 1</span>
+      </div>,
+      container,
+    );
+
+    const input = container.querySelector('#test-input') as HTMLInputElement;
+    // Simulate user typing — this is internal DOM state not controlled by VDOM
+    input.value = 'user typed this';
+
+    // Re-render with updated content but same input
+    render(
+      <div>
+        <input type="text" id="test-input" />
+        <span>count: 2</span>
+      </div>,
+      container,
+    );
+
+    // The input should be the SAME element with user's value preserved
+    const inputAfter = container.querySelector('#test-input') as HTMLInputElement;
+    expect(inputAfter).toBe(input);
+    expect(inputAfter.value).toBe('user typed this');
+
+    // The span should be updated
+    await expect($(container.querySelector('span')!)).toHaveText('count: 2');
+  });
 });

--- a/test/wdio/render/render.test.tsx
+++ b/test/wdio/render/render.test.tsx
@@ -4,15 +4,22 @@ import { $, expect } from '@wdio/globals';
 import { defineCustomElement } from '../test-components/complex-properties.js';
 
 describe('Render VDOM', () => {
+  let container: HTMLDivElement;
+
   beforeEach(async () => {
-    document.querySelector('div')?.remove();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(async () => {
+    container.remove();
   });
 
   it('can render an arbitrary VDOM tree', async () => {
     const vdom = h('div', { className: 'test' }, 'Hello, world!');
-    render(vdom, document.body);
+    render(vdom, container);
 
-    await expect($(document.body).$('div')).toMatchInlineSnapshot(`"<div class="test">Hello, world!</div>"`);
+    await expect($(container).$('div')).toMatchInlineSnapshot(`"<div class="test">Hello, world!</div>"`);
   });
 
   it('can render a VDOM with a Stencil component', async () => {
@@ -31,7 +38,7 @@ describe('Render VDOM', () => {
         ></complex-properties>
       </div>
     );
-    render(vdom, document.body);
+    render(vdom, container);
 
     // Use separate assertions instead of inline snapshot to avoid framework issues
     const component = await $('complex-properties');
@@ -51,9 +58,6 @@ describe('Render VDOM', () => {
   });
 
   it('preserves DOM elements when re-rendering to the same container', async () => {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-
     // Initial render with three items
     render(
       <ul>
@@ -93,9 +97,6 @@ describe('Render VDOM', () => {
   });
 
   it('preserves custom element state across re-renders', async () => {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-
     // Initial render with an input element
     render(
       <div>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

`render()` method creates a new host ref on every call. This causes the whole DOM subtree to be replaced instead of patching only what's changed. 

This was observed in Storybook for example, if you use `useState()` hooks to manage state. State-driven re-renders cause the whole story to re-render.

This change caches the host refs, so the element state is preserved across re-renders.
